### PR TITLE
fix: dashboard points stuck at 0 + lender-alarm false positive on /fundpool

### DIFF
--- a/src/api/activity-api.js
+++ b/src/api/activity-api.js
@@ -53,6 +53,8 @@ export async function handleActivity(req, url) {
     { rows: refRows },
     { rows: holderRows },
     { rows: lockRows },
+    { rows: creditEventRows },
+    { rows: [pointsAgg] },
   ] = await Promise.all([
     // Add loan_pda + program_id so we can scope to THIS WALLET via PDA-
     // derivation. Multi-wallet users were seeing borrows from ALL their
@@ -146,6 +148,27 @@ export async function handleActivity(req, url) {
         LIMIT $2`,
       [userId, limit],
     ),
+    // Credit events — sum of score_delta is what the dashboard renders
+    // as "points". Without this join, every event in the response had
+    // score_delta undefined and the dashboard's reduce returned 0
+    // even when credit_events.score_delta totalled positive.
+    query(
+      `SELECT id, loan_id, event_type, score_delta, created_at
+         FROM credit_events
+        WHERE user_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2`,
+      [userId, limit],
+    ),
+    // Total points across the user's entire history — a single SUM is
+    // cheaper than asking the dashboard to reconstruct from per-event
+    // deltas, and it correctly counts events older than the `limit`.
+    query(
+      `SELECT COALESCE(SUM(score_delta), 0)::int AS total_points
+         FROM credit_events
+        WHERE user_id = $1`,
+      [userId],
+    ),
   ]);
 
   // ── Wallet-scope the loan-derived events ──────────────────────
@@ -169,6 +192,47 @@ export async function handleActivity(req, url) {
   );
   const protectRows = protectRowsRaw.filter((r) => walletLoanIds.has(String(r.loan_id)));
 
+  // Build a quick lookup of credit_events by loan_db_id so we can attach
+  // score_delta to the matching activity event. credit_events.loan_id
+  // is the DB primary key (loans.id), not the on-chain loan_id.
+  // Group by (loan_id, event_type) so a single loan with multiple
+  // credit-affecting events (e.g. borrow + repay_early) gets each one
+  // attached to the right activity row.
+  const creditByLoanAndType = new Map();
+  for (const ce of creditEventRows) {
+    const key = `${ce.loan_id}:${ce.event_type}`;
+    if (!creditByLoanAndType.has(key)) creditByLoanAndType.set(key, ce.score_delta);
+  }
+  // Map activity-event kind → the credit_events.event_type names that
+  // produce score for it. Multiple credit events can affect one
+  // activity event (e.g. a repaid loan has BOTH "repay_early" and the
+  // implicit "borrow" delta from earlier). For "borrow" the
+  // credit_event is recorded with the loan_id at borrow time.
+  function deltaForLoanEvent(loanDbId, kind) {
+    if (loanDbId == null) return null;
+    if (kind === "borrow") {
+      return creditByLoanAndType.get(`${loanDbId}:borrow`) ?? null;
+    }
+    if (kind === "repaid") {
+      // Could be repay_ontime, repay_early, or repay_late.
+      return (
+        creditByLoanAndType.get(`${loanDbId}:repay_early`) ??
+        creditByLoanAndType.get(`${loanDbId}:repay_ontime`) ??
+        creditByLoanAndType.get(`${loanDbId}:repay_late`) ??
+        null
+      );
+    }
+    if (kind === "liquidated") {
+      return creditByLoanAndType.get(`${loanDbId}:liquidated`) ?? null;
+    }
+    if (kind === "auto_protect") {
+      // auto_protect actions don't map 1:1 to credit events; closest
+      // is `partial_repay` which we record on the underlying loan.
+      return creditByLoanAndType.get(`${loanDbId}:partial_repay`) ?? null;
+    }
+    return null;
+  }
+
   const events = [];
   for (const r of borrowsRows) {
     events.push({
@@ -180,6 +244,7 @@ export async function handleActivity(req, url) {
       ltv_percentage: r.ltv_percentage,
       duration_days: r.duration_days,
       tx_signature: r.tx_signature,
+      score_delta: deltaForLoanEvent(r.id, "borrow"),
     });
   }
   for (const r of closedRows) {
@@ -190,6 +255,7 @@ export async function handleActivity(req, url) {
       collateral_mint: r.collateral_mint,
       amount_lamports: r.amount,
       tx_signature: r.tx_signature,
+      score_delta: deltaForLoanEvent(r.id, r.status),
     });
   }
   for (const r of protectRows) {
@@ -202,6 +268,7 @@ export async function handleActivity(req, url) {
       health_before: r.health_before,
       health_after: r.health_after,
       tx_signature: r.signature,
+      score_delta: deltaForLoanEvent(r.loan_id, "auto_protect"),
     });
   }
   for (const r of withdrawRows) {
@@ -247,6 +314,14 @@ export async function handleActivity(req, url) {
 
   return {
     status: 200,
-    body: { linked: true, events: events.slice(0, limit) },
+    body: {
+      linked: true,
+      events: events.slice(0, limit),
+      // Total credit points across the user's entire history. Surfaced
+      // here (not derived from `events`) because the activity feed is
+      // limit-paged but points are cumulative — the dashboard needs the
+      // honest lifetime total even when only the last 30 events render.
+      total_points: pointsAgg?.total_points ?? 0,
+    },
   };
 }

--- a/src/api/lender-alarm-webhook.js
+++ b/src/api/lender-alarm-webhook.js
@@ -46,20 +46,62 @@ if (!LENDER) {
 const THRESHOLD = BigInt(process.env.LENDER_ALARM_THRESHOLD_LAMPORTS || "10000000"); // 0.01 SOL
 const WEBHOOK_SECRET = process.env.LENDER_ALARM_WEBHOOK_SECRET;
 
+// Self-ATA suppression set. Outflows FROM the lender wallet TO an ATA
+// the lender itself owns are not drains — they're wrap-SOL or
+// fund-own-ATA steps of routine flows like /fundpool (the deposit
+// instruction needs the lender's wSOL ATA to be funded before it can
+// transfer wSOL into the pool vault).
+//
+// Built lazily on first webhook call (lender pubkey + derivation
+// requires @solana/web3.js and @solana/spl-token which we don't want
+// to import at module-load time of an auth-gated webhook).
+let SUPPRESSED_DESTS = null;
+async function getSuppressedDests() {
+  if (SUPPRESSED_DESTS) return SUPPRESSED_DESTS;
+  if (!LENDER) return new Set();
+  try {
+    const { PublicKey } = await import("@solana/web3.js");
+    const spl = await import("@solana/spl-token");
+    const { getAssociatedTokenAddressSync } = spl;
+    const lenderPk = new PublicKey(LENDER);
+    const wsol = new PublicKey("So11111111111111111111111111111111111111112");
+    const usdc = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    const out = new Set([
+      // Both legacy SPL Token and Token-2022 programs derive ATAs the
+      // same way for the same (mint, owner); only one of these ATAs
+      // actually exists per (mint, owner) on chain. Pre-deriving both
+      // tells the suppression set what to silence.
+      getAssociatedTokenAddressSync(wsol, lenderPk, true).toBase58(),
+      getAssociatedTokenAddressSync(usdc, lenderPk, true).toBase58(),
+    ]);
+    SUPPRESSED_DESTS = out;
+    console.log(`[lender-alarm-webhook] self-ATA suppression armed: ${[...out].map(a => a.slice(0, 8) + "…").join(", ")}`);
+    return out;
+  } catch (err) {
+    console.error("[lender-alarm-webhook] failed to derive self-ATAs (suppression disabled this boot):", err.message);
+    return new Set();
+  }
+}
+
 // Helius sends a batch of transactions; webhook receives an array.
-function isOutflowFromLender(tx) {
+async function isOutflowFromLender(tx) {
   // Helius enhanced format gives us nativeTransfers and tokenTransfers
   // arrays. We care about nativeTransfers where the lender is the source.
   if (!Array.isArray(tx.nativeTransfers)) return null;
+  const suppressed = await getSuppressedDests();
   for (const t of tx.nativeTransfers) {
-    if (t.fromUserAccount === LENDER && BigInt(t.amount || 0) >= THRESHOLD) {
-      return {
-        amount: BigInt(t.amount),
-        to: t.toUserAccount,
-        signature: tx.signature,
-        timestamp: tx.timestamp,
-      };
-    }
+    if (t.fromUserAccount !== LENDER) continue;
+    if (BigInt(t.amount || 0) < THRESHOLD) continue;
+    // Suppress wrap-SOL-into-own-ATA outflows. These show up during
+    // /fundpool (lender → own wSOL ATA → pool deposit) and any other
+    // path that prepares the lender's own token account.
+    if (suppressed.has(t.toUserAccount)) continue;
+    return {
+      amount: BigInt(t.amount),
+      to: t.toUserAccount,
+      signature: tx.signature,
+      timestamp: tx.timestamp,
+    };
   }
   return null;
 }
@@ -156,7 +198,7 @@ export async function handleLenderAlarmWebhook(req) {
 
   const txs = Array.isArray(body) ? body : [body];
   for (const tx of txs) {
-    const outflow = isOutflowFromLender(tx);
+    const outflow = await isOutflowFromLender(tx);
     if (!outflow) continue;
     // Drop replays — Helius can retry the same payload, and a captured
     // valid payload replayed by an attacker would otherwise spam the


### PR DESCRIPTION
## Summary

Two operator-reported bugs from the same session, fixed together because the root causes are in adjacent code.

### 1. Dashboard points stuck at 0

Operator wallet \`FxDAn6bT…\` has 1 repaid loan, \`credit_events\` has a \`repay_early +20\` row, but the dashboard shows 0 points.

**Root cause:** the activity endpoint builds events from \`loans\` / \`auto_protect_actions\` / \`referrals\` / etc but **never joins \`credit_events\`**. The dashboard reads \`activity.reduce((sum, e) => sum + (e.score_delta || 0), 0)\`, so every event has \`score_delta\` undefined and the total is 0.

**Fix:**
- Load \`credit_events\` for the user in parallel with the existing queries
- Attach \`score_delta\` to each matching loan-derived activity event (borrow / repaid / liquidated / auto_protect) via a \`(loan_id, event_type)\` lookup
- Also return \`total_points\` at the response top-level (SUM across all history — honest lifetime total even when events are paged to \`limit\`)

Verified live on \`FxDAn6bT…\`: response now returns \`{ total_points: 20, events[].score_delta: 20 }\`.

### 2. Lender-alarm false positive on /fundpool

Operator added SOL via /fundpool and got: \"LENDER WALLET OUTFLOW DETECTED — 5 SOL to 3wk75XDABdEEec28c9ES6KdH2V9zh8h76Q8oTitEe4TE\".

Investigation confirmed: the destination is the **lender's own wSOL ATA** (owner = lender wallet, mint = wSOL, isNative = true). The 5 SOL was the wrap-SOL step of /fundpool — moving SOL from lender → lender's wSOL ATA so the pool deposit can use it. **Not a drain.**

**Fix:** suppress alarm when the outflow destination is the lender's own wSOL ATA or USDC ATA. Derived lazily on first webhook call, cached. Real drains to attacker wallets still fire (those aren't the lender's own ATAs). Suppression silently disables if derivation fails — fail-loud, not fail-quiet.

## Test plan

- [ ] CI leak-check passes
- [ ] After deploy, repeat /fundpool — no LENDER WALLET OUTFLOW alarm should fire
- [ ] Test the dashboard for wallet \`FxDAn6bT…\` — points should display 20
- [ ] Verify a synthetic outflow to a non-self wallet still triggers the alarm (the suppression is destination-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)