### PR TITLE
loans: fix /reborrow silently inserting NULL borrower_wallet

### DIFF
--- a/src/commands/reborrow.js
+++ b/src/commands/reborrow.js
@@ -164,6 +164,8 @@ export function registerReborrowCallbacks(bot) {
     await ctx.editMessageText("⏳ Submitting on-chain...");
 
     try {
+      const { publicKey: borrowerWallet } = await ensureWallet(user.id);
+
       const result = await executeBorrow({
         userId: user.id,
         collateralMint: mint,
@@ -187,6 +189,7 @@ export function registerReborrowCallbacks(bot) {
         durationDays: tier.days,
         txSignature: result.signature,
         programId: result.programId,
+        borrowerWallet,
       });
       await incrementBorrowed(user.id, loanAmount);
 

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -451,6 +451,18 @@ export async function recordLoan({
   // don't pass programId fall through to v1 — matches the column backfill.
   const recordedProgramId = programId ?? PROGRAM_ID.toBase58();
 
+  // A missing borrowerWallet here means the loan row gets inserted as NULL,
+  // which silently excludes the borrower from governance snapshots + holder
+  // aggregations. /reborrow shipped without this for a while — keep the
+  // surface visible so any future caller bug is immediately noisy.
+  if (!borrowerWallet) {
+    console.warn(
+      `[loans.recordLoan] borrowerWallet missing for loan_id=${loanId} ` +
+        `loan_pda=${loanPda} — row will be inserted with NULL; ` +
+        `re-check the caller (this used to silently drop borrowers from snapshots).`,
+    );
+  }
+
   const { rows } = await query(
     `INSERT INTO loans (
        user_id, loan_id, loan_pda, collateral_mint, collateral_amount,


### PR DESCRIPTION
## What

The `/reborrow` Telegram command path didn't pass `borrowerWallet` to `recordLoan`, so every re-borrow inserted a `loans` row with `borrower_wallet=NULL`. This silently excluded those borrowers from the governance snapshot (`getCollateralizedBorrowers` filters `WHERE borrower_wallet IS NOT NULL`) — costing them their vote weight and any future holder-pool accrual.

## Why this matters

Discovered while preparing the MGP-001 governance snapshot. Five real loans had `borrower_wallet=NULL`:

| loan_id | collateral | principal | recovered borrower |
|---|---|---|---|
| 1780881173819 | `$MAGPIE` | 0.4798 SOL | `CxV1ZW…LGNm` |
| 1780553998556 | `5vAExw…pump` | 0.0070 SOL | `EAytzt…6XQm` |
| 1780885228074 | `HVFJvV…pump` | 0.4360 SOL | `3uD3gS…pepAS` |
| 1780895951907 | `DezXAZ…PB263` | 0.0057 SOL | `H38wbm…JLttT` |
| 1780900127119 | `Tqj8yF…pump` | 1.3479 SOL | `E2jdVi…UCFb` |

Recovered by fetching each Loan PDA on-chain, decoding the Anchor struct at the `borrower` field offset (16, 32 bytes), and cross-checking `loan_id` + `collateral_mint` + `collateral_amount` against the DB row before backfilling. All three cross-checks matched on every recovery.

DB is now clean: `SELECT COUNT(*) FROM loans WHERE borrower_wallet IS NULL AND status='active'` → 0.

## What's in the patch

- **`reborrow.js`**: call `ensureWallet(user.id)` before `recordLoan`, pass the wallet pubkey through. Mirrors the pattern `borrow.js` (line 403) already uses correctly. `cosign-borrow.js` and `sync-loan.js` were also already correct — `reborrow` was the lone hole.
- **`loans.js` `recordLoan`**: `console.warn` when `borrowerWallet` is missing. Non-throwing — preserves any legitimate older-row insertion path — but makes future caller bugs immediately visible in logs.

## Tested

- `node -c` syntax check both files: ✓
- Recovery script ran cleanly: 4 of 4 recovered with all cross-checks matching, 0 NULL rows remaining
- (The fifth recovery was done earlier in the same workstream, before this PR.)

## Test plan

- [ ] Run `/reborrow` end-to-end in a dev env, verify the new row has the expected `borrower_wallet`
- [ ] Confirm the warn fires if `borrowerWallet` is intentionally omitted in a test (manual)
- [ ] Re-run `verify-snapshot.sh MGP-001` after this lands — no change expected (DB already backfilled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)