### PR TITLE
rwa: pin AAPLx + add issuer deny-list (PreStocks defense)

### DIFF
--- a/migrations/024_pin_aaplx.sql
+++ b/migrations/024_pin_aaplx.sql
@@ -1,0 +1,28 @@
+-- Pin AAPLx in canonical_rwa_mints.
+--
+-- AAPLx (Apple — Backed xStock) is a tokenized US equity issued by Backed
+-- Finance, the same issuer behind every other xStock Magpie already pins
+-- (SPYx, TSLAx, NVDAx, etc.). It uses the identical authority set:
+--   mint authority      = 7pt9tkctJPK7PPNQJ77GKg8ZffSF6QxoMiCFYHxrtaCj
+--   freeze authority    = JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs
+--   permanent delegate  = 5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq
+-- All three match the existing RWA env vars on Railway, so no screener
+-- env changes are required.
+--
+-- The canonical pin protects against the symbol-spoofing attack from
+-- migration 020: an attacker inserting `supported_mints.symbol='AAPLx'`
+-- with a different mint would now fail the
+-- `trg_supported_mints_rwa_canonical` trigger.
+--
+-- Verified on-chain 2026-06-11:
+--   Token-2022 ✓
+--   supply 15,376,550,662,207 (15.38M units at 8 decimals)
+--   mint authority matches Backed ✓
+--   freeze authority matches Backed ✓
+--   permanent delegate matches Backed ✓
+--   8 extensions present (ScaledUiAmount, etc.)
+
+INSERT INTO canonical_rwa_mints (symbol, mint, issuer, notes) VALUES
+  ('AAPLx', 'XsbEhLAtcf6HdfpFZ5xEMdqW8nfAvcsP5bdudRLJzJp', 'backed_finance',
+   'Apple — Backed xStock. Pinned 2026-06-11 post-RWA-research. Same authority set as other Backed xStocks.')
+ON CONFLICT (symbol) DO NOTHING;

--- a/src/services/rwa-screener.js
+++ b/src/services/rwa-screener.js
@@ -132,6 +132,20 @@ async function verifyMintOnChain(mintStr) {
     }
     const m = await getMint(connection, mintPk, "confirmed", TOKEN_2022_PROGRAM_ID);
     const authStr = m.mintAuthority?.toBase58() ?? null;
+
+    // Hard reject if the mint authority is on the operator-curated
+    // deny-list. This catches RWA-shaped tokens we explicitly DO NOT
+    // want to onboard even if the rest of their shape passes —
+    // currently used to block PreStocks-class issuers whose underlying
+    // SPVs are repudiated by the underlying companies (see comment
+    // on RWA_DENIED_ISSUER_AUTHORITIES below for context).
+    if (authStr && RWA_DENIED_ISSUER_AUTHORITIES.has(authStr)) {
+      return {
+        ok: false,
+        error: `RWA_UNVERIFIED_SPV: issuer ${authStr.slice(0, 8)}… is on the operator deny-list (likely PreStocks-class unverified SPV)`,
+      };
+    }
+
     const issuer = authStr ? KNOWN_ISSUERS.get(authStr) ?? null : null;
 
     // Pausable: read pause state if extension present
@@ -206,6 +220,38 @@ const RWA_TRANSFER_HOOK_PROGRAMS = new Set([
 ]);
 const RWA_TRANSFER_HOOK_AUTHORITIES = _parseAllowlist("RWA_TRANSFER_HOOK_AUTHORITIES", process.env.RWA_TRANSFER_HOOK_AUTHORITIES);
 const RWA_TRANSFER_FEE_AUTHORITIES = _parseAllowlist("RWA_TRANSFER_FEE_AUTHORITIES", process.env.RWA_TRANSFER_FEE_AUTHORITIES);
+
+// Issuer deny-list. Mint authorities here are HARD-REJECTED by the RWA
+// audit regardless of whether the rest of the token shape passes.
+//
+// Use for issuers whose token economics are structurally broken even
+// when the on-chain shape looks correct. The current motivating case
+// (post 2026-06-11 RWA research):
+//
+//   PreStocks (https://prestocks.com) — issues pre-IPO equity tokens
+//   like ANTHRP, OPENAI, SPACEX, etc. May 13 2026: Anthropic AND
+//   OpenAI publicly stated unauthorized SPV transfers may be invalid
+//   and confer no shareholder rights. Tokens dropped 39%/34% in 7
+//   days. Pricing decoupled from underlying (ANTHRP traded at 2.5x
+//   the issuer-stated NAV). Operator's own legal text says tokens
+//   "confer no ownership, voting, dividend, information, or other
+//   legal rights." Closer to a memecoin than to a backed RWA.
+//
+// Env format: comma-separated base58 pubkeys (same as the allowlists).
+// PreStocks mint authority should be added here as it's discovered
+// on-chain — we don't pre-seed because the deny-list is operator-
+// curated and the on-chain authority isn't reliably documented.
+//
+// Even without specific entries, the screener's primary defense
+// already handles this case: a token whose mint authority is NOT in
+// KNOWN_ISSUERS gets rejected as "unknown issuer". This list is
+// defense-in-depth — an explicit deny gives a clean log signal and
+// catches cases where someone manually tries to enable a PreStocks
+// mint via /enablemint.
+const RWA_DENIED_ISSUER_AUTHORITIES = _parseAllowlist(
+  "RWA_DENIED_ISSUER_AUTHORITIES",
+  process.env.RWA_DENIED_ISSUER_AUTHORITIES,
+);
 
 // Transfer-fee cap with sanity ceiling. Backed Finance charges 0, so 0
 // is the strict-by-default value. Operator can raise it via env if a


### PR DESCRIPTION
## Summary

From the 2026-06-11 RWA platform research deep-dive. Two focused changes.

### 1. Migration 024 — pin AAPLx in canonical_rwa_mints

\`AAPLx\` is a Backed Finance xStock with identical authorities to every other xStock already pinned. **Verified on-chain just now:**

| Property | Value | Matches existing Backed |
|---|---|---|
| Owner program | Token-2022 | ✓ |
| Mint authority | \`7pt9tkctJPK7PPNQJ77GKg8ZffSF6QxoMiCFYHxrtaCj\` | ✓ |
| Freeze authority | \`JDq14BWvqCRFNu1krb12bcRpbGtJZ1FLEakMw6FdxJNs\` | ✓ |
| Permanent delegate | \`5aMNNLQJwAEeoemTEMkv5NVjqKwvvefRYCQ5Z67HFvEq\` | ✓ |
| Supply | 15,376,550,662,207 (15.38M units at 8 decimals) | — |
| Extensions | 8 present | — |

Same authorities as existing pinned xStocks ⇒ zero env changes on Railway. Once pinned, the \`trg_supported_mints_rwa_canonical\` trigger from migration 020 blocks any insert/update to \`supported_mints\` with \`symbol=AAPLx\` + a non-canonical mint. RWA screener will auto-approve on its next 4h DexScreener cycle.

### 2. \`RWA_DENIED_ISSUER_AUTHORITIES\` env-driven deny-list

Defense-in-depth against PreStocks-class issuers. The screener already rejects unknown issuers via the \`KNOWN_ISSUERS\` allowlist, but an explicit deny adds:
- Clean log signal when a denied issuer is encountered
- Protection if an operator accidentally tries to \`/enablemint\` a PreStocks token manually
- A list to grow as new bad-issuer authorities are discovered

**Why PreStocks specifically:** May 13 2026, Anthropic AND OpenAI publicly stated unauthorized SPV transfers may be invalid and confer no shareholder rights. ANTHRP / OPENAI tokens dropped 39% / 34% in 7 days. Pricing decoupled from underlying (ANTHRP traded at 2.5x the issuer-stated NAV). PreStocks' own legal disclaimer says tokens \"confer no ownership, voting, dividend, information, or other legal rights.\"

Env starts empty — operator populates with specific PreStocks mint authorities as they're identified on-chain.

## What's NOT in this PR (operator decisions deferred)

- **USDY (Ondo Treasury)**: classic SPL not Token-2022. Current screener rejects all classic-SPL RWAs. Needs a separate code path + LTV decision.
- **Ondo Global Markets (AAPLon, SPYon, etc.)**: requires (a) deriving Ondo's mint authority on-chain and adding to \`RWA_ISSUER_AUTHORITIES\`, AND (b) contacting Ondo to whitelist Magpie's vault PDA in their transfer hook allowlist (else liquidation withdrawals can fail).

## Test plan

- [ ] CI leak-check passes
- [ ] After deploy, migration 024 auto-applies (verified locally already)
- [ ] On the next /tokens admin probe, AAPLx is recognized as a canonical pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)