### PR TITLE
governance: wire autopilot into bot startup + command router

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,6 +284,7 @@ bot.command("pools", handleHolderPool); // alias
 // operator can enable it on demand; the per-chat enable check inside
 // the handlers ensures it does nothing in groups that haven't opted in.
 import { handleCommunityEnable, handleCommunityDisable, handleCommunityStatus, handleCommunityAllowlist, handleCommunityBroadcastNow, handleCommunityRepostGuidelines, handleCommunityUnban, handleCommunityStrikes, handleCommunityClearStrikes, handleCommunityCrosspost } from "./commands/community-admin.js";
+import { handleGovPause, handleGovResume, handleGovStatus, handleGovConfirmManual } from "./commands/gov-admin.js";
 bot.command("community_enable", handleCommunityEnable);
 bot.command("community_disable", handleCommunityDisable);
 bot.command("community_status", handleCommunityStatus);
@@ -295,6 +296,17 @@ bot.command("unban", handleCommunityUnban);
 bot.command("strikes", handleCommunityStrikes);
 bot.command("clear_strikes", handleCommunityClearStrikes);
 bot.command("crosspost", handleCommunityCrosspost);
+
+// Governance autopilot admin — operator-only commands gated inside each handler
+// via OPERATOR_TG_IDS env var. /gov-pause is the master kill switch.
+bot.command("gov-pause", handleGovPause);
+bot.command("gov_pause", handleGovPause);   // underscore alias (TG strips dashes inconsistently on some clients)
+bot.command("gov-resume", handleGovResume);
+bot.command("gov_resume", handleGovResume);
+bot.command("gov-status", handleGovStatus);
+bot.command("gov_status", handleGovStatus);
+bot.command("gov-confirm-manual", handleGovConfirmManual);
+bot.command("gov_confirm_manual", handleGovConfirmManual);
 
 // Inline callback registration.
 //
@@ -455,6 +467,13 @@ bot.start({
     // ON CONFLICT-safe so re-runs are a no-op.
     initGovernanceSchema().catch((err) =>
       console.warn("[bot] initGovernanceSchema failed (continuing):", err.message),
+    );
+    // Governance autopilot — wakes every 5 min, processes any proposal whose
+    // voting window has closed. No-op while autopilot is disabled (operator
+    // toggle via /gov-pause /gov-resume; DB-backed flag). Safe to start even
+    // before any proposal is active — pipeline finds no work and exits clean.
+    import("./services/governance-pipeline-scheduler.js").then((m) =>
+      m.startGovernancePipelineScheduler(),
     );
     setTimeout(() => startDailyOpsReport(bot), 60_000);
     startUsedNoncesCleaner();

--- a/src/services/governance-pipeline-scheduler.js
+++ b/src/services/governance-pipeline-scheduler.js
@@ -1,0 +1,60 @@
+/**
+ * Governance autopilot scheduler.
+ *
+ * Wakes every 5 minutes and runs the pipeline tick. The pipeline itself
+ * holds a Postgres advisory lock so overlapping ticks are safe — but the
+ * 5 min cadence is the default heartbeat.
+ *
+ * No-op until the autopilot is enabled (via /gov-resume). Pipeline reads
+ * the enabled flag from DB; even if the scheduler is firing, halted-by-flag
+ * proposals exit clean without mutating anything.
+ *
+ * Started from src/index.js onStart, following the same pattern as the
+ * other periodic services (community-broadcast, risk-engine, etc.).
+ */
+
+const TICK_INTERVAL_MS = 5 * 60 * 1000;
+const FIRST_TICK_DELAY_MS = 60_000;  // wait 1 min after bot start so other services init
+
+let _timer = null;
+
+export function startGovernancePipelineScheduler() {
+  if (_timer) return;  // idempotent — second call is a no-op
+
+  // First tick after delay
+  setTimeout(async () => {
+    await tick();
+    _timer = setInterval(tick, TICK_INTERVAL_MS);
+  }, FIRST_TICK_DELAY_MS);
+
+  console.log(
+    `[governance-autopilot] scheduler armed — first tick in ${FIRST_TICK_DELAY_MS / 1000}s, ` +
+      `then every ${TICK_INTERVAL_MS / 60_000} min`,
+  );
+}
+
+async function tick() {
+  try {
+    const { runPipelineTick } = await import("../governance/pipeline.js");
+    const result = await runPipelineTick();
+    // Quiet logging — only log when there's work or an issue
+    if (result.ran === false) {
+      console.log("[governance-autopilot] tick skipped:", result.reason);
+    } else if (result.processed > 0) {
+      console.log("[governance-autopilot] tick processed", result.processed, "proposal(s):", JSON.stringify(result.outcomes));
+    }
+    // ran=true, processed=0 → no work this tick; silent (5min × 288 ticks/day; don't spam logs)
+  } catch (err) {
+    console.error("[governance-autopilot] tick threw:", err.message);
+    // Tick will retry in 5 min — no need to alert on transient failures.
+    // If failures persist, the operator will see it via /gov-status showing
+    // last_run_status='error' with the message in last_run_detail.
+  }
+}
+
+export function stopGovernancePipelineScheduler() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}


### PR DESCRIPTION
## What

Companion PR to #12 (the autopilot itself). This wires the autopilot into the live bot:

1. **Register 4 operator-only admin commands** with dash + underscore aliases:
   `/gov-pause` `/gov_pause` — master kill switch
   `/gov-resume` `/gov_resume` — re-enable
   `/gov-status` `/gov_status` — view current state
   `/gov-confirm-manual` `/gov_confirm_manual` — confirm a manual_required action

2. **Add the scheduler service** — wakes every 5 min, invokes the pipeline tick. Mirrors the existing periodic-service pattern (community-broadcast, risk-engine, helius-usage-watcher, etc.).

3. **Scheduler starts in the same onStart block** as initGovernanceSchema. Idempotent — second call is a no-op. Picks up automatically on bot restart.

## Files

```
src/index.js                                    (+17 lines)
src/services/governance-pipeline-scheduler.js   (NEW, 55 lines)
```

## Dependency

This PR depends on **#12** being merged first (the autopilot module files must exist on main).

## Production deploy checklist (operator action)

```
[ ] Merge PR #12 (autopilot)
[ ] Merge this PR (wiring)
[ ] Migration 013 — ALREADY APPLIED to current production DB on 2026-06-10
[ ] Set env vars in Railway:
      OPERATOR_TG_IDS              = <your TG user ID, comma-separated for multi-op>
      GOVERNANCE_BROADCAST_CHAT_ID = <community chat ID for autopilot posts>
      OPERATOR_DM_CHAT_ID          = <your TG DM chat ID for status alerts>
[ ] Restart the bot — scheduler picks up automatically
[ ] /gov-status from your TG → confirms autopilot is live
```

## Safety notes preserved from #12

- Scheduler firing ≠ pipeline executing. Pipeline checks `governance_autopilot_state.enabled` before any state mutation. If you've paused via /gov-pause, the scheduler still wakes but the pipeline exits clean immediately.
- Pipeline holds a Postgres advisory lock during execution, so overlapping ticks can't race.
- First tick is delayed 60s after bot start, so other init services finish first.
- Quiet logging: only logs when work happens or there's an error. 288 ticks/day of "no work" don't spam logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)