### PR TITLE
security: strip operator-id leak, gate per-user TG cmds to DM, opt-in heartbeat reminders

### DIFF
--- a/src/commands/distributions.js
+++ b/src/commands/distributions.js
@@ -33,6 +33,12 @@ export async function handleDistributions(ctx) {
   const tgUser = ctx.from;
   if (!tgUser) return;
 
+  if (ctx.chat?.type !== "private") {
+    return ctx.reply(
+      "Your distributions are private. DM me to see them — run /distributions in a direct message with @magpie_capital_bot.",
+    );
+  }
+
   const user = await upsertUser(tgUser.id, tgUser.username);
 
   // All wallets owned by this user

--- a/src/commands/gov-admin.js
+++ b/src/commands/gov-admin.js
@@ -27,28 +27,17 @@ function isOperator(ctx) {
   return OPERATOR_IDS.includes(String(ctx.from?.id ?? ""));
 }
 
-// Diagnostic helper for the temporary debug rejection. Surfaces enough
-// info to know whether the env var is missing, the value mismatches,
-// or the caller's id is reading differently than expected. Strip back
-// to a quiet "Command is operator-only" once the autopilot is verified
-// wired up correctly.
-function rejectWithDebug(ctx) {
-  const callerId = String(ctx.from?.id ?? "(no id)");
-  const whitelistDump = OPERATOR_IDS.length === 0
-    ? "(env var EMPTY at bot startup — Railway didn't load OPERATOR_TG_IDS)"
-    : `[${OPERATOR_IDS.map((s) => `"${s}"`).join(", ")}]`;
-  return ctx.reply(
-    `Command is operator-only.\n\n` +
-      `Debug:\n` +
-      `  Your TG id : "${callerId}"\n` +
-      `  Whitelist  : ${whitelistDump}\n` +
-      `  Count      : ${OPERATOR_IDS.length}\n\n` +
-      `If your id is NOT in the whitelist, fix the Railway env var. If the whitelist is empty, the env var didn't load at startup — re-check Railway and redeploy.`,
-  );
+function rejectNonOperator(ctx) {
+  if (OPERATOR_IDS.length === 0) {
+    console.error(
+      "[gov-admin] OPERATOR_TG_IDS env var is empty — operator commands are unreachable. Set OPERATOR_TG_IDS in the deploy environment.",
+    );
+  }
+  return ctx.reply("Command is operator-only.");
 }
 
 export async function handleGovPause(ctx) {
-  if (!isOperator(ctx)) return rejectWithDebug(ctx);
+  if (!isOperator(ctx)) return rejectNonOperator(ctx);
   const reason = (ctx.message?.text ?? "").replace(/^\/gov-pause\s*/, "").trim() || "(no reason given)";
   await query(
     `UPDATE governance_autopilot_state
@@ -63,7 +52,7 @@ export async function handleGovPause(ctx) {
 }
 
 export async function handleGovResume(ctx) {
-  if (!isOperator(ctx)) return rejectWithDebug(ctx);
+  if (!isOperator(ctx)) return rejectNonOperator(ctx);
   await query(
     `UPDATE governance_autopilot_state
         SET enabled = true,
@@ -76,7 +65,7 @@ export async function handleGovResume(ctx) {
 }
 
 export async function handleGovStatus(ctx) {
-  if (!isOperator(ctx)) return rejectWithDebug(ctx);
+  if (!isOperator(ctx)) return rejectNonOperator(ctx);
   const { rows: [s] } = await query(
     `SELECT enabled, paused_by, paused_at, paused_reason, last_run_at, last_run_status, last_run_detail
        FROM governance_autopilot_state WHERE id = 1`,
@@ -104,7 +93,7 @@ export async function handleGovStatus(ctx) {
 }
 
 export async function handleGovConfirmManual(ctx) {
-  if (!isOperator(ctx)) return rejectWithDebug(ctx);
+  if (!isOperator(ctx)) return rejectNonOperator(ctx);
   const parts = (ctx.message?.text ?? "").split(/\s+/);
   const proposalId = parts[1];
   const actionIdxStr = parts[2];

--- a/src/commands/nominations.js
+++ b/src/commands/nominations.js
@@ -191,6 +191,11 @@ export async function handleNominationReview(ctx) {
 export async function handleMyNominations(ctx) {
   const tgUser = ctx.from;
   if (!tgUser) return;
+  if (ctx.chat?.type !== "private") {
+    return ctx.reply(
+      "Your nominations list is private. DM me — run /my_nominations in a direct message with @magpie_capital_bot.",
+    );
+  }
   const { query } = await import("../db/pool.js");
   const { rows } = await query(
     `SELECT id, nomination_text, status, upvote_count, created_at

--- a/src/commands/vote.js
+++ b/src/commands/vote.js
@@ -70,6 +70,12 @@ export async function handleVotingPower(ctx) {
   const tgUser = ctx.from;
   if (!tgUser) return;
 
+  if (ctx.chat?.type !== "private") {
+    return ctx.reply(
+      "Your voting weight is private. DM me to see it — run /votingpower in a direct message with @magpie_capital_bot.",
+    );
+  }
+
   const user = await upsertUser(tgUser.id, tgUser.username);
   let wallet;
   try {

--- a/src/services/governance-reminder-scheduler.js
+++ b/src/services/governance-reminder-scheduler.js
@@ -14,6 +14,19 @@ let _timer = null;
 export function startGovernanceReminderScheduler() {
   if (_timer) return;
 
+  // Heartbeat reminders broadcast to GOVERNANCE_BROADCAST_CHAT_ID without a
+  // per-broadcast operator green light. The autopilot's one-shot post-vote
+  // announcement is explicitly authorized; these midstream reminders are NOT,
+  // and the operator's voter-fatigue rule says don't autonomously broadcast.
+  // Require explicit opt-in to enable. When disabled, the autopilot announcement
+  // path is unaffected.
+  if (process.env.ENABLE_GOV_HEARTBEAT_REMINDERS !== "true") {
+    console.log(
+      "[gov-reminders] scheduler DISABLED — set ENABLE_GOV_HEARTBEAT_REMINDERS=true to enable autonomous milestone reminders to the broadcast chat.",
+    );
+    return;
+  }
+
   setTimeout(async () => {
     await tick();
     _timer = setInterval(tick, TICK_INTERVAL_MS);


### PR DESCRIPTION
## Summary

Three HIGH-severity items from today's audit, all small focused changes:

1. **gov-admin.js — strip operator-id leak.** `rejectWithDebug()` was dumping the full `OPERATOR_TG_IDS` array to any non-operator caller of `/gov-pause`, `/gov-resume`, `/gov-status`, `/gov-confirm-manual`. Replaced with a quiet "Command is operator-only." reply. Empty-env diagnostic goes to the deploy console instead of the chat.

2. **distributions.js, vote.js, nominations.js — gate per-user replies to DMs.** `/distributions`, `/votingpower`, and `/my_nominations` were replying in whatever chat they were invoked in. If a user ran them in @magpietalk the bot would post their wallet's lifetime SOL totals, voting weight, or nomination history into the public channel. Each handler now checks `ctx.chat.type === "private"` and, if not, redirects the user to DM the bot.

3. **governance-reminder-scheduler.js — opt-in for heartbeat broadcasts.** The 5-min reminder tick was broadcasting milestone reminders to `GOVERNANCE_BROADCAST_CHAT_ID` autonomously, which violates the voter-fatigue rule (no autonomous group broadcasts without per-broadcast green light). Scheduler now requires `ENABLE_GOV_HEARTBEAT_REMINDERS=true` to start. The autopilot's one-shot post-vote announcement is on a separate path and is unaffected.

## Test plan

- [ ] Non-operator runs `/gov-status` in any chat → reply is just "Command is operator-only." (no whitelist dump)
- [ ] User runs `/distributions`, `/votingpower`, or `/my_nominations` in a group → bot redirects them to DM
- [ ] User runs same commands in DM → full per-user data returns as before
- [ ] Bot restart with `ENABLE_GOV_HEARTBEAT_REMINDERS` unset → log line "scheduler DISABLED", no broadcasts fire
- [ ] Autopilot post-vote announcement path still fires once per closed proposal