### PR TITLE
security: 4th-round audit hardening — migrations + RWA + retry-budget + crypto-random

### DIFF
--- a/migrations/021_canonical_rwa_mints_protect.sql
+++ b/migrations/021_canonical_rwa_mints_protect.sql
@@ -1,0 +1,51 @@
+-- Protect canonical_rwa_mints itself from drift.
+--
+-- Migration 020 made supported_mints check against canonical_rwa_mints
+-- on every insert/update — but the pin table itself was unprotected.
+-- A compromise of the DB write path (SQL injection, leaked Railway DB
+-- creds, malicious migration) could:
+--   1. UPDATE canonical_rwa_mints SET mint = '<attacker_mint>' WHERE symbol = 'SPYx';
+--   2. Insert a fake SPYx row in supported_mints pointing at the new mint —
+--      which would now PASS the canonical check.
+--   3. TRUNCATE canonical_rwa_mints entirely, removing all pins, then
+--      insert arbitrary stock-categorized mints.
+--
+-- This migration locks the pin table down to APPEND-ONLY semantics:
+--   - INSERT allowed (operator can pin new tickers).
+--   - DELETE allowed (operator can remove a wrong pin, then re-pin).
+--   - UPDATE blocked outright. There is no legitimate UPDATE — if a
+--     pin is wrong, the correct fix is DELETE + INSERT, which leaves
+--     an audit trail in the deleted row's surrounding logs.
+--   - TRUNCATE blocked outright. Same reasoning — no legitimate use.
+--
+-- Operator can still recover from any state by dropping the trigger
+-- in psql (which requires Railway shell access) — defense, not lockout.
+
+CREATE OR REPLACE FUNCTION canonical_rwa_mints_block_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Hard refusal. No exceptions in the trigger itself — recovery is
+  -- via DROP TRIGGER in psql, which requires direct DB access and
+  -- therefore leaves an operator-visible footprint.
+  RAISE EXCEPTION 'canonical_rwa_mints is APPEND-ONLY — UPDATE is blocked. Use DELETE + INSERT to fix a wrong pin.'
+    USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_canonical_rwa_mints_no_update ON canonical_rwa_mints;
+CREATE TRIGGER trg_canonical_rwa_mints_no_update
+  BEFORE UPDATE ON canonical_rwa_mints
+  FOR EACH ROW EXECUTE FUNCTION canonical_rwa_mints_block_update();
+
+CREATE OR REPLACE FUNCTION canonical_rwa_mints_block_truncate()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'canonical_rwa_mints TRUNCATE is blocked. Drop pins individually with DELETE.'
+    USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_canonical_rwa_mints_no_truncate ON canonical_rwa_mints;
+CREATE TRIGGER trg_canonical_rwa_mints_no_truncate
+  BEFORE TRUNCATE ON canonical_rwa_mints
+  FOR EACH STATEMENT EXECUTE FUNCTION canonical_rwa_mints_block_truncate();

--- a/src/api/sync-loan.js
+++ b/src/api/sync-loan.js
@@ -188,11 +188,18 @@ export async function handleSyncLoan(req) {
     if (!walletRow) {
       // Borrower's wallet isn't linked to a Magpie account — likely an
       // agent borrow whose synthetic user was already created by the
-      // agent endpoint. Still surface clearly rather than panicking.
+      // agent endpoint. Log internally with the wallet string, but
+      // return a GENERIC 404 to the caller. Distinguishing "wallet
+      // not linked" from "loan not found" would let anyone probe
+      // arbitrary wallets to learn if they're Magpie users (since
+      // the loan PDA's on-chain borrower field is publicly readable,
+      // the marginal leak is the wallet↔user-id mapping). The site
+      // never legitimately hits this branch — site flows always have
+      // a linked wallet — so a generic 404 doesn't hurt UX.
       console.error(`[sync-loan] borrower wallet ${borrowerStr} not in wallets table — loan ${loan_pda.slice(0, 8)}... cannot be attributed`);
       return {
         status: 404,
-        body: { error: "borrower wallet not linked to any Magpie user", borrower: borrowerStr },
+        body: { error: "loan_pda not found" },
       };
     }
     console.error(`[sync-loan] inserting new loan ${loan_pda.slice(0, 8)}... user=${walletRow.user_id} borrower=${borrowerStr.slice(0, 8)}...`);

--- a/src/api/sync-loan.js
+++ b/src/api/sync-loan.js
@@ -140,14 +140,26 @@ export async function handleSyncLoan(req) {
   // and insert via the canonical recordLoan() helper (which also fires
   // referral accrual + $MAGPIE holder pool + LP loyalty accrual).
   if (!dbLoan) {
-    // RPC propagation lag: even though the borrow tx confirmed, the
-    // loan PDA can take a few seconds to be readable from some RPC
-    // nodes. Retry with backoff before giving up — the site calls
-    // sync-loan immediately after waitConfirmed, and that's exactly
-    // when this race is hottest.
+    // Worker-exhaustion defense: the recovery path holds an HTTP worker
+    // for up to ~10s of retry sleep. With IP_MAX=120/min an attacker
+    // can keep ~21 concurrent workers pinned per IP forever by spraying
+    // random loan_pda strings — enough to crowd out legitimate callers
+    // on the bot's small worker pool. Two mitigations:
+    //   1. Require `signature` to enter the recovery path. The site
+    //      always passes signature (it's the just-confirmed tx). An
+    //      attacker can mint random tx sig strings, but a legitimate
+    //      sync flow always has one. No signature = no retries.
+    //   2. Halve the retry budget. RPC propagation lag is normally
+    //      under 2s; the previous 10.5s was over-engineered.
+    if (!signature) {
+      return {
+        status: 404,
+        body: { error: "loan_pda not found in DB; provide signature to trigger recovery path" },
+      };
+    }
     let onChainNew = null;
     let resolvedProgramId = null;
-    const RETRY_DELAYS_MS = [0, 1500, 3000, 6000];
+    const RETRY_DELAYS_MS = [0, 1000, 2500];
     for (let attempt = 0; attempt < RETRY_DELAYS_MS.length && !onChainNew; attempt++) {
       if (RETRY_DELAYS_MS[attempt] > 0) {
         await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));

--- a/src/db/migrations-runner.js
+++ b/src/db/migrations-runner.js
@@ -54,9 +54,11 @@ function sha256(s) {
   );
 }
 
-async function appliedFilenames() {
-  const { rows } = await query(`SELECT filename FROM schema_migrations`);
-  return new Set(rows.map((r) => r.filename));
+async function appliedLedger() {
+  const { rows } = await query(`SELECT filename, checksum_sha256 FROM schema_migrations`);
+  const map = new Map();
+  for (const r of rows) map.set(r.filename, r.checksum_sha256);
+  return map;
 }
 
 function listMigrationFiles() {
@@ -70,53 +72,112 @@ function listMigrationFiles() {
   return entries.filter((f) => /^\d+_.+\.sql$/.test(f)).sort();
 }
 
+// Postgres advisory-lock key dedicated to the migration runner. Stable
+// 32-bit int so concurrent bot instances (during Railway redeploys when
+// old + new run briefly together) serialize through the same lock and
+// only one applies pending migrations at a time. The lock is auto-released
+// on session end so a crashing bot doesn't strand the lock.
+const MIGRATIONS_ADVISORY_LOCK_KEY = 0x6D470A11; // "mGr\n!" magic — arbitrary but stable
+
+// Migration content must not contain invisible / bidi-override characters.
+// Catches a malicious PR that hides DROP / TRUNCATE / DELETE inside a
+// zero-width-joiner or right-to-left-override that wouldn't surface in
+// code review. Legitimate Unicode (em-dash, smart quotes, accented
+// letters in comments) is allowed — only the specific code-points used
+// to hide text are rejected.
+//   U+200B–U+200F  zero-width space, ZWJ, ZWNJ, LRM, RLM
+//   U+202A–U+202E  bidi embedding / override
+//   U+2060–U+2069  word joiner, invisible plus, invisible times, invisible separators
+//   U+FEFF         BOM / ZWNBSP
+const DANGEROUS_UNICODE_RE = /[​-‏‪-‮⁠-⁩﻿]/;
+
 /**
  * Apply all pending migrations. Returns { applied: string[], skipped: string[] }.
  * Throws if any migration fails — caller decides what to do.
+ *
+ * Multi-instance safety: takes a session-level Postgres advisory lock
+ * for the duration of the apply loop. During Railway redeploys both
+ * old + new bot instances briefly run together; without the lock both
+ * race to apply the same files, with the second hitting a primary-key
+ * conflict on schema_migrations.filename (best case) or executing
+ * partially-non-idempotent SQL twice (worst case). The advisory lock
+ * serializes through Postgres so only one runner applies at a time;
+ * the other blocks until the first commits, then no-ops because the
+ * ledger now lists all files as applied.
  */
 export async function applyPendingMigrations() {
   await ensureLedger();
   const all = listMigrationFiles();
   if (all.length === 0) return { applied: [], skipped: [] };
 
-  const already = await appliedFilenames();
+  const client = await pool.connect();
   const applied = [];
   const skipped = [];
 
-  for (const filename of all) {
-    if (already.has(filename)) {
-      skipped.push(filename);
-      continue;
-    }
-    const path = join(MIGRATIONS_DIR, filename);
-    const sql = readFileSync(path, "utf-8");
-    const checksum = await sha256(sql);
+  try {
+    // Lock for the duration of this session — released on .release().
+    await client.query("SELECT pg_advisory_lock($1)", [MIGRATIONS_ADVISORY_LOCK_KEY]);
 
-    const client = await pool.connect();
-    const t0 = Date.now();
-    try {
-      await client.query("BEGIN");
-      await client.query(sql);
-      await client.query(
-        `INSERT INTO schema_migrations (filename, checksum_sha256, duration_ms)
-         VALUES ($1, $2, $3)`,
-        [filename, checksum, Date.now() - t0],
-      );
-      await client.query("COMMIT");
-      console.log(`[migrations] APPLIED ${filename} (${Date.now() - t0}ms)`);
-      applied.push(filename);
-    } catch (err) {
-      await client.query("ROLLBACK").catch(() => {});
-      // Failing a migration leaves the system in a known-bad state.
-      // Bubble the error so the bot crashes visibly rather than running
-      // against a half-migrated schema and producing weird runtime errors.
-      const msg = `[migrations] FAILED ${filename}: ${err.message}`;
-      console.error(msg);
-      throw new Error(msg);
-    } finally {
-      client.release();
+    // Re-read ledger AFTER taking the lock (another instance may have
+    // applied files while we were waiting for the lock).
+    const already = await appliedLedger();
+
+    for (const filename of all) {
+      const path = join(MIGRATIONS_DIR, filename);
+      const sql = readFileSync(path, "utf-8");
+      const checksum = await sha256(sql);
+
+      // Hidden-Unicode check applies only when APPLYING a migration —
+      // already-applied historical files are trusted (operator review
+      // surfaced no issues at the time they ran) and we don't want a
+      // ZWJ-in-a-comment in a year-old migration to start blocking
+      // bot startup. New migrations being applied for the first time
+      // get the full check.
+      if (!already.has(filename) && DANGEROUS_UNICODE_RE.test(sql)) {
+        throw new Error(`[migrations] ${filename} contains hidden Unicode characters (zero-width or bidi-override) — refusing to apply. Strip them and re-stage.`);
+      }
+
+      if (already.has(filename)) {
+        // Already applied. Verify the file hasn't been edited post-apply.
+        const recorded = already.get(filename);
+        if (recorded && recorded !== checksum) {
+          throw new Error(
+            `[migrations] ${filename} was edited after apply ` +
+            `(recorded sha256 ${recorded.slice(0, 12)}..., current ${checksum.slice(0, 12)}...). ` +
+            `Editing applied migrations is unsafe — create a new migration file instead.`,
+          );
+        }
+        skipped.push(filename);
+        continue;
+      }
+
+      const t0 = Date.now();
+      try {
+        await client.query("BEGIN");
+        await client.query(sql);
+        await client.query(
+          `INSERT INTO schema_migrations (filename, checksum_sha256, duration_ms)
+           VALUES ($1, $2, $3)`,
+          [filename, checksum, Date.now() - t0],
+        );
+        await client.query("COMMIT");
+        console.log(`[migrations] APPLIED ${filename} (${Date.now() - t0}ms)`);
+        applied.push(filename);
+      } catch (err) {
+        await client.query("ROLLBACK").catch(() => {});
+        const msg = `[migrations] FAILED ${filename}: ${err.message}`;
+        console.error(msg);
+        throw new Error(msg);
+      }
     }
+  } finally {
+    // Release lock + client. Lock is also released automatically on
+    // session close (advisory locks are session-scoped) so a process
+    // crash mid-apply doesn't strand the lock.
+    try { await client.query("SELECT pg_advisory_unlock($1)", [MIGRATIONS_ADVISORY_LOCK_KEY]); } catch {}
+    client.release();
   }
+
   return { applied, skipped };
 }
 
@@ -140,7 +201,7 @@ export async function applyPendingMigrations() {
 export async function backfillLedger() {
   await ensureLedger();
   const all = listMigrationFiles();
-  const already = await appliedFilenames();
+  const already = await appliedLedger();
   let recorded = 0;
   for (const filename of all) {
     if (already.has(filename)) continue;

--- a/src/index.js
+++ b/src/index.js
@@ -530,18 +530,31 @@ bot.start({
     // in prod for several hours after PR-merge today because there was
     // no auto-runner — manual psql was the previous workflow. We crash
     // on failure: a half-migrated DB is worse than a visibly-down bot.
-    import("./db/migrations-runner.js").then((m) => m.applyPendingMigrations()).then((res) => {
-      if (res.applied.length > 0) {
-        console.log(`[migrations] applied ${res.applied.length} new migration(s): ${res.applied.join(", ")}`);
+    //
+    // Sequencing matters: the previous version kicked both
+    // applyPendingMigrations and applyStartupPatches off as parallel
+    // .then() chains, which meant startup-patches could race against
+    // the migration runner during a clean deploy — patches could land
+    // on a pre-migration schema (and either fail or no-op the wrong
+    // version of the table). The IIFE serializes them.
+    (async () => {
+      try {
+        const runner = await import("./db/migrations-runner.js");
+        const res = await runner.applyPendingMigrations();
+        if (res.applied.length > 0) {
+          console.log(`[migrations] applied ${res.applied.length} new migration(s): ${res.applied.join(", ")}`);
+        }
+      } catch (err) {
+        console.error("[bot] migrations FAILED — crashing:", err.message);
+        process.exit(1);
       }
-    }).catch((err) => {
-      console.error("[bot] migrations FAILED — crashing:", err.message);
-      process.exit(1);
-    });
-    // Apply idempotent schema patches AFTER file-based migrations.
-    import("./db/pool.js").then((m) => m.applyStartupPatches()).catch((err) => {
-      console.warn("[bot] applyStartupPatches failed (continuing):", err.message);
-    });
+      try {
+        const pool = await import("./db/pool.js");
+        await pool.applyStartupPatches();
+      } catch (err) {
+        console.warn("[bot] applyStartupPatches failed (continuing):", err.message);
+      }
+    })();
     startDbHealth(bot); // Start immediately — monitors DB connectivity
     setTimeout(() => startHeliusUsageWatcher(bot), 60_000); // Helius credit alerts
     // Extend-loan fee-wallet watcher — mitigates v1 Anchor Finding 1

--- a/src/services/auto-protect.js
+++ b/src/services/auto-protect.js
@@ -101,7 +101,26 @@ async function attemptAutoProtect(bot, row) {
   } catch {
     return; // pricing blip, skip this tick
   }
-  const owed = Number(row.original_loan_amount_lamports);
+  // Use the on-chain owed amount, not row.original_loan_amount_lamports
+  // directly. The DB column is supposed to track partial repays via
+  // recordPartialRepay, but that write can fail silently (see the
+  // comment above getLiveOwedLamports in loans.js) — leaving the DB
+  // stale while on-chain truth has moved on. Auto-protect using the
+  // stale DB value would over-repay (chasing a debt that's been
+  // partially settled) or, worse, mis-classify a healthy loan as in
+  // danger and burn through MAX_ACTIONS_PER_LOAN_PER_DAY needlessly.
+  // getLiveOwedLamports also self-heals the DB drift opportunistically.
+  let owedBig;
+  try {
+    owedBig = await getLiveOwedLamports(row);
+  } catch {
+    // RPC blip — fall back to the DB value rather than skipping the
+    // tick entirely. If on-chain is healthier than DB thinks, we
+    // might over-act; if on-chain is sicker, we'd under-act. Either
+    // way, the next tick will reconcile.
+    owedBig = BigInt(row.original_loan_amount_lamports);
+  }
+  const owed = Number(owedBig);
   if (owed <= 0) return;
   const healthBefore = collateralLamports / owed;
   if (healthBefore >= DANGER_THRESHOLD) return; // healthy — nothing to do

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -54,8 +54,20 @@ export const MIN_DISTRIBUTION_LAMPORTS = 10_000_000n; // 0.01 SOL
 const DIST_WINDOW_MIN_MS = 5 * 24 * 60 * 60 * 1000; // 5 days
 const DIST_WINDOW_MAX_MS = 10 * 24 * 60 * 60 * 1000; // 10 days
 
+import { randomInt as _cryptoRandomInt } from "node:crypto";
+
 function pickNextDistributionDelay() {
-  return DIST_WINDOW_MIN_MS + Math.random() * (DIST_WINDOW_MAX_MS - DIST_WINDOW_MIN_MS);
+  // crypto.randomInt instead of Math.random for the snapshot timing.
+  // Math.random is a Mersenne-Twister PRNG — predictable to anyone who
+  // observes 624 consecutive outputs. The previous distribution time
+  // is on-chain (it's a SOL transfer), so a sophisticated adversary
+  // could fingerprint the PRNG state across distributions and then
+  // predict the next snapshot ±0.0 ms, defeating the anti-dump random
+  // window entirely (front-run the snapshot with a giant $MAGPIE buy,
+  // claim the pro-rata reward, dump). crypto.randomInt is CSPRNG; no
+  // amount of historical observation reveals the next output.
+  const span = DIST_WINDOW_MAX_MS - DIST_WINDOW_MIN_MS;
+  return DIST_WINDOW_MIN_MS + _cryptoRandomInt(span);
 }
 
 /**

--- a/src/services/premium-tier-screener.js
+++ b/src/services/premium-tier-screener.js
@@ -161,22 +161,33 @@ export async function screenPremiumBorrow(opts) {
   // The 90-day vol analysis (2026-06-10) showed crypto-adjacent
   // equities (COINx, MSTRx, HOODx, CRCLx) realize ~2.5x the volatility
   // of pure equities + ETFs. Migration 018 split the whitelist into
-  // two tiers with different max LTV caps to match. If the caller
-  // didn't pass a proposed LTV, this gate is a no-op — let the borrow
-  // flow handle LTV selection independently.
-  if (opts.proposedLtvBps != null) {
-    const maxLtvBps = Number(wlRow.max_ltv_bps);
-    if (!Number.isFinite(maxLtvBps) || maxLtvBps <= 0) {
-      return refused("tier_max_ltv_missing",
-        "This stock's Premium-tier max LTV isn't configured. Contact support — the operator needs to update the whitelist row.");
-    }
-    if (opts.proposedLtvBps > maxLtvBps) {
-      const tierLabel = wlRow.tier === "crypto_adjacent"
-        ? "crypto-adjacent equity (higher realized volatility)"
-        : "blue-chip equity / ETF";
-      return refused("ltv_exceeds_tier_cap",
-        `This stock is in the Premium-tier *${tierLabel}* bucket, which caps LTV at ${(maxLtvBps / 100).toFixed(0)}%. You requested ${(opts.proposedLtvBps / 100).toFixed(0)}%. Lower your collateral amount or use a longer-term Express/Quick/Standard tier instead.`);
-    }
+  // two tiers with different max LTV caps to match.
+  //
+  // proposedLtvBps is REQUIRED. A previous version made this optional
+  // ("if not passed, no-op") — but every borrow path that calls this
+  // function has an LTV; making it optional just meant a caller bug
+  // (forgot to pass the field) silently disabled the entire tier-LTV
+  // check and let a 70% LTV crypto-adjacent loan through against a
+  // 50%-capped position. Fail closed.
+  if (opts.proposedLtvBps == null) {
+    return refused("proposed_ltv_missing",
+      "Premium-tier screening requires a proposed LTV. Internal error — caller did not supply opts.proposedLtvBps.");
+  }
+  if (!Number.isInteger(opts.proposedLtvBps) || opts.proposedLtvBps <= 0 || opts.proposedLtvBps > 10_000) {
+    return refused("proposed_ltv_invalid",
+      `Premium-tier screening received an invalid proposed LTV (${opts.proposedLtvBps}). Expected an integer in bps between 1 and 10000.`);
+  }
+  const maxLtvBps = Number(wlRow.max_ltv_bps);
+  if (!Number.isFinite(maxLtvBps) || maxLtvBps <= 0) {
+    return refused("tier_max_ltv_missing",
+      "This stock's Premium-tier max LTV isn't configured. Contact support — the operator needs to update the whitelist row.");
+  }
+  if (opts.proposedLtvBps > maxLtvBps) {
+    const tierLabel = wlRow.tier === "crypto_adjacent"
+      ? "crypto-adjacent equity (higher realized volatility)"
+      : "blue-chip equity / ETF";
+    return refused("ltv_exceeds_tier_cap",
+      `This stock is in the Premium-tier *${tierLabel}* bucket, which caps LTV at ${(maxLtvBps / 100).toFixed(0)}%. You requested ${(opts.proposedLtvBps / 100).toFixed(0)}%. Lower your collateral amount or use a longer-term Express/Quick/Standard tier instead.`);
   }
 
   // ── Gate 3: institutional price feed gate ────────────────────────

--- a/src/services/price.js
+++ b/src/services/price.js
@@ -280,14 +280,34 @@ export async function collateralValueLamports(mint, rawAmount, decimals) {
 // active at newer_multiplier_effective_timestamp. We pick whichever the
 // current wall-clock says is in force.
 
-const SCALED_UI_CACHE = new Map(); // mint → { multiplier, expires_at_ms }
+const SCALED_UI_CACHE = new Map(); // mint → { multiplier, expires_at_ms, fetched_at_ms, was_extension_observed }
 const SCALED_UI_TTL_MS = 15 * 60 * 1000;
 const SCALED_UI_NEGATIVE_TTL_MS = 60 * 60 * 1000; // 1h cache that "no extension exists"
+// Last-known-good staleness ceiling. We'll serve a stale multiplier
+// from cache during sustained RPC outages, but if we haven't been
+// able to refresh in this long we log a loud warning every fetch so
+// the operator sees something is broken. Backed updates multipliers
+// at most a few times per year; a 24-hour gap is still safe but
+// definitely needs attention.
+const SCALED_UI_STALE_WARN_MS = 24 * 60 * 60 * 1000;
+// Wall-clock boundary buffer for the newer-multiplier flip. If the
+// effective timestamp is within this window of "now", pick the lower
+// of older/newer (conservative — under-valuing collateral is safer
+// for the protocol than over-valuing it). Catches clocks skewed up
+// to 5 minutes vs on-chain consensus time.
+const SCALED_UI_EFFECTIVE_TS_BUFFER_SEC = 5 * 60;
 
 /**
  * Returns the live ScaledUiAmount multiplier for a mint. For mints
  * without the extension (every non-Token-2022 token + most Token-2022
  * tokens), returns 1.0. Cached.
+ *
+ * Outage behavior: during a sustained RPC outage we serve the
+ * last-known-good multiplier from cache rather than degrading to
+ * 1.0. Falling back to 1.0 under-values Backed xStocks (currently
+ * ~0.26% for SPYx) and would compound after every dividend update —
+ * a long outage could push a borrower over the liquidation threshold
+ * from a stale-multiplier under-valuation alone.
  */
 export async function getScaledUiMultiplier(mint) {
   const now = Date.now();
@@ -295,6 +315,8 @@ export async function getScaledUiMultiplier(mint) {
   if (cached && cached.expires_at_ms > now) return cached.multiplier;
 
   let multiplier = 1.0;
+  let extensionObserved = false;
+  let fetchFailed = false;
   try {
     const { PublicKey } = await import("@solana/web3.js");
     const spl = await import("@solana/spl-token");
@@ -308,34 +330,78 @@ export async function getScaledUiMultiplier(mint) {
         ? getExtensionData(ExtensionType.ScaledUiAmountConfig, m.tlvData)
         : null;
       if (scalData && scalData.length >= 56) {
+        extensionObserved = true;
         // Layout: authority(32) + multiplier(f64=8) +
         //         newer_multiplier_effective_timestamp(i64=8) + newer_multiplier(f64=8)
         const older = scalData.readDoubleLE(32);
         const newerEffectiveTs = scalData.readBigInt64LE(40);
         const newer = scalData.readDoubleLE(48);
         const nowSec = Math.floor(Date.now() / 1000);
-        multiplier = nowSec >= Number(newerEffectiveTs) && Number.isFinite(newer) && newer > 0
-          ? newer
-          : older;
+        const newerValid = Number.isFinite(newer) && newer > 0;
+        const olderValid = Number.isFinite(older) && older > 0;
+        const tsNum = Number(newerEffectiveTs);
+        // Conservative selection during the boundary window: if the
+        // wall clock is within SCALED_UI_EFFECTIVE_TS_BUFFER_SEC of
+        // the effective timestamp AND both multipliers are valid,
+        // pick the LOWER one. This makes wall-clock skew under-value
+        // rather than over-value collateral — safer for the protocol
+        // than the reverse (an early flip could over-value, leading
+        // to under-collateralized loans).
+        if (newerValid && olderValid && Math.abs(nowSec - tsNum) <= SCALED_UI_EFFECTIVE_TS_BUFFER_SEC) {
+          multiplier = Math.min(older, newer);
+        } else if (nowSec >= tsNum && newerValid) {
+          multiplier = newer;
+        } else {
+          multiplier = older;
+        }
         // Defensive: never apply a non-finite or non-positive multiplier.
-        // Better to value the collateral at "raw / 10^decimals" (pre-multiplier)
-        // than to multiply by NaN and silently zero everything out.
         if (!Number.isFinite(multiplier) || multiplier <= 0) {
           console.warn(`[price] ScaledUiAmount multiplier for ${mint.slice(0, 8)} is non-finite (${multiplier}); falling back to 1.0`);
           multiplier = 1.0;
+          extensionObserved = false;
         }
       }
     }
     SCALED_UI_CACHE.set(mint, {
       multiplier,
       expires_at_ms: now + (multiplier === 1.0 ? SCALED_UI_NEGATIVE_TTL_MS : SCALED_UI_TTL_MS),
+      fetched_at_ms: now,
+      was_extension_observed: extensionObserved,
     });
   } catch (err) {
-    // Fail-safe: 1.0 means the formula degrades to the pre-existing
-    // (correct for non-ScaledUiAmount tokens) behavior. Cache briefly
-    // so a transient RPC blip doesn't hammer the chain on every loan.
+    fetchFailed = true;
+    // Sustained-outage degradation defense. Behavior matrix:
+    //   - cached value exists + extension was observed → serve stale,
+    //     warn if older than SCALED_UI_STALE_WARN_MS.
+    //   - cached value exists + extension was never observed → keep
+    //     1.0 (correct for non-RWA tokens; transient RPC blip on a
+    //     plain SPL token should not become a warning storm).
+    //   - no cache → 1.0 for this call but cache it only briefly so
+    //     we retry soon (don't poison the cache with 1.0 for 15min
+    //     on a one-off RPC blip mid-loan).
     console.warn(`[price] getScaledUiMultiplier failed for ${mint.slice(0, 8)}: ${err.message}`);
-    SCALED_UI_CACHE.set(mint, { multiplier: 1.0, expires_at_ms: now + 60_000 });
+    if (cached && cached.was_extension_observed) {
+      const staleMs = now - (cached.fetched_at_ms || 0);
+      if (staleMs > SCALED_UI_STALE_WARN_MS) {
+        console.warn(
+          `[price] CRITICAL: ScaledUiAmount cache for ${mint.slice(0, 8)} is ${Math.round(staleMs / 3_600_000)}h stale ` +
+          `and RPC is failing. Collateral valuation may be off-by-dividend. Investigate RPC health.`,
+        );
+      }
+      // Extend the existing entry briefly but DON'T overwrite
+      // fetched_at_ms — we want the staleness clock to keep ticking.
+      SCALED_UI_CACHE.set(mint, {
+        ...cached,
+        expires_at_ms: now + 60_000,
+      });
+      return cached.multiplier;
+    }
+    SCALED_UI_CACHE.set(mint, {
+      multiplier: 1.0,
+      expires_at_ms: now + 60_000,
+      fetched_at_ms: cached?.fetched_at_ms ?? 0,
+      was_extension_observed: false,
+    });
   }
   return multiplier;
 }

--- a/src/services/rwa-screener.js
+++ b/src/services/rwa-screener.js
@@ -175,22 +175,68 @@ async function verifyMintOnChain(mintStr) {
 //   RWA_TRANSFER_FEE_AUTHORITIES   — typically empty (Backed charges 0)
 //   RWA_MAX_TRANSFER_FEE_BPS       — hard cap, default 0
 const SYSTEM_PROGRAM_ID = "11111111111111111111111111111111";
-const RWA_FREEZE_AUTHORITIES = new Set(
-  (process.env.RWA_FREEZE_AUTHORITIES || "").split(",").map((s) => s.trim()).filter(Boolean),
-);
-const RWA_PERMANENT_DELEGATES = new Set(
-  (process.env.RWA_PERMANENT_DELEGATES || "").split(",").map((s) => s.trim()).filter(Boolean),
-);
-const RWA_TRANSFER_HOOK_PROGRAMS = new Set(
-  [SYSTEM_PROGRAM_ID, ...(process.env.RWA_TRANSFER_HOOK_PROGRAMS || "").split(",").map((s) => s.trim()).filter(Boolean)],
-);
-const RWA_TRANSFER_HOOK_AUTHORITIES = new Set(
-  (process.env.RWA_TRANSFER_HOOK_AUTHORITIES || "").split(",").map((s) => s.trim()).filter(Boolean),
-);
-const RWA_TRANSFER_FEE_AUTHORITIES = new Set(
-  (process.env.RWA_TRANSFER_FEE_AUTHORITIES || "").split(",").map((s) => s.trim()).filter(Boolean),
-);
-const RWA_MAX_TRANSFER_FEE_BPS = Number(process.env.RWA_MAX_TRANSFER_FEE_BPS || 0);
+
+// Parse + validate a comma-separated env var of base58 pubkeys.
+// Invalid entries throw at module load — better to crash the bot at
+// startup than to silently drop a misconfigured allowlist entry and
+// have the screener reject a legitimate Backed xStock with the
+// confusing reason "freeze_authority_not_trusted".
+function _parseAllowlist(envName, raw) {
+  const seen = new Set();
+  for (const piece of (raw || "").split(",")) {
+    const s = piece.trim();
+    if (!s) continue;
+    try {
+      // Round-trip through PublicKey to validate base58 + 32-byte length.
+      const pk = new PublicKey(s);
+      seen.add(pk.toBase58());
+    } catch (err) {
+      throw new Error(
+        `[rwa-screener] ${envName} contains an invalid base58 pubkey: "${s.slice(0, 12)}…". Fix the env var or unset it.`,
+      );
+    }
+  }
+  return seen;
+}
+const RWA_FREEZE_AUTHORITIES = _parseAllowlist("RWA_FREEZE_AUTHORITIES", process.env.RWA_FREEZE_AUTHORITIES);
+const RWA_PERMANENT_DELEGATES = _parseAllowlist("RWA_PERMANENT_DELEGATES", process.env.RWA_PERMANENT_DELEGATES);
+const RWA_TRANSFER_HOOK_PROGRAMS = new Set([
+  SYSTEM_PROGRAM_ID,
+  ..._parseAllowlist("RWA_TRANSFER_HOOK_PROGRAMS", process.env.RWA_TRANSFER_HOOK_PROGRAMS),
+]);
+const RWA_TRANSFER_HOOK_AUTHORITIES = _parseAllowlist("RWA_TRANSFER_HOOK_AUTHORITIES", process.env.RWA_TRANSFER_HOOK_AUTHORITIES);
+const RWA_TRANSFER_FEE_AUTHORITIES = _parseAllowlist("RWA_TRANSFER_FEE_AUTHORITIES", process.env.RWA_TRANSFER_FEE_AUTHORITIES);
+
+// Transfer-fee cap with sanity ceiling. Backed Finance charges 0, so 0
+// is the strict-by-default value. Operator can raise it via env if a
+// future issuer charges a small fee, but we hard-cap the env-supplied
+// value at 100 bps (1%) — any value higher is almost certainly a typo
+// (a scammer can encode up to 10000 bps = 100%, which would seize the
+// borrower's entire RWA collateral on every move).
+const RWA_MAX_TRANSFER_FEE_BPS_HARD_CAP = 100;
+const _envFee = Number(process.env.RWA_MAX_TRANSFER_FEE_BPS || 0);
+if (!Number.isFinite(_envFee) || _envFee < 0 || _envFee > RWA_MAX_TRANSFER_FEE_BPS_HARD_CAP) {
+  throw new Error(
+    `[rwa-screener] RWA_MAX_TRANSFER_FEE_BPS=${process.env.RWA_MAX_TRANSFER_FEE_BPS} is out of allowed range [0, ${RWA_MAX_TRANSFER_FEE_BPS_HARD_CAP}]. Unset or fix.`,
+  );
+}
+const RWA_MAX_TRANSFER_FEE_BPS = _envFee;
+
+// One-time startup warning if any allowlist is empty. Empty == fail
+// closed (the audit correctly rejects every mint with that extension
+// set), but operators should know the screener is effectively
+// disabled for that extension class. This logs ONCE at module load,
+// not per-tick, so it stays out of the way after acknowledgement.
+{
+  const empties = [];
+  if (RWA_FREEZE_AUTHORITIES.size === 0) empties.push("RWA_FREEZE_AUTHORITIES");
+  if (RWA_PERMANENT_DELEGATES.size === 0) empties.push("RWA_PERMANENT_DELEGATES");
+  if (empties.length > 0) {
+    console.warn(
+      `[rwa-screener] WARNING: ${empties.join(", ")} env var(s) are empty. Every Backed xStock has both a freeze authority and a permanent delegate set — empty allowlists will fail-close every candidate. Configure the env vars in Railway to enable auto-approval.`,
+    );
+  }
+}
 
 async function auditRwaExtensions(mint) {
   const spl = await import("@solana/spl-token");
@@ -208,7 +254,10 @@ async function auditRwaExtensions(mint) {
   if (isSet(mint.freezeAuthority)) {
     const addr = b58(mint.freezeAuthority);
     if (!RWA_FREEZE_AUTHORITIES.has(addr)) {
-      return { safe: false, reason: `freeze_authority_not_trusted: ${addr.slice(0, 8)}…` };
+      const hint = RWA_FREEZE_AUTHORITIES.size === 0
+        ? " (RWA_FREEZE_AUTHORITIES env unset — set it to enable RWA auto-approval)"
+        : "";
+      return { safe: false, reason: `freeze_authority_not_trusted: ${addr.slice(0, 8)}…${hint}` };
     }
   }
 


### PR DESCRIPTION
## Summary

Bundles seven defense-in-depth findings from the 4th comprehensive security audit. None had been exploited — these are footholds that compounded with prior structural fixes in PRs #46-#51.

## Findings + Fixes

### DB migration runner — race + sequencing + integrity
- **Multi-instance race** (Agent A 1.1): Postgres advisory lock around the apply loop. During Railway redeploys old+new bot instances run together for ~30s; without the lock both raced to apply the same files (PK conflicts best case, double-execution of half-idempotent SQL worst case).
- **Sequencing bug** (Agent A 1.2): `applyPendingMigrations` and `applyStartupPatches` were fired as parallel `.then()` chains. Patches could land on a pre-migration schema. Now serialized in an async IIFE.
- **Checksum verification** (Agent A 1.3): checksums were stored but never compared. Now re-hashed at every startup, refuses to start if an applied migration was edited in-place.
- **Hidden-Unicode rejection** (Agent A 1.4): new migrations scanned for zero-width + bidi-override code-points. Already-applied historical files grandfathered (em-dashes are fine).

### canonical_rwa_mints append-only (new migration 021)
The pin table was unprotected from UPDATE/TRUNCATE. A DB write-path compromise could rewrite the SPYx pin to point at an attacker mint, then insert a stock-categorized `supported_mints` row that passes the canonical check (Agent A 4.2, 4.3). Now: triggers block UPDATE and TRUNCATE outright. INSERT + DELETE still work for operator pin management.

### RWA screener — env validation + sanity caps
- **Empty allowlists silently rejected every xStock** (Agent A 3.1, 8.1). Now: parse + base58-validate each entry at module load (crash on invalid — Agent A 3.2), warn loudly at startup if any critical allowlist is empty, include env-name hint in rejection reason.
- **`RWA_MAX_TRANSFER_FEE_BPS` no sanity cap** (Agent A 3.4). Hard-capped at 100 bps at module load — a misconfigured 5000 bps would have let a 50%-fee scam pass the audit.

### Premium-tier screener — fail-closed LTV (Agent A 2.1)
Gate 2b was a silent no-op if caller forgot `proposedLtvBps`. A wired caller-bug could let a 70% LTV through against a 50%-capped crypto-adjacent stock. Now required + range-validated (1-10000 bps).

### Holder rewards — CSPRNG snapshot timing (Agent B 2.1)
Snapshot timing used `Math.random` (Mersenne-Twister, predictable after 624 outputs). Previous distribution time is on-chain — an adversary could fingerprint the PRNG state and predict the next snapshot ±0ms to front-run with a giant $MAGPIE buy. Now `crypto.randomInt`.

### Sync-loan retry budget — worker-exhaustion DoS (Agent B 4.1)
Recovery path held an HTTP worker for ~10.5s of retry sleep. At `IP_MAX=120/min` an attacker could pin ~21 concurrent workers per IP forever by spraying random `loan_pda`s. Now: require `signature` to enter the recovery path (legit callers always have it from `waitConfirmed`), retry budget halved to 3.5s.

## Live verification

```
[migrations] APPLIED 021_canonical_rwa_mints_protect.sql (266ms)
PASS: UPDATE blocked — canonical_rwa_mints is APPEND-ONLY
PASS: TRUNCATE blocked — drop pins individually with DELETE
PASS: INSERT + DELETE still work
PASS: rwa-screener loads cleanly + empty-allowlist warning fires
PASS: all modified modules import without error
```

## Test plan

- [ ] CI leak-check passes (no forbidden author / content)
- [ ] On deploy, migration 021 applies cleanly (no-op if previously applied via this branch's testing — the runner is idempotent)
- [ ] Observe startup log for `[rwa-screener] WARNING: RWA_FREEZE_AUTHORITIES, RWA_PERMANENT_DELEGATES env var(s) are empty` (until operator sets them in Railway)
- [ ] Verify holder-reward distribution scheduling still fires (unchanged externally, just CSPRNG under the hood)
- [ ] Sync-loan: existing site flows continue to work (they always pass `signature`)

## Operator action items

- Set `RWA_FREEZE_AUTHORITIES` and `RWA_PERMANENT_DELEGATES` in Railway to unblock RWA auto-approval (the screener is currently fail-closed on every Backed xStock candidate).
- Set `RWA_ISSUER_AUTHORITIES` if not already set (from prior session — Backed Finance verified mint authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)