### PR TITLE
fix: snapshots in DB + hide snapshot-only from /vote

### DIFF
--- a/migrations/015_governance_snapshot_storage.sql
+++ b/migrations/015_governance_snapshot_storage.sql
@@ -1,0 +1,31 @@
+-- Persist governance snapshots in DB so the bot (running on Railway / any
+-- ephemeral filesystem) can query per-wallet voting weight without needing
+-- access to the snapshot author's local disk.
+--
+-- The snapshot JSON file remains the operator-private master record on
+-- disk (mode 0600); the DB stores a normalized, queryable mirror.
+
+CREATE TABLE IF NOT EXISTS governance_snapshots (
+  snapshot_id              text        PRIMARY KEY,
+  proposal_id              text,
+  taken_at_utc             timestamptz NOT NULL,
+  hash_sha256              text        NOT NULL,
+  scope_version            text        NOT NULL,
+  totals                   jsonb       NOT NULL,
+  total_eligible_weight    numeric     NOT NULL,  -- sum of held + collateralized across the eligible set
+  unique_eligible_count    integer     NOT NULL,
+  created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+-- Per-wallet weights — O(1) lookup by (snapshot_id, wallet).
+CREATE TABLE IF NOT EXISTS governance_snapshot_weights (
+  snapshot_id              text        NOT NULL REFERENCES governance_snapshots(snapshot_id) ON DELETE CASCADE,
+  wallet                   text        NOT NULL,
+  held_raw                 numeric     NOT NULL DEFAULT 0,
+  collateralized_raw       numeric     NOT NULL DEFAULT 0,
+  lp_shares                numeric     NOT NULL DEFAULT 0,
+  PRIMARY KEY (snapshot_id, wallet)
+);
+
+CREATE INDEX IF NOT EXISTS idx_governance_snapshot_weights_wallet
+  ON governance_snapshot_weights(wallet);

--- a/src/api/governance-voting-power-api.js
+++ b/src/api/governance-voting-power-api.js
@@ -40,7 +40,7 @@ export async function handleVotingPowerQuery(req, url) {
     return { status: 404, body: { error: "proposal_not_found", proposal_id: proposalId } };
   }
 
-  const power = getVotingPower({
+  const power = await getVotingPower({
     wallet,
     proposalId,
     snapshotId: proposal.snapshot_id,

--- a/src/commands/vote.js
+++ b/src/commands/vote.js
@@ -17,6 +17,10 @@ function activeProposals() {
     .map(getProposal)
     .filter((p) => {
       if (!p?.voting_started_at_iso || !p?.voting_ends_at_iso) return false;
+      // Skip snapshot-only proposals (MGP-001 etc.) — they're not votes,
+      // they're eligibility-snapshot records for a distribution. Showing
+      // them with a "Cast your vote" button confuses users.
+      if (p.proposal_type === "snapshot_only") return false;
       const start = new Date(p.voting_started_at_iso);
       const end = new Date(p.voting_ends_at_iso);
       return now >= start && now <= end;
@@ -76,10 +80,11 @@ export async function handleVotingPower(ctx) {
   }
 
   const active = activeProposals();
-  // Also include the most recent CLOSED proposal so users can see their historical weight
+  // Also include the most recent CLOSED proposal so users can see their
+  // historical weight. Skip snapshot_only entries — they're not votes.
   const allRecent = listProposalIds()
     .map(getProposal)
-    .filter((p) => p.voting_ends_at_iso)
+    .filter((p) => p.voting_ends_at_iso && p.proposal_type !== "snapshot_only")
     .sort((a, b) => new Date(b.voting_ends_at_iso) - new Date(a.voting_ends_at_iso))
     .slice(0, 3);
 
@@ -90,7 +95,7 @@ export async function handleVotingPower(ctx) {
 
   const lines = ["⚖️ *Your Voting Weight*", "", `Wallet: \`${wallet.slice(0, 8)}...${wallet.slice(-4)}\``, ""];
   for (const p of proposalsToShow) {
-    const power = getVotingPower({ wallet, proposalId: p.id, snapshotId: p.snapshot_id });
+    const power = await getVotingPower({ wallet, proposalId: p.id, snapshotId: p.snapshot_id });
     lines.push(`*${p.id}* — ${p.title}`);
     if (!power.eligible) {
       lines.push(`  ❌ Not eligible — ${power.reason}`);

--- a/src/governance/reminders.js
+++ b/src/governance/reminders.js
@@ -150,6 +150,9 @@ export async function reminderTick() {
   for (const proposalId of listProposalIds()) {
     const p = getProposal(proposalId);
     if (!p?.voting_started_at_iso || !p?.voting_ends_at_iso) continue;
+    // Snapshot-only proposals (MGP-001 etc.) don't get reminder broadcasts —
+    // they're not votes, they're eligibility records for a distribution.
+    if (p.proposal_type === "snapshot_only") continue;
     const start = new Date(p.voting_started_at_iso);
     const end = new Date(p.voting_ends_at_iso);
     if (now < start || now > end) continue;  // not in active window

--- a/src/governance/voting-power.js
+++ b/src/governance/voting-power.js
@@ -1,35 +1,14 @@
 /**
  * Voting-power lookup — exposes "what's MY voting weight on proposal X?"
  *
- * Reads the proposal's snapshot file, returns the caller's eligible
- * weight, post-whale-cap weight, and their share of the eligible pool.
- *
- * Used by:
- *   - /votingpower TG command (caller's wallet looked up via /me state)
- *   - dashboard /api/v1/governance/voting-power?wallet=...&proposal_id=...
- *   - Pip nudges when user mentions voting
+ * Reads from the governance_snapshots + governance_snapshot_weights DB
+ * tables. The snapshot's JSON file remains on the snapshot-author's disk
+ * as the operator-private master record (mode 0600); the DB stores a
+ * normalized, queryable mirror so the bot (on Railway / any ephemeral
+ * filesystem) can answer per-wallet voting weight without disk access.
  */
 
-import { readFileSync, existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
-
-const SNAPSHOT_DIR = process.env.GOVERNANCE_SNAPSHOT_DIR || `${process.env.HOME}/.magpie-private/snapshots`;
-
-/**
- * Find the most recent snapshot file for a snapshot_id.
- * Returns null if not found.
- */
-function findSnapshotFile(snapshotId) {
-  try {
-    const files = readdirSync(SNAPSHOT_DIR)
-      .filter((f) => f.startsWith(snapshotId + "-") && f.endsWith(".json"))
-      .sort();
-    if (files.length === 0) return null;
-    return join(SNAPSHOT_DIR, files[files.length - 1]);
-  } catch {
-    return null;
-  }
-}
+import { query } from "../db/pool.js";
 
 /**
  * Lookup voting power for a given (wallet, proposal_id).
@@ -49,28 +28,37 @@ function findSnapshotFile(snapshotId) {
  *     cap_fraction: number,
  *     reason?: string              // present when eligible=false
  *   }
+ *
+ * NOTE: async now (DB-backed). Previous file-backed version was sync.
  */
-export function getVotingPower({ wallet, proposalId, snapshotId, capFraction = 0.02 }) {
+export async function getVotingPower({ wallet, proposalId, snapshotId, capFraction = 0.02 }) {
   const snapId = snapshotId || proposalId;
-  const path = findSnapshotFile(snapId);
-  if (!path) {
+
+  const headerRes = await query(
+    `SELECT taken_at_utc, total_eligible_weight, hash_sha256
+       FROM governance_snapshots WHERE snapshot_id = $1`,
+    [snapId],
+  );
+  if (headerRes.rows.length === 0) {
     return {
       eligible: false,
       wallet,
-      reason: "no_snapshot_found",
+      reason: "no_snapshot_in_db",
       snapshot_id: snapId,
     };
   }
-  let snap;
-  try {
-    snap = JSON.parse(readFileSync(path, "utf8"));
-  } catch (err) {
-    return { eligible: false, wallet, reason: `snapshot_unreadable: ${err.message}` };
-  }
-  const holder = (snap.categories?.holders ?? []).find((h) => h.wallet === wallet);
-  const collat = (snap.categories?.collateralized_borrowers ?? []).find((c) => c.wallet === wallet);
-  const held = holder ? BigInt(holder.magpie_balance_raw) : 0n;
-  const locked = collat ? BigInt(collat.magpie_collateralized_raw) : 0n;
+  const header = headerRes.rows[0];
+  const totalRaw = BigInt(header.total_eligible_weight);
+
+  const weightRes = await query(
+    `SELECT held_raw::text AS held, collateralized_raw::text AS collat, lp_shares::text AS lp
+       FROM governance_snapshot_weights
+       WHERE snapshot_id = $1 AND wallet = $2`,
+    [snapId, wallet],
+  );
+  const row = weightRes.rows[0];
+  const held = BigInt(row?.held ?? "0");
+  const locked = BigInt(row?.collat ?? "0");
   const raw = held + locked;
 
   if (raw === 0n) {
@@ -79,26 +67,10 @@ export function getVotingPower({ wallet, proposalId, snapshotId, capFraction = 0
       wallet,
       reason: "wallet_not_in_snapshot_or_zero_balance",
       snapshot_id: snapId,
-      snapshot_taken_at: snap.taken_at_utc,
+      snapshot_taken_at: header.taken_at_utc,
     };
   }
 
-  // Compute pool totals (raw and capped)
-  let totalRaw = 0n;
-  const allWeights = new Map();
-  for (const h of snap.categories?.holders ?? []) {
-    const w = BigInt(h.magpie_balance_raw);
-    allWeights.set(h.wallet, w);
-    totalRaw += w;
-  }
-  for (const c of snap.categories?.collateralized_borrowers ?? []) {
-    const cur = allWeights.get(c.wallet) ?? 0n;
-    const add = BigInt(c.magpie_collateralized_raw);
-    allWeights.set(c.wallet, cur + add);
-    totalRaw += add;
-  }
-
-  // Per-wallet cap in raw units
   const capBps = BigInt(Math.round(capFraction * 10_000));
   const capWeight = (totalRaw * capBps) / 10_000n;
   const cappedRaw = raw > capWeight ? capWeight : raw;
@@ -110,7 +82,7 @@ export function getVotingPower({ wallet, proposalId, snapshotId, capFraction = 0
     eligible: true,
     wallet,
     snapshot_id: snapId,
-    snapshot_taken_at: snap.taken_at_utc,
+    snapshot_taken_at: header.taken_at_utc,
     raw_weight: raw.toString(),
     held_raw: held.toString(),
     collateralized_raw: locked.toString(),


### PR DESCRIPTION
Two fixes from /vote testing post-MGP-002 activation. Snapshot files weren't reachable from Railway (lived on local Mac); now DB-backed. MGP-001 was showing as a 'Cast your vote' item but it's a holder snapshot, not a vote. Migration 015 already applied to production.