### PR TITLE
security: block pump.fun mints from ever being classified as stock / etf / metal

### DIFF
--- a/migrations/019_block_pump_mints_from_stock_class.sql
+++ b/migrations/019_block_pump_mints_from_stock_class.sql
@@ -1,0 +1,33 @@
+-- HARD CONSTRAINT: pump.fun memecoin mints can never be classified as
+-- stock / etf / metal in supported_mints, and can never be added to
+-- premium_tier_whitelist.
+--
+-- Operator surfaced 2026-06-10 that '$FATHER' (HVFJvVHY8muTRGhD5BZ6p2TZ5TozSWyTcs9CDJo3pump)
+-- was sitting in supported_mints with category='stock' at one point.
+-- Same pattern for '白毛股神' and 'ITLG'. Migration 017 reclassified them
+-- after the fact; this migration makes the rule structural so no future
+-- code path — auto-classifier bug, manual SQL, a future onboarding
+-- script — can re-create the same situation.
+--
+-- Why this is safe / no false positives:
+--   - Real Backed Finance xStocks use the Token-2022 standard and have
+--     mint addresses starting with 'Xs...' (verified for all 18 RWA
+--     tokens currently in supported_mints). None end in 'pump'.
+--   - pump.fun is exclusively a memecoin launchpad. Their token mints
+--     are minted by a pump.fun program and the suffix 'pump' is the
+--     reliable canonical signature.
+--   - No legitimate stock/etf/metal mint has ever ended in 'pump'.
+
+ALTER TABLE supported_mints
+  DROP CONSTRAINT IF EXISTS supported_mints_no_pump_as_rwa;
+ALTER TABLE supported_mints
+  ADD CONSTRAINT supported_mints_no_pump_as_rwa
+  CHECK (
+    NOT (mint LIKE '%pump' AND category IN ('stock', 'etf', 'metal'))
+  );
+
+ALTER TABLE premium_tier_whitelist
+  DROP CONSTRAINT IF EXISTS premium_tier_whitelist_no_pump_mints;
+ALTER TABLE premium_tier_whitelist
+  ADD CONSTRAINT premium_tier_whitelist_no_pump_mints
+  CHECK (NOT (mint LIKE '%pump'));

--- a/src/services/rwa-screener.js
+++ b/src/services/rwa-screener.js
@@ -162,7 +162,15 @@ async function verifyMintOnChain(mintStr) {
 const ETF_TICKERS = new Set(["SPY", "QQQ", "IWM", "VOO", "VTI", "DIA", "EFA", "EEM", "TQQQ", "SOXL"]);
 const METAL_SYMBOLS = new Set(["VNXAU", "PAXG", "XAUT", "VNXAG"]);
 
-function classify(symbol, name) {
+function classify(symbol, name, mint = null) {
+  // Hard rule: pump.fun mints can NEVER classify as stock/etf/metal.
+  // Real Backed xStocks use Xs... mints; pump.fun memecoins end in
+  // 'pump'. The DB CHECK constraint (migration 019) is the backstop;
+  // this rejects in code so the rest of the rwa-screener never tries
+  // to insert a pump.fun mint into supported_mints with an RWA category.
+  if (typeof mint === "string" && mint.endsWith("pump")) {
+    return "memecoin";
+  }
   const sym = (symbol || "").toUpperCase();
   if (METAL_SYMBOLS.has(sym)) return "metal";
   // Backed Finance ETFs follow <TICKER>x. Strip the trailing x and match.
@@ -192,7 +200,7 @@ async function decideForCandidate(candidate, dbRow) {
     return { action: "skip", reason: "issuer-paused, currently disabled" };
   }
 
-  const category = classify(candidate.symbol, candidate.name);
+  const category = classify(candidate.symbol, candidate.name, candidate.mint);
   const meetsApprove = candidate.liquidity >= APPROVE_LIQUIDITY_USD
     && candidate.volume24h >= APPROVE_VOLUME_24H_USD;
   const failsDisable = candidate.liquidity < DISABLE_LIQUIDITY_USD

--- a/src/services/token-screener.js
+++ b/src/services/token-screener.js
@@ -156,6 +156,20 @@ function detectCategory(symbol, name, onChain = null) {
   const sym = (symbol || "").toUpperCase();
   const nm = (name || "").toLowerCase();
 
+  // Hard rule: pump.fun memecoin mints can NEVER be classified as
+  // stock/etf/metal regardless of name or mint authority. Real Backed
+  // xStocks use the Token-2022 standard with mint addresses starting
+  // with 'Xs...'. pump.fun mints always end in 'pump' and are
+  // exclusively memecoins. Without this guard, a memecoin named
+  // "FATHER of Nvidia" could pass the name-pattern gate. The DB-side
+  // CHECK constraint added in migration 019 catches it as a backstop;
+  // this rejects earlier so the rest of the pipeline never sees a
+  // pump.fun mint with stock intent.
+  const mint = onChain?.mint ?? null;
+  if (typeof mint === "string" && mint.endsWith("pump")) {
+    return "memecoin";
+  }
+
   // Gate 1: does the name/symbol SUGGEST RWA?
   const patternSuggestsStock =
     (sym.startsWith("X") && STOCK_TICKERS.includes(sym.slice(1))) ||


### PR DESCRIPTION
## Summary

Operator flagged the \$FATHER exploit (pump.fun memecoin sitting in supported_mints with \`category='stock'\` at one point). Migration 017 reclassified it after the fact; this PR makes the rule structural so no code path can ever recreate the situation.

### Three layers of defense

**1. \`migrations/019\` — DB CHECK constraints (already applied to prod)**
- \`supported_mints\` rejects rows where \`mint LIKE '%pump' AND category IN ('stock', 'etf', 'metal')\`
- \`premium_tier_whitelist\` rejects any \`mint LIKE '%pump'\`
- Any future code path (auto-classifier bug, manual SQL, integration) gets a Postgres error instead of silent insertion

**2. \`src/services/token-screener.js\` — runtime short-circuit**
- \`detectCategory()\` returns \`'memecoin'\` immediately if \`onChain.mint\` ends in \`'pump'\`, BEFORE the existing name-pattern + issuer-allowlist gates

**3. \`src/services/rwa-screener.js\` — same short-circuit**
- \`classify()\` rejects pump-suffix mints to \`'memecoin'\` before the symbol/name heuristic

### Why zero false positives

- Real Backed Finance xStocks use Token-2022 mints starting with \`Xs...\` — verified for all 18 currently-enabled RWA tokens
- pump.fun is exclusively a memecoin launchpad; \`pump\` suffix is the canonical signature
- No legitimate stock/etf/metal mint has ever ended in pump

### Live attack tests against the just-applied prod constraint

| Test | Result |
| --- | --- |
| INSERT supported_mints + pump suffix + category=stock | REJECTED (\`supported_mints_no_pump_as_rwa\`) |
| INSERT premium_tier_whitelist + pump suffix | REJECTED (\`premium_tier_whitelist_no_pump_mints\`) |
| INSERT supported_mints + Xs... mint + category=stock | PASSED (no false positive) |