### PR TITLE
security: real snapshot integrity check, autopilot git precheck, public-route rate limit

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -133,13 +133,50 @@ function checkRateLimit(keyHash, limitRpm) {
   return true;
 }
 
-// Clean up rate limit store every 5 minutes
+// Per-IP rate limiter for PUBLIC routes — API-key gate doesn't apply, but
+// we still don't want a single source enumerating per-wallet endpoints
+// (governance distribution lookups, voting power, holder rewards) at scrape
+// speed. Default 240 req/min/IP — well above legitimate dashboard polling,
+// well below a useful scraper. Tunable per route below.
+const ipRateLimitStore = new Map();
+const PUBLIC_IP_LIMIT_RPM = parseInt(process.env.PUBLIC_IP_LIMIT_RPM || "240", 10);
+
+function extractClientIp(req) {
+  // Trust the leftmost x-forwarded-for value when behind Railway's proxy.
+  const xff = req.headers["x-forwarded-for"];
+  if (typeof xff === "string" && xff.length > 0) {
+    return xff.split(",")[0].trim();
+  }
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
+function checkIpRateLimit(ip, limitRpm) {
+  const now = Date.now();
+  const windowMs = 60_000;
+  if (!ipRateLimitStore.has(ip)) {
+    ipRateLimitStore.set(ip, []);
+  }
+  const timestamps = ipRateLimitStore.get(ip).filter((t) => now - t < windowMs);
+  if (timestamps.length >= limitRpm) {
+    return false;
+  }
+  timestamps.push(now);
+  ipRateLimitStore.set(ip, timestamps);
+  return true;
+}
+
+// Clean up rate limit stores every 5 minutes
 setInterval(() => {
   const now = Date.now();
   for (const [key, timestamps] of rateLimitStore) {
     const valid = timestamps.filter(t => now - t < 60_000);
     if (valid.length === 0) rateLimitStore.delete(key);
     else rateLimitStore.set(key, valid);
+  }
+  for (const [ip, timestamps] of ipRateLimitStore) {
+    const valid = timestamps.filter((t) => now - t < 60_000);
+    if (valid.length === 0) ipRateLimitStore.delete(ip);
+    else ipRateLimitStore.set(ip, valid);
   }
 }, 300_000);
 
@@ -1602,8 +1639,16 @@ async function router(req, res) {
     }));
   }
 
-  // Auth required for all other routes
-  if (!PUBLIC_ROUTES.has(path)) {
+  // Per-IP rate limit for public routes — auth-gated routes use the
+  // per-API-key limiter inside authenticateRequest() instead.
+  if (PUBLIC_ROUTES.has(path)) {
+    const clientIp = extractClientIp(req);
+    if (!checkIpRateLimit(clientIp, PUBLIC_IP_LIMIT_RPM)) {
+      res.writeHead(429, { "Content-Type": "application/json" });
+      return res.end(JSON.stringify({ error: "Rate limit exceeded" }));
+    }
+  } else {
+    // Auth required for all other routes
     const auth = await authenticateRequest(req);
     if (!auth) {
       res.writeHead(401, { "Content-Type": "application/json" });

--- a/src/governance/implementation.js
+++ b/src/governance/implementation.js
@@ -63,6 +63,40 @@ async function executeDbConfigUpdate(action, proposalId) {
 async function executeBotConstantPr(action, proposalId) {
   const { file_path, old_string, new_string, branch_name, description } = action;
 
+  // Precheck: working tree must be clean and HEAD must be on main. If the
+  // bot's git state is dirty or detached at the moment a vote passes, the
+  // sequence of checkout/commit/push below would silently mangle whatever
+  // is already there. Halt instead and let the operator clean it up.
+  try {
+    const statusOut = execSync("git status --porcelain", { stdio: ["ignore", "pipe", "pipe"] })
+      .toString()
+      .trim();
+    if (statusOut.length > 0) {
+      return {
+        ok: false,
+        detail: {
+          error: "working_tree_dirty",
+          hint: "Autopilot refuses to checkout a new branch when the bot's working tree has uncommitted changes. Investigate before resuming.",
+          status_porcelain: statusOut.slice(0, 500),
+        },
+      };
+    }
+    const headOut = execSync("git rev-parse --abbrev-ref HEAD", { stdio: ["ignore", "pipe", "pipe"] })
+      .toString()
+      .trim();
+    if (headOut !== "main") {
+      return {
+        ok: false,
+        detail: {
+          error: "not_on_main",
+          hint: `Autopilot expected HEAD on main but found '${headOut}'. Investigate before resuming.`,
+        },
+      };
+    }
+  } catch (err) {
+    return { ok: false, detail: { error: "git_precheck_failed", stderr: err.stderr?.toString?.()?.slice(0, 500) } };
+  }
+
   // Check if branch already exists on remote
   let branchExists = false;
   try {

--- a/src/governance/pipeline.js
+++ b/src/governance/pipeline.js
@@ -13,7 +13,8 @@
  * prevent two scheduler ticks from racing.
  */
 
-import { randomUUID } from "node:crypto";
+import { randomUUID, createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
 import { query } from "../db/pool.js";
 import { getProposal, listProposalIds } from "./registry.js";
 import { tallyProposal } from "./tally.js";
@@ -81,7 +82,6 @@ async function findReadyProposals() {
  * Find the most recent snapshot file matching the proposal's snapshot_id.
  */
 function findSnapshotFile(snapshotId) {
-  const { readdirSync } = require("node:fs");
   try {
     const files = readdirSync(SNAPSHOT_DIR)
       .filter((f) => f.startsWith(snapshotId + "-") && f.endsWith(".json"))
@@ -168,14 +168,46 @@ export async function processProposal(proposal) {
   let anomaly;
   {
     const t0 = Date.now();
-    const { createHash } = await import("node:crypto");
-    const { readFileSync } = await import("node:fs");
-    const expectedHash = createHash("sha256").update(readFileSync(snapshotPath)).digest("hex");
+    // Canonical hash comes from the registry (set at activation time, never
+    // edited). The pipeline rejects the run if the on-disk snapshot's hash
+    // doesn't match — an attacker who tampered with the snapshot file
+    // between activation and tally is detected here. If a proposal lacks a
+    // canonical hash, fail closed rather than computing-and-comparing the
+    // file to itself (which is a tautology).
+    if (!proposal.snapshot_sha256) {
+      await log(
+        "anomaly",
+        "halted",
+        { proposal_id: proposalId },
+        "snapshot_sha256_missing_in_registry",
+        Date.now() - t0,
+      );
+      await markPipelineError(proposalId, "snapshot_sha256_missing_in_registry");
+      await operatorDm(
+        `AUTOPILOT HALT: ${proposalId} has no canonical snapshot_sha256 in the registry. Add it before the pipeline can verify snapshot integrity.`,
+      );
+      return "pipeline_error";
+    }
+    const actualHash = createHash("sha256").update(readFileSync(snapshotPath)).digest("hex");
+    if (actualHash !== proposal.snapshot_sha256) {
+      await log(
+        "anomaly",
+        "halted",
+        { expected: proposal.snapshot_sha256, actual: actualHash, snapshot_path: snapshotPath },
+        "snapshot_hash_mismatch",
+        Date.now() - t0,
+      );
+      await markPipelineError(proposalId, "snapshot_hash_mismatch");
+      await operatorDm(
+        `AUTOPILOT HALT: ${proposalId} snapshot hash MISMATCH.\nExpected: ${proposal.snapshot_sha256}\nActual:   ${actualHash}\nThe on-disk snapshot has been altered since activation — manual review required.`,
+      );
+      return "pipeline_error";
+    }
     anomaly = await runAnomalyChecks({
       proposalId,
       tally,
       snapshotPath,
-      expectedSnapshotHash: expectedHash,
+      expectedSnapshotHash: proposal.snapshot_sha256,
       windowEndsAtIso: proposal.voting_ends_at_iso,
     });
     if (!anomaly.ok) {
@@ -254,8 +286,6 @@ export async function processProposal(proposal) {
   // ── STEP 7: ANNOUNCE — only after audit passes ──────────────────
   if (proposal.announcement_template && COMMUNITY_CHAT_ID && BOT_TOKEN) {
     const t0 = Date.now();
-    const { createHash } = await import("node:crypto");
-    const { readFileSync } = await import("node:fs");
     const snapshotHash = createHash("sha256").update(readFileSync(snapshotPath)).digest("hex");
     const variables = buildVariables({ proposal, tally, outcome, snapshotHash });
     const renderedText = renderTemplate(proposal.announcement_template, variables);

--- a/src/governance/registry.js
+++ b/src/governance/registry.js
@@ -65,6 +65,11 @@ export const PROPOSALS = {
     quorum_pct: 10.0,
     threshold_pct: 66.6,
     snapshot_id: "MGP-002",
+    // Canonical sha256 of the snapshot file captured at activation. The
+    // pipeline rejects the run if the on-disk file's hash doesn't match —
+    // an attacker who tampered with the snapshot between activation and
+    // tally would be detected here. Set at activation time; never edited.
+    snapshot_sha256: "f217caef513729bc37e8f89d1205ba6d641640f05f314127a606d856fc0abc69",
     // The implementation_plan below is the autopilot's task list IF MGP-002 passes.
     // Order matters — actions execute sequentially; failure halts the rest.
     implementation_plan: [


### PR DESCRIPTION
## Summary

Second pass on the audit — the two MEDIUMs and three LOWs that weren't in PR #31:

1. **Snapshot integrity check is now real** (`pipeline.js` + `registry.js`). Before this change the anomaly step hashed the snapshot file and compared that hash against… the hash of the same file — a tautology that always passed. Canonical sha256 now lives in the registry entry (set at activation time); pipeline halts the run if the on-disk file doesn't match. Fails closed if a proposal's registry entry omits \`snapshot_sha256\`. MGP-002's canonical hash recorded.

2. **Autopilot git precheck** (\`implementation.js\`). The \`bot_constant_pr\` action now refuses to checkout a new branch if \`git status --porcelain\` is non-empty or HEAD is not on main. Prevents the deploy environment's dirty state from getting mangled into an auto-PR.

3. **Per-IP rate limit on public routes** (\`server.js\`). Public routes (\`/api/v1/governance/distributions\`, \`/voting-power\`, etc.) accept a \`?wallet=\` query and previously had no rate limit — an enumeration scraper could iterate every holder unbounded. Default 240 req/min/IP, tunable via \`PUBLIC_IP_LIMIT_RPM\`. Well above legitimate dashboard polling, well below useful scraping. Auth-gated routes continue to use the per-API-key limiter.

4. **Pipeline cleanup**: top-level static imports for \`node:crypto\` and \`node:fs\` instead of \`require()\` and dynamic \`await import()\` inside hot paths.

## Test plan

- [ ] Pipeline run on MGP-002 — anomaly step logs canonical hash + actual hash, both match, run continues.
- [ ] Manually corrupt a snapshot file's bytes — anomaly step halts with \`snapshot_hash_mismatch\`, operator DM fires, no announcement sent.
- [ ] Manually create a proposal with no \`snapshot_sha256\` — pipeline halts with \`snapshot_sha256_missing_in_registry\`.
- [ ] Run autopilot \`bot_constant_pr\` action against a dirty deploy — refuses with \`working_tree_dirty\` instead of proceeding.
- [ ] Burst 300 requests/min from one IP to \`/api/v1/governance/distributions\` — 60 succeed (above 240 + minute window edge), rest get 429.