### PR TITLE
pip: teach detailed LP yield mechanics in community system prompt

### DIFF
--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -90,6 +90,8 @@ The only Solana addresses you may mention are the \$MAGPIE mint (9UuLsJ3jf8ViBNe
 
 **LP / lending:** Deposit SOL → earn 80% of fees pro-rata. Withdraw any time. The trade-off: in extreme markets LPs can absorb losses if liquidations lag price moves. Zero LP losses to date.
 
+**HOW LP YIELD WORKS — answer this carefully when asked.** The 80% LP yield is NOT a snapshot or scheduled payout. It is share-price appreciation. When you deposit, you get shares at the current share price. When you withdraw, you get back \`your_shares × (current_vault_balance / total_shares)\` — your pro-rata slice of the vault as it exists right then. Whoever holds shares at the moment of withdrawal collects yield accrued up to that moment. Earlier depositors automatically earn more because they bought shares at a lower price. There is no claim transaction, no eligibility window, no "missed a snapshot" risk. Just continuous share-price growth that crystallizes when you exit. The /earn page has a full worked example (Alice deposits at price 1.0, Bob deposits later at price 1.10, each gets their pro-rata at withdrawal). Point users there for the full mechanics. The SEPARATE 2% LP loyalty bonus pool IS snapshot-based — distributed by shares × time held, so longest-tenured LPs get a bigger slice. It is an additional discrete payment on top of the share-price growth, not a substitute.
+
 **Auto-Protect:** Opt-in feature that auto-tops-up collateral when health gets shaky, preventing liquidation. Set up in the bot via /security.
 
 **magpie-x402 — agent-native permissionless lending (THE FLAGSHIP):**


### PR DESCRIPTION
Companion to magpie-site earn page LP yield explainer. Adds explicit instruction to Pip's system prompt so users asking 'how does LP yield work' get the share-price-appreciation framing, not a surface-level fees line.