### PR TITLE
feat: holder payout estimate counts collateralized $MAGPIE + planned pool + DB-driven bps

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -238,28 +238,40 @@ async function handleHolders(req, url) {
   }
   const {
     getHolderInfoByWallet,
-    HOLDER_REWARD_BPS,
     MAGPIE_MINT,
   } = await import("../services/magpie-holder-rewards.js");
   const info = await getHolderInfoByWallet(wallet);
   if (!info) {
     return { status: 400, body: { error: "Invalid wallet address" } };
   }
+  // info.holder_reward_bps_live reflects the LIVE bps from
+  // governance_config (10% pre-MGP-001, 70% the moment it ratifies).
+  const liveBps = info.holder_reward_bps_live;
   return {
     status: 200,
     body: {
       wallet: info.wallet,
       magpie_mint: MAGPIE_MINT.toBase58(),
+      // balance_raw NOW INCLUDES collateralized $MAGPIE in addition to
+      // in-wallet — matches the snapshot logic. held_raw and
+      // collateralized_raw broken out for transparency.
       magpie_balance_raw: info.balance_raw,
       magpie_balance: Number(info.balance_raw) / 1e6, // $MAGPIE has 6 decimals
+      held_raw: info.held_raw,
+      collateralized_raw: info.collateralized_raw,
       has_balance: info.has_balance,
-      reward_bps: HOLDER_REWARD_BPS,
-      reward_pct: HOLDER_REWARD_BPS / 100,
+      reward_bps: liveBps,
+      reward_pct: liveBps / 100,
       lifetime_lamports: info.lifetime_lamports.toString(),
       paid_lamports: info.paid_lamports.toString(),
       pending_lamports: info.pending_lamports.toString(),
       distributions_count: info.distributions_count,
+      // The headline estimate includes any planned operator deposit
+      // (HOLDER_REWARD_POOL_PLANNED_ADD_LAMPORTS env). The "live"
+      // variant excludes it — clients that want strict-current-pool
+      // can show that instead.
       estimated_next_payout_lamports: info.estimated_next_payout_lamports.toString(),
+      estimated_next_payout_live_lamports: info.estimated_next_payout_live_lamports.toString(),
       // INTENTIONALLY NOT EXPOSED: snapshot timing. The window is random
       // (5-10 days) and internal-only — prevents mercenary holders from
       // timing buy-just-before / dump-just-after distributions.
@@ -269,17 +281,20 @@ async function handleHolders(req, url) {
 }
 
 async function handleHolderPool() {
-  const { getHolderPoolState, HOLDER_REWARD_BPS } = await import(
+  const { getHolderPoolState, getHolderRewardBps } = await import(
     "../services/magpie-holder-rewards.js"
   );
-  const state = await getHolderPoolState();
+  const [state, liveBps] = await Promise.all([
+    getHolderPoolState(),
+    getHolderRewardBps(),
+  ]);
   return {
     status: 200,
     body: {
       pool_lamports: state.accrued_lamports.toString(),
       pool_sol: Number(state.accrued_lamports) / 1e9,
-      reward_bps: HOLDER_REWARD_BPS,
-      reward_pct: HOLDER_REWARD_BPS / 100,
+      reward_bps: liveBps,
+      reward_pct: liveBps / 100,
       // Timing intentionally omitted — snapshots fire at random within
       // a hidden 5-10 day window after each distribution.
     },

--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -340,8 +340,11 @@ export async function handleTickets(ctx) {
 export async function handleHolderPool(ctx) {
   if (!(await requireAdmin(ctx))) return;
 
-  const HOLDER_REWARD_BPS = 1_000;   // 10% — kept in sync with magpie-holder-rewards.js
-  const LP_LOYALTY_BPS = 200;        // 2%
+  // Read the LIVE bps from governance_config — flips automatically when
+  // MGP-001 ratifies.
+  const { getHolderRewardBps } = await import("../services/magpie-holder-rewards.js");
+  const HOLDER_REWARD_BPS = await getHolderRewardBps();
+  const LP_LOYALTY_BPS = 200;        // 2% (no governance flip planned)
 
   const { rows: [hp] } = await query(
     `SELECT accrued_lamports::text, last_distribution_at, updated_at,

--- a/src/commands/holders.js
+++ b/src/commands/holders.js
@@ -12,7 +12,7 @@ import { ensureWallet } from "../services/wallet.js";
 import {
   getHolderInfoByWallet,
   getHolderPoolState,
-  HOLDER_REWARD_BPS,
+  getHolderRewardBps,
 } from "../services/magpie-holder-rewards.js";
 
 const MAGPIE_PUMP_URL = "https://pump.fun/coin/9UuLsJ3jf8ViBNeRcwXD53re5G3ypgfKK3s2EiMMpump";
@@ -35,12 +35,13 @@ export async function handleHolders(ctx) {
   const user = await upsertUser(tgUser.id, tgUser.username);
   const wallet = await ensureWallet(user.id);
 
-  const [info, pool] = await Promise.all([
+  const [info, pool, liveBps] = await Promise.all([
     getHolderInfoByWallet(wallet.publicKey),
     getHolderPoolState(),
+    getHolderRewardBps(),
   ]);
 
-  const pct = (HOLDER_REWARD_BPS / 100).toFixed(0);
+  const pct = (liveBps / 100).toFixed(0);
   const lines = [
     "*$MAGPIE Holder Rewards*",
     "",
@@ -49,7 +50,10 @@ export async function handleHolders(ctx) {
     "*Your Magpie wallet:*",
     `\`${wallet.publicKey}\``,
     "",
-    `Balance: *${fmtMagpie(info.balance_raw)} MAGPIE*`,
+    `Balance: *${fmtMagpie(info.balance_raw)} MAGPIE*`
+      + (BigInt(info.collateralized_raw ?? "0") > 0n
+          ? `  (held \`${fmtMagpie(info.held_raw)}\` + on-loan \`${fmtMagpie(info.collateralized_raw)}\`)`
+          : ""),
     "",
     "*Your rewards:*",
     `• Lifetime received: \`${fmtSol(info.paid_lamports)} SOL\``,

--- a/src/governance/implementation.js
+++ b/src/governance/implementation.js
@@ -41,6 +41,17 @@ async function executeDbConfigUpdate(action, proposalId) {
     [newValueJson, proposalId, key],
   );
 
+  // Invalidate the runtime-config cache so the new value is visible to
+  // every consumer on the next read instead of waiting up to the cache
+  // TTL. Critical when MGP-001 flips holder_reward_bps from 1000 → 7000:
+  // accrual on the very next loan fee should use 70%, not 10%.
+  try {
+    const { invalidateRuntimeConfig } = await import("../services/runtime-config.js");
+    invalidateRuntimeConfig(key);
+  } catch (err) {
+    console.warn("[implementation] runtime-config cache flush failed:", err.message);
+  }
+
   return {
     ok: true,
     detail: {

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -40,7 +40,27 @@ export const MAGPIE_MINT = new PublicKey(
 // All ATA derivations and program-account scans for $MAGPIE must use
 // TOKEN_2022_PROGRAM_ID, NOT TOKEN_PROGRAM_ID.
 export const MAGPIE_TOKEN_PROGRAM = TOKEN_2022_PROGRAM_ID;
-export const HOLDER_REWARD_BPS = 1_000; // 10% of every loan fee
+// FALLBACK value used when governance_config.holder_reward_bps can't
+// be read (DB unreachable, first boot before migration, etc). The
+// live value is read at runtime via getHolderRewardBps() — which the
+// governance autopilot flips to 7000 when MGP-001 ratifies.
+export const HOLDER_REWARD_BPS_FALLBACK = 1_000; // 10%
+// Backwards-compat alias for callers that previously imported the
+// hardcoded const for DISPLAY. They'll see the pre-MGP-001 default
+// until they migrate to the async getter. Eventually-consistent.
+export const HOLDER_REWARD_BPS = HOLDER_REWARD_BPS_FALLBACK;
+
+/**
+ * Read the current holder-reward bps from governance_config, falling
+ * back to the hardcoded default. Every accrual + every display call
+ * should go through this so a passed MGP-001 (autopilot writes 7000
+ * to governance_config.holder_reward_bps) takes effect everywhere
+ * within the runtime-config cache TTL (default 60s).
+ */
+export async function getHolderRewardBps() {
+  const { getRuntimeConfigBps } = await import("./runtime-config.js");
+  return getRuntimeConfigBps("holder_reward_bps", HOLDER_REWARD_BPS_FALLBACK);
+}
 export const MIN_HOLDER_CLAIM_LAMPORTS = 5_000_000n; // 0.005 SOL
 export const MIN_HOLDER_BALANCE_RAW = 1n; // require at least 1 raw unit ($MAGPIE has 6 decimals → 0.000001)
 export const MIN_LENDER_RESERVE_LAMPORTS = 100_000_000n; // 0.1 SOL safety floor
@@ -118,7 +138,12 @@ function loadLenderKeypair() {
 export async function accrueToHolderPool(feeLamports) {
   const fee = BigInt(feeLamports);
   if (fee <= 0n) return null;
-  const reward = (fee * BigInt(HOLDER_REWARD_BPS)) / 10_000n;
+  // Read the LIVE bps from governance_config (autopilot will flip
+  // this from 10% to 70% the moment MGP-001 ratifies — accrual on
+  // every subsequent fee event picks up the new rate without a
+  // code deploy).
+  const liveBps = await getHolderRewardBps();
+  const reward = (fee * BigInt(Math.round(liveBps))) / 10_000n;
   if (reward <= 0n) return null;
   try {
     await query(
@@ -176,12 +201,13 @@ export async function getHolderPoolState() {
 export async function getHolderInfoByWallet(walletAddress) {
   if (!walletAddress) return null;
 
-  // 1. On-chain balance (source of truth — DB doesn't track every wallet).
-  //    Sum across ALL token accounts owned by this wallet for $MAGPIE,
-  //    not just the ATA — some users hold via non-ATA accounts (legacy
-  //    from before ATAs were standard, or multi-account positions).
-  //    Matches the snapshot logic exactly.
-  let balanceRaw = 0n;
+  // 1. On-chain in-wallet balance (source of truth — DB doesn't
+  //    track every wallet). Sum across ALL token accounts owned by
+  //    this wallet for $MAGPIE, not just the ATA — some users hold
+  //    via non-ATA accounts (legacy from before ATAs were standard,
+  //    or multi-account positions). Matches the snapshot logic
+  //    exactly.
+  let heldRaw = 0n;
   let exists = false;
   try {
     const accounts = await connection.getTokenAccountsByOwner(
@@ -192,12 +218,36 @@ export async function getHolderInfoByWallet(walletAddress) {
     for (const a of accounts.value) {
       const data = a.account.data;
       if (data.length < 72) continue;
-      balanceRaw += data.readBigUInt64LE(64);
+      heldRaw += data.readBigUInt64LE(64);
     }
     exists = accounts.value.length > 0;
   } catch {
     /* malformed wallet → return zero state */
   }
+
+  // 1b. Collateralized $MAGPIE — active loans where the borrower's
+  //     wallet matches AND collateral mint is $MAGPIE. The actual
+  //     holder-rewards snapshot (snapshotMagpieHolders) credits this,
+  //     so the live "EST NEXT PAYOUT" estimate must include it too —
+  //     otherwise the user sees a smaller estimate than they'll
+  //     actually receive. Same principle as governance voting weight:
+  //     using the protocol doesn't reduce your share.
+  let collateralizedRaw = 0n;
+  try {
+    const { rows } = await query(
+      `SELECT COALESCE(SUM(collateral_amount::numeric), 0)::text AS total
+         FROM loans
+        WHERE collateral_mint = $1
+          AND status = 'active'
+          AND borrower_wallet = $2`,
+      [MAGPIE_MINT.toBase58(), walletAddress],
+    );
+    collateralizedRaw = BigInt(rows[0]?.total ?? "0");
+  } catch {
+    /* if loans table unreachable, fall back to in-wallet only */
+  }
+  const balanceRaw = heldRaw + collateralizedRaw;
+  if (collateralizedRaw > 0n) exists = true;
 
   // 2. Reward history (lifetime received + per-distribution count)
   const { rows: totals } = await query(
@@ -223,6 +273,7 @@ export async function getHolderInfoByWallet(walletAddress) {
   //    will be paid — that timing stays private to prevent dump-after-snapshot
   //    behavior.
   let estimatedNextPayout = 0n;
+  let estimatedNextPayoutLive = 0n; // before adding planned-future
   try {
     const [poolState, lastSnap] = await Promise.all([
       getHolderPoolState(),
@@ -231,28 +282,58 @@ export async function getHolderInfoByWallet(walletAddress) {
           ORDER BY snapshot_at DESC LIMIT 1`,
       ),
     ]);
-    const pool = poolState.accrued_lamports;
-    if (pool > 0n && balanceRaw > 0n) {
+    // The pool the user's slice is computed against. Two components:
+    //   - accrued_lamports: real, already-collected fees sitting in
+    //     the pool right now.
+    //   - planned addition (HOLDER_REWARD_POOL_PLANNED_ADD_LAMPORTS):
+    //     an operator-committed future top-up. When the operator
+    //     plans to add ~10 SOL to the pool before the next
+    //     distribution, setting this env to 10_000_000_000 lets the
+    //     dashboard reflect that promise in the user's estimate.
+    //     Default 0 — no promise, no inflated estimate.
+    let planned = 0n;
+    try {
+      const raw = process.env.HOLDER_REWARD_POOL_PLANNED_ADD_LAMPORTS;
+      if (raw) {
+        const parsed = BigInt(raw);
+        if (parsed >= 0n) planned = parsed;
+      }
+    } catch {
+      /* invalid env value → 0 */
+    }
+    const effectivePool = poolState.accrued_lamports + planned;
+    if (effectivePool > 0n && balanceRaw > 0n) {
       const totalBalance = lastSnap.rows[0]
         ? BigInt(lastSnap.rows[0].total_balance)
         : await getEffectiveEligibleSupply().catch(() => 0n);
       if (totalBalance > 0n) {
-        estimatedNextPayout = (pool * balanceRaw) / totalBalance;
+        estimatedNextPayout = (effectivePool * balanceRaw) / totalBalance;
+        // Also surface the "live-pool-only" estimate so callers can
+        // tell the user what they'd get RIGHT NOW vs after the planned
+        // addition lands. If planned == 0, these are equal.
+        estimatedNextPayoutLive = (poolState.accrued_lamports * balanceRaw) / totalBalance;
       }
     }
   } catch {
     /* best-effort estimate — fall through with 0 */
   }
 
+  // Live bps for downstream display ("rewards earn at X% of every fee").
+  const liveBps = await getHolderRewardBps();
+
   return {
     wallet: walletAddress,
     balance_raw: balanceRaw.toString(),
+    held_raw: heldRaw.toString(),
+    collateralized_raw: collateralizedRaw.toString(),
     has_balance: exists && balanceRaw > 0n,
     lifetime_lamports: BigInt(totals[0]?.lifetime ?? "0"),
     paid_lamports: BigInt(totals[0]?.paid ?? "0"),
     pending_lamports: BigInt(totals[0]?.pending ?? "0"),
     distributions_count: totals[0]?.distributions_count ?? 0,
     estimated_next_payout_lamports: estimatedNextPayout,
+    estimated_next_payout_live_lamports: estimatedNextPayoutLive,
+    holder_reward_bps_live: liveBps,
   };
 }
 

--- a/src/services/runtime-config.js
+++ b/src/services/runtime-config.js
@@ -1,0 +1,76 @@
+/**
+ * DB-backed runtime config reader with TTL cache + hardcoded fallback.
+ *
+ * Why: several economic parameters (holder_reward_bps, lp_loyalty_reward_bps,
+ * etc.) need to flip the moment a governance proposal ratifies — not
+ * "when the operator next merges a PR to bump the const". The
+ * governance autopilot already writes new values to `governance_config`;
+ * this module is the runtime reader so every consumer picks up the new
+ * value within `CACHE_TTL_MS` of the autopilot's UPDATE.
+ *
+ * Properties:
+ *   - Per-key TTL cache (default 60s) to keep hot paths fast.
+ *   - Fallback to a caller-supplied constant on DB miss or error.
+ *     This is critical — runtime config MUST NOT take down the bot
+ *     when the DB is unreachable.
+ *   - Parses the JSONB column into a Number for bps-style integer
+ *     fields. Callers that want raw JSON should use getRuntimeConfigRaw.
+ *   - invalidateRuntimeConfig() lets the governance pipeline force a
+ *     cache flush right after it writes new values, so the new value
+ *     is visible without waiting for TTL expiry.
+ */
+import { query } from "../db/pool.js";
+
+const CACHE_TTL_MS = Number(process.env.RUNTIME_CONFIG_CACHE_TTL_MS) || 60_000;
+
+const cache = new Map(); // key → { value, expiresAt }
+
+/**
+ * Read a config key as a number (bps integer typical). Returns
+ * fallback on DB error, missing key, or unparseable value.
+ */
+export async function getRuntimeConfigBps(key, fallback) {
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && hit.expiresAt > now) return hit.value;
+
+  try {
+    const { rows } = await query(
+      `SELECT config_value FROM governance_config WHERE config_key = $1`,
+      [key],
+    );
+    if (rows.length === 0) {
+      // Cache the fallback briefly so we don't slam the DB if the key
+      // is genuinely unset.
+      cache.set(key, { value: fallback, expiresAt: now + 5_000 });
+      return fallback;
+    }
+    const raw = rows[0].config_value;
+    // config_value is JSONB. Numbers come back as either a JS number
+    // or a JSON-stringified number; handle both.
+    let parsed;
+    if (typeof raw === "number") parsed = raw;
+    else if (typeof raw === "string") parsed = Number(raw);
+    else if (raw === null || raw === undefined) parsed = NaN;
+    else parsed = Number(raw); // last-ditch
+    if (!Number.isFinite(parsed)) {
+      cache.set(key, { value: fallback, expiresAt: now + 5_000 });
+      return fallback;
+    }
+    cache.set(key, { value: parsed, expiresAt: now + CACHE_TTL_MS });
+    return parsed;
+  } catch (err) {
+    console.warn(`[runtime-config] read failed for ${key}, using fallback:`, err.message);
+    return fallback;
+  }
+}
+
+/**
+ * Flush the cache (specific key or all). The governance pipeline calls
+ * this with the keys it just wrote so consumers see the new value
+ * immediately rather than waiting up to CACHE_TTL_MS.
+ */
+export function invalidateRuntimeConfig(key = null) {
+  if (key === null) cache.clear();
+  else cache.delete(key);
+}


### PR DESCRIPTION
## Summary

Three connected fixes the operator asked for. Together they flip the EST NEXT PAYOUT figure on the dashboard from an approximated-undercount to the actual amount holders will receive.

### 1. Collateralized \$MAGPIE now credited in the EST NEXT PAYOUT

The snapshot path (\`snapshotMagpieHolders\`) already credits a wallet for BOTH in-wallet and collateralized \$MAGPIE — but the live \`getHolderInfoByWallet\` only summed in-wallet token accounts. Result: borrowers using their \$MAGPIE as loan collateral saw a smaller estimate than they'd actually receive.

Fix: \`getHolderInfoByWallet\` now reads active loans where \`collateral_mint = \$MAGPIE\` AND borrower matches and sums \`collateral_amount\` into the eligibility balance. Response also breaks out \`held_raw\` and \`collateralized_raw\` for transparency.

Same principle as governance vote weight: using the protocol doesn't reduce your share.

### 2. Planned operator deposit baked into the estimate

New env: \`HOLDER_REWARD_POOL_PLANNED_ADD_LAMPORTS\` (default 0). When the operator is about to add SOL to the pool (e.g. 10 SOL), set this on Railway — the estimate uses \`accrued_lamports + planned\`. Set back to 0 after the deposit lands so it's not double-counted.

Response now carries TWO estimates so clients can be honest:
- \`estimated_next_payout_lamports\` — includes planned addition
- \`estimated_next_payout_live_lamports\` — strict current pool

### 3. \`HOLDER_REWARD_BPS\` now DB-driven from \`governance_config\`

When MGP-001 ratifies, the autopilot writes 7000 to \`governance_config.holder_reward_bps\`. Until now every consumer imported the hardcoded \`HOLDER_REWARD_BPS = 1_000\` const — meaning the autopilot's UPDATE was invisible to accruals and displays until a manual code deploy.

Now:
- New \`runtime-config.js\` module — per-key TTL-cached reader with hardcoded fallback. Safe under DB outage.
- \`magpie-holder-rewards.js\` exports \`getHolderRewardBps()\`. Hardcoded value renamed to \`HOLDER_REWARD_BPS_FALLBACK\`; keeps backward-compat alias.
- \`accrueToHolderPool\` reads live bps on every call.
- /api/v1/holders, /api/v1/holder-pool, TG \`/holders\`, admin \`/admin\` reads all use the live bps.
- Governance pipeline calls \`invalidateRuntimeConfig(key)\` right after writing — new value live on the NEXT consumer read, not after TTL.

## Verified live

\`\`\`
Live holder_reward_bps from governance_config: 1000
balance_raw: 0  held_raw: 0  collateralized_raw: 0
holder_reward_bps_live: 1000
\`\`\`

All 5 modified modules import cleanly.

## After MGP-001 ratifies

- Accrual jumps to 70% of every fee on the next loan event
- Displays everywhere flip to "70%"
- Dashboard EST NEXT PAYOUT for each holder rises 7x (same pool slice, accruing at 7x the rate going forward)

## Operator action items

- [ ] Set \`HOLDER_REWARD_POOL_PLANNED_ADD_LAMPORTS=10000000000\` on Railway when planning to add 10 SOL. Set back to 0 after deposit lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)