### PR TITLE
security: timing-safe shared-secret compare on lender-alarm webhook + strip operator-DM emojis

### DIFF
--- a/src/api/lender-alarm-webhook.js
+++ b/src/api/lender-alarm-webhook.js
@@ -23,6 +23,7 @@
  * Configurable via LENDER_ALARM_THRESHOLD_LAMPORTS env var.
  */
 import "dotenv/config";
+import { timingSafeEqual } from "node:crypto";
 import { notifyAdmin } from "../services/admin-notify.js";
 
 // Bot reference is injected at startup via setLenderAlarmBot(bot) so
@@ -87,7 +88,18 @@ export async function handleLenderAlarmWebhook(req) {
     };
   }
   const got = req.headers["authorization"] || req.headers["Authorization"];
-  if (got !== WEBHOOK_SECRET) {
+  // Constant-time compare to avoid timing-side-channel reveal of the
+  // shared-secret. String !== compares byte-by-byte and short-circuits on
+  // first mismatch, which is observable from outside via response-time
+  // measurement.
+  const gotBuf = Buffer.from(String(got ?? ""), "utf-8");
+  const expectedBuf = Buffer.from(WEBHOOK_SECRET, "utf-8");
+  const lengthsMatch = gotBuf.length === expectedBuf.length;
+  // Pad to equal length to keep timingSafeEqual happy even on length mismatch —
+  // if lengths differ, the final equality result is forced false.
+  const a = lengthsMatch ? gotBuf : Buffer.alloc(expectedBuf.length);
+  const ok = lengthsMatch && timingSafeEqual(a, expectedBuf);
+  if (!ok) {
     console.warn("[lender-alarm-webhook] bad auth header");
     return { status: 401, body: { error: "auth" } };
   }
@@ -106,7 +118,7 @@ export async function handleLenderAlarmWebhook(req) {
 
     const solAmount = (Number(outflow.amount) / 1e9).toFixed(6);
     const message =
-      `🚨 *Lender wallet outflow detected*\n\n` +
+      `*LENDER WALLET OUTFLOW DETECTED*\n\n` +
       `*Amount:* ${solAmount} SOL\n` +
       `*To:* \`${outflow.to}\`\n` +
       `*Tx:* [${outflow.signature.slice(0, 16)}…](https://solscan.io/tx/${outflow.signature})\n` +

--- a/src/governance/pipeline.js
+++ b/src/governance/pipeline.js
@@ -160,7 +160,7 @@ export async function processProposal(proposal) {
     if (!match) {
       await log("verify", "halted", { first: tally, second: crossTally }, "tally_cross_check_mismatch", Date.now() - t0);
       await markPipelineError(proposalId, "tally_cross_check_mismatch");
-      await operatorDm(`⚠️ AUTOPILOT HALT: ${proposalId} tally cross-check disagreed. Manual review required.`);
+      await operatorDm(`AUTOPILOT HALT: ${proposalId} tally cross-check disagreed. Manual review required.`);
       return "pipeline_error";
     }
     await log("verify", "ok", { match: true }, null, Date.now() - t0);
@@ -220,7 +220,7 @@ export async function processProposal(proposal) {
           WHERE proposal_id = $2`,
         [anomaly.flags, proposalId],
       );
-      await operatorDm(`⚠️ AUTOPILOT HALT: ${proposalId} anomaly checks failed:\n${anomaly.flags.join("\n")}`);
+      await operatorDm(`AUTOPILOT HALT: ${proposalId} anomaly checks failed:\n${anomaly.flags.join("\n")}`);
       return "anomaly_held";
     }
     await log("anomaly", "ok", null, null, Date.now() - t0);
@@ -277,7 +277,7 @@ export async function processProposal(proposal) {
     );
     if (!auditResult.overall_verified) {
       await operatorDm(
-        `⚠️ AUTOPILOT HALT: ${proposalId} passed the vote but implementation audit failed.\n` +
+        `AUTOPILOT HALT: ${proposalId} passed the vote but implementation audit failed.\n` +
         `Blocking unverified actions: ${auditResult.summary.blocking_unverified}\n` +
         `Announcement WITHHELD. Manual review required.`,
       );
@@ -311,7 +311,7 @@ export async function processProposal(proposal) {
   {
     const t0 = Date.now();
     await operatorDm(
-      `✅ AUTOPILOT: ${proposalId} (${proposal.title})\n` +
+      `AUTOPILOT: ${proposalId} (${proposal.title})\n` +
       `Outcome: ${outcome}\n` +
       `Yes: ${tally.percentages.yes_share_of_cast_pct.toFixed(2)}% | Participation: ${tally.percentages.participation_pct.toFixed(2)}%\n` +
       `Implementation: ${auditResult.summary.verified_count} verified / ${auditResult.summary.unverified_count} pending`,


### PR DESCRIPTION
## Summary

Two findings from the third-round audit:

1. **lender-alarm-webhook.js:90 — timing side-channel on shared-secret compare.** The Authorization header was compared to \`WEBHOOK_SECRET\` via JavaScript's \`!==\`, which short-circuits on first byte mismatch. Attacker can measure response-time deltas to learn the secret. Replaced with \`Buffer\` + \`timingSafeEqual\` + length-equality guard.

2. **Residual emojis on operator-DM surfaces.** \`pipeline.js\` (⚠️, ✅) and \`lender-alarm-webhook.js\` (🚨). Per the 2026-06-10 no-emojis-anywhere rule.

No behavior changes beyond what's described.

## Test plan

- [ ] Webhook still accepts requests with correct Authorization header
- [ ] Webhook rejects requests with wrong / missing header
- [ ] Pipeline operator-DM alerts arrive without emoji glyphs