### PR TITLE
feat: agent_delegations table + TG commands for x402 limit-close authorization

### DIFF
--- a/migrations/026_agent_delegations.sql
+++ b/migrations/026_agent_delegations.sql
@@ -1,0 +1,75 @@
+-- agent_delegations — per-(user, agent) grants for x402-mediated actions.
+--
+-- A TG user runs /agent-authorize once to grant a specific agent pubkey
+-- a bounded right to perform an action (initially: arm limit-close
+-- orders) on the user's behalf. The x402 endpoint validates incoming
+-- agent requests against this table BEFORE writing any state.
+--
+-- Bounds, not blanket trust. Every delegation row carries explicit
+-- caps the agent cannot exceed:
+--   max_per_order_lamports — single-order notional ceiling
+--   max_active_orders     — how many orders the agent can have armed
+--                           concurrently for this user
+--   max_slippage_bps      — slippage cap for any order the agent arms
+--   expires_at            — auto-revoke after this time
+--
+-- The user can revoke at any time via /agent-revoke. Revocation is
+-- soft (status='revoked') so we keep an audit trail. The engine and
+-- the x402 endpoint MUST treat any status != 'active' as "no grant".
+
+CREATE TABLE IF NOT EXISTS agent_delegations (
+  id                       SERIAL PRIMARY KEY,
+  user_id                  INTEGER NOT NULL REFERENCES users(id),
+  user_wallet              TEXT NOT NULL,           -- borrower wallet the grant applies to
+  agent_pubkey             TEXT NOT NULL,           -- the agent's Solana pubkey (proven via x402 payment)
+  action                   TEXT NOT NULL
+                           CHECK (action IN ('limit_close')),
+
+  -- Constraints the agent cannot exceed
+  max_per_order_lamports   NUMERIC(20,0) NOT NULL DEFAULT 10000000000,  -- 10 SOL
+  max_active_orders        INTEGER NOT NULL DEFAULT 5,
+  max_slippage_bps         INTEGER NOT NULL DEFAULT 500
+                           CHECK (max_slippage_bps >= 10 AND max_slippage_bps <= 1000),
+
+  -- Lifecycle
+  status                   TEXT NOT NULL DEFAULT 'active'
+                           CHECK (status IN ('active','revoked','expired')),
+  granted_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at               TIMESTAMPTZ,  -- nullable = no expiration
+  revoked_at               TIMESTAMPTZ,
+  revoked_by               TEXT,         -- 'user' | 'operator' | 'system'
+
+  -- Audit
+  notes                    TEXT,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One active delegation per (user_wallet, agent, action) tuple. A
+-- second /agent-authorize with the same tuple updates the existing
+-- row instead of stacking. UNIQUE partial index enforces this at
+-- the storage layer.
+CREATE UNIQUE INDEX IF NOT EXISTS agent_delegations_one_active_idx
+  ON agent_delegations(user_wallet, agent_pubkey, action) WHERE status = 'active';
+
+-- Hot-path lookup for the x402 endpoint: given (user_wallet, agent,
+-- action), is there an active grant?
+CREATE INDEX IF NOT EXISTS agent_delegations_lookup_idx
+  ON agent_delegations(user_wallet, agent_pubkey, action, status);
+
+CREATE INDEX IF NOT EXISTS agent_delegations_user_idx
+  ON agent_delegations(user_id, status);
+
+-- updated_at touch trigger
+CREATE OR REPLACE FUNCTION agent_delegations_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_agent_delegations_updated_at ON agent_delegations;
+CREATE TRIGGER trg_agent_delegations_updated_at
+  BEFORE UPDATE ON agent_delegations
+  FOR EACH ROW EXECUTE FUNCTION agent_delegations_touch_updated_at();

--- a/src/commands/agent-delegations.js
+++ b/src/commands/agent-delegations.js
@@ -1,0 +1,230 @@
+/**
+ * Agent delegations — TG commands.
+ *
+ *   /agent-authorize <agent_pubkey> limit_close [max_per_order_sol=10]
+ *                                                [max_active=5]
+ *                                                [max_slippage_bps=500]
+ *                                                [expires=30d]
+ *   /agent-revoke <agent_pubkey> [action]
+ *   /agent-list
+ *
+ * The user is the SOURCE OF TRUTH for what an agent can do on their
+ * behalf. Every constraint here flows into agent_delegations and is
+ * re-checked at every agent action — the x402 endpoint cannot exceed
+ * these bounds, the engine cannot exceed these bounds.
+ *
+ * Security:
+ *   - Ownership enforced on every read AND write (WHERE user_id = ctx.from.id)
+ *   - Pubkey validated as base58 + correct length before any write
+ *   - Schema CHECK constraints catch anything the parser missed
+ *   - Revocation is one-way (status='revoked' is terminal) so audit
+ *     trail is preserved
+ */
+import { PublicKey } from "@solana/web3.js";
+import { query } from "../db/pool.js";
+import { upsertUser } from "../services/users.js";
+import { ensureWallet } from "../services/wallet.js";
+
+const VALID_ACTIONS = new Set(["limit_close"]);
+const MIN_ORDER_LAMPORTS = BigInt(100_000_000n);          // 0.1 SOL floor
+const MAX_ORDER_LAMPORTS_HARD_CAP = BigInt(100_000_000_000n); // 100 SOL hard ceiling
+
+function isValidPubkey(s) {
+  if (typeof s !== "string") return false;
+  if (s.length < 32 || s.length > 44) return false;
+  try { new PublicKey(s); return true; } catch { return false; }
+}
+
+function parseDuration(s) {
+  // "30d" / "12h" / "7d"
+  const m = String(s).match(/^(\d+)([dh])$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  const ms = m[2] === "d" ? n * 86_400_000 : n * 3_600_000;
+  if (ms > 365 * 86_400_000) return null;
+  return new Date(Date.now() + ms).toISOString();
+}
+
+function parseSolToLamports(s) {
+  const n = Number(s);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return BigInt(Math.round(n * 1e9));
+}
+
+/* ─── /agent-authorize ─────────────────────────────────────────── */
+
+export async function handleAgentAuthorize(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const text = ctx.message?.text || "";
+  const tokens = text.trim().split(/\s+/).slice(1); // strip /agent-authorize
+  if (tokens.length < 2) {
+    return ctx.reply(
+      "Usage: `/agent-authorize <agent_pubkey> limit_close [max_per_order_sol=10] [max_active=5] [max_slippage_bps=500] [expires=30d]`",
+      { parse_mode: "Markdown" },
+    );
+  }
+  const agentPubkeyRaw = tokens[0];
+  const action = tokens[1];
+
+  if (!isValidPubkey(agentPubkeyRaw)) {
+    return ctx.reply("Invalid agent pubkey. Must be a valid Solana base58 pubkey.");
+  }
+  if (!VALID_ACTIONS.has(action)) {
+    return ctx.reply(`Unknown action \`${action}\`. Allowed: ${[...VALID_ACTIONS].join(", ")}`, { parse_mode: "Markdown" });
+  }
+
+  // Parse optional key=value bounds
+  let maxPerOrderLamports = BigInt(10_000_000_000n); // 10 SOL default
+  let maxActiveOrders = 5;
+  let maxSlippageBps = 500;
+  let expiresAt = null;
+  for (const t of tokens.slice(2)) {
+    const m = t.match(/^([a-z_]+)=(.+)$/i);
+    if (!m) return ctx.reply(`Unrecognized argument: \`${t}\``, { parse_mode: "Markdown" });
+    const k = m[1].toLowerCase();
+    const v = m[2];
+    if (k === "max_per_order_sol") {
+      const lamports = parseSolToLamports(v);
+      if (!lamports) return ctx.reply(`Invalid max_per_order_sol: \`${v}\``, { parse_mode: "Markdown" });
+      if (lamports < MIN_ORDER_LAMPORTS) {
+        return ctx.reply(`max_per_order_sol must be at least ${Number(MIN_ORDER_LAMPORTS) / 1e9} SOL.`);
+      }
+      if (lamports > MAX_ORDER_LAMPORTS_HARD_CAP) {
+        return ctx.reply(`max_per_order_sol cannot exceed ${Number(MAX_ORDER_LAMPORTS_HARD_CAP) / 1e9} SOL.`);
+      }
+      maxPerOrderLamports = lamports;
+    } else if (k === "max_active") {
+      const n = Number(v);
+      if (!Number.isInteger(n) || n < 1 || n > 50) {
+        return ctx.reply("max_active must be an integer between 1 and 50.");
+      }
+      maxActiveOrders = n;
+    } else if (k === "max_slippage_bps") {
+      const n = Number(v);
+      if (!Number.isInteger(n) || n < 10 || n > 1000) {
+        return ctx.reply("max_slippage_bps must be between 10 and 1000 (0.1% to 10%).");
+      }
+      maxSlippageBps = n;
+    } else if (k === "expires") {
+      const iso = parseDuration(v);
+      if (!iso) return ctx.reply("expires must be like `30d` or `12h` (max 365d).");
+      expiresAt = iso;
+    } else {
+      return ctx.reply(`Unknown option \`${k}=\`. Allowed: max_per_order_sol, max_active, max_slippage_bps, expires.`, { parse_mode: "Markdown" });
+    }
+  }
+
+  const user = await upsertUser(tgUser.id, tgUser.username);
+  const userWallet = await ensureWallet(user.id);
+
+  // UPSERT — overwriting existing active grant for same (wallet, agent, action).
+  // The UNIQUE partial index makes "two active grants for the same tuple"
+  // physically impossible. ON CONFLICT updates the bounds + extends expiry.
+  try {
+    await query(
+      `INSERT INTO agent_delegations
+         (user_id, user_wallet, agent_pubkey, action,
+          max_per_order_lamports, max_active_orders, max_slippage_bps,
+          status, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 'active', $8)
+       ON CONFLICT (user_wallet, agent_pubkey, action) WHERE status = 'active'
+       DO UPDATE SET
+         max_per_order_lamports = EXCLUDED.max_per_order_lamports,
+         max_active_orders      = EXCLUDED.max_active_orders,
+         max_slippage_bps       = EXCLUDED.max_slippage_bps,
+         expires_at             = EXCLUDED.expires_at,
+         notes                  = COALESCE(agent_delegations.notes, '') || '\nupdated via /agent-authorize ' || NOW()::text`,
+      [user.id, userWallet.publicKey, agentPubkeyRaw, action,
+       maxPerOrderLamports.toString(), maxActiveOrders, maxSlippageBps,
+       expiresAt],
+    );
+  } catch (err) {
+    console.error("[agent-authorize] insert failed:", err.message);
+    return ctx.reply(`Couldn't grant: ${err.message?.slice(0, 100)}`);
+  }
+
+  const expiryLabel = expiresAt ? `\nExpires: \`${expiresAt.slice(0, 10)}\`` : "";
+  await ctx.reply(
+    [
+      `*Agent authorized*`,
+      ``,
+      `Agent: \`${agentPubkeyRaw.slice(0, 8)}…\``,
+      `Action: \`${action}\``,
+      `Max per order: \`${(Number(maxPerOrderLamports) / 1e9).toFixed(2)} SOL\``,
+      `Max active orders: \`${maxActiveOrders}\``,
+      `Max slippage: \`${(maxSlippageBps / 100).toFixed(2)}%\``,
+      expiryLabel,
+      ``,
+      `The agent can now arm \`${action}\` orders on your custodial wallet within these bounds.`,
+      `Revoke any time: \`/agent-revoke ${agentPubkeyRaw.slice(0, 8)}…\``,
+    ].join("\n"),
+    { parse_mode: "Markdown" },
+  );
+}
+
+/* ─── /agent-revoke ───────────────────────────────────────────── */
+
+export async function handleAgentRevoke(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const text = ctx.message?.text || "";
+  const tokens = text.trim().split(/\s+/).slice(1);
+  if (tokens.length < 1) {
+    return ctx.reply("Usage: `/agent-revoke <agent_pubkey> [action]`", { parse_mode: "Markdown" });
+  }
+  const agentPubkey = tokens[0];
+  const action = tokens[1] || null;
+  if (!isValidPubkey(agentPubkey)) {
+    return ctx.reply("Invalid agent pubkey.");
+  }
+  if (action && !VALID_ACTIONS.has(action)) {
+    return ctx.reply(`Unknown action \`${action}\`.`, { parse_mode: "Markdown" });
+  }
+  const user = await upsertUser(tgUser.id, tgUser.username);
+
+  const result = await query(
+    `UPDATE agent_delegations
+        SET status = 'revoked',
+            revoked_at = NOW(),
+            revoked_by = 'user'
+      WHERE user_id = $1
+        AND agent_pubkey = $2
+        AND status = 'active'
+        AND ($3::text IS NULL OR action = $3)
+      RETURNING id, action`,
+    [user.id, agentPubkey, action],
+  );
+  if (result.rows.length === 0) {
+    return ctx.reply(`No active grant found for that agent.`);
+  }
+  const list = result.rows.map((r) => `\`${r.action}\``).join(", ");
+  await ctx.reply(`Revoked ${result.rows.length} grant(s) for agent \`${agentPubkey.slice(0, 8)}…\`: ${list}`, { parse_mode: "Markdown" });
+}
+
+/* ─── /agent-list ─────────────────────────────────────────────── */
+
+export async function handleAgentList(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const user = await upsertUser(tgUser.id, tgUser.username);
+  const { rows } = await query(
+    `SELECT agent_pubkey, action, max_per_order_lamports::text AS cap,
+            max_active_orders, max_slippage_bps, expires_at, granted_at
+       FROM agent_delegations
+      WHERE user_id = $1 AND status = 'active'
+      ORDER BY granted_at DESC`,
+    [user.id],
+  );
+  if (rows.length === 0) {
+    return ctx.reply("No active agent delegations. Grant one with `/agent-authorize`.", { parse_mode: "Markdown" });
+  }
+  const lines = [`*Active agent delegations* (${rows.length})`, ``];
+  for (const r of rows) {
+    const expiry = r.expires_at ? ` · expires ${new Date(r.expires_at).toISOString().slice(0, 10)}` : "";
+    const capSol = (Number(r.cap) / 1e9).toFixed(2);
+    lines.push(`\`${r.agent_pubkey.slice(0, 8)}…\`  ${r.action}  cap=${capSol} SOL  max_active=${r.max_active_orders}  slip≤${(r.max_slippage_bps / 100).toFixed(1)}%${expiry}`);
+  }
+  lines.push(``, `Revoke: \`/agent-revoke <agent_pubkey>\``);
+  await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -330,6 +330,17 @@ bot.command("crosspost", handleCommunityCrosspost);
   bot.command("limitorders", lc.handleLimitOrders);
   bot.command("cancellimitorder", lc.handleCancelLimitOrder);
 }
+// Agent delegations — Tier 2 (x402 agentic wrapper). Users authorize
+// agents to arm limit-close orders on their behalf within explicit
+// bounds (max per order, max active, max slippage, expiry). The
+// magpie-x402 endpoint validates every agent request against these
+// rows BEFORE writing to limit_close_orders.
+{
+  const ad = await import("./commands/agent-delegations.js");
+  bot.command("agent_authorize", ad.handleAgentAuthorize);
+  bot.command("agent_revoke", ad.handleAgentRevoke);
+  bot.command("agent_list", ad.handleAgentList);
+}
 
 // Governance autopilot admin — operator-only commands gated inside each handler
 // via OPERATOR_TG_IDS env var. /gov-pause is the master kill switch.


### PR DESCRIPTION
Tier 2 (agentic via x402) of the limit-close-and-sell architecture. The x402 endpoint itself lives in `magpiecapital/magpie-x402` (separate PR coming next). This PR is the public-bot side — the delegation table users populate via TG commands.

## How it composes with Tier 1

1. User: `/agent_authorize <agent_pubkey> limit_close [max_per_order_sol=10] [max_active=5] [max_slippage_bps=500] [expires=30d]`
2. Server upserts an active row in `agent_delegations`
3. When the agent calls `POST /api/v1/agent/limit-close` on magpie-x402, that endpoint joins on this table to verify the grant + check that the requested order fits within every bound BEFORE inserting into `limit_close_orders` with `source='agent_x402'`
4. The private engine processes the row identically to a TG-armed order — same atomic claim, same pre-flight gates, same safety floor

## Migration 026

- `agent_delegations` — `(user_id, user_wallet, agent_pubkey, action, bounds…, status, expiry, audit)`
- **UNIQUE partial index** on `(wallet, agent, action) WHERE status='active'` — physically prevents two active grants per tuple, race-safe at the storage layer
- Composite index for the x402 hot-path lookup
- Touch-updated_at trigger

## Commands (`src/commands/agent-delegations.js`)

| Command | Purpose |
|---|---|
| `/agent_authorize` | Grant or update bounds for a (wallet, agent, action) tuple |
| `/agent_revoke` | Revoke one or all actions for an agent. One-way (`status='revoked'`) — audit trail preserved |
| `/agent_list` | Show all active grants for the calling user |

**Defense:**
- Pubkey validated as base58 + `PublicKey` constructor before any write
- Per-order ceiling capped at 100 SOL absolute regardless of input
- Slippage floor 0.1%, ceiling 10% (matches `limit_close_orders` constraint)
- Ownership enforced on every read AND write (`WHERE user_id = …`)
- Revocation is terminal — no in-place delete

## Verified

- Migration 026 applies cleanly (table + 3 indexes + 1 trigger)
- All exports load
- `node --check` passes on `index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)