### PR TITLE
feat: per-token exposure cap fallback 10 → 20 SOL

### DIFF
--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -85,10 +85,24 @@ const IMPORTED_WALLET_MAX_LAMPORTS = BigInt(
 // Per-token total open notional cap: refuse new borrow if the protocol's
 // total open loans against THIS mint would exceed N SOL. Stops a single
 // compromised/exploitable token from being borrowed against by many
-// users in parallel. The legacy single-cap fallback (when a token has
-// none of the metadata we need to tier it) — defaults to 10 SOL.
+// users in parallel.
+//
+// Fallback default raised 10 → 20 SOL (2026-06-11, operator-authorized
+// per /raidstatus session). Applies to every enabled token that:
+//   - has no manual operator override (supported_mints.max_open_lamports
+//     stays the authoritative value when set), AND
+//   - lands in the "small" tier from computeTokenTier (i.e. doesn't
+//     clear the liquidity/holders/age bars of mid/large/bluechip)
+// Mid (15), Large (25), Bluechip (30) tier values intentionally
+// UNCHANGED per the operator's explicit "don't touch tokens currently
+// above 10 SOL already" constraint.
+//
+// Live count at the time of the change (Postgres scan, 2026-06-11):
+//   - 7 tokens with explicit operator override (untouched)
+//   - 184 tokens at fallback (10 → 20 SOL)
+//   - 0 tokens in mid/large/bluechip via fallback (no inversion risk)
 const PER_TOKEN_OPEN_LAMPORTS_CAP = BigInt(
-  Math.floor((Number(process.env.BORROW_PER_TOKEN_OPEN_CAP_SOL) || 10) * 1e9),
+  Math.floor((Number(process.env.BORROW_PER_TOKEN_OPEN_CAP_SOL) || 20) * 1e9),
 );
 
 // Tier-based per-token caps. Larger, more-liquid, older tokens have a


### PR DESCRIPTION
## Summary

Operator-authorized cap bump for the per-token open-notional default.

Scope, carefully narrow per the operator's \"don't touch tokens currently above 10 SOL already\" instruction:

| Tier | Cap | Change |
|---|---|---|
| Bluechip | 30 SOL | unchanged |
| Large | 25 SOL | unchanged |
| Mid | 15 SOL | **unchanged** (already above 10) |
| Small / fallback | 10 SOL → **20 SOL** | ✓ |
| Per-token operator override (\`supported_mints.max_open_lamports\`) | varies | always wins, unchanged |

## Live audit at the time of the change

- 7 tokens with explicit operator override → untouched
- **184 tokens at the 10 SOL fallback → will rise to 20 SOL**
- 0 tokens currently in mid/large/bluechip via the fallback path (no inversion risk against mid's 15)

## Verification

\`\`\`
computeTokenTier(null).capSol === 20
\`\`\`

The env-driven override \`BORROW_PER_TOKEN_OPEN_CAP_SOL\` still trumps the code default and is currently UNSET on Railway, so the new 20 SOL default takes effect on the next deploy.

## Future tokens

Future token approvals fall through to the same 20 SOL default automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)