### PR TITLE
feature: split Premium-tier whitelist into blue-chip vs crypto-adjacent

### DIFF
--- a/migrations/018_premium_tier_split_by_volatility.sql
+++ b/migrations/018_premium_tier_split_by_volatility.sql
@@ -1,0 +1,56 @@
+-- Premium-tier whitelist: two-tier split by realized volatility.
+--
+-- The 90-day vol pull (in-conversation analysis 2026-06-10) showed the
+-- "tokenized stocks" basket is actually two very different risk shapes:
+--
+--   * Pure equities / ETFs (SPYx, QQQx, GLDx, big tech): mean 32.3%
+--     annualized vol, mean max drawdown -13.1%, zero >10% single-day
+--     moves across 9 names × 90 days. Behaves like equities.
+--
+--   * Crypto-adjacent equities (COINx, MSTRx, HOODx, CRCLx): mean 79.4%
+--     annualized vol, mean max drawdown -33.3%, 16 single-day >10%
+--     moves. Their fundamentals are crypto exposure; their volatility
+--     reflects that. Memecoin-shaped risk inside an equity wrapper.
+--
+-- The original migration 017 lumped both buckets at the same caps. This
+-- migration splits them: tier-aware max LTV + tighter aggregate caps
+-- for the crypto-adjacent bucket.
+
+ALTER TABLE premium_tier_whitelist
+  ADD COLUMN IF NOT EXISTS tier         TEXT,
+  ADD COLUMN IF NOT EXISTS max_ltv_bps  INTEGER;
+
+-- Blue-chip tier — pure equities + index ETFs + GLD. ~32% annualized vol.
+-- Max LTV 50% (5000 bps): ~3x the median name's max drawdown leaves a
+-- comfortable safety margin. Aggregate cap 50 SOL per mint.
+UPDATE premium_tier_whitelist
+   SET tier = 'blue_chip',
+       max_ltv_bps = 5000,
+       max_open_lamports = 50000000000
+ WHERE symbol IN ('SPYx', 'QQQx', 'GLDx', 'NVDAx', 'TSLAx',
+                  'GOOGLx', 'MSFTx', 'METAx', 'AMZNx');
+
+-- Crypto-adjacent tier — COINx, MSTRx, HOODx, CRCLx. ~79% annualized vol.
+-- Max LTV 30% (3000 bps): vol is ~2.5x blue-chip; LTV haircut compensates.
+-- Aggregate cap 15 SOL per mint (vs 25 SOL in migration 017 — tightened
+-- because the realized vol justifies smaller per-mint concentration).
+UPDATE premium_tier_whitelist
+   SET tier = 'crypto_adjacent',
+       max_ltv_bps = 3000,
+       max_open_lamports = 15000000000
+ WHERE symbol IN ('COINx', 'MSTRx', 'HOODx', 'CRCLx');
+
+-- Make tier + max_ltv_bps mandatory going forward.
+ALTER TABLE premium_tier_whitelist
+  ALTER COLUMN tier        SET NOT NULL,
+  ALTER COLUMN max_ltv_bps SET NOT NULL;
+
+-- Sanity-check constraint: tier must be one of the known buckets.
+ALTER TABLE premium_tier_whitelist
+  DROP CONSTRAINT IF EXISTS premium_tier_whitelist_tier_check;
+ALTER TABLE premium_tier_whitelist
+  ADD CONSTRAINT premium_tier_whitelist_tier_check
+  CHECK (tier IN ('blue_chip', 'crypto_adjacent'));
+
+CREATE INDEX IF NOT EXISTS idx_premium_tier_whitelist_tier
+  ON premium_tier_whitelist (tier, enabled);

--- a/src/services/premium-tier-screener.js
+++ b/src/services/premium-tier-screener.js
@@ -145,7 +145,7 @@ export async function screenPremiumBorrow(opts) {
   // ── Gate 2: Premium whitelist gate ───────────────────────────────
   t = Date.now();
   const { rows: [wlRow] } = await query(
-    `SELECT mint, max_open_lamports
+    `SELECT mint, max_open_lamports, tier, max_ltv_bps
        FROM premium_tier_whitelist
        WHERE mint = $1 AND enabled = TRUE`,
     [opts.collateralMint],
@@ -155,6 +155,28 @@ export async function screenPremiumBorrow(opts) {
   if (!wlRow) {
     return refused("not_on_premium_whitelist",
       "This stock isn't yet on the Premium-tier whitelist. The operator adds stocks via governance proposals (see magpie.capital/governance). For now, use a shorter-tier loan.");
+  }
+
+  // ── Gate 2b: tier-aware max LTV ──────────────────────────────────
+  // The 90-day vol analysis (2026-06-10) showed crypto-adjacent
+  // equities (COINx, MSTRx, HOODx, CRCLx) realize ~2.5x the volatility
+  // of pure equities + ETFs. Migration 018 split the whitelist into
+  // two tiers with different max LTV caps to match. If the caller
+  // didn't pass a proposed LTV, this gate is a no-op — let the borrow
+  // flow handle LTV selection independently.
+  if (opts.proposedLtvBps != null) {
+    const maxLtvBps = Number(wlRow.max_ltv_bps);
+    if (!Number.isFinite(maxLtvBps) || maxLtvBps <= 0) {
+      return refused("tier_max_ltv_missing",
+        "This stock's Premium-tier max LTV isn't configured. Contact support — the operator needs to update the whitelist row.");
+    }
+    if (opts.proposedLtvBps > maxLtvBps) {
+      const tierLabel = wlRow.tier === "crypto_adjacent"
+        ? "crypto-adjacent equity (higher realized volatility)"
+        : "blue-chip equity / ETF";
+      return refused("ltv_exceeds_tier_cap",
+        `This stock is in the Premium-tier *${tierLabel}* bucket, which caps LTV at ${(maxLtvBps / 100).toFixed(0)}%. You requested ${(opts.proposedLtvBps / 100).toFixed(0)}%. Lower your collateral amount or use a longer-term Express/Quick/Standard tier instead.`);
+    }
   }
 
   // ── Gate 3: institutional price feed gate ────────────────────────


### PR DESCRIPTION
## Summary

90-day realized volatility analysis (in-conversation 2026-06-10) showed \"tokenized stocks\" is two very different risk shapes:

| Bucket | Names | Mean vol | Mean max DD | >10% days |
| --- | --- | ---: | ---: | ---: |
| Pure equities + ETFs | SPYx, QQQx, GLDx, NVDAx, TSLAx, GOOGLx, MSFTx, METAx, AMZNx | **32.3%** | -13.1% | 0 |
| Crypto-adjacent | COINx, MSTRx, HOODx, CRCLx | **79.4%** | -33.3% | 16 |

The original migration 017 lumped both at the same caps. This splits them.

### \`migrations/018_premium_tier_split_by_volatility.sql\`
- Adds \`tier\` and \`max_ltv_bps\` columns (both NOT NULL after backfill)
- Blue-chip rows: \`tier='blue_chip'\`, max LTV 50%, aggregate cap 50 SOL
- Crypto-adjacent: \`tier='crypto_adjacent'\`, max LTV 30%, aggregate cap 15 SOL (down from 25)
- CHECK constraint locks tier to the two-value enum
- **Already applied to prod via the auto-runner from PR #45** — all 13 rows verified populated

### \`premium-tier-screener.js\` — new Gate 2b
- Reads \`tier\` + \`max_ltv_bps\` from the whitelist row (already fetched for the existing whitelist gate)
- If \`opts.proposedLtvBps\` is passed, refuse when request exceeds per-tier cap
- Refusal message includes tier label + numeric cap + numeric request so the borrow UI can render a clean explanation
- Backwards compatible: \`proposedLtvBps\` is optional. The v3 borrow flow (not yet shipped) will pass it

## Test plan

- [ ] Screener with collateralMint=SPYx + proposedLtvBps=4500 → passes (under 50% cap)
- [ ] Screener with collateralMint=SPYx + proposedLtvBps=5500 → refuses with ltv_exceeds_tier_cap, blue-chip label
- [ ] Screener with collateralMint=COINx + proposedLtvBps=4500 → refuses, crypto-adjacent label, 30% cap
- [ ] Screener with no proposedLtvBps → gate is no-op, proceeds to subsequent gates