### PR TITLE
ux: loan listings show due dates, position-numbered, no emojis

### DIFF
--- a/src/commands/calendar.js
+++ b/src/commands/calendar.js
@@ -2,7 +2,7 @@
  * /calendar — chronological view of all the user's active loans
  * sorted by due date. One screen, full mental model.
  *
- * Health badge per loan: 🟢 healthy / 🟡 watch / 🟠 tight / 🔴 imminent.
+ * Health rendered as plain-text labels (no emojis per the standing rule).
  */
 import { InlineKeyboard } from "grammy";
 import { upsertUser } from "../services/users.js";
@@ -10,28 +10,11 @@ import { query } from "../db/pool.js";
 import { collateralValueLamports } from "../services/price.js";
 import { getLiveOwedLamports } from "../services/loans.js";
 import { scopeLoansToActiveWallet } from "../services/wallet-scoped-loans.js";
-
-function fmtSol(lamports) {
-  return (Number(lamports) / 1e9).toFixed(4);
-}
-
-function timeUntil(timestamp) {
-  const ms = new Date(timestamp).getTime() - Date.now();
-  if (ms <= 0) return "PAST DUE";
-  const hours = Math.floor(ms / 3_600_000);
-  const days = Math.floor(hours / 24);
-  if (days >= 1) return `in ${days}d ${hours % 24}h`;
-  if (hours >= 1) return `in ${hours}h`;
-  return `in ${Math.max(1, Math.floor(ms / 60_000))}m`;
-}
-
-function healthBadge(ratio) {
-  if (ratio == null || !Number.isFinite(ratio)) return "⚪";
-  if (ratio >= 1.5) return "🟢";
-  if (ratio >= 1.3) return "🟡";
-  if (ratio >= 1.1) return "🟠";
-  return "🔴";
-}
+import {
+  formatLoanCard,
+  totalOwedSol,
+  countDueWithin,
+} from "../services/loan-display.js";
 
 export async function handleCalendar(ctx) {
   const tgUser = ctx.from;
@@ -40,7 +23,8 @@ export async function handleCalendar(ctx) {
 
   const { rows: rawRows } = await query(
     `SELECT l.id, l.loan_id, l.loan_pda, l.collateral_mint, l.collateral_amount,
-            l.original_loan_amount_lamports, l.due_timestamp,
+            l.original_loan_amount_lamports, l.loan_amount_lamports, l.due_timestamp,
+            l.ltv_percentage, l.duration_days,
             sm.symbol, sm.decimals
      FROM loans l
      LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
@@ -55,7 +39,7 @@ export async function handleCalendar(ctx) {
   if (rows.length === 0) {
     return ctx.reply(
       [
-        "📅 *Loan Calendar*",
+        "*Loan Calendar*",
         "",
         otherWalletCount > 0
           ? `No active loans on your current wallet.\n\n${otherWalletCount} loan${otherWalletCount === 1 ? "" : "s"} on another linked wallet — /wallets to switch.`
@@ -69,48 +53,57 @@ export async function handleCalendar(ctx) {
   const enriched = await Promise.all(rows.map(async (r) => {
     let liveOwed = null;
     let healthRatio = null;
+    let currentLamports = null;
     try {
       liveOwed = await getLiveOwedLamports(r);
     } catch { /* fall through to DB */ }
     const owed = liveOwed ?? BigInt(r.original_loan_amount_lamports ?? "0");
     try {
       if (r.decimals != null && owed > 0n) {
-        const collateralLamports = await collateralValueLamports(
+        currentLamports = await collateralValueLamports(
           r.collateral_mint,
           r.collateral_amount,
           r.decimals,
         );
-        healthRatio = Number(collateralLamports) / Number(owed);
+        healthRatio = Number(currentLamports) / Number(owed);
       }
     } catch { /* skip health if price feed blips */ }
-    return { ...r, liveOwed: owed, healthRatio };
+    return { ...r, liveOwed: owed, currentLamports, healthRatio };
   }));
 
+  const totalSol = totalOwedSol(enriched.map((l) => l.liveOwed));
+  const dueSoonCount = countDueWithin(enriched, 24);
+  const summary = [
+    `${enriched.length} active`,
+    `${totalSol} SOL owed`,
+  ];
+  if (dueSoonCount > 0) summary.push(`${dueSoonCount} due within 24h`);
+
   const lines = [
-    "📅 *Loan Calendar*",
-    `${enriched.length} active · sorted by due date`,
+    "*Loan Calendar*",
+    `_${summary.join(" · ")} · sorted by due date_`,
     "",
   ];
 
-  for (const loan of enriched) {
-    const badge = healthBadge(loan.healthRatio);
-    const when = timeUntil(loan.due_timestamp);
-    const healthStr = loan.healthRatio != null ? `${loan.healthRatio.toFixed(2)}x` : "?";
-    lines.push(
-      `${badge} *#${loan.loan_id}* — ${loan.symbol ?? "?"}`,
-      `  Due ${when} · Health ${healthStr} · Owed \`${fmtSol(loan.liveOwed)} SOL\``,
-      "",
-    );
+  for (let i = 0; i < enriched.length; i++) {
+    const loan = enriched[i];
+    const card = formatLoanCard(loan, {
+      owedLamports: loan.liveOwed,
+      healthRatio: loan.healthRatio,
+      collateralValueLamports: loan.currentLamports,
+      position: i + 1,
+    });
+    lines.push(card, "");
   }
 
   // Inline action buttons for the first few loans
   const kb = new InlineKeyboard();
   for (let i = 0; i < Math.min(3, enriched.length); i++) {
     const l = enriched[i];
-    kb.text(`Manage #${l.loan_id}`, `calendar:loan:${l.id}`).row();
+    kb.text(`Manage ${l.symbol ?? "?"} (${i + 1})`, `calendar:loan:${l.id}`).row();
   }
   if (enriched.length > 0) {
-    lines.push("_Pick a loan below to repay / topup / extend, or use /repay /topup /extend directly._");
+    lines.push("_Tap a loan below for repay / topup / extend, or use /repay /topup /extend directly._");
   }
   if (otherWalletCount > 0) {
     lines.push("", `_+${otherWalletCount} loan${otherWalletCount === 1 ? "" : "s"} on another linked wallet — /wallets to switch._`);
@@ -127,11 +120,11 @@ export function registerCalendarCallbacks(bot) {
     await ctx.answerCallbackQuery();
     const loanId = Number(ctx.match[1]);
     const kb = new InlineKeyboard()
-      .text("🔧 Repay", `repay:loan:${loanId}`)
-      .text("➕ Top up", `topup:loan:${loanId}`)
+      .text("Repay", `repay:loan:${loanId}`)
+      .text("Top up", `topup:loan:${loanId}`)
       .row()
-      .text("⏱ Extend", `extend:loan:${loanId}`)
-      .text("💰 Partial", `partialrepay:loan:${loanId}`);
+      .text("Extend", `extend:loan:${loanId}`)
+      .text("Partial repay", `partialrepay:loan:${loanId}`);
     await ctx.reply(`*Loan management actions:*`, {
       parse_mode: "Markdown",
       reply_markup: kb,

--- a/src/commands/extend.js
+++ b/src/commands/extend.js
@@ -6,6 +6,7 @@ import { getSolBalance } from "../services/deposits.js";
 import { executeExtendLoan, recordExtendLoan, getLiveOwedLamports, checkLoanOwnership } from "../services/loans.js";
 import { scopeLoansToActiveWallet } from "../services/wallet-scoped-loans.js";
 import { translateTxError, errorActionKeyboard, renderWalletMismatchMessage } from "../services/tx-error-translator.js";
+import { formatTimeToDue, countDueWithin } from "../services/loan-display.js";
 
 const pending = new Map();
 
@@ -37,7 +38,7 @@ export async function handleExtend(ctx) {
   );
 
   if (rows.length === 0) {
-    return ctx.reply("📭 No active loans.");
+    return ctx.reply("No active loans.");
   }
 
   // Scope to active wallet — multi-wallet users were seeing every loan
@@ -47,7 +48,7 @@ export async function handleExtend(ctx) {
 
   if (scopedRows.length === 0) {
     return ctx.reply(
-      `📭 No active loans on your *current* wallet.` +
+      `No active loans on your *current* wallet.` +
       (otherWalletCount > 0
         ? `\n\n${otherWalletCount} loan${otherWalletCount === 1 ? "" : "s"} on other linked wallets — /wallets to switch.`
         : ""),
@@ -63,25 +64,33 @@ export async function handleExtend(ctx) {
   scopedRows.forEach((loan, i) => {
     const bps = feeBpsForLtv(loan.ltv_percentage);
     const fee = (liveAmounts[i] * bps) / 10_000n;
+    // Extend-specific label: time-to-due + the fee. Lets the user
+    // see at a glance which loans are urgent enough to want to extend.
+    const symbol = loan.symbol ?? "?";
+    const timeStr = formatTimeToDue(loan.due_timestamp);
     kb.text(
-      `#${loan.loan_id} · ${loan.symbol ?? "?"} · fee ${fmtSol(fee)} SOL`,
+      `${i + 1}. ${symbol} · ${timeStr} · fee ${fmtSol(fee)} SOL`,
       `extend:loan:${loan.id}`,
     ).row();
   });
-  kb.text("✕ Cancel", "extend:cancel");
+  kb.text("Cancel", "extend:cancel");
 
-  const header = `*Extend loan* — adds the original duration for the tier fee.\n\nPick a loan:` +
-    (otherWalletCount > 0
-      ? `\n_${otherWalletCount} more on other wallets — /wallets to switch._`
-      : "");
-  await ctx.reply(header, { parse_mode: "Markdown", reply_markup: kb });
+  const dueSoonCount = countDueWithin(scopedRows, 24);
+  const headerLines = [
+    `*Extend loan* — adds the original duration for the tier fee.`,
+    `_${scopedRows.length} active${dueSoonCount > 0 ? ` · ${dueSoonCount} due within 24h` : ""} · sorted by due date_`,
+  ];
+  if (otherWalletCount > 0) {
+    headerLines.push("", `_+${otherWalletCount} more on other wallets — /wallets to switch._`);
+  }
+  await ctx.reply(headerLines.join("\n"), { parse_mode: "Markdown", reply_markup: kb });
 }
 
 export function registerExtendCallbacks(bot) {
   bot.callbackQuery(/^extend:cancel$/, async (ctx) => {
     pending.delete(ctx.chat.id);
     await ctx.answerCallbackQuery("Cancelled");
-    await ctx.editMessageText("❌ Extend cancelled.");
+    await ctx.editMessageText("Extend cancelled.");
   });
 
   bot.callbackQuery(/^extend:loan:(\d+)$/, async (ctx) => {
@@ -107,12 +116,12 @@ export function registerExtendCallbacks(bot) {
     if (!loan) {
       // We already ack'd above; surface the not-found state inline
       // instead of via the popup-style answerCallbackQuery text.
-      await ctx.editMessageText("❌ Loan not found.").catch(() => {});
+      await ctx.editMessageText("Loan not found.").catch(() => {});
       return;
     }
     if (loan.suspended) {
       await ctx.editMessageText(
-        "⚠️ This loan is under review and cannot be extended. Contact support.",
+        "This loan is under review and cannot be extended. Contact support.",
       ).catch(() => {});
       return;
     }
@@ -126,7 +135,7 @@ export function registerExtendCallbacks(bot) {
     if (BigInt(sol) < fee + 3_000_000n) {
       await ctx.editMessageText(
         [
-          `❌ Insufficient SOL for extension fee.`,
+          `Insufficient SOL for extension fee.`,
           ``,
           `Needed: ~${fmtSol(fee + 3_000_000n)} SOL`,
           `Wallet: ${fmtSol(sol)} SOL`,
@@ -147,13 +156,12 @@ export function registerExtendCallbacks(bot) {
       : new Date(new Date(loan.due_timestamp).getTime() + loan.duration_days * 86400_000);
 
     const kb = new InlineKeyboard()
-      .text("✅ Confirm extension", `extend:confirm:${loan.id}`)
-      .row().text("✕ Cancel", "extend:cancel");
+      .text("Confirm extension", `extend:confirm:${loan.id}`)
+      .row().text("Cancel", "extend:cancel");
 
     await ctx.editMessageText(
       [
-        `*Extend loan #${loan.loan_id}*`,
-        `Symbol: ${loan.symbol ?? "?"}`,
+        `*Extend ${loan.symbol ?? "?"} loan*`,
         `Extension fee: *${fmtSol(fee)} SOL* (${Number(bps) / 100}%)`,
         `New due: ${newDue.toUTCString()}`,
         wasDue ? "_(loan was past due — clock resets from now)_" : "",
@@ -185,7 +193,7 @@ export function registerExtendCallbacks(bot) {
       return;
     }
 
-    await ctx.editMessageText("⏳ Extending loan on-chain...");
+    await ctx.editMessageText("Extending loan on-chain...");
 
     try {
       const result = await executeExtendLoan({
@@ -198,10 +206,10 @@ export function registerExtendCallbacks(bot) {
 
       await ctx.editMessageText(
         [
-          "✅ *Loan extended*",
+          "*Loan extended*",
           "",
           `Fee paid: ${fmtSol(result.feeLamports)} SOL`,
-          `Loan #${state.loan.loan_id} extended by ${state.loan.duration_days} days.`,
+          `${state.loan.symbol ?? "?"} loan extended by ${state.loan.duration_days} days.`,
           "",
           `[View tx](https://solscan.io/tx/${result.signature})`,
           "",

--- a/src/commands/health.js
+++ b/src/commands/health.js
@@ -13,16 +13,18 @@ import { query } from "../db/pool.js";
 import { collateralValueLamports } from "../services/price.js";
 import { getLiveOwedLamports } from "../services/loans.js";
 import { scopeLoansToActiveWallet } from "../services/wallet-scoped-loans.js";
+import { formatTimeToDueLong, formatHealthLabel } from "../services/loan-display.js";
 
 function fmtSol(lamports) {
   return (Number(lamports) / 1e9).toFixed(4);
 }
 
-function healthBadge(ratio) {
-  if (ratio >= 1.5) return { emoji: "🟢", label: "Healthy", color: "green" };
-  if (ratio >= 1.3) return { emoji: "🟡", label: "Watch", color: "yellow" };
-  if (ratio >= 1.1) return { emoji: "🟠", label: "Tight", color: "orange" };
-  return { emoji: "🔴", label: "Imminent liquidation", color: "red" };
+function healthHeadline(ratio) {
+  if (ratio == null || !Number.isFinite(ratio)) return "Unknown";
+  if (ratio >= 1.5) return "Healthy";
+  if (ratio >= 1.3) return "Watch";
+  if (ratio >= 1.1) return "Tight";
+  return "AT RISK — liquidation imminent";
 }
 
 function advice(ratio) {
@@ -123,16 +125,20 @@ export async function handleHealth(ctx) {
 
 async function renderHealth(ctx, loan, snap, multiple, otherWalletCount = 0) {
   const ratio = snap.ratio;
-  const badge = ratio != null ? healthBadge(ratio) : { emoji: "⚪", label: "Unknown" };
+  const symbol = loan.symbol ?? "?";
+  const headline = healthHeadline(ratio);
+  const timeStr = formatTimeToDueLong(loan.due_timestamp);
+  const healthBand = ratio != null ? formatHealthLabel(ratio) : "—";
 
   const lines = [
-    `${badge.emoji} *Loan #${loan.loan_id} — ${badge.label}*`,
+    `*${symbol} loan — ${headline}*`,
+    `_${timeStr} · ${loan.ltv_percentage}% LTV · ${loan.duration_days}d term_`,
     "",
-    `Collateral: \`${snap.tokens.toLocaleString(undefined, { maximumFractionDigits: 4 })} ${loan.symbol ?? "?"}\``,
+    `Collateral: \`${snap.tokens.toLocaleString(undefined, { maximumFractionDigits: 4 })} ${symbol}\``,
     snap.collateralLamports != null ? `  Value: \`${fmtSol(snap.collateralLamports)} SOL\`` : "  Value: _price feed unavailable_",
     `Owed:       \`${fmtSol(snap.liveOwed)} SOL\``,
-    ratio != null ? `Health:     *${ratio.toFixed(2)}x*` : "Health:     _unknown_",
-    snap.liqPriceSol != null ? `Liq. price: \`${snap.liqPriceSol.toFixed(9)} SOL/${loan.symbol ?? "token"}\`` : "",
+    ratio != null ? `Health:     *${ratio.toFixed(2)}× (${healthBand})*` : "Health:     _unknown_",
+    snap.liqPriceSol != null ? `Liq. price: \`${snap.liqPriceSol.toFixed(9)} SOL/${symbol === "?" ? "token" : symbol}\`` : "",
     "",
     ratio != null ? advice(ratio) : "Couldn't compute health right now — try /health again in 15s.",
   ].filter(Boolean);
@@ -145,11 +151,11 @@ async function renderHealth(ctx, loan, snap, multiple, otherWalletCount = 0) {
   }
 
   const kb = new InlineKeyboard()
-    .text("🔧 Repay", `repay:loan:${loan.id}`)
-    .text("➕ Top up", `topup:loan:${loan.id}`)
+    .text("Repay", `repay:loan:${loan.id}`)
+    .text("Top up", `topup:loan:${loan.id}`)
     .row()
-    .text("⏱ Extend", `extend:loan:${loan.id}`)
-    .text("💰 Partial", `partialrepay:loan:${loan.id}`);
+    .text("Extend", `extend:loan:${loan.id}`)
+    .text("Partial repay", `partialrepay:loan:${loan.id}`);
 
   await ctx.reply(lines.join("\n"), {
     parse_mode: "Markdown",

--- a/src/commands/partial-repay.js
+++ b/src/commands/partial-repay.js
@@ -6,6 +6,7 @@ import { getSolBalance } from "../services/deposits.js";
 import { executePartialRepay, recordPartialRepay, getLiveOwedLamports, checkLoanOwnership } from "../services/loans.js";
 import { scopeLoansToActiveWallet } from "../services/wallet-scoped-loans.js";
 import { translateTxError, errorActionKeyboard, renderWalletMismatchMessage } from "../services/tx-error-translator.js";
+import { formatLoanButtonLabel, totalOwedSol, countDueWithin } from "../services/loan-display.js";
 
 const pending = new Map();
 
@@ -30,7 +31,7 @@ export async function handlePartialRepay(ctx) {
   );
 
   if (rows.length === 0) {
-    return ctx.reply("📭 No active loans.");
+    return ctx.reply("No active loans.");
   }
 
   const { filtered: scopedRows, otherWalletCount } =
@@ -38,7 +39,7 @@ export async function handlePartialRepay(ctx) {
 
   if (scopedRows.length === 0) {
     return ctx.reply(
-      `📭 No active loans on your *current* wallet.` +
+      `No active loans on your *current* wallet.` +
       (otherWalletCount > 0
         ? `\n\n${otherWalletCount} loan${otherWalletCount === 1 ? "" : "s"} on other linked wallets — /wallets to switch.`
         : ""),
@@ -52,24 +53,31 @@ export async function handlePartialRepay(ctx) {
   const kb = new InlineKeyboard();
   scopedRows.forEach((loan, i) => {
     kb.text(
-      `#${loan.loan_id} · ${loan.symbol ?? "?"} · owe ${fmtSol(liveAmounts[i])} SOL`,
+      formatLoanButtonLabel(loan, liveAmounts[i], i + 1),
       `prepay:loan:${loan.id}`,
     ).row();
   });
-  kb.text("✕ Cancel", "prepay:cancel");
+  kb.text("Cancel", "prepay:cancel");
 
-  const header = "*Partial repay* (collateral stays locked until full payoff)\n\nPick a loan:" +
-    (otherWalletCount > 0
-      ? `\n_${otherWalletCount} more on other wallets — /wallets to switch._`
-      : "");
-  await ctx.reply(header, { parse_mode: "Markdown", reply_markup: kb });
+  const totalSol = totalOwedSol(liveAmounts);
+  const dueSoonCount = countDueWithin(scopedRows, 24);
+  const summaryParts = [`${scopedRows.length} active`, `${totalSol} SOL owed total`];
+  if (dueSoonCount > 0) summaryParts.push(`${dueSoonCount} due within 24h`);
+  const headerLines = [
+    "*Partial repay* — collateral stays locked until full payoff.",
+    `_${summaryParts.join(" · ")} · sorted by due date_`,
+  ];
+  if (otherWalletCount > 0) {
+    headerLines.push("", `_+${otherWalletCount} more on other wallets — /wallets to switch._`);
+  }
+  await ctx.reply(headerLines.join("\n"), { parse_mode: "Markdown", reply_markup: kb });
 }
 
 export function registerPartialRepayCallbacks(bot) {
   bot.callbackQuery(/^prepay:cancel$/, async (ctx) => {
     pending.delete(ctx.chat.id);
     await ctx.answerCallbackQuery("Cancelled");
-    await ctx.editMessageText("❌ Partial repay cancelled.");
+    await ctx.editMessageText("Partial repay cancelled.");
   });
 
   bot.callbackQuery(/^prepay:loan:(\d+)$/, async (ctx) => {
@@ -92,7 +100,7 @@ export function registerPartialRepayCallbacks(bot) {
     if (loan.suspended) {
       await ctx.answerCallbackQuery();
       await ctx.editMessageText(
-        "⚠️ This loan is under review and cannot be modified. Contact support.",
+        "This loan is under review and cannot be modified. Contact support.",
       );
       return;
     }
@@ -106,7 +114,7 @@ export function registerPartialRepayCallbacks(bot) {
     if (available <= 0) {
       await ctx.answerCallbackQuery();
       await ctx.editMessageText(
-        `📭 Not enough SOL in wallet.\n\nDeposit SOL to:\n\`${publicKey}\``,
+        `Not enough SOL in wallet.\n\nDeposit SOL to:\n\`${publicKey}\``,
         { parse_mode: "Markdown" },
       );
       return;
@@ -118,7 +126,7 @@ export function registerPartialRepayCallbacks(bot) {
       .text("25%", "prepay:pct:25").text("50%", "prepay:pct:50")
       .text("75%", "prepay:pct:75")
       .row().text("✏️ Custom %", "prepay:custom")
-      .row().text("✕ Cancel", "prepay:cancel");
+      .row().text("Cancel", "prepay:cancel");
 
     await ctx.answerCallbackQuery();
     await ctx.editMessageText(
@@ -256,7 +264,7 @@ async function submitPartialRepay(ctx, state, repayLamports) {
     );
   }
 
-  await ctx.reply("⏳ Submitting partial repay on-chain...");
+  await ctx.reply("Submitting partial repay on-chain...");
 
   try {
     const result = await executePartialRepay({
@@ -270,7 +278,7 @@ async function submitPartialRepay(ctx, state, repayLamports) {
     const remaining = state.owed - repayLamports;
     await ctx.reply(
       [
-        "✅ *Partial repay submitted*",
+        "*Partial repay submitted*",
         "",
         `Paid: ${fmtSol(repayLamports)} SOL`,
         `Remaining: ${fmtSol(remaining)} SOL`,

--- a/src/commands/positions.js
+++ b/src/commands/positions.js
@@ -3,26 +3,13 @@ import { upsertUser } from "../services/users.js";
 import { collateralValueLamports } from "../services/price.js";
 import { getLiveOwedLamports } from "../services/loans.js";
 import { scopeLoansToActiveWallet } from "../services/wallet-scoped-loans.js";
-
-function formatSol(lamports) {
-  return (Number(lamports) / 1e9).toFixed(4);
-}
-
-function timeLeft(due) {
-  const ms = new Date(due).getTime() - Date.now();
-  if (ms <= 0) return "⚠️ PAST DUE";
-  const hours = Math.floor(ms / 3_600_000);
-  const days = Math.floor(hours / 24);
-  if (days > 0) return `${days}d ${hours % 24}h left`;
-  return `${hours}h left`;
-}
-
-function healthEmoji(ratio) {
-  if (ratio >= 1.5) return "🟢";
-  if (ratio >= 1.2) return "🟡";
-  if (ratio >= 1.1) return "🟠";
-  return "🔴";
-}
+import {
+  formatLoanCard,
+  totalOwedSol,
+  countDueWithin,
+  formatTimeToDue,
+  formatHealthLabel,
+} from "../services/loan-display.js";
 
 async function enrichWithHealth(loan, owedLamports) {
   try {
@@ -38,7 +25,7 @@ async function enrichWithHealth(loan, owedLamports) {
     );
     const owed = Number(owedLamports ?? loan.original_loan_amount_lamports);
     const ratio = owed > 0 ? currentLamports / owed : 0;
-    return { currentLamports, ratio };
+    return { currentLamports, ratio, decimals: rows[0].decimals };
   } catch {
     return null;
   }
@@ -51,7 +38,7 @@ export async function handlePositions(ctx) {
   const user = await upsertUser(tgUser.id, tgUser.username);
 
   const { rows: rawRows } = await query(
-    `SELECT l.*, sm.symbol
+    `SELECT l.*, sm.symbol, sm.decimals
      FROM loans l
      LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
      WHERE l.user_id = $1 AND l.status = 'active'
@@ -60,23 +47,20 @@ export async function handlePositions(ctx) {
   );
 
   if (rawRows.length === 0) {
-    return ctx.reply("📭 No active loans.\n\nUse /borrow to take one out.");
+    return ctx.reply("No active loans.\n\nUse /borrow to take one out.");
   }
 
   // Wallet-scope: only show loans owned by the user's currently-active
-  // wallet. Per the multi-wallet design principle ("only credit + points
-  // aggregate across linked wallets; holdings stay separate"), showing
-  // every wallet's loans here would be confusing — the user runs /repay
-  // and gets a CONSTRAINT_HAS_ONE because the active wallet didn't open
-  // the loan. Scope here, surface a hint at the bottom for cross-wallet
-  // visibility.
+  // wallet. Per the multi-wallet design principle, every wallet's loans
+  // here would confuse the signer (they run /repay and get
+  // CONSTRAINT_HAS_ONE because the active wallet didn't open it).
   const { filtered: rows, otherWalletCount } = await scopeLoansToActiveWallet(user.id, rawRows);
 
   if (rows.length === 0) {
     return ctx.reply(
       otherWalletCount > 0
-        ? `📭 No active loans on your current wallet.\n\n${otherWalletCount} loan${otherWalletCount === 1 ? "" : "s"} on another linked wallet — /wallets to switch.`
-        : "📭 No active loans.\n\nUse /borrow to take one out.",
+        ? `No active loans on your current wallet.\n\n${otherWalletCount} loan${otherWalletCount === 1 ? "" : "s"} on another linked wallet — /wallets to switch.`
+        : "No active loans.\n\nUse /borrow to take one out.",
     );
   }
 
@@ -86,30 +70,36 @@ export async function handlePositions(ctx) {
     rows.map((loan, i) => enrichWithHealth(loan, liveAmounts[i])),
   );
 
-  const lines = ["📊 *Your Active Loans*", ""];
-  for (let i = 0; i < rows.length; i++) {
-    const loan = rows[i];
-    const health = healthResults[i];
-    const owed = liveAmounts[i];
-    lines.push(
-      `*Loan #${loan.loan_id}* — ${loan.symbol ?? "Unknown"}`,
-      `Collateral: ${loan.collateral_amount}`,
-      `Borrowed: ${formatSol(loan.loan_amount_lamports)} SOL`,
-      `Repay: ${formatSol(owed)} SOL`,
-      `LTV: ${loan.ltv_percentage}% | ${loan.duration_days}d term`,
-    );
-    if (health) {
-      lines.push(
-        `${healthEmoji(health.ratio)} Health: ${health.ratio.toFixed(2)}x ` +
-          `(collateral now ${formatSol(health.currentLamports)} SOL)`,
-      );
-    }
-    lines.push(`⏱ ${timeLeft(loan.due_timestamp)}`, "");
-  }
-  lines.push(
-    "_Health <1.1x risks liquidation._",
+  const totalSol = totalOwedSol(liveAmounts);
+  const dueSoonCount = countDueWithin(rows, 24);
+
+  const summary = [
+    `${rows.length} active`,
+    `${totalSol} SOL owed`,
+  ];
+  if (dueSoonCount > 0) summary.push(`${dueSoonCount} due within 24h`);
+
+  const lines = [
+    "*Your Active Loans*",
+    `_${summary.join(" · ")} · sorted by due date_`,
     "",
-    "Actions: /repay · /partialrepay · /topup · /extend",
+  ];
+
+  for (let i = 0; i < rows.length; i++) {
+    const loan = { ...rows[i], decimals: healthResults[i]?.decimals ?? rows[i].decimals };
+    const card = formatLoanCard(loan, {
+      owedLamports: liveAmounts[i],
+      healthRatio: healthResults[i]?.ratio,
+      collateralValueLamports: healthResults[i]?.currentLamports,
+      position: i + 1,
+    });
+    lines.push(card, "");
+  }
+
+  lines.push(
+    "_Health < 1.1× risks liquidation._",
+    "",
+    "Actions: /repay · /partialrepay · /topup · /extend · /health",
   );
   if (otherWalletCount > 0) {
     lines.push(
@@ -120,10 +110,10 @@ export async function handlePositions(ctx) {
 
   // Pip-as-coach: surface ONE actionable suggestion if we see a clear
   // opportunity in the user's book. Read-only — Pip only suggests, never
-  // takes action. Keeps the output concise (1 line max).
+  // takes action.
   const coachLine = pipCoachSuggestion(rows, healthResults, liveAmounts);
   if (coachLine) {
-    lines.push("", `🦅 *Pip:* ${coachLine}`);
+    lines.push("", `*Pip:* ${coachLine}`);
   }
 
   await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
@@ -132,58 +122,66 @@ export async function handlePositions(ctx) {
 /**
  * Returns ONE coaching suggestion based on the user's active loan book,
  * or null if nothing actionable. Ordered by urgency — most urgent wins.
- * Pure read-only; no action taken. The user has to actually run the
- * suggested command themselves.
  *
  * Priority order:
  *   1. Past-due loans (most urgent — liquidation imminent)
  *   2. Health <1.15 (one move from liquidation)
  *   3. Due within 24h (clock pressure)
  *   4. Health <1.30 (mild buffer suggestion)
- *   5. Healthy book → reinforce the good behavior (rare suggestion path)
+ *   5. Healthy book → reinforce
  */
 function pipCoachSuggestion(loans, healthResults, liveAmounts) {
   if (!loans || loans.length === 0) return null;
   let minHealth = Infinity;
   let minHealthLoan = null;
+  let minHealthIdx = -1;
   let earliestDueMs = Infinity;
   let earliestDueLoan = null;
+  let earliestDueIdx = -1;
   let pastDueLoan = null;
+  let pastDueIdx = -1;
   for (let i = 0; i < loans.length; i++) {
     const loan = loans[i];
     const dueMs = new Date(loan.due_timestamp).getTime();
     const msLeft = dueMs - Date.now();
-    if (msLeft <= 0 && !pastDueLoan) pastDueLoan = loan;
+    if (msLeft <= 0 && !pastDueLoan) {
+      pastDueLoan = loan;
+      pastDueIdx = i;
+    }
     if (msLeft > 0 && dueMs < earliestDueMs) {
       earliestDueMs = dueMs;
       earliestDueLoan = loan;
+      earliestDueIdx = i;
     }
     const h = healthResults[i];
     if (h && Number.isFinite(h.ratio) && h.ratio < minHealth) {
       minHealth = h.ratio;
       minHealthLoan = loan;
+      minHealthIdx = i;
     }
   }
+  // Loans are referred to by position number (matches the cards above)
+  // rather than the long loan_id u64 — much easier to follow.
   // 1. Past due — liquidation imminent
   if (pastDueLoan) {
-    return `Loan #${pastDueLoan.loan_id} (${pastDueLoan.symbol ?? "?"}) is *past due*. /repay now or it'll be liquidated.`;
+    return `Loan ${pastDueIdx + 1} (${pastDueLoan.symbol ?? "?"}) is *past due*. /repay now or it'll be liquidated.`;
   }
   // 2. Health critical
   if (minHealthLoan && minHealth < 1.15) {
-    return `Loan #${minHealthLoan.loan_id} (${minHealthLoan.symbol ?? "?"}) health is *${minHealth.toFixed(2)}×* — one bad candle from liquidation. Consider /topup to add collateral.`;
+    return `Loan ${minHealthIdx + 1} (${minHealthLoan.symbol ?? "?"}) health is *${minHealth.toFixed(2)}×* — one bad candle from liquidation. Consider /topup to add collateral.`;
   }
   // 3. Due within 24h
   if (earliestDueLoan) {
     const hoursLeft = (earliestDueMs - Date.now()) / 3_600_000;
     if (hoursLeft < 24) {
-      return `Loan #${earliestDueLoan.loan_id} (${earliestDueLoan.symbol ?? "?"}) due in *${Math.floor(hoursLeft)}h*. /repay early (zero penalty) or /extend if you need more time.`;
+      return `Loan ${earliestDueIdx + 1} (${earliestDueLoan.symbol ?? "?"}) ${formatTimeToDue(earliestDueLoan.due_timestamp)} until due. /repay early (zero penalty) or /extend if you need more time.`;
     }
   }
   // 4. Mild health concern
   if (minHealthLoan && minHealth < 1.30) {
-    return `Loan #${minHealthLoan.loan_id} health is ${minHealth.toFixed(2)}× — comfy but not flush. /topup adds buffer with no fee.`;
+    return `Loan ${minHealthIdx + 1} (${minHealthLoan.symbol ?? "?"}) health is ${minHealth.toFixed(2)}× (${formatHealthLabel(minHealth)}) — comfy but not flush. /topup adds buffer with no fee.`;
   }
-  // 5. Reinforce — only if multiple loans and all healthy
+  // 5. Reinforce
   if (loans.length >= 2 && minHealth >= 1.50) {
     return `All ${loans.length} positions healthy. Keep an eye on token volatility — /health any time for a snapshot.`;
   }

--- a/src/commands/repay.js
+++ b/src/commands/repay.js
@@ -8,6 +8,7 @@ import { ensureWallet } from "../services/wallet.js";
 import { connection } from "../solana/connection.js";
 import { incrementRepaid } from "../services/reputation.js";
 import { translateTxError, errorActionKeyboard, renderWalletMismatchMessage } from "../services/tx-error-translator.js";
+import { formatLoanButtonLabel, totalOwedSol, countDueWithin } from "../services/loan-display.js";
 
 function fmtSol(lamports) {
   return (Number(lamports) / 1e9).toFixed(4);
@@ -33,7 +34,7 @@ export async function handleRepay(ctx) {
   );
 
   if (rows.length === 0) {
-    return ctx.reply("📭 No active loans to repay.");
+    return ctx.reply("No active loans to repay.");
   }
 
   // Scope to the user's CURRENTLY ACTIVE wallet — multi-wallet users
@@ -45,7 +46,7 @@ export async function handleRepay(ctx) {
 
   if (scopedRows.length === 0) {
     return ctx.reply(
-      `📭 No active loans on your *current* wallet.\n\n` +
+      `No active loans on your *current* wallet.\n\n` +
       (otherWalletCount > 0
         ? `You have *${otherWalletCount}* loan${otherWalletCount === 1 ? "" : "s"} on other linked wallets. Use /wallets to switch, then /repay.`
         : `Nothing to repay anywhere on this account.`),
@@ -59,17 +60,35 @@ export async function handleRepay(ctx) {
   const kb = new InlineKeyboard();
   scopedRows.forEach((loan, i) => {
     kb.text(
-      `#${loan.loan_id} · ${loan.symbol ?? "?"} · ${fmtSol(liveAmounts[i])} SOL`,
+      formatLoanButtonLabel(loan, liveAmounts[i], i + 1),
       `repay:loan:${loan.id}`,
     ).row();
   });
-  kb.text("✕ Cancel", "repay:cancel");
+  kb.text("Cancel", "repay:cancel");
 
-  const header = `*Pick a loan to repay:*` +
-    (otherWalletCount > 0
-      ? `\n_Showing loans on your active wallet. ${otherWalletCount} more on other linked wallets — switch with /wallets to see them._`
-      : "");
-  await ctx.reply(header, {
+  // Header with at-a-glance summary so the user understands what's on
+  // the screen before tapping. Lists count + total owed + how many are
+  // urgent (within 24h or already overdue).
+  const totalSol = totalOwedSol(liveAmounts);
+  const dueSoonCount = countDueWithin(scopedRows, 24);
+  const summaryParts = [
+    `${scopedRows.length} active`,
+    `${totalSol} SOL owed total`,
+  ];
+  if (dueSoonCount > 0) {
+    summaryParts.push(`${dueSoonCount} due within 24h`);
+  }
+  const headerLines = [
+    `*Pick a loan to repay*`,
+    `_${summaryParts.join(" · ")} · sorted by due date_`,
+  ];
+  if (otherWalletCount > 0) {
+    headerLines.push(
+      "",
+      `_+${otherWalletCount} more on other linked wallets — /wallets to switch._`,
+    );
+  }
+  await ctx.reply(headerLines.join("\n"), {
     parse_mode: "Markdown",
     reply_markup: kb,
   });
@@ -78,7 +97,7 @@ export async function handleRepay(ctx) {
 export function registerRepayCallbacks(bot) {
   bot.callbackQuery(/^repay:cancel$/, async (ctx) => {
     await ctx.answerCallbackQuery("Cancelled");
-    await ctx.editMessageText("❌ Repay cancelled.");
+    await ctx.editMessageText("Repay cancelled.");
   });
 
   bot.callbackQuery(/^repay:loan:(\d+)$/, async (ctx) => {
@@ -107,7 +126,7 @@ export function registerRepayCallbacks(bot) {
       // We already ack'd above, so use editMessageText (replaces the
       // notification body) instead of the popup-style answerCallbackQuery
       // text we used to surface here.
-      await ctx.editMessageText("❌ Loan not found or already closed.").catch(() => {});
+      await ctx.editMessageText("Loan not found or already closed.").catch(() => {});
       return;
     }
 
@@ -145,7 +164,7 @@ export function registerRepayCallbacks(bot) {
         const recommendedSend = short + 1_000_000n;
         await ctx.editMessageText(
           [
-            "⚠️ *Your wallet doesn't have enough SOL*",
+            "*Your wallet doesn't have enough SOL*",
             "",
             "Repaying a loan needs the *loan amount + Solana network fees*. Here's the math:",
             "",
@@ -179,7 +198,7 @@ export function registerRepayCallbacks(bot) {
       console.warn("[repay] preflight balance check failed:", err.message);
     }
 
-    await ctx.editMessageText("⏳ Submitting repayment on-chain...");
+    await ctx.editMessageText("Submitting repayment on-chain...");
 
     try {
       const result = await executeRepay({ userId: user.id, loanDbRow: loan });
@@ -211,31 +230,30 @@ export function registerRepayCallbacks(bot) {
 
         if (milestone) {
           // Hit a milestone — celebrate + offer streak-specific share
-          milestoneLine = `\n🔥 *${streak} on-time repays in a row — milestone unlocked!*\n`;
+          milestoneLine = `\n*${streak} on-time repays in a row — milestone unlocked.*\n`;
           const streakCard = shareStreak({ streak, referralCode: code });
           shareKb = new InlineKeyboard()
-            .url(`𝕏 Flex ${streak}-streak`, streakCard.twitterUrl)
+            .url(`Flex ${streak}-streak on X`, streakCard.twitterUrl)
             .row()
-            .url("𝕏 Share repay", repayCard.twitterUrl)
-            .url("📨 Tell a friend", repayCard.telegramShareUrl);
+            .url("Share repay on X", repayCard.twitterUrl)
+            .url("Tell a friend", repayCard.telegramShareUrl);
         } else if (streak > 0) {
-          milestoneLine = `\n🔥 _On-time streak: ${streak}_\n`;
+          milestoneLine = `\n_On-time streak: ${streak}_\n`;
           shareKb = new InlineKeyboard()
-            .url("𝕏 Share to Twitter", repayCard.twitterUrl)
-            .url("📨 Tell a friend", repayCard.telegramShareUrl);
+            .url("Share on X", repayCard.twitterUrl)
+            .url("Tell a friend", repayCard.telegramShareUrl);
         } else {
           shareKb = new InlineKeyboard()
-            .url("𝕏 Share to Twitter", repayCard.twitterUrl)
-            .url("📨 Tell a friend", repayCard.telegramShareUrl);
+            .url("Share on X", repayCard.twitterUrl)
+            .url("Tell a friend", repayCard.telegramShareUrl);
         }
       } catch { /* non-critical */ }
 
       await ctx.editMessageText(
         [
-          "✅ *Loan repaid*",
+          "*Loan repaid*",
           "",
-          `Loan #${loan.loan_id} · ${loan.symbol ?? "?"}`,
-          `Repaid: ${fmtSol(owedNow)} SOL`,
+          `${loan.symbol ?? "?"} loan · ${fmtSol(owedNow)} SOL`,
           "Collateral returned to your wallet.",
           milestoneLine,
           `[View tx](https://solscan.io/tx/${result.signature})`,

--- a/src/commands/topup.js
+++ b/src/commands/topup.js
@@ -3,9 +3,10 @@ import { upsertUser } from "../services/users.js";
 import { ensureWallet } from "../services/wallet.js";
 import { query } from "../db/pool.js";
 import { getTokenBalance } from "../services/deposits.js";
-import { executeAddCollateral, recordAddCollateral, checkLoanOwnership } from "../services/loans.js";
+import { executeAddCollateral, recordAddCollateral, getLiveOwedLamports, checkLoanOwnership } from "../services/loans.js";
 import { scopeLoansToActiveWallet } from "../services/wallet-scoped-loans.js";
 import { translateTxError, errorActionKeyboard, renderWalletMismatchMessage } from "../services/tx-error-translator.js";
+import { formatLoanButtonLabel, countDueWithin } from "../services/loan-display.js";
 
 const pending = new Map();
 
@@ -29,7 +30,7 @@ export async function handleTopup(ctx) {
   );
 
   if (rows.length === 0) {
-    return ctx.reply("📭 No active loans. Use /borrow to open one.");
+    return ctx.reply("No active loans. Use /borrow to open one.");
   }
 
   // Scope to active wallet (multi-wallet users were seeing loans they
@@ -39,7 +40,7 @@ export async function handleTopup(ctx) {
 
   if (scopedRows.length === 0) {
     return ctx.reply(
-      `📭 No active loans on your *current* wallet.\n\n` +
+      `No active loans on your *current* wallet.\n\n` +
       (otherWalletCount > 0
         ? `You have *${otherWalletCount}* loan${otherWalletCount === 1 ? "" : "s"} on other linked wallets. Use /wallets to switch first.`
         : `Use /borrow to open one.`),
@@ -47,28 +48,38 @@ export async function handleTopup(ctx) {
     );
   }
 
+  // Live owed amounts for the button labels so users see what's
+  // outstanding alongside the time-to-due (matches /repay's UI).
+  const liveAmounts = await Promise.all(scopedRows.map(getLiveOwedLamports));
+
   const kb = new InlineKeyboard();
-  for (const loan of scopedRows) {
-    const human = fmtAmount(loan.collateral_amount, loan.decimals ?? 9);
+  scopedRows.forEach((loan, i) => {
     kb.text(
-      `#${loan.loan_id} · ${loan.symbol ?? "?"} · ${human.toLocaleString()}`,
+      formatLoanButtonLabel(loan, liveAmounts[i], i + 1),
       `topup:loan:${loan.id}`,
     ).row();
-  }
-  kb.text("✕ Cancel", "topup:cancel");
+  });
+  kb.text("Cancel", "topup:cancel");
 
-  const header = `*Add collateral* (improves health ratio, no fee)\n\nPick a loan:` +
-    (otherWalletCount > 0
-      ? `\n_Showing loans on your active wallet. ${otherWalletCount} more on other wallets — /wallets to switch._`
-      : "");
-  await ctx.reply(header, { parse_mode: "Markdown", reply_markup: kb });
+  const dueSoonCount = countDueWithin(scopedRows, 24);
+  const headerLines = [
+    `*Add collateral* — improves health, no fee.`,
+    `_${scopedRows.length} active${dueSoonCount > 0 ? ` · ${dueSoonCount} due within 24h` : ""} · sorted by due date_`,
+  ];
+  if (otherWalletCount > 0) {
+    headerLines.push(
+      "",
+      `_+${otherWalletCount} more on other wallets — /wallets to switch._`,
+    );
+  }
+  await ctx.reply(headerLines.join("\n"), { parse_mode: "Markdown", reply_markup: kb });
 }
 
 export function registerTopupCallbacks(bot) {
   bot.callbackQuery(/^topup:cancel$/, async (ctx) => {
     pending.delete(ctx.chat.id);
     await ctx.answerCallbackQuery("Cancelled");
-    await ctx.editMessageText("❌ Top-up cancelled.");
+    await ctx.editMessageText("Top-up cancelled.");
   });
 
   bot.callbackQuery(/^topup:loan:(\d+)$/, async (ctx) => {
@@ -93,7 +104,7 @@ export function registerTopupCallbacks(bot) {
     if (!balance || BigInt(balance.rawAmount) === 0n) {
       await ctx.answerCallbackQuery();
       await ctx.editMessageText(
-        `📭 No ${loan.symbol ?? "tokens"} in your wallet to add as collateral.\n\nDeposit to:\n\`${publicKey}\``,
+        `No ${loan.symbol ?? "tokens"} in your wallet to add as collateral.\n\nDeposit to:\n\`${publicKey}\``,
         { parse_mode: "Markdown" },
       );
       return;
@@ -104,14 +115,14 @@ export function registerTopupCallbacks(bot) {
     const kb = new InlineKeyboard()
       .text("25%", "topup:pct:25").text("50%", "topup:pct:50")
       .text("75%", "topup:pct:75").text("100%", "topup:pct:100")
-      .row().text("✏️ Custom %", "topup:custom")
-      .row().text("✕ Cancel", "topup:cancel");
+      .row().text("Custom %", "topup:custom")
+      .row().text("Cancel", "topup:cancel");
 
     await ctx.answerCallbackQuery();
     await ctx.editMessageText(
       [
-        `Loan #${loan.loan_id} · ${loan.symbol ?? "?"}`,
-        `Current collateral: ${fmtAmount(loan.collateral_amount, loan.decimals ?? 9).toLocaleString()}`,
+        `${loan.symbol ?? "?"} loan`,
+        `Current collateral: ${fmtAmount(loan.collateral_amount, loan.decimals ?? 9).toLocaleString()} ${loan.symbol ?? ""}`,
         `Wallet balance: ${balance.humanAmount.toLocaleString()} ${loan.symbol ?? ""}`,
         "",
         "*How much to add?*",
@@ -132,7 +143,7 @@ export function registerTopupCallbacks(bot) {
     await ctx.answerCallbackQuery();
     await ctx.editMessageText(
       [
-        `Loan #${state.loan.loan_id} · ${state.loan.symbol ?? "?"}`,
+        `${state.loan.symbol ?? "?"} loan`,
         `Wallet balance: ${state.balance.humanAmount.toLocaleString()} ${state.loan.symbol ?? ""}`,
         "",
         `Type the *%* of your wallet balance to add as collateral.`,
@@ -211,7 +222,7 @@ async function submitTopup(ctx, state, rawBig) {
     );
   }
 
-  await ctx.reply("⏳ Adding collateral on-chain...");
+  await ctx.reply("Adding collateral on-chain...");
 
   try {
     const result = await executeAddCollateral({
@@ -225,10 +236,10 @@ async function submitTopup(ctx, state, rawBig) {
     const addedHuman = Number(rawBig) / Math.pow(10, state.loan.decimals ?? 9);
     await ctx.reply(
       [
-        "✅ *Collateral added*",
+        "*Collateral added*",
         "",
         `Added: ${addedHuman.toLocaleString()} ${state.loan.symbol ?? ""}`,
-        `Loan #${state.loan.loan_id} health improved.`,
+        `${state.loan.symbol ?? "?"} loan health improved.`,
         "",
         `[View tx](https://solscan.io/tx/${result.signature})`,
         "",

--- a/src/services/loan-display.js
+++ b/src/services/loan-display.js
@@ -1,0 +1,189 @@
+/**
+ * Loan display helpers — single source of truth for how loans render
+ * across /repay, /topup, /partialrepay, /extend, /positions, /calendar,
+ * /health.
+ *
+ * Before this module each command rolled its own time-to-due formatter
+ * and emoji-coded health badges, which (a) drifted between commands
+ * and (b) violated the no-emoji rule. Centralised here so a single
+ * tweak ripples to every loan-listing surface.
+ */
+
+/**
+ * Compact time-to-due for inline-button labels.
+ * Examples: "2d 3h", "14h", "47m", "OVERDUE", "DUE NOW"
+ */
+export function formatTimeToDue(due_timestamp) {
+  const ms = new Date(due_timestamp).getTime() - Date.now();
+  if (ms <= 0) return "OVERDUE";
+  const totalMinutes = Math.floor(ms / 60_000);
+  const totalHours = Math.floor(ms / 3_600_000);
+  const days = Math.floor(totalHours / 24);
+  if (days > 0) return `${days}d ${totalHours % 24}h`;
+  if (totalHours > 0) return `${totalHours}h`;
+  if (totalMinutes > 0) return `${totalMinutes}m`;
+  return "DUE NOW";
+}
+
+/**
+ * Long-form time-to-due for text-report cards.
+ * Examples: "due in 2d 3h", "due in 14h 7m", "due in 47m",
+ *           "OVERDUE by 2h", "DUE NOW"
+ */
+export function formatTimeToDueLong(due_timestamp) {
+  const ms = new Date(due_timestamp).getTime() - Date.now();
+  if (ms <= 0) {
+    const overdue = -ms;
+    const overdueHours = Math.floor(overdue / 3_600_000);
+    const overdueDays = Math.floor(overdueHours / 24);
+    if (overdueDays > 0) return `OVERDUE by ${overdueDays}d ${overdueHours % 24}h`;
+    if (overdueHours > 0) return `OVERDUE by ${overdueHours}h`;
+    const overdueMinutes = Math.floor(overdue / 60_000);
+    if (overdueMinutes > 0) return `OVERDUE by ${overdueMinutes}m`;
+    return "DUE NOW";
+  }
+  const totalMinutes = Math.floor(ms / 60_000);
+  const totalHours = Math.floor(ms / 3_600_000);
+  const days = Math.floor(totalHours / 24);
+  if (days > 0) return `due in ${days}d ${totalHours % 24}h`;
+  if (totalHours > 0) return `due in ${totalHours}h ${totalMinutes % 60}m`;
+  if (totalMinutes > 0) return `due in ${totalMinutes}m`;
+  return "DUE NOW";
+}
+
+/**
+ * Plain-text health label. No emojis.
+ */
+export function formatHealthLabel(ratio) {
+  if (ratio == null || !Number.isFinite(ratio)) return "—";
+  if (ratio >= 1.5) return "healthy";
+  if (ratio >= 1.3) return "OK";
+  if (ratio >= 1.1) return "tight";
+  return "AT RISK";
+}
+
+/**
+ * Health-band severity: 0=healthy, 1=OK, 2=tight, 3=AT RISK, -1=unknown.
+ * Useful for sorting + alerting.
+ */
+export function healthSeverity(ratio) {
+  if (ratio == null || !Number.isFinite(ratio)) return -1;
+  if (ratio >= 1.5) return 0;
+  if (ratio >= 1.3) return 1;
+  if (ratio >= 1.1) return 2;
+  return 3;
+}
+
+function fmtSol(lamports, dp = 2) {
+  return (Number(lamports) / 1e9).toFixed(dp);
+}
+
+/**
+ * Inline-button label for action menus (repay / topup / partialrepay /
+ * extend). Constraint: stays under ~42 chars so Telegram doesn't
+ * truncate on mobile.
+ *
+ * Format: `N. SYMBOL · X.XX SOL · TIME`
+ * Examples:
+ *   "1. BUTTCOIN · 3.79 SOL · 2d 3h"
+ *   "3. PUMP · 5.26 SOL · OVERDUE"
+ *   "5. WORLDCUP · 3.44 SOL · DUE NOW"
+ *
+ * Position-numbered so users can disambiguate when they have multiple
+ * loans against the same token. The position matches the order shown
+ * in /positions and /calendar.
+ *
+ * @param {object} loan        the loan row (needs symbol, due_timestamp)
+ * @param {bigint|number} owed live owed amount in lamports
+ * @param {number} position    1-indexed position number
+ */
+export function formatLoanButtonLabel(loan, owed, position) {
+  const symbol = loan.symbol ?? "?";
+  const sol = fmtSol(owed);
+  const timeStr = formatTimeToDue(loan.due_timestamp);
+  const prefix = position != null ? `${position}. ` : "";
+  return `${prefix}${symbol} · ${sol} SOL · ${timeStr}`;
+}
+
+/**
+ * Multi-line text card for /positions and /calendar. Two-line dense
+ * format that scans cleanly even for users with many active loans.
+ *
+ * Example:
+ *   *1. BUTTCOIN* — 3.79 SOL — due in 2d 3h
+ *      Collateral 1.54M BUTTCOIN · health 1.48× (OK) · 25% LTV
+ *
+ * @param {object} loan
+ * @param {object} opts        { owedLamports, healthRatio,
+ *                               collateralValueLamports, position }
+ */
+export function formatLoanCard(loan, opts = {}) {
+  const {
+    owedLamports,
+    healthRatio,
+    collateralValueLamports,
+    position,
+  } = opts;
+  const symbol = loan.symbol ?? "?";
+  const owed = fmtSol(owedLamports ?? loan.loan_amount_lamports, 4);
+  const timeStr = formatTimeToDueLong(loan.due_timestamp);
+  const idxStr = position != null ? `${position}. ` : "";
+
+  const collateralAmountStr = formatTokenAmount(
+    loan.collateral_amount,
+    loan.decimals ?? 9,
+  );
+  const collateralValueStr = collateralValueLamports != null
+    ? ` (worth ${fmtSol(collateralValueLamports, 3)} SOL)`
+    : "";
+
+  let healthStr;
+  if (healthRatio != null && Number.isFinite(healthRatio)) {
+    healthStr = `health ${healthRatio.toFixed(2)}× (${formatHealthLabel(healthRatio)})`;
+  } else {
+    healthStr = "health —";
+  }
+
+  return [
+    `*${idxStr}${symbol}* — ${owed} SOL — ${timeStr}`,
+    `   Collateral ${collateralAmountStr} ${symbol}${collateralValueStr} · ${healthStr} · ${loan.ltv_percentage}% LTV`,
+  ].join("\n");
+}
+
+/**
+ * Compact human-readable token amount (e.g. "1.54M", "12.3K", "847").
+ * Decimals-aware. Keeps display tight in mobile.
+ */
+export function formatTokenAmount(rawAmount, decimals) {
+  const human = Number(BigInt(rawAmount ?? 0)) / Math.pow(10, decimals);
+  if (!Number.isFinite(human) || human === 0) return "0";
+  const abs = Math.abs(human);
+  if (abs >= 1_000_000_000) return `${(human / 1_000_000_000).toFixed(2)}B`;
+  if (abs >= 1_000_000) return `${(human / 1_000_000).toFixed(2)}M`;
+  if (abs >= 1_000) return `${(human / 1_000).toFixed(2)}K`;
+  if (abs >= 1) return human.toFixed(2);
+  if (abs >= 0.01) return human.toFixed(4);
+  return human.toFixed(6);
+}
+
+/**
+ * Total SOL owed across a list of loans (lamports → SOL string).
+ */
+export function totalOwedSol(owedLamportsArray) {
+  let total = 0n;
+  for (const v of owedLamportsArray) total += BigInt(v ?? 0);
+  return (Number(total) / 1e9).toFixed(4);
+}
+
+/**
+ * Count how many loans in the list are within `withinHours` of due.
+ */
+export function countDueWithin(loans, withinHours) {
+  const cutoffMs = Date.now() + withinHours * 3_600_000;
+  let count = 0;
+  for (const l of loans) {
+    const dueMs = new Date(l.due_timestamp).getTime();
+    if (dueMs <= cutoffMs) count++;
+  }
+  return count;
+}


### PR DESCRIPTION
## Summary

Operator screenshot of \`/repay\` showed 6 loans rendered as a stack of opaque button labels:

\`\`\`
#1781034779350 · BUTTCOIN · 3.7913 SOL
#1781049313691 · WORLDCUP · 3.4458 SOL
#1781054402514 · FARTCOIN · 4.2026 SOL
...
\`\`\`

No way to tell which was due first, which was urgent, which was overdue. Same UX issue across \`/topup\`, \`/partialrepay\`, \`/extend\`. \`/positions\`, \`/calendar\`, \`/health\` were verbose AND violated the no-emoji rule.

### Centralised display helper — \`src/services/loan-display.js\`

Single source of truth for how loans render across every surface. Exports \`formatTimeToDue\`, \`formatTimeToDueLong\`, \`formatHealthLabel\`, \`formatLoanButtonLabel\`, \`formatLoanCard\`, \`formatTokenAmount\`, \`totalOwedSol\`, \`countDueWithin\`.

### Surface changes

**Action menus (\`/repay\`, \`/topup\`, \`/partialrepay\`)** — buttons now read:

\`\`\`
1. BUTTCOIN · 3.79 SOL · 2d 3h
2. WORLDCUP · 3.44 SOL · 14h
3. FARTCOIN · 4.20 SOL · 4h
4. PUMP · 5.26 SOL · OVERDUE
5. BUTTCOIN · 2.37 SOL · 1d 12h
6. BUTTCOIN · 6.16 SOL · 6h
\`\`\`

Position-numbered so the user can disambiguate three BUTTCOIN loans without parsing a 13-digit u64.

**Headers** — every action menu now shows a summary line: \`6 active · 25.34 SOL owed total · 3 due within 24h · sorted by due date\`.

**\`/extend\`** — button shows time-to-due + the fee (the decision-relevant numbers), not the loan_id.

**\`/positions\`** — replaced 6-line per-loan block with a 2-line card:

\`\`\`
*1. BUTTCOIN* — 3.79 SOL — due in 2d 3h
   Collateral 1.54M BUTTCOIN (worth 5.61 SOL) · health 1.48× (OK) · 25% LTV
\`\`\`

**\`/calendar\`** — same card format. Quick-manage buttons now carry symbol + position so the user knows which is which before tapping.

**\`/health\`** — emoji health badge replaced with plain-text band label (\`Watch\`, \`AT RISK — liquidation imminent\`). Due-date line added to the header.

**Pip coach** — refers to loans by position number (matches the cards), not the 13-digit \`loan_id\`.

### No-emoji compliance

Per the rule reaffirmed 2026-06-10, all loan-listing surfaces get scrubbed: 📭, ⏱, 📊, 📅, 🟢🟡🟠🔴⚪, 🔧, ➕, 💰, 🛡, ✅, ❌, ⚠️, ⏳, 🔥, 🦅, ✕, ✏️ across the touched files.

## Test plan

- [ ] \`/repay\` shows position-numbered buttons with symbol + amount + time-to-due
- [ ] \`/topup\`, \`/partialrepay\`, \`/extend\` buttons follow the same format
- [ ] Overdue loans show "OVERDUE" instead of negative time
- [ ] \`/positions\` cards are 2-line and include health band labels
- [ ] \`/calendar\` cards match \`/positions\` format
- [ ] \`/health\` renders cleanly without emoji glyphs
- [ ] No regressions in the success/error message paths (no emoji glyphs surface)