### PR TITLE
security: shadow-pool watcher had wrong dataSize filter — 0 matches since deployment

### DIFF
--- a/src/services/shadow-pool-watcher.js
+++ b/src/services/shadow-pool-watcher.js
@@ -90,9 +90,16 @@ async function tick() {
 
   let accounts;
   try {
+    // Filter by discriminator ONLY — not by dataSize. The original watcher
+    // used dataSize=121 based on a hand-computed LendingPool struct size,
+    // but the actual on-chain account is 159 bytes (Anchor pads + future-
+    // proofs the layout). With the wrong dataSize, getProgramAccounts
+    // returned zero matches — including the canonical pool — making the
+    // watcher silently useless since deployment. Matching by discriminator
+    // is the durable choice: even if Backed-style upgrades grow the struct,
+    // the discriminator stays the same.
     accounts = await connection.getProgramAccounts(programId, {
       filters: [
-        { dataSize: LENDING_POOL_ACCOUNT_SIZE },
         {
           memcmp: {
             offset: 0,
@@ -109,6 +116,10 @@ async function tick() {
 
   const shadows = [];
   for (const { pubkey, account } of accounts) {
+    // Length sanity — every LendingPool has at least discriminator + lender.
+    // Reject anything too short to avoid out-of-bounds reads on a malformed
+    // account that happens to start with the discriminator bytes.
+    if (account.data.length < LENDER_OFFSET + LENDER_LEN) continue;
     const lenderBytes = account.data.subarray(LENDER_OFFSET, LENDER_OFFSET + LENDER_LEN);
     const lender = new PublicKey(lenderBytes);
     if (!lender.equals(canonicalLender)) {


### PR DESCRIPTION
## Summary

PR #36 shipped the shadow-pool watcher with two filters: \`dataSize: 121\` (hand-computed from state.rs) + memcmp on the LendingPool discriminator. **The actual on-chain LendingPool is 159 bytes**, not 121 — Anchor pads for future fields. With \`dataSize: 121\`, \`getProgramAccounts\` returned ZERO matches against the live program. The watcher couldn't see the canonical pool OR a shadow pool.

This was the active detective control for the deferred Anchor CRITICAL (loan↔pool binding fix waiting on v3). It's been silently useless since deployment.

Verified live today:

\`\`\`
TOTAL program accounts on 4FEFPeMH...: 675
LendingPool discriminator (d028f252ba124b24) matches: 1
That match's data_size: 159B (NOT 121)
Lender: 4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx (canonical operator)
\`\`\`

## Fix

Drop \`dataSize\` from the filter. Discriminator alone is sufficient and durable across struct-size changes. Added a defensive length check before the lender-byte extraction.

## Test plan

- [ ] Bot restart logs \`[shadow-pool-watcher] armed\`
- [ ] First tick finds the canonical pool (lender = canonical, NOT a shadow)
- [ ] No operator DM fires for the canonical pool
- [ ] Future v3 / struct upgrades that grow the account don't break the filter