### PR TITLE
ux: emoji strip on /supported, /holders, /deposit, /credit

### DIFF
--- a/src/commands/credit.js
+++ b/src/commands/credit.js
@@ -7,20 +7,13 @@
 import { getCreditScore, getScoreHistory, tierBenefits } from "../services/credit-score.js";
 import { findUserByTelegramId } from "../services/users.js";
 
-const TIER_EMOJI = {
-  bronze: "🥉",
-  silver: "🥈",
-  gold: "🥇",
-  platinum: "💎",
-};
-
 function factorBar(value, max = 100) {
   const filled = Math.round((value / max) * 10);
   return "█".repeat(filled) + "░".repeat(10 - filled);
 }
 
 function tierLabel(tier) {
-  return `${TIER_EMOJI[tier] || ""} ${tier.charAt(0).toUpperCase() + tier.slice(1)}`;
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
 }
 
 /**
@@ -31,8 +24,8 @@ function tierLabel(tier) {
  */
 function creditCoachLine(score, trendStr) {
   const s = score.score;
-  const trendingUp = trendStr.includes("+");
-  const trendingDown = trendStr.includes("📉");
+  const trendingUp = trendStr.includes("up");
+  const trendingDown = trendStr.includes("down");
   if (s >= 800) {
     return trendingDown
       ? `Elite tier, but trending down — one liquidation can move you fast at this level. Stay defensive.`
@@ -72,8 +65,8 @@ export async function handleCredit(ctx) {
     const score = await getCreditScore(user.id);
     if (!score) {
       return ctx.reply(
-        "📊 <b>Credit Score</b>\n\n" +
-        "No credit history yet. Take out a loan and repay it to start building your score!",
+        "<b>Credit Score</b>\n\n" +
+        "No credit history yet. Take out a loan and repay it to start building your score.",
         { parse_mode: "HTML" },
       );
     }
@@ -85,7 +78,7 @@ export async function handleCredit(ctx) {
     let trend = "";
     if (history.length >= 2) {
       const diff = score.score - history[history.length - 1].score;
-      trend = diff > 0 ? `📈 +${diff}` : diff < 0 ? `📉 ${diff}` : "➡️ stable";
+      trend = diff > 0 ? `up +${diff}` : diff < 0 ? `down ${diff}` : "stable";
     }
 
     // Pip's read of the score — short, warm, scored to the actual number.
@@ -94,10 +87,10 @@ export async function handleCredit(ctx) {
     const coachLine = creditCoachLine(score, trend);
 
     const msg = [
-      `📊 <b>Magpie Credit Score</b>`,
+      `<b>Magpie Credit Score</b>`,
       ``,
-      `<b>${score.score}</b> / 850  ${tierLabel(score.tier)}  ${trend}`,
-      coachLine ? `<i>🦅 ${coachLine}</i>` : null,
+      `<b>${score.score}</b> / 850 · ${tierLabel(score.tier)} tier${trend ? ` · ${trend}` : ""}`,
+      coachLine ? `<i>Pip: ${coachLine}</i>` : null,
       ``,
       `<b>Factor Breakdown:</b>`,
       `Repayment History (35%)`,

--- a/src/commands/deposit.js
+++ b/src/commands/deposit.js
@@ -10,7 +10,7 @@ export async function handleDeposit(ctx) {
   const { publicKey } = await ensureWallet(user.id);
 
   const msg = [
-    "💰 *Your Magpie wallet*",
+    "*Your Magpie wallet*",
     "",
     `\`${publicKey}\``,
     "",
@@ -24,10 +24,10 @@ export async function handleDeposit(ctx) {
   ].join("\n");
 
   const kb = new InlineKeyboard()
-    .text("💰 Borrow now", "start:borrow")
+    .text("Borrow now", "start:borrow")
     .row()
-    .text("📋 Supported tokens", "start:supported")
-    .text("🏠 Home", "start:home");
+    .text("Supported tokens", "start:supported")
+    .text("Home", "start:home");
 
   await ctx.reply(msg, { parse_mode: "Markdown", reply_markup: kb });
 }

--- a/src/commands/holders.js
+++ b/src/commands/holders.js
@@ -1,9 +1,10 @@
 /**
  * /holders — $MAGPIE holder dashboard inside Telegram.
  *
- * Holders earn 10% of every loan fee, distributed AUTOMATICALLY every
- * 7 days as SOL directly to their wallet. No claim button — the bot
- * sends SOL during the snapshot itself.
+ * Holders earn a share of every loan fee (currently 10%; MGP-001 proposes
+ * 70%) distributed AUTOMATICALLY on a randomized cadence as SOL directly
+ * to their wallet. No claim button — the bot sends SOL during the
+ * snapshot itself.
  */
 import { InlineKeyboard } from "grammy";
 import { upsertUser } from "../services/users.js";
@@ -41,7 +42,7 @@ export async function handleHolders(ctx) {
 
   const pct = (HOLDER_REWARD_BPS / 100).toFixed(0);
   const lines = [
-    "💎 *$MAGPIE Holder Rewards*",
+    "*$MAGPIE Holder Rewards*",
     "",
     `*${pct}% of every loan fee* is auto-distributed to $MAGPIE holders. SOL hits your wallet directly — no claim, no signing.`,
     "",
@@ -77,7 +78,7 @@ export async function handleHolders(ctx) {
   if (info.pending_lamports > 0n) {
     lines.push(
       "",
-      `⚠️ *Pending payout:* \`${fmtSol(info.pending_lamports)} SOL\` from a previous distribution will be retried automatically.`,
+      `*Pending payout:* \`${fmtSol(info.pending_lamports)} SOL\` from a previous distribution will be retried automatically.`,
     );
   }
 
@@ -85,7 +86,7 @@ export async function handleHolders(ctx) {
   if (!info.has_balance) {
     kb.url("Buy $MAGPIE on pump.fun", MAGPIE_PUMP_URL).row();
   }
-  kb.text("🏠 Home", "start:home");
+  kb.text("Home", "start:home");
 
   await ctx.reply(lines.join("\n"), {
     parse_mode: "Markdown",

--- a/src/commands/supported.js
+++ b/src/commands/supported.js
@@ -29,7 +29,7 @@ export async function handleSupported(ctx) {
   );
 
   if (top.length === 0) {
-    return ctx.reply("📭 No supported collateral mints right now.");
+    return ctx.reply("No supported collateral mints right now.");
   }
 
   // Batch price fetch — 1-2 Jupiter calls total instead of N per-mint calls.
@@ -41,9 +41,8 @@ export async function handleSupported(ctx) {
   }
 
   const lines = [
-    `🪙 *Top ${top.length} supported tokens* (of ${totalCount} approved)`,
-    "",
-    "Sorted by liquidity. Prices in SOL.",
+    `*Top ${top.length} supported tokens* — ${totalCount} approved total`,
+    "_Sorted by liquidity · prices in SOL._",
     "",
   ];
 
@@ -61,8 +60,8 @@ export async function handleSupported(ctx) {
   const kb = new InlineKeyboard()
     .url("View all tokens", "https://www.magpie.capital/tokens")
     .row()
-    .text("💰 Borrow", "start:borrow")
-    .text("📋 Simulate", "fallback:simulate");
+    .text("Borrow", "start:borrow")
+    .text("Simulate", "fallback:simulate");
 
   await ctx.reply(lines.join("\n"), { parse_mode: "Markdown", reply_markup: kb, disable_web_page_preview: true });
 }


### PR DESCRIPTION
## Summary

Continuing the no-emoji cleanup (PRs #40, #41, #42) across the remaining high-traffic user-facing info commands.

- **/supported** — 🪙 header dropped; header reformatted ('Top X supported tokens — Y approved total'). Inline buttons (💰 📋) stripped.
- **/holders** — 💎 header dropped. Pending-payout warning ⚠️ removed (the bold *Pending payout:* label already conveys urgency). 🏠 button stripped. Also tightened the file-level comment so it stops saying 'every 7 days' — cadence is randomized 5–10 days; the old comment was misleading.
- **/deposit** — 💰 header dropped. Button row 💰 📋 🏠 stripped.
- **/credit** — bigger pass: \`TIER_EMOJI\` map (🥉🥈🥇💎) deleted; \`tierLabel\` just capitalizes the tier name now. Trend indicator 📈 +N / 📉 -N / ➡️ stable becomes plain text 'up +N' / 'down -N' / 'stable'. \`creditCoachLine\`'s trend detection updated to match new strings. 📊 header dropped. Pip eagle 🦅 replaced with plain 'Pip:' prefix.

## Test plan

- [ ] /supported lists tokens without any emojis in the body or buttons
- [ ] /holders shows balance + rewards summary cleanly without emoji headers
- [ ] /deposit shows wallet pubkey with plain text buttons
- [ ] /credit shows score + tier + plain-text trend (up / down / stable) + factor breakdown bars