### PR TITLE
security: strip dashboard aggregate leaks + lender-keypair fail-closed

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -116,7 +116,16 @@ function loadLenderKeypair() {
     const decode = bs58.decode || (bs58.default && bs58.default.decode);
     return Keypair.fromSecretKey(decode(b58));
   }
-  const kpPath = process.env.LENDER_KEYPAIR_PATH || path.resolve("lender-keypair.json");
+  // Fail closed when neither env var is set. The previous behavior fell
+  // back to ./lender-keypair.json in CWD, which is a defaultable path —
+  // a misconfigured deploy from a different CWD could silently load the
+  // wrong keypair (or a stray file someone planted). Explicit is safer.
+  const kpPath = process.env.LENDER_KEYPAIR_PATH;
+  if (!kpPath) {
+    throw new Error(
+      "[cosign-borrow] LENDER_PRIVATE_KEY or LENDER_KEYPAIR_PATH must be set — refusing to fall back to a CWD-relative default",
+    );
+  }
   const raw = JSON.parse(fs.readFileSync(kpPath, "utf-8"));
   return Keypair.fromSecretKey(new Uint8Array(raw));
 }

--- a/src/api/credit-attest.js
+++ b/src/api/credit-attest.js
@@ -57,7 +57,14 @@ function loadLenderKeypair() {
   if (b58) {
     return Keypair.fromSecretKey(bs58.decode(b58));
   }
-  const kpPath = process.env.LENDER_KEYPAIR_PATH || path.resolve("lender-keypair.json");
+  // Fail closed if neither env var is set — never fall back to a CWD-
+  // relative default path. See cosign-borrow.js for the same pattern.
+  const kpPath = process.env.LENDER_KEYPAIR_PATH;
+  if (!kpPath) {
+    throw new Error(
+      "[credit-attest] LENDER_PRIVATE_KEY or LENDER_KEYPAIR_PATH must be set — refusing to fall back to a CWD-relative default",
+    );
+  }
   const raw = JSON.parse(fs.readFileSync(kpPath, "utf-8"));
   return Keypair.fromSecretKey(new Uint8Array(raw));
 }

--- a/src/api/dashboard-api.js
+++ b/src/api/dashboard-api.js
@@ -185,7 +185,10 @@ export async function handleDashboardAggregate(req, url) {
       asset: r.asset,
       raw_amount: r.amount,
       decimals: r.decimals,
-      to: r.to_pubkey,
+      // to_pubkey deliberately stripped — leaking the destination of every
+      // recent site-withdraw to anyone who knows one of the user's wallets
+      // makes their counterparty graph readable. The wallet owner can
+      // re-derive destinations from their own tx history if they need them.
       status: r.status,
       tx_signature: r.tx_signature,
     });
@@ -200,7 +203,13 @@ export async function handleDashboardAggregate(req, url) {
       // is in PUBLIC_ROUTES and anyone with the wallet pubkey can read
       // it — exposing the TG handle here was a real leak. The site
       // doesn't display the handle anyway; matches link/status policy.
-      active_custodial_wallet: activeCustodial?.public_key ?? null,
+      //
+      // active_custodial_wallet was previously returned here but it
+      // surfaces operator-internal routing (which managed wallet the
+      // user is currently active on). The dashboard's CustodialWithdraw
+      // widget fetches this via its own signed flow when needed; do not
+      // surface it on the unsigned aggregate.
+      has_active_custodial_wallet: !!activeCustodial?.public_key,
       prefs: {
         auto_protect: !!prefs.auto_protect,
         auto_repay: !!prefs.auto_repay,

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -85,7 +85,14 @@ const EXCLUDED_WALLETS = new Set([
 function loadLenderKeypair() {
   const b58 = process.env.LENDER_PRIVATE_KEY;
   if (b58) return Keypair.fromSecretKey(bs58.decode(b58));
-  const kpPath = process.env.LENDER_KEYPAIR_PATH || path.resolve("lender-keypair.json");
+  // Fail closed if neither env var is set — never fall back to a CWD-
+  // relative default path. See cosign-borrow.js for the same pattern.
+  const kpPath = process.env.LENDER_KEYPAIR_PATH;
+  if (!kpPath) {
+    throw new Error(
+      "[magpie-holder-rewards] LENDER_PRIVATE_KEY or LENDER_KEYPAIR_PATH must be set — refusing to fall back to a CWD-relative default",
+    );
+  }
   const raw = JSON.parse(fs.readFileSync(kpPath, "utf8"));
   return Keypair.fromSecretKey(new Uint8Array(raw));
 }


### PR DESCRIPTION
## Summary

Two HIGH findings, batched.

### 1. Dashboard aggregate leak strip
\`handleDashboardAggregate\` is in \`PUBLIC_ROUTES\` and accepts \`?wallet=\` with no signature. Anyone who knows one of a user's linked wallet pubkeys could read:

- **\`active_custodial_wallet\`** — the operator-routed managed wallet the user is currently active on. **Replaced with \`has_active_custodial_wallet\` boolean.** \`CustodialWithdraw\` widget has its own signed flow when it needs the actual pubkey.
- **\`to\` field on site_withdraw events** — destination of every recent site-withdraw. **Stripped entirely.** The wallet owner can re-derive destinations from their own tx history if they need to display them.

The full fix is a signed-flow conversion of the entire dashboard endpoint — flagged for operator design call. This PR closes the two highest-impact leak vectors without breaking the live dashboard UX.

### 2. Lender-keypair load fail-closed
\`loadLenderKeypair()\` in \`cosign-borrow.js\`, \`credit-attest.js\`, and \`magpie-holder-rewards.js\` all had a CWD-relative fallback (\`path.resolve("lender-keypair.json")\`). A misconfigured deploy from a different CWD could silently load a stray keypair file. All three now require explicit env (\`LENDER_PRIVATE_KEY\` or \`LENDER_KEYPAIR_PATH\`) and throw a loud error if both are unset.

## Test plan

- [ ] Dashboard widget still loads correctly with the connected wallet (visual smoke test)
- [ ] CustodialWithdraw widget still shows the active managed wallet (uses its own endpoint)
- [ ] Site_withdraw activity rows still appear in the feed (without \`to\` field)
- [ ] Bot startup with \`LENDER_PRIVATE_KEY\` set continues to work
- [ ] Bot startup with neither env var set throws a clear error mentioning both env names