### PR TITLE
fix: lp_positions per-pool tracking + post-/fundpool sync

### DIFF
--- a/migrations/023_lp_positions_per_pool.sql
+++ b/migrations/023_lp_positions_per_pool.sql
@@ -1,0 +1,67 @@
+-- lp_positions: track per-pool LP shares instead of one row per wallet.
+--
+-- Why this exists: the original table was created before v2/v3 lending
+-- programs were live, so it implicitly assumed a single pool. The
+-- syncOnChainPositions service only iterates the v1 pool. Operator's
+-- post-/fundpool deposits into v2 were invisible, and even v1 syncs
+-- ran on a 6h cycle so the row was perpetually stale just after a
+-- deposit.
+--
+-- Schema:
+--   - Add `pool` (text) — the pool PDA the position is in.
+--   - Add `program_id` (text) — which lending program (v1, v2, v3).
+--   - Replace the wallet_address PRIMARY KEY with (wallet_address, pool).
+--   - Backfill: every existing row gets pool = the live v1 pool PDA
+--     and program_id = the v1 program id (the historical truth — every
+--     position predating this migration was a v1 deposit).
+--
+-- Compatibility:
+--   - Aggregate queries (SUM(shares) for TVL display) continue to work
+--     unchanged — they just sum more rows.
+--   - Per-wallet queries that previously got at most one row may now
+--     get multiple. Callers that intended "this wallet's v1 LP" need
+--     to filter by pool; callers that intended "this wallet's total
+--     LP across all pools" should SUM. Code updates accompany this
+--     migration.
+
+ALTER TABLE lp_positions
+  ADD COLUMN IF NOT EXISTS pool       TEXT,
+  ADD COLUMN IF NOT EXISTS program_id TEXT;
+
+-- Backfill existing rows with the live v1 pool PDA + program id.
+-- These are operator-known constants (also stored in Railway env vars),
+-- pinned here so the migration is idempotent and doesn't depend on
+-- runtime config at apply time.
+UPDATE lp_positions
+   SET pool       = COALESCE(pool,       'EynWtuRMUKU3zHzfLv7Y5Qu6MWpwqG17X91QAuHSww9u'),
+       program_id = COALESCE(program_id, '4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh')
+ WHERE pool IS NULL OR program_id IS NULL;
+
+ALTER TABLE lp_positions
+  ALTER COLUMN pool       SET NOT NULL,
+  ALTER COLUMN program_id SET NOT NULL;
+
+-- Drop the old PK on wallet_address (it had to be unique before) and
+-- replace with the composite (wallet_address, pool). Postgres won't
+-- let us redefine an existing PK in-place — we drop the constraint
+-- explicitly. The auto-generated PK name follows the
+-- `<table>_pkey` convention.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'lp_positions'::regclass AND contype = 'p'
+  ) THEN
+    EXECUTE 'ALTER TABLE lp_positions DROP CONSTRAINT ' || (
+      SELECT conname FROM pg_constraint
+       WHERE conrelid = 'lp_positions'::regclass AND contype = 'p'
+       LIMIT 1
+    );
+  END IF;
+END $$;
+
+ALTER TABLE lp_positions
+  ADD CONSTRAINT lp_positions_wallet_pool_pk PRIMARY KEY (wallet_address, pool);
+
+CREATE INDEX IF NOT EXISTS lp_positions_pool_shares_idx
+  ON lp_positions(pool, shares) WHERE shares > 0;

--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -824,15 +824,29 @@ export async function handleFundPool(ctx) {
     const p = await program.account.lendingPool.fetch(pool);
     const newTvl = Number(p.totalDeposits) / 1e9;
 
+    // Sync the lender's lp_positions row immediately. Without this,
+    // the row stays at its old shares value until the next 6h lp-loyalty
+    // tick, leaving every read of "operator's LP share" wrong post-/fundpool.
+    let syncedShares = null;
+    try {
+      const { syncPositionsForWallet } = await import("../services/lp-loyalty.js");
+      const updates = await syncPositionsForWallet(lender.publicKey);
+      const match = updates.find((u) => u.pool === pool.toBase58());
+      if (match) syncedShares = match.shares;
+    } catch (err) {
+      console.warn("[fundpool] post-deposit lp_positions sync failed:", err.message);
+    }
+
     await ctx.reply(
       [
         `✅ *${poolLabel} funded*`,
         "",
         `Deposited: \`${amountSol} SOL\``,
         `New pool TVL: \`${newTvl.toFixed(4)} SOL\``,
+        syncedShares ? `Your shares now: \`${syncedShares}\`` : null,
         "",
         `[View tx](https://solscan.io/tx/${sig})`,
-      ].join("\n"),
+      ].filter(Boolean).join("\n"),
       { parse_mode: "Markdown", disable_web_page_preview: true },
     );
   } catch (err) {

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -27,7 +27,7 @@ import fs from "node:fs";
 import path from "node:path";
 import "dotenv/config";
 import { connection } from "../solana/connection.js";
-import { getReadOnlyProgram } from "../solana/program.js";
+import { getReadOnlyProgram, PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3 } from "../solana/program.js";
 import { lendingPoolPda } from "../solana/pdas.js";
 import { query } from "../db/pool.js";
 
@@ -104,37 +104,29 @@ export async function getLpLoyaltyPoolState() {
 }
 
 /**
- * Sync on-chain depositor positions into the lp_positions DB table.
+ * Sync on-chain depositor positions into the lp_positions DB table
+ * for one specific pool / program. Internal helper — callers below
+ * use this to iterate across all live programs.
  *
  * For each on-chain DepositorPosition:
  *   - If new: insert with first_seen_at = NOW(), weighted_deposit_at = NOW()
  *   - If shares increased (new deposit): advance weighted_deposit_at
  *     proportionally toward NOW(). Formula:
- *
  *       new_weighted_time = (old_shares × old_time + added × NOW) / new_shares
- *
- *     This time-weights the deposit moment correctly. A user who added 50%
- *     more shares right before snapshot won't get full credit for the new
- *     half — their effective deposit time moves halfway toward now.
- *   - If shares decreased (withdrew): keep weighted_deposit_at as-is
- *     (they're reducing their position, not resetting their loyalty clock).
+ *   - If shares decreased (withdrew): keep weighted_deposit_at as-is.
  *   - If shares == 0: clear the row (fully exited).
- *
- * Called on every distribution tick (every 6h) so the DB stays in sync
- * without needing real-time event subscriptions.
  */
-export async function syncOnChainPositions() {
-  const program = getReadOnlyProgram();
-  const [poolPda] = lendingPoolPda(LENDER_PUBKEY);
+async function syncPositionsForPool(programId) {
+  const program = getReadOnlyProgram(programId);
+  const [poolPda] = lendingPoolPda(LENDER_PUBKEY, programId);
+  const poolStr = poolPda.toBase58();
+  const programStr = programId.toBase58();
 
-  // Enumerate all depositor positions for this pool.
+  // Enumerate all depositor positions for THIS pool.
   // Layout: [discriminator(8)] [owner pubkey(32)] [pool pubkey(32)] ...
-  // So `pool` lives at offset 40, not 8. The earlier offset=8 silently
-  // filtered out every position (matched on `owner` bytes against the
-  // pool pubkey, which obviously never matched), leaving the entire
-  // lp_positions table empty.
+  // `pool` lives at offset 40.
   const positions = await program.account.depositorPosition.all([
-    { memcmp: { offset: 40, bytes: poolPda.toBase58() } },
+    { memcmp: { offset: 40, bytes: poolStr } },
   ]);
 
   const onChainByOwner = new Map();
@@ -144,72 +136,181 @@ export async function syncOnChainPositions() {
     if (shares > 0n) onChainByOwner.set(owner, shares);
   }
 
-  // Pull current DB state
-  const { rows: dbRows } = await query(`SELECT * FROM lp_positions WHERE shares > 0`);
+  // Pull current DB state for THIS pool.
+  const { rows: dbRows } = await query(
+    `SELECT wallet_address, shares::text AS shares, weighted_deposit_at
+       FROM lp_positions WHERE pool = $1 AND shares > 0`,
+    [poolStr],
+  );
   const dbByOwner = new Map(
     dbRows.map((r) => [r.wallet_address, { shares: BigInt(r.shares), weightedAt: r.weighted_deposit_at }]),
   );
 
-  // Reconcile
   for (const [owner, onChainShares] of onChainByOwner) {
     const dbEntry = dbByOwner.get(owner);
     if (!dbEntry) {
-      // New position
       await query(
-        `INSERT INTO lp_positions (wallet_address, shares, weighted_deposit_at, first_seen_at, last_synced_at)
-         VALUES ($1, $2, NOW(), NOW(), NOW())
-         ON CONFLICT (wallet_address) DO UPDATE SET
+        `INSERT INTO lp_positions
+           (wallet_address, pool, program_id, shares, weighted_deposit_at, first_seen_at, last_synced_at)
+         VALUES ($1, $2, $3, $4, NOW(), NOW(), NOW())
+         ON CONFLICT (wallet_address, pool) DO UPDATE SET
            shares = EXCLUDED.shares,
            weighted_deposit_at = NOW(),
            first_seen_at = lp_positions.first_seen_at,
            last_synced_at = NOW()`,
-        [owner, onChainShares.toString()],
+        [owner, poolStr, programStr, onChainShares.toString()],
       );
     } else if (onChainShares > dbEntry.shares) {
-      // Net deposit — advance weighted_deposit_at proportionally
-      // new_time = (old_shares × old_time + added × NOW) / new_shares
       const added = onChainShares - dbEntry.shares;
       await query(
         `UPDATE lp_positions
-            SET shares = $2,
+            SET shares = $3,
                 weighted_deposit_at = TO_TIMESTAMP(
-                  ( $3::numeric * EXTRACT(EPOCH FROM weighted_deposit_at)
-                  + $4::numeric * EXTRACT(EPOCH FROM NOW()) )
-                  / $5::numeric
+                  ( $4::numeric * EXTRACT(EPOCH FROM weighted_deposit_at)
+                  + $5::numeric * EXTRACT(EPOCH FROM NOW()) )
+                  / $6::numeric
                 ),
                 last_synced_at = NOW()
-          WHERE wallet_address = $1`,
-        [owner, onChainShares.toString(), dbEntry.shares.toString(), added.toString(), onChainShares.toString()],
+          WHERE wallet_address = $1 AND pool = $2`,
+        [owner, poolStr, onChainShares.toString(), dbEntry.shares.toString(), added.toString(), onChainShares.toString()],
       );
     } else if (onChainShares < dbEntry.shares) {
-      // Net withdraw — keep weighted_deposit_at, just reduce shares
       await query(
         `UPDATE lp_positions
-            SET shares = $2,
-                last_synced_at = NOW()
-          WHERE wallet_address = $1`,
-        [owner, onChainShares.toString()],
+            SET shares = $3, last_synced_at = NOW()
+          WHERE wallet_address = $1 AND pool = $2`,
+        [owner, poolStr, onChainShares.toString()],
       );
     } else {
-      // No change — just touch last_synced_at
       await query(
-        `UPDATE lp_positions SET last_synced_at = NOW() WHERE wallet_address = $1`,
-        [owner],
+        `UPDATE lp_positions SET last_synced_at = NOW()
+          WHERE wallet_address = $1 AND pool = $2`,
+        [owner, poolStr],
       );
     }
   }
 
-  // Mark fully-exited positions (in DB but not on-chain)
+  // Mark fully-exited positions (in DB but not on-chain), pool-scoped.
   for (const owner of dbByOwner.keys()) {
     if (!onChainByOwner.has(owner)) {
       await query(
-        `UPDATE lp_positions SET shares = 0, last_synced_at = NOW() WHERE wallet_address = $1`,
-        [owner],
+        `UPDATE lp_positions SET shares = 0, last_synced_at = NOW()
+          WHERE wallet_address = $1 AND pool = $2`,
+        [owner, poolStr],
       );
     }
   }
 
-  return { tracked: onChainByOwner.size, db_rows_seen: dbByOwner.size };
+  return { pool: poolStr, tracked: onChainByOwner.size, db_rows_seen: dbByOwner.size };
+}
+
+/**
+ * Sync every live lending program's positions into lp_positions.
+ * Called on every distribution tick (every 6h) so the DB stays in sync
+ * across v1 / v2 / v3 without needing real-time event subscriptions.
+ *
+ * Programs that aren't configured (env unset locally) are silently
+ * skipped — production has all of them set on Railway.
+ */
+export async function syncOnChainPositions() {
+  const programs = [PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3].filter(Boolean);
+  const results = [];
+  for (const pid of programs) {
+    try {
+      results.push(await syncPositionsForPool(pid));
+    } catch (err) {
+      console.warn(`[lp-loyalty] sync failed for program ${pid.toBase58().slice(0, 8)}:`, err.message);
+    }
+  }
+  const total_tracked = results.reduce((s, r) => s + r.tracked, 0);
+  const total_db_rows = results.reduce((s, r) => s + r.db_rows_seen, 0);
+  return { tracked: total_tracked, db_rows_seen: total_db_rows, pools: results };
+}
+
+/**
+ * Fast single-wallet sync. Reads the wallet's Position PDA on each
+ * known program and updates the corresponding lp_positions row. Used
+ * by /fundpool right after a deposit lands so the DB reflects the new
+ * shares immediately instead of waiting for the next 6h tick.
+ */
+export async function syncPositionsForWallet(walletPubkey) {
+  const { PublicKey } = await import("@solana/web3.js");
+  const ownerPk = walletPubkey instanceof PublicKey ? walletPubkey : new PublicKey(walletPubkey);
+  const programs = [PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3].filter(Boolean);
+  const updates = [];
+  for (const pid of programs) {
+    try {
+      const program = getReadOnlyProgram(pid);
+      const [poolPda] = lendingPoolPda(LENDER_PUBKEY, pid);
+      const [posPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("position"), poolPda.toBuffer(), ownerPk.toBuffer()],
+        pid,
+      );
+      let shares = 0n;
+      try {
+        const posAcc = await program.account.depositorPosition.fetch(posPda);
+        shares = BigInt(posAcc.shares.toString());
+      } catch {
+        // Position doesn't exist on this program for this wallet — that's
+        // fine, this wallet just isn't an LP in this pool. shares stays 0.
+      }
+      const poolStr = poolPda.toBase58();
+      const programStr = pid.toBase58();
+      if (shares > 0n) {
+        // UPSERT with weighted-time correctness. We can't run the exact
+        // same time-weighting formula without knowing the previous DB
+        // shares; instead we fetch them and branch by direction.
+        const { rows: [existing] } = await query(
+          `SELECT shares::text AS shares
+             FROM lp_positions WHERE wallet_address = $1 AND pool = $2`,
+          [ownerPk.toBase58(), poolStr],
+        );
+        if (!existing) {
+          await query(
+            `INSERT INTO lp_positions
+               (wallet_address, pool, program_id, shares, weighted_deposit_at, first_seen_at, last_synced_at)
+             VALUES ($1, $2, $3, $4, NOW(), NOW(), NOW())`,
+            [ownerPk.toBase58(), poolStr, programStr, shares.toString()],
+          );
+        } else {
+          const oldShares = BigInt(existing.shares);
+          if (shares > oldShares) {
+            const added = shares - oldShares;
+            await query(
+              `UPDATE lp_positions
+                  SET shares = $3,
+                      weighted_deposit_at = TO_TIMESTAMP(
+                        ( $4::numeric * EXTRACT(EPOCH FROM weighted_deposit_at)
+                        + $5::numeric * EXTRACT(EPOCH FROM NOW()) )
+                        / $6::numeric
+                      ),
+                      last_synced_at = NOW()
+                WHERE wallet_address = $1 AND pool = $2`,
+              [ownerPk.toBase58(), poolStr, shares.toString(), oldShares.toString(), added.toString(), shares.toString()],
+            );
+          } else {
+            await query(
+              `UPDATE lp_positions
+                  SET shares = $3, last_synced_at = NOW()
+                WHERE wallet_address = $1 AND pool = $2`,
+              [ownerPk.toBase58(), poolStr, shares.toString()],
+            );
+          }
+        }
+        updates.push({ pool: poolStr, shares: shares.toString() });
+      } else {
+        // Zero or missing on-chain — mark any DB row to 0.
+        await query(
+          `UPDATE lp_positions SET shares = 0, last_synced_at = NOW()
+            WHERE wallet_address = $1 AND pool = $2`,
+          [ownerPk.toBase58(), poolStr],
+        );
+      }
+    } catch (err) {
+      console.warn(`[lp-loyalty] syncPositionsForWallet failed on ${pid.toBase58().slice(0, 8)}:`, err.message);
+    }
+  }
+  return updates;
 }
 
 /**


### PR DESCRIPTION
## Summary

Operator's 34 SOL /fundpool deposit landed on-chain (v1 pool went 85.33 → 119.73 SOL, position shares grew 48.9B → 85.245B) but the dashboard / pool-share reads from \`lp_positions\` still returned 48.9B for hours. Two stacked bugs:

1. **Schema** — \`lp_positions\` had \`PRIMARY KEY (wallet_address)\` with no \`pool\` column. Only one row per wallet ever, so v2 LP was invisible and the same row was returned regardless of which pool a caller asked about.
2. **Sync** — \`syncOnChainPositions\` only called \`getReadOnlyProgram()\` with no arg (defaults to v1). v2 positions were never enumerated. Also the sync only ran on the 6h lp-loyalty distribution tick, so even v1 was stale immediately post-/fundpool.

## Changes

### Migration 023
- Adds \`pool\` (text) + \`program_id\` (text) columns; backfills existing rows with the live v1 pool PDA + v1 program id.
- Replaces the (wallet_address) PK with composite \`(wallet_address, pool)\`.
- Adds \`(pool, shares)\` index for per-pool TVL queries.

### \`src/services/lp-loyalty.js\`
- Refactors \`syncOnChainPositions\` into a per-pool inner helper iterated across \`[PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3]\`. Programs not configured locally are silently skipped; production has all three set.
- Adds \`syncPositionsForWallet(walletPubkey)\` — fast single-account sync that reads each program's Position PDA directly. Used for hot paths where waiting 6h isn't acceptable.
- All DB writes are pool-scoped via \`(wallet_address, pool)\`.

### \`src/commands/admin.js\`
- \`/fundpool\` now calls \`syncPositionsForWallet(lender.publicKey)\` after the deposit confirms. Reply message shows the post-sync share count.

## Verified live

- Migration 023 applied; existing rows backfilled.
- Full sync now tracks **40 positions across 2 pools** (was 39 v1-only).
- Operator now has two rows in \`lp_positions\`:
  - v1 pool: **85,245,491,529 shares** (matches on-chain ✓)
  - v2 pool: **17,734,086,232 shares** (matches on-chain ✓ — currently 100% of v2)
- Operator's pool slice now reads consistently between DB and on-chain.

## Test plan

- [ ] CI leak-check passes
- [ ] After deploy + Railway restart, migration 023 auto-applies (verified locally)
- [ ] Run \`/fundpool 1\` — reply should include \`Your shares now: <new count>\`
- [ ] Aggregate queries (TVL display in /stats, governance snapshot lp_providers section) keep working

## Downstream callers

- Aggregate \`SUM(shares)\` queries (TVL display, governance snapshot) work unchanged — they just sum more rows.
- Per-user queries that previously got at most one row may now get multiple. Treat as "this wallet's LP across all pools" and SUM if the intent is total exposure.
- Per-pool queries should add a \`WHERE pool = $X\` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)