### PR TITLE
security: CRITICAL — three governance tally bugs would have erased all MGP-001 votes

### DIFF
--- a/src/governance/pipeline.js
+++ b/src/governance/pipeline.js
@@ -123,11 +123,27 @@ export async function processProposal(proposal) {
       await markPipelineError(proposalId, "no_snapshot_file_found");
       return "pipeline_error";
     }
+    // questionId MUST match what the vote-submission API stored. Votes
+    // are stored with question_id = the key in
+    // src/api/governance-api.js:51-53 — currently "Vote" for MGP-001 and
+    // MGP-003 (the only proposals with active voting in v0). Without
+    // this match the WHERE clause in loadVotes returns zero rows and the
+    // entire tally collapses to 0/0/0, failing the proposal at close.
+    // Hardcoded "Vote" matches today's single-question structure; a
+    // future multi-question proposal will need a refactor to iterate
+    // proposal.questions and tally each separately.
+    const questionId = "Vote";
+    // expectedSnapshotId tells tallyProposal what to verify against the
+    // snapshot file's internal proposal_id field. MGP-001 intentionally
+    // reuses the MGP-002 snapshot (per registry.snapshot_id); the file's
+    // proposal_id is "MGP-002" even though we're tallying MGP-001.
+    const expectedSnapshotId = proposal.snapshot_id ?? proposalId;
     try {
       tally = await tallyProposal({
         proposalId,
-        questionId: proposal.id,
+        questionId,
         snapshotPath,
+        expectedSnapshotId,
         capFraction: 0.02,
       });
       await log("tally", "ok", tally, null, Date.now() - t0);
@@ -145,8 +161,9 @@ export async function processProposal(proposal) {
     try {
       crossTally = await tallyProposal({
         proposalId,
-        questionId: proposal.id,
+        questionId: "Vote",
         snapshotPath,
+        expectedSnapshotId: proposal.snapshot_id ?? proposalId,
         capFraction: 0.02,
       });
     } catch (err) {

--- a/src/governance/tally.js
+++ b/src/governance/tally.js
@@ -89,14 +89,22 @@ export function applyWhaleCap(weights, capFraction) {
  *
  * Snapshot file lives at SNAPSHOT_PATH (operator-private, mode 0600).
  * We read it inline (small enough — < 1 MB typically).
+ *
+ * Snapshot files are tagged with the snapshot_id they were generated
+ * UNDER, not the proposal they're used FOR. A proposal can intentionally
+ * reuse another proposal's snapshot (MGP-001 reuses MGP-002's snapshot
+ * per the registry's snapshot_id field). The caller passes the
+ * expected snapshot_id; this function verifies the file matches that,
+ * not the proposal id.
  */
-export async function loadEligibleVoters(proposalId, snapshotPath) {
+export async function loadEligibleVoters(proposalId, snapshotPath, expectedSnapshotId = null) {
   const fs = await import("node:fs");
   const raw = fs.readFileSync(snapshotPath, "utf8");
   const snap = JSON.parse(raw);
-  if (snap.proposal_id !== proposalId) {
+  const expected = expectedSnapshotId ?? proposalId;
+  if (snap.proposal_id !== expected) {
     throw new Error(
-      `Snapshot file proposal_id (${snap.proposal_id}) does not match expected ${proposalId} — refusing to tally.`,
+      `Snapshot file proposal_id (${snap.proposal_id}) does not match expected snapshot id ${expected} — refusing to tally.`,
     );
   }
   const weights = new Map();
@@ -132,8 +140,8 @@ export async function loadVotes(proposalId, questionId) {
  * Compute a full tally for a proposal. Returns an object with all
  * the numbers the rest of the pipeline needs.
  */
-export async function tallyProposal({ proposalId, questionId, snapshotPath, capFraction = 0.02 }) {
-  const eligible = await loadEligibleVoters(proposalId, snapshotPath);
+export async function tallyProposal({ proposalId, questionId, snapshotPath, expectedSnapshotId = null, capFraction = 0.02 }) {
+  const eligible = await loadEligibleVoters(proposalId, snapshotPath, expectedSnapshotId);
   const votes = await loadVotes(proposalId, questionId);
 
   // Build raw weights of voters who actually voted, restricted to eligible set
@@ -149,7 +157,14 @@ export async function tallyProposal({ proposalId, questionId, snapshotPath, capF
 
   let yesWeight = 0n, noWeight = 0n, abstainWeight = 0n;
   for (const [voter, w] of capped) {
-    const choice = votes.get(voter);
+    // Normalize case before comparison. Votes are stored as the literal
+    // choice strings from the proposal's `choices` array (e.g. "YES",
+    // "NO", "ABSTAIN" for MGP-001 — see ACTIVE_PROPOSALS in
+    // src/api/governance-api.js:51-53). Without normalization, every
+    // uppercase vote fell into the `else` branch and was counted as
+    // abstain — meaning MGP-001's 15+ live YES votes would have tallied
+    // as 0% YES, failing the proposal at autopilot close.
+    const choice = (votes.get(voter) || "").toLowerCase();
     if (choice === "yes") yesWeight += w;
     else if (choice === "no") noWeight += w;
     else abstainWeight += w;


### PR DESCRIPTION
## Summary

MGP-001 is open right now with **15 YES votes already recorded**. At vote close (2026-06-13 22:00 UTC), three compounding bugs in the tally + pipeline would have either errored the autopilot out with \`tally_failed\` or announced \`FAILED — 0% participation\` regardless of actual vote turnout.

### Bug 1 — vote case mismatch (\`tally.js:153\`)
Votes stored as uppercase \`"YES"\` / \`"NO"\` / \`"ABSTAIN"\` (from the API's choice set), but tally compared \`choice === "yes"\` (lowercase). Every vote silently fell through to the \`abstain\` branch.

### Bug 2 — questionId mismatch (\`pipeline.js:128,148\`)
Votes stored with \`question_id = "Vote"\` (the registry key in \`ACTIVE_PROPOSALS\`), but pipeline passed \`questionId = proposal.id\` (\`"MGP-001"\`). The \`loadVotes\` WHERE clause returned zero rows. Even with bug 1 fixed, the tally would have been \`0/0/0\`.

### Bug 3 — snapshot proposal_id strict-check (\`tally.js:97\`)
\`loadEligibleVoters\` strict-rejected any snapshot file whose internal \`proposal_id\` field didn't equal the passed proposalId. MGP-001 reuses MGP-002's snapshot (per \`registry.snapshot_id = "MGP-002"\`). Strict-check refused to load eligible voters at all.

## Live validation

After fix, against current MGP-001 vote state:

| Field | Value |
| --- | ---: |
| Unique YES voters | 14 |
| yes_weight | 21,279,821.67 $MAGPIE |
| participation_pct | 2.80% |
| yes_share_of_cast | 100.00% |
| WOULD PASS quorum? | NO (below 10% threshold) |

The proposal currently fails the quorum check, but the **tally itself is now correct**. Operator can decide whether to extend voting / push for more participation based on accurate data. Without these fixes the announcement would have published a 0/0/0 FAILED result regardless of actual votes.

## Test plan

- [ ] Live tally on MGP-001 returns 14 voters / 21.28M $MAGPIE / 100% YES share
- [ ] Autopilot dry-run on MGP-001 at vote-close-simulation passes the tally step
- [ ] Backwards compat: old callers that pass proposalId without expectedSnapshotId still strict-check (no regressions on MGP-003 / future proposals where snapshot_id == proposal.id)