### PR TITLE
feature: premium-tier whitelist (top-12 tokenized stocks) + Friday-close weekend cutoff

### DIFF
--- a/migrations/017_premium_tier_whitelist.sql
+++ b/migrations/017_premium_tier_whitelist.sql
@@ -1,0 +1,70 @@
+-- Premium-tier whitelist + Friday-close cutoff infrastructure.
+--
+-- The premium_tier_whitelist table gates which tokenized stocks can be
+-- used as collateral on the v3-premium pool. The screener at
+-- src/services/premium-tier-screener.js was already referencing this
+-- table but it didn't exist — every premium borrow would fail with
+-- "relation not found" once the screener wired up. This migration
+-- creates the table and seeds it with the operator-approved top names.
+--
+-- Per-mint max_open_lamports is the AGGREGATE exposure cap: when the
+-- sum of currently-active premium loans against this mint exceeds
+-- max_open_lamports, new borrows refuse until existing loans repay.
+-- Conservative defaults below; operator can raise as the tier matures
+-- and liquidation data accumulates.
+
+CREATE TABLE IF NOT EXISTS premium_tier_whitelist (
+  mint                text        PRIMARY KEY,
+  symbol              text        NOT NULL,
+  max_open_lamports   numeric     NOT NULL,
+  enabled             boolean     NOT NULL DEFAULT TRUE,
+  added_at            timestamptz NOT NULL DEFAULT now(),
+  added_by            text,
+  notes               text
+);
+
+-- Seed the operator's recommended top-12 (minus AAPLx which isn't yet
+-- in supported_mints — operator to confirm mint address + add via
+-- /onboard-rwa-collateral.js).
+--
+-- Initial caps: 50 SOL per mint for the top names, 25 SOL for the rest.
+-- These are AGGREGATE exposure caps (sum of all active loans against
+-- the mint), not per-loan. The per-loan cap stays at PREMIUM_TIER_MAX_LOAN_LAMPORTS
+-- (10 SOL by default).
+
+INSERT INTO premium_tier_whitelist (mint, symbol, max_open_lamports, notes)
+VALUES
+  -- ETFs / index — deepest weekend liquidity per xStocks roundup
+  ('XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W', 'SPYx',  50000000000, 'S&P 500 — deepest weekend liquidity on Kraken Pro'),
+  ('Xs8S1uUs1zvS2p7iwtsG3b6fkhpvmwz4GYU3gWAmWHZ', 'QQQx',  50000000000, 'Nasdaq 100 — deep weekend liquidity'),
+  ('Xsv9hRk1z5ystj9MhnA7Lq4vjSsLwzL2nxrwmwtD3re', 'GLDx',  50000000000, 'Gold ETF — non-equity, weekend-resilient'),
+  -- Mega-cap tech
+  ('Xsc9qvGR1efVDFGLrVsmkzv3qi45LTBjeUKSPmx9qEh', 'NVDAx', 50000000000, 'NVIDIA — top-3 active wallet count'),
+  ('XsDoVfqeBukxuZHWhdvWHBhgEHjGNst4MLodqsJHzoB', 'TSLAx', 50000000000, 'Tesla — top weekend liquidity tier'),
+  ('XsCPL9dNWBMvFtTmwcCA5v3xWPSMEBCszbQdiLLq6aN', 'GOOGLx', 25000000000, 'Alphabet — deep weekend liquidity'),
+  ('XspzcW1PRtgf6Wj92HCiZdjzKCyFekVD8P5Ueh3dRMX', 'MSFTx', 25000000000, 'Microsoft — deep weekend liquidity'),
+  ('Xsa62P5mvPszXL1krVUnU5ar38bBSVcWAB6fmPCo5Zu', 'METAx', 25000000000, 'Meta — deep weekend liquidity'),
+  ('Xs3eBt7uRfJX8QUs4suhyU8p2M6DoUDrJyWBa8LLZsg', 'AMZNx', 25000000000, 'Amazon — deep weekend liquidity'),
+  -- Crypto-adjacent equities
+  ('Xs7ZdzSHLU9ftNJsii5fCeJhoRWSC32SQGzGQtePxNu', 'COINx', 25000000000, 'Coinbase — crypto-adjacent, demand expected'),
+  ('XsP7xzNPvEHS1m6qfanPUGjNmdnmsLKEoNAnHjdxxyZ', 'MSTRx', 25000000000, 'MicroStrategy — crypto-adjacent, deep weekend liquidity'),
+  ('XsvNBAYkrDRNhA7wPHQfX3ZUXZyZLdnCQDfHZ56bzpg', 'HOODx', 25000000000, 'Robinhood — deep weekend liquidity'),
+  ('XsueG8BtpquVJX9LVLLEGuViXUungE6WmK5YZ3p3bd1', 'CRCLx', 25000000000, 'Circle — crypto-adjacent, top active wallets')
+ON CONFLICT (mint) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_premium_tier_whitelist_enabled
+  ON premium_tier_whitelist(enabled, symbol);
+
+-- ─── Security cleanup: reclassify mis-categorized memecoins ────────
+-- The supported_mints table has tokens classified as category='stock'
+-- that are actually pump.fun memecoins (mint ends in 'pump' suffix).
+-- Without this fix they would pass the category gate at
+-- premium-tier-screener.js:58. This isn't exploitable on its own (every
+-- subsequent gate would still refuse since they're not in
+-- premium_tier_whitelist) but it's defense-in-depth: don't let the
+-- category lie.
+
+UPDATE supported_mints
+   SET category = 'memecoin', enabled = FALSE
+ WHERE category = 'stock'
+   AND mint LIKE '%pump';

--- a/src/services/premium-tier-screener.js
+++ b/src/services/premium-tier-screener.js
@@ -25,6 +25,67 @@ const PREMIUM_TIER_MAX_LOAN_LAMPORTS = BigInt(
   process.env.PREMIUM_TIER_MAX_LOAN_LAMPORTS || "10000000000", // 10 SOL
 );
 
+// Friday-close cutoff. Tokenized stocks' AMM peg degrades 3-5% on
+// weekend news/earnings events because the Backed/MM arb path goes
+// stale once Kraken's full equity book closes. We refuse to ORIGINATE
+// new premium-tier loans inside the weekend window so the borrower
+// can't open a loan against TSLAx at Friday 4pm ET and watch earnings
+// blow up the collateral over the weekend before any liquidator can
+// react with reliable price data. Existing loans roll through the
+// weekend unaffected — repay/extend/topup remain available.
+//
+// Window definition (UTC):
+//   - Window CLOSES Friday at PREMIUM_TIER_WEEKEND_CLOSE_HOUR (default 21:00 UTC = 16:00 ET = US RTH close)
+//   - Window REOPENS Monday at PREMIUM_TIER_WEEKEND_OPEN_HOUR (default 13:30 UTC = 08:30 ET = pre-market open)
+//   - All of Saturday + Sunday refuse.
+//   - PREMIUM_TIER_WEEKEND_CUTOFF_DISABLED=true bypasses the gate entirely.
+const PREMIUM_TIER_WEEKEND_CLOSE_HOUR_UTC = Number(
+  process.env.PREMIUM_TIER_WEEKEND_CLOSE_HOUR || 21,
+);
+const PREMIUM_TIER_WEEKEND_OPEN_HOUR_UTC = Number(
+  process.env.PREMIUM_TIER_WEEKEND_OPEN_HOUR || 13,
+);
+const PREMIUM_TIER_WEEKEND_OPEN_MINUTE_UTC = Number(
+  process.env.PREMIUM_TIER_WEEKEND_OPEN_MINUTE || 30,
+);
+const PREMIUM_TIER_WEEKEND_CUTOFF_DISABLED =
+  process.env.PREMIUM_TIER_WEEKEND_CUTOFF_DISABLED === "true";
+
+/**
+ * Returns true if `at` is inside the weekend cutoff window where new
+ * premium-tier borrows are refused.
+ */
+export function isInWeekendCutoff(at = new Date()) {
+  if (PREMIUM_TIER_WEEKEND_CUTOFF_DISABLED) return false;
+  const dow = at.getUTCDay();           // 0 Sun, 5 Fri, 6 Sat
+  const hour = at.getUTCHours();
+  const minute = at.getUTCMinutes();
+  if (dow === 6 || dow === 0) return true;                // Sat / Sun all day
+  if (dow === 5 && hour >= PREMIUM_TIER_WEEKEND_CLOSE_HOUR_UTC) return true;  // Fri after close
+  if (dow === 1) {                                         // Mon before open
+    if (hour < PREMIUM_TIER_WEEKEND_OPEN_HOUR_UTC) return true;
+    if (hour === PREMIUM_TIER_WEEKEND_OPEN_HOUR_UTC && minute < PREMIUM_TIER_WEEKEND_OPEN_MINUTE_UTC) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns a human-readable next-open timestamp in UTC for the message.
+ */
+function nextWeekendOpenIso(at = new Date()) {
+  const dow = at.getUTCDay();
+  const next = new Date(at);
+  // Find next Monday (or stay on Monday if today is Monday before open)
+  let daysToAdd;
+  if (dow === 5) daysToAdd = 3;                  // Fri → Mon
+  else if (dow === 6) daysToAdd = 2;             // Sat → Mon
+  else if (dow === 0) daysToAdd = 1;             // Sun → Mon
+  else daysToAdd = 0;                            // Mon early
+  next.setUTCDate(at.getUTCDate() + daysToAdd);
+  next.setUTCHours(PREMIUM_TIER_WEEKEND_OPEN_HOUR_UTC, PREMIUM_TIER_WEEKEND_OPEN_MINUTE_UTC, 0, 0);
+  return next.toISOString().slice(0, 16) + " UTC";
+}
+
 /**
  * @param {object} opts
  * @param {string} opts.collateralMint base58 pubkey
@@ -41,6 +102,19 @@ export async function screenPremiumBorrow(opts) {
 
   const gateStart = Date.now();
   const gateTimes = {};
+
+  // ── Gate 0: Friday-close cutoff ───────────────────────────────────
+  // Refuse to ORIGINATE new premium-tier loans during the weekend window.
+  // Cheap to evaluate (no DB / RPC) so it short-circuits before the rest.
+  // Existing premium loans roll through the weekend unaffected.
+  const at = opts.now ? new Date(opts.now * 1000) : new Date();
+  if (isInWeekendCutoff(at)) {
+    const reopens = nextWeekendOpenIso(at);
+    return refused(
+      "weekend_cutoff",
+      `New premium-tier borrows pause Friday ${PREMIUM_TIER_WEEKEND_CLOSE_HOUR_UTC.toString().padStart(2, "0")}:00 UTC → Monday ${PREMIUM_TIER_WEEKEND_OPEN_HOUR_UTC.toString().padStart(2, "0")}:${PREMIUM_TIER_WEEKEND_OPEN_MINUTE_UTC.toString().padStart(2, "0")} UTC so US-equity peg + oracle data stay reliable. Existing premium loans are unaffected — repay/extend/topup remain available. New borrows reopen ${reopens}.`,
+    );
+  }
 
   // ── Gate 1: category gate ────────────────────────────────────────
   let t = Date.now();


### PR DESCRIPTION
## Summary

Wires the long-DRAFT premium-tier-screener.js for activation. Two deliverables in one PR.

### 1. \`migrations/017_premium_tier_whitelist.sql\`
- Creates \`premium_tier_whitelist\` — the screener at \`premium-tier-screener.js:75\` was already querying this table, but the table didn't exist (every premium borrow would error \"relation not found\" once the screener wired up).
- Seeds the operator-approved top-12 by liquidity / weekend depth: **SPYx, QQQx, GLDx, NVDAx, TSLAx, GOOGLx, MSFTx, METAx, AMZNx, COINx, MSTRx, HOODx, CRCLx**. Mint addresses pulled from current \`supported_mints\` set. 50 SOL aggregate exposure cap on the deepest-liquidity names, 25 SOL on the rest.
- **Security cleanup**: a pump.fun memecoin ('白毛股神') is currently labeled \`category='stock', enabled=TRUE\` in supported_mints. It would have passed the screener's category gate. Migration re-classifies any \`category='stock' AND mint LIKE '%pump'\` row to \`category='memecoin', enabled=FALSE\`.
- **AAPLx is NOT in supported_mints** — operator to add via \`scripts/onboard-rwa-collateral.js\` when Backed mints a Solana SPL (or confirm if one already exists).

### 2. \`src/services/premium-tier-screener.js\` — Gate 0: Friday-close cutoff
- Refuses NEW premium-tier borrows during the window **Fri 21:00 UTC → Mon 13:30 UTC** (US RTH close → pre-market open).
- Existing premium loans roll through the weekend unaffected — repay/extend/topup remain available.
- Cheap to evaluate (no DB / RPC), so short-circuits before all other gates.
- Tunable: \`PREMIUM_TIER_WEEKEND_CLOSE_HOUR\` / \`OPEN_HOUR\` / \`OPEN_MINUTE\` env vars. Bypassable: \`PREMIUM_TIER_WEEKEND_CUTOFF_DISABLED=true\`.
- Smoke-tested 8/8 cases (Fri 20:59 OK, Fri 21:00 closed, Sat/Sun closed, Mon 13:29 closed, Mon 13:30 OK, Thu 14:00 OK).

## Why a weekend cutoff matters for tokenized stocks

Chainlink Data Streams cover 24/5, NOT weekends. xStock prices can drift 3–5% from underlying on weekend earnings events, and only ~10 tickers have deep weekend liquidity on Kraken Pro. A borrower opens 15d loan against TSLAx at Friday 4pm ET → earnings Monday morning → collateral down 8% before oracle reports → liquidation triggers at a stale price. Avoiding origination in this window pushes the discovery problem onto cooperative borrowers, not unlucky ones.

## Test plan

- [ ] Migration applies cleanly to a fresh DB
- [ ] Migration re-classifies the existing '白毛股神' mint
- [ ] \`SELECT * FROM premium_tier_whitelist WHERE enabled = TRUE\` returns 13 rows
- [ ] \`isInWeekendCutoff()\` returns true Sat midday, false Wed midday
- [ ] Screener called with pool='v3-premium' on Sat → \`{ blocked: true, reason: 'weekend_cutoff' }\`
- [ ] Screener called with pool='v3-premium' on Wed during RTH → proceeds to subsequent gates