### PR TITLE
feat: internal endpoint for x402-mediated agent limit-close

### DIFF
--- a/migrations/026_agent_delegations.sql
+++ b/migrations/026_agent_delegations.sql
@@ -1,0 +1,75 @@
+-- agent_delegations — per-(user, agent) grants for x402-mediated actions.
+--
+-- A TG user runs /agent-authorize once to grant a specific agent pubkey
+-- a bounded right to perform an action (initially: arm limit-close
+-- orders) on the user's behalf. The x402 endpoint validates incoming
+-- agent requests against this table BEFORE writing any state.
+--
+-- Bounds, not blanket trust. Every delegation row carries explicit
+-- caps the agent cannot exceed:
+--   max_per_order_lamports — single-order notional ceiling
+--   max_active_orders     — how many orders the agent can have armed
+--                           concurrently for this user
+--   max_slippage_bps      — slippage cap for any order the agent arms
+--   expires_at            — auto-revoke after this time
+--
+-- The user can revoke at any time via /agent-revoke. Revocation is
+-- soft (status='revoked') so we keep an audit trail. The engine and
+-- the x402 endpoint MUST treat any status != 'active' as "no grant".
+
+CREATE TABLE IF NOT EXISTS agent_delegations (
+  id                       SERIAL PRIMARY KEY,
+  user_id                  INTEGER NOT NULL REFERENCES users(id),
+  user_wallet              TEXT NOT NULL,           -- borrower wallet the grant applies to
+  agent_pubkey             TEXT NOT NULL,           -- the agent's Solana pubkey (proven via x402 payment)
+  action                   TEXT NOT NULL
+                           CHECK (action IN ('limit_close')),
+
+  -- Constraints the agent cannot exceed
+  max_per_order_lamports   NUMERIC(20,0) NOT NULL DEFAULT 10000000000,  -- 10 SOL
+  max_active_orders        INTEGER NOT NULL DEFAULT 5,
+  max_slippage_bps         INTEGER NOT NULL DEFAULT 500
+                           CHECK (max_slippage_bps >= 10 AND max_slippage_bps <= 1000),
+
+  -- Lifecycle
+  status                   TEXT NOT NULL DEFAULT 'active'
+                           CHECK (status IN ('active','revoked','expired')),
+  granted_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at               TIMESTAMPTZ,  -- nullable = no expiration
+  revoked_at               TIMESTAMPTZ,
+  revoked_by               TEXT,         -- 'user' | 'operator' | 'system'
+
+  -- Audit
+  notes                    TEXT,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One active delegation per (user_wallet, agent, action) tuple. A
+-- second /agent-authorize with the same tuple updates the existing
+-- row instead of stacking. UNIQUE partial index enforces this at
+-- the storage layer.
+CREATE UNIQUE INDEX IF NOT EXISTS agent_delegations_one_active_idx
+  ON agent_delegations(user_wallet, agent_pubkey, action) WHERE status = 'active';
+
+-- Hot-path lookup for the x402 endpoint: given (user_wallet, agent,
+-- action), is there an active grant?
+CREATE INDEX IF NOT EXISTS agent_delegations_lookup_idx
+  ON agent_delegations(user_wallet, agent_pubkey, action, status);
+
+CREATE INDEX IF NOT EXISTS agent_delegations_user_idx
+  ON agent_delegations(user_id, status);
+
+-- updated_at touch trigger
+CREATE OR REPLACE FUNCTION agent_delegations_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_agent_delegations_updated_at ON agent_delegations;
+CREATE TRIGGER trg_agent_delegations_updated_at
+  BEFORE UPDATE ON agent_delegations
+  FOR EACH ROW EXECUTE FUNCTION agent_delegations_touch_updated_at();

--- a/migrations/027_limit_close_auto_escalate.sql
+++ b/migrations/027_limit_close_auto_escalate.sql
@@ -1,0 +1,62 @@
+-- limit_close_orders — auto-escalate slippage support.
+--
+-- Adds optional auto-escalation: when an agent (or, later, a TG user)
+-- opts in, the engine bumps slippage_bps up a 1.5x curve on each
+-- proceeds-insufficient revert, never exceeding max_slippage_bps_cap.
+-- This is what handles the case "trigger hit but the slippage we
+-- armed with isn't enough to execute" without ever exceeding the
+-- borrower's explicit ceiling.
+--
+-- New columns:
+--   auto_escalate_slippage  — opt-in flag. Default FALSE so existing
+--                             TG-armed orders keep exact-slippage behavior.
+--   max_slippage_bps_cap    — the hard ceiling the engine MUST NOT
+--                             cross. For agent orders this is captured
+--                             from agent_delegations.max_slippage_bps
+--                             at arm time. For TG orders we can later
+--                             let the user pass slip_cap= as a separate
+--                             knob. Nullable means "no escalation
+--                             allowed" — the engine treats null as
+--                             "use slippage_bps exactly, don't move it".
+--   initial_slippage_bps    — what the order was armed with. Frozen
+--                             at arm time so audit / debugging shows
+--                             the original intent regardless of how
+--                             many escalations happened.
+--   slippage_escalations    — counter for how many times the engine
+--                             bumped slippage. Caps out at log_1.5(cap/initial)
+--                             but no hard upper bound; failure_count
+--                             still terminates the order at
+--                             MAX_FAILURE_COUNT.
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS auto_escalate_slippage BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS max_slippage_bps_cap   INTEGER,
+  ADD COLUMN IF NOT EXISTS initial_slippage_bps   INTEGER,
+  ADD COLUMN IF NOT EXISTS slippage_escalations   INTEGER NOT NULL DEFAULT 0;
+
+-- Cap must be within the global allowable range AND must be ≥ the
+-- order's current slippage. Engine never reads max_slippage_bps_cap
+-- without checking it's > current slippage_bps, but we belt-and-suspenders
+-- this at the schema layer.
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_cap_in_range
+  CHECK (
+    max_slippage_bps_cap IS NULL OR
+    (max_slippage_bps_cap >= 10 AND max_slippage_bps_cap <= 1000)
+  );
+
+-- Initial slippage, if recorded, must match schema bounds too.
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_initial_slippage_in_range
+  CHECK (
+    initial_slippage_bps IS NULL OR
+    (initial_slippage_bps >= 10 AND initial_slippage_bps <= 1000)
+  );
+
+-- Backfill — for any existing armed orders we set initial_slippage_bps
+-- = slippage_bps so audit trails make sense. We leave auto_escalate_slippage
+-- FALSE and max_slippage_bps_cap NULL on these so the engine's behavior
+-- on them is exactly what it is today (no escalation).
+UPDATE limit_close_orders
+   SET initial_slippage_bps = slippage_bps
+ WHERE initial_slippage_bps IS NULL;

--- a/migrations/028_limit_close_fill_guarantee.sql
+++ b/migrations/028_limit_close_fill_guarantee.sql
@@ -1,0 +1,130 @@
+-- limit_close_orders — fill-guarantee layers (preflight + TWAP + intervention).
+--
+-- This migration adds the columns + state-machine extensions for three
+-- "ensure it fills" mechanisms layered on top of the existing
+-- auto-escalate behavior:
+--
+--   Layer 1 (pre-flight): the bot's internal arm endpoint runs a
+--     Jupiter quote at current liquidity BEFORE accepting an order.
+--     If the quote can't clear at the user's slippage, we reject with
+--     a suggested slippage. preflight_* columns store what we saw at
+--     arm time for audit + later comparison ("liquidity got worse").
+--
+--   Layer 2 (TWAP): when the engine's single-block sell can't clear
+--     even at the cap, it falls back to slicing the position across
+--     N chunks. Each chunk has less price impact, raising the chance
+--     that ALL chunks fit within the slippage cap.
+--
+--     New status 'twap_in_progress' sits between 'firing' and 'fired'.
+--     The watcher resumes TWAP across restarts by reading
+--     twap_chunks_completed + the user's ATA balance.
+--
+--   Layer 3 (intervention): if both single-block and TWAP fail at the
+--     cap, the engine flips the order to 'awaiting_user' (terminal
+--     from the engine's perspective until the user responds). The
+--     bot DMs the borrower with an inline keyboard offering YES
+--     (allow new higher cap), NO (keep trying at current cap), or
+--     CANCEL. A timeout cron flips stale interventions to 'failed'.
+--
+-- All transitions are guarded by status enum CHECK + by SQL UPDATE
+-- conditions in the engine that ensure we only ever move from one
+-- specific state to the next. The state machine is auditable from
+-- the row alone.
+
+ALTER TABLE limit_close_orders
+  -- ── Layer 1: pre-flight ─────────────────────────────────────────
+  -- The Jupiter-quoted slippage that would have actually cleared at
+  -- arm time. If the user's slippage_bps was insufficient, the arm
+  -- endpoint returns this as the suggested floor and refuses to insert
+  -- — so the row never reaches the DB in that case. We do store it
+  -- for orders that pass arm so we can later detect "liquidity has
+  -- gotten WORSE since you armed."
+  ADD COLUMN IF NOT EXISTS preflight_slippage_quoted_bps INT,
+  ADD COLUMN IF NOT EXISTS preflight_quoted_at           TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS preflight_proceeds_lamports   NUMERIC(20,0),
+
+  -- ── Layer 2: TWAP state ─────────────────────────────────────────
+  ADD COLUMN IF NOT EXISTS twap_chunks_total             INT,
+  ADD COLUMN IF NOT EXISTS twap_chunks_completed         INT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS twap_proceeds_accumulated_lamports NUMERIC(20,0) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS twap_last_chunk_at            TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS twap_started_at               TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS twap_tx_signatures            TEXT[],
+
+  -- ── Layer 3: user intervention ──────────────────────────────────
+  -- intervention_state is a sub-state of status='awaiting_user'. Even
+  -- if status flips back (engine retries after approval), the
+  -- intervention_state row stays as the historical audit of what the
+  -- user said.
+  ADD COLUMN IF NOT EXISTS intervention_state TEXT NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS intervention_requested_at         TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS intervention_suggested_slippage_bps INT,
+  ADD COLUMN IF NOT EXISTS intervention_response_at          TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS intervention_response             TEXT,
+  ADD COLUMN IF NOT EXISTS intervention_notification_id      INT,
+  ADD COLUMN IF NOT EXISTS intervention_count                INT NOT NULL DEFAULT 0;
+
+-- Status enum extension. Order matters: we DROP the existing CHECK
+-- before re-adding with the wider set. IF EXISTS guards against
+-- a fresh DB that doesn't have the old constraint yet.
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_status_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_status_check
+  CHECK (status IN (
+    'armed',
+    'firing',
+    'twap_in_progress',
+    'awaiting_user',
+    'fired',
+    'partial_fired',
+    'cancelled',
+    'expired',
+    'failed'
+  ));
+
+-- intervention_state CHECK. Enforces the small enum at the storage
+-- layer so a typo in the engine or bot can't push the row into a
+-- state the rest of the system doesn't understand.
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_intervention_state_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_intervention_state_check
+  CHECK (intervention_state IN (
+    'none', 'requested', 'approved', 'declined', 'timed_out'
+  ));
+
+-- TWAP coherence: if twap_chunks_total is non-null, twap_chunks_completed
+-- must be in [0, twap_chunks_total]. Defense in depth — the engine
+-- enforces this in UPDATE clauses but the schema enforces it too so a
+-- buggy ad-hoc UPDATE can't corrupt the row.
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_twap_completed_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_twap_completed_check
+  CHECK (
+    twap_chunks_total IS NULL OR
+    (twap_chunks_completed >= 0 AND twap_chunks_completed <= twap_chunks_total)
+  );
+
+-- intervention_response is constrained to the three options users pick
+-- + a 'timeout' sentinel set by the cron. NULL means "not yet responded".
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_intervention_response_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_intervention_response_check
+  CHECK (
+    intervention_response IS NULL OR
+    intervention_response IN ('approve', 'decline', 'cancel', 'timeout')
+  );
+
+-- New partial index — TWAP watcher scans these. Same idea as the armed
+-- partial index: keeps the hot-path scan O(twap_in_flight) not O(all_orders).
+CREATE INDEX IF NOT EXISTS limit_close_orders_twap_idx
+  ON limit_close_orders(twap_last_chunk_at)
+  WHERE status = 'twap_in_progress';
+
+-- New partial index — intervention timeout cron scans these.
+CREATE INDEX IF NOT EXISTS limit_close_orders_awaiting_user_idx
+  ON limit_close_orders(intervention_requested_at)
+  WHERE status = 'awaiting_user';
+
+-- Backfill preflight column from any data we have. For pre-feature rows
+-- nothing to backfill; columns stay NULL which the rest of the system
+-- treats as "no pre-flight data, behave as before".

--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -104,6 +104,11 @@ export async function handleAgentLimitCloseArm(req) {
   const sellDestination  = String(body?.sell_destination ?? "sol").toLowerCase();
   const expiresAt        = body?.expires_at ? String(body.expires_at) : null;
   const x402TxSignature  = String(body?.x402_tx_signature ?? "");
+  const autoEscalateRaw  = body?.auto_escalate_slippage;
+  // Coerce to strict boolean — accept true/false explicitly, anything else
+  // is treated as false. We don't want truthy strings like "yes" sneaking
+  // in and flipping the behavior.
+  const autoEscalate     = autoEscalateRaw === true;
 
   // ── Shape validation ─────────────────────────────────────────
   if (!isValidPubkey(userWallet))  return bad("invalid_user_wallet");
@@ -236,6 +241,20 @@ export async function handleAgentLimitCloseArm(req) {
   }
 
   // ── INSERT — UNIQUE partial index catches dup-arm races ──────
+  //
+  // For auto-escalation we snapshot the borrower's delegation cap into
+  // max_slippage_bps_cap at arm time. If the borrower later tightens
+  // the delegation (revoke + re-authorize with a lower cap), the engine
+  // still honors THIS order's original ceiling — preventing a surprise
+  // mid-flight tightening from breaking an order the borrower already
+  // consented to.
+  //
+  // If auto_escalate is false, we still set max_slippage_bps_cap to the
+  // initial slippage (i.e. no headroom for escalation). The engine
+  // treats current == cap as "no further escalation possible" which is
+  // exactly the non-escalating behavior.
+  const capBps = autoEscalate ? delegation.max_slippage_bps : slippageBps;
+
   let inserted;
   try {
     inserted = await query(
@@ -243,15 +262,19 @@ export async function handleAgentLimitCloseArm(req) {
          (user_id, loan_id, trigger_kind, trigger_value_micro,
           slippage_bps, sell_destination, expires_at,
           source, source_agent_pubkey, status, armed_at,
+          auto_escalate_slippage, max_slippage_bps_cap, initial_slippage_bps,
           notes)
        VALUES ($1, $2, $3, $4, $5, $6, $7,
                'agent_x402', $8, 'armed', NOW(),
-               $9)
+               $9, $10, $11,
+               $12)
        RETURNING id, armed_at`,
       [delegation.user_id, loan.id, triggerKind, triggerValueMicro.toString(),
        slippageBps, sellDestination, expiresAt,
        agentPubkey,
-       `armed via x402 tx ${x402TxSignature.slice(0, 16)}...`],
+       autoEscalate, capBps, slippageBps,
+       `armed via x402 tx ${x402TxSignature.slice(0, 16)}...; ` +
+       `auto_escalate=${autoEscalate} cap=${capBps}bps`],
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message)) {
@@ -299,6 +322,9 @@ export async function handleAgentLimitCloseArm(req) {
       expires_at: expiresAt,
       source: "agent_x402",
       source_agent_pubkey: agentPubkey,
+      auto_escalate_slippage: autoEscalate,
+      max_slippage_bps_cap: capBps,
+      initial_slippage_bps: slippageBps,
     },
   };
 }
@@ -337,7 +363,9 @@ export async function handleAgentLimitCloseGet(req, params) {
             lc.proceeds_lamports::text AS proceeds_lamports,
             lc.protocol_fee_lamports::text AS protocol_fee_lamports,
             lc.net_to_user_lamports::text AS net_to_user_lamports,
-            lc.failure_reason, lc.cancellation_reason,
+            lc.failure_reason, lc.cancellation_reason, lc.failure_count,
+            lc.auto_escalate_slippage, lc.max_slippage_bps_cap,
+            lc.initial_slippage_bps, lc.slippage_escalations,
             l.loan_id AS chain_loan_id
        FROM limit_close_orders lc
        JOIN loans l ON l.id = lc.loan_id
@@ -373,6 +401,9 @@ export async function handleAgentLimitCloseList(req, params) {
             lc.trigger_value_micro::text AS trigger_value_micro,
             lc.slippage_bps, lc.sell_destination, lc.status,
             lc.armed_at, lc.expires_at,
+            lc.auto_escalate_slippage, lc.max_slippage_bps_cap,
+            lc.initial_slippage_bps, lc.slippage_escalations,
+            lc.failure_count,
             l.loan_id AS chain_loan_id,
             l.collateral_mint
        FROM limit_close_orders lc

--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -1,0 +1,386 @@
+/**
+ * Internal endpoint — POST /api/v1/internal/agent/limit-close/arm.
+ *
+ * Called by the magpie-x402 service AFTER it has verified an x402
+ * payment from the agent. We do not re-verify the payment here; the
+ * x402 service is the trusted gatekeeper for that. Instead we trust
+ * INTERNAL_API_TOKEN-gated callers and focus on the authorization
+ * model: did the wallet's owner pre-authorize THIS agent to arm
+ * THIS kind of order within THESE bounds?
+ *
+ * Auth model (defense in depth):
+ *   1. Network layer:  X-Internal-Token must match INTERNAL_API_TOKEN.
+ *      Anyone past this is treated as "the x402 service".
+ *   2. App layer:      An active row in agent_delegations for
+ *      (user_wallet, agent_pubkey, action='limit_close') must exist
+ *      AND not be expired AND bound the requested order on every
+ *      dimension: per-order notional cap, concurrent-orders cap,
+ *      slippage cap.
+ *   3. Storage layer:  The UNIQUE partial index on limit_close_orders
+ *      (loan_id WHERE status='armed') physically prevents the agent
+ *      from double-arming the same loan even if the app-layer check
+ *      had a race.
+ *
+ * The agent never names the user by Telegram id or DB primary key —
+ * it identifies the borrower by on-chain wallet pubkey, which is what
+ * the user knew when they ran /agent-authorize.
+ */
+import { query } from "../db/pool.js";
+import { constantTimeEqual } from "./auth-utils.js";
+
+const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN || "";
+
+const MIN_LOAN_LAMPORTS = 1_000_000_000n; // 1 SOL eligibility floor (same as TG path)
+const MIN_TRIGGER_VALUE_MICRO = 1n;
+const MAX_TRIGGER_VALUE_MICRO = 1_000_000_000_000_000n;
+const VALID_TRIGGER_KINDS = new Set(["mc_usd", "price_usd", "price_sol"]);
+const VALID_DESTINATIONS = new Set(["sol", "usdc"]);
+
+function isValidPubkey(s) {
+  return typeof s === "string" && s.length >= 32 && s.length <= 44 &&
+    /^[1-9A-HJ-NP-Za-km-z]+$/.test(s);
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+/**
+ * POST /api/v1/internal/agent/limit-close/arm
+ *
+ * Body:
+ *   {
+ *     user_wallet:        <pubkey>      borrower's custodial wallet
+ *     agent_pubkey:       <pubkey>      x402 payer = agent identity
+ *     loan_id:            <number>      on-chain loan id (loans.loan_id)
+ *     trigger_kind:       'mc_usd' | 'price_usd' | 'price_sol'
+ *     trigger_value_micro: <decimal-string>
+ *     slippage_bps:       <integer>     10..1000
+ *     sell_destination:   'sol' | 'usdc'
+ *     expires_at:         <ISO string or null>
+ *     x402_tx_signature:  <signature>   for audit trail
+ *   }
+ */
+export async function handleAgentLimitCloseArm(req) {
+  if (!INTERNAL_API_TOKEN) {
+    return { status: 503, body: { error: "service_not_configured" } };
+  }
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch {
+    return { status: 400, body: { error: "Invalid JSON body" } };
+  }
+
+  const userWallet       = String(body?.user_wallet ?? "");
+  const agentPubkey      = String(body?.agent_pubkey ?? "");
+  const loanIdRaw        = String(body?.loan_id ?? "");
+  const triggerKind      = String(body?.trigger_kind ?? "");
+  const triggerValueMicroRaw = String(body?.trigger_value_micro ?? "");
+  const slippageBpsRaw   = body?.slippage_bps;
+  const sellDestination  = String(body?.sell_destination ?? "sol").toLowerCase();
+  const expiresAt        = body?.expires_at ? String(body.expires_at) : null;
+  const x402TxSignature  = String(body?.x402_tx_signature ?? "");
+
+  // ── Shape validation ─────────────────────────────────────────
+  if (!isValidPubkey(userWallet))  return bad("invalid_user_wallet");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+  if (!/^\d+$/.test(loanIdRaw))    return bad("invalid_loan_id");
+  if (!VALID_TRIGGER_KINDS.has(triggerKind)) return bad("invalid_trigger_kind");
+  if (!/^\d+$/.test(triggerValueMicroRaw))   return bad("invalid_trigger_value");
+  let triggerValueMicro;
+  try { triggerValueMicro = BigInt(triggerValueMicroRaw); } catch { return bad("invalid_trigger_value"); }
+  if (triggerValueMicro < MIN_TRIGGER_VALUE_MICRO || triggerValueMicro > MAX_TRIGGER_VALUE_MICRO) {
+    return bad("trigger_value_out_of_range");
+  }
+  if (!Number.isInteger(slippageBpsRaw) || slippageBpsRaw < 10 || slippageBpsRaw > 1000) {
+    return bad("invalid_slippage_bps");
+  }
+  const slippageBps = slippageBpsRaw;
+  if (!VALID_DESTINATIONS.has(sellDestination)) return bad("invalid_sell_destination");
+  if (expiresAt && Number.isNaN(Date.parse(expiresAt))) return bad("invalid_expires_at");
+
+  // ── Authorization: delegation must exist + cover this order ─────
+  // The composite index agent_delegations_lookup_idx makes this a
+  // sub-ms hit. We pull the bounds back so we can apply them below.
+  const { rows: [delegation] } = await query(
+    `SELECT id,
+            max_per_order_lamports::text AS max_per_order_lamports,
+            max_active_orders,
+            max_slippage_bps,
+            expires_at,
+            user_id
+       FROM agent_delegations
+      WHERE user_wallet = $1
+        AND agent_pubkey = $2
+        AND action = 'limit_close'
+        AND status = 'active'`,
+    [userWallet, agentPubkey],
+  );
+  if (!delegation) {
+    return { status: 403, body: { error: "no_active_delegation" } };
+  }
+  if (delegation.expires_at && new Date(delegation.expires_at) < new Date()) {
+    // Best-effort cleanup; the next /agent-authorize will overwrite.
+    await query(
+      `UPDATE agent_delegations SET status = 'expired', revoked_at = NOW(), revoked_by = 'system'
+        WHERE id = $1`,
+      [delegation.id],
+    ).catch(() => {});
+    return { status: 403, body: { error: "delegation_expired" } };
+  }
+
+  // ── Loan ownership + state ──────────────────────────────────
+  // The agent supplied user_wallet AND loan_id; we re-derive
+  // user_id from the delegation and require the loan to belong to
+  // that same user. This is the load-bearing check that an agent
+  // authorized for wallet A cannot arm an order on wallet B's loan.
+  const { rows: [loan] } = await query(
+    `SELECT l.id, l.loan_id, l.status,
+            l.original_loan_amount_lamports::text AS owed,
+            l.collateral_mint,
+            u.id AS owner_user_id
+       FROM loans l
+       JOIN users u ON u.id = l.user_id
+       JOIN wallets w ON w.user_id = u.id AND w.public_key = $1
+      WHERE l.user_id = $2 AND l.loan_id = $3`,
+    [userWallet, delegation.user_id, loanIdRaw],
+  );
+  if (!loan) {
+    return { status: 404, body: { error: "loan_not_found_for_wallet" } };
+  }
+  if (loan.status !== "active") {
+    return { status: 409, body: { error: "loan_not_active", loan_status: loan.status } };
+  }
+  if (BigInt(loan.owed) < MIN_LOAN_LAMPORTS) {
+    return { status: 409, body: { error: "loan_below_minimum_size" } };
+  }
+
+  // ── Collateral allowlist (mirrors TG path) ──────────────────
+  const { rows: [mintRow] } = await query(
+    `SELECT enabled, category FROM supported_mints WHERE mint = $1`,
+    [loan.collateral_mint],
+  );
+  if (!mintRow || !mintRow.enabled) {
+    return { status: 409, body: { error: "collateral_not_enabled" } };
+  }
+  if (["stock", "etf", "metal"].includes(mintRow.category)) {
+    return { status: 409, body: { error: "rwa_collateral_not_supported_in_v1" } };
+  }
+
+  // ── Delegation BOUNDS check ─────────────────────────────────
+  // (a) per-order notional ceiling
+  if (BigInt(loan.owed) > BigInt(delegation.max_per_order_lamports)) {
+    return {
+      status: 403,
+      body: {
+        error: "order_exceeds_delegation_cap",
+        loan_owed_lamports: loan.owed,
+        max_per_order_lamports: delegation.max_per_order_lamports,
+      },
+    };
+  }
+  // (b) slippage ceiling
+  if (slippageBps > delegation.max_slippage_bps) {
+    return {
+      status: 403,
+      body: {
+        error: "slippage_exceeds_delegation_cap",
+        requested_bps: slippageBps,
+        max_allowed_bps: delegation.max_slippage_bps,
+      },
+    };
+  }
+  // (c) concurrent-orders ceiling (count only orders this agent armed for this user)
+  const { rows: [activeCount] } = await query(
+    `SELECT COUNT(*)::int AS n
+       FROM limit_close_orders
+      WHERE user_id = $1
+        AND status = 'armed'
+        AND source = 'agent_x402'
+        AND source_agent_pubkey = $2`,
+    [delegation.user_id, agentPubkey],
+  );
+  if (activeCount.n >= delegation.max_active_orders) {
+    return {
+      status: 429,
+      body: {
+        error: "agent_concurrency_cap_reached",
+        active: activeCount.n,
+        max_active_orders: delegation.max_active_orders,
+      },
+    };
+  }
+
+  // ── INSERT — UNIQUE partial index catches dup-arm races ──────
+  let inserted;
+  try {
+    inserted = await query(
+      `INSERT INTO limit_close_orders
+         (user_id, loan_id, trigger_kind, trigger_value_micro,
+          slippage_bps, sell_destination, expires_at,
+          source, source_agent_pubkey, status, armed_at,
+          notes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7,
+               'agent_x402', $8, 'armed', NOW(),
+               $9)
+       RETURNING id, armed_at`,
+      [delegation.user_id, loan.id, triggerKind, triggerValueMicro.toString(),
+       slippageBps, sellDestination, expiresAt,
+       agentPubkey,
+       `armed via x402 tx ${x402TxSignature.slice(0, 16)}...`],
+    );
+  } catch (err) {
+    if (/duplicate key value violates unique constraint/i.test(err.message)) {
+      return { status: 409, body: { error: "loan_already_has_active_order" } };
+    }
+    console.error("[internal-agent-limitclose] insert failed:", err.message);
+    return { status: 500, body: { error: "insert_failed" } };
+  }
+
+  const orderId = inserted.rows[0].id;
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      order_id: orderId,
+      loan_id: loan.loan_id,
+      trigger_kind: triggerKind,
+      trigger_value_micro: triggerValueMicro.toString(),
+      slippage_bps: slippageBps,
+      sell_destination: sellDestination,
+      armed_at: inserted.rows[0].armed_at,
+      expires_at: expiresAt,
+      source: "agent_x402",
+      source_agent_pubkey: agentPubkey,
+    },
+  };
+}
+
+/**
+ * GET /api/v1/internal/agent/limit-close?agent=<pubkey>&id=<order_id>
+ *
+ * Read one order — scoped to the agent that armed it. Free (no x402)
+ * because read-only and the agent is identified by query param the
+ * x402 service has already proven (via payment verifying agent's
+ * payer key on the original arm call).
+ *
+ * Wait — but a free read endpoint can't trust a self-asserted agent
+ * pubkey. The x402 service must therefore re-charge for reads OR we
+ * make this internal-only and let the x402 service do the pubkey
+ * binding upstream. We chose the latter: internal-token-gated, the
+ * x402 service binds (agent_pubkey ← verified x402 payer) before
+ * calling us. So this endpoint is safe to scope by agent_pubkey
+ * because INTERNAL_API_TOKEN already authenticated the caller.
+ */
+export async function handleAgentLimitCloseGet(req, params) {
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  const agentPubkey = String(params.agent ?? "");
+  const orderId     = String(params.id ?? "");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+  if (!/^\d+$/.test(orderId))      return bad("invalid_order_id");
+
+  const { rows: [order] } = await query(
+    `SELECT lc.id, lc.trigger_kind,
+            lc.trigger_value_micro::text AS trigger_value_micro,
+            lc.slippage_bps, lc.sell_destination, lc.status,
+            lc.armed_at, lc.expires_at, lc.firing_started_at, lc.fired_at,
+            lc.tx_signature_repay, lc.tx_signature_swap,
+            lc.proceeds_lamports::text AS proceeds_lamports,
+            lc.protocol_fee_lamports::text AS protocol_fee_lamports,
+            lc.net_to_user_lamports::text AS net_to_user_lamports,
+            lc.failure_reason, lc.cancellation_reason,
+            l.loan_id AS chain_loan_id
+       FROM limit_close_orders lc
+       JOIN loans l ON l.id = lc.loan_id
+      WHERE lc.id = $1
+        AND lc.source = 'agent_x402'
+        AND lc.source_agent_pubkey = $2`,
+    [orderId, agentPubkey],
+  );
+  if (!order) {
+    return { status: 404, body: { error: "order_not_found" } };
+  }
+  return { status: 200, body: order };
+}
+
+/**
+ * GET /api/v1/internal/agent/limit-close/list?agent=<pubkey>&status=<armed|all>
+ *
+ * List orders armed by this agent. Default status filter is 'armed'
+ * (the common case — "what do I have working right now"); pass
+ * status=all to include terminal states for audit.
+ */
+export async function handleAgentLimitCloseList(req, params) {
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  const agentPubkey = String(params.agent ?? "");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+  const statusFilter = String(params.status ?? "armed");
+  const filterArmed = statusFilter !== "all";
+
+  const { rows } = await query(
+    `SELECT lc.id, lc.trigger_kind,
+            lc.trigger_value_micro::text AS trigger_value_micro,
+            lc.slippage_bps, lc.sell_destination, lc.status,
+            lc.armed_at, lc.expires_at,
+            l.loan_id AS chain_loan_id,
+            l.collateral_mint
+       FROM limit_close_orders lc
+       JOIN loans l ON l.id = lc.loan_id
+      WHERE lc.source = 'agent_x402'
+        AND lc.source_agent_pubkey = $1
+        AND ($2::boolean = FALSE OR lc.status = 'armed')
+      ORDER BY lc.armed_at DESC
+      LIMIT 100`,
+    [agentPubkey, filterArmed],
+  );
+  return { status: 200, body: { count: rows.length, orders: rows } };
+}
+
+/**
+ * DELETE /api/v1/internal/agent/limit-close?agent=<pubkey>&id=<order_id>
+ *
+ * Cancel an armed order. Race-safe: WHERE status='armed' so a
+ * cancel-against-firing returns "not_cancellable" instead of leaving
+ * the user with a half-executed order. Same defense the TG cancel
+ * uses — the engine flips status to 'firing' before doing any
+ * on-chain work, so once 'firing' the cancel is too late.
+ */
+export async function handleAgentLimitCloseDelete(req, params) {
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  const agentPubkey = String(params.agent ?? "");
+  const orderId     = String(params.id ?? "");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+  if (!/^\d+$/.test(orderId))      return bad("invalid_order_id");
+
+  const result = await query(
+    `UPDATE limit_close_orders
+        SET status = 'cancelled',
+            cancellation_reason = 'agent_cancel_via_x402',
+            updated_at = NOW()
+      WHERE id = $1
+        AND source = 'agent_x402'
+        AND source_agent_pubkey = $2
+        AND status = 'armed'
+      RETURNING id, armed_at`,
+    [orderId, agentPubkey],
+  );
+  if (result.rows.length === 0) {
+    return { status: 409, body: { error: "not_cancellable_or_not_found" } };
+  }
+  return { status: 200, body: { ok: true, cancelled_order_id: result.rows[0].id } };
+}
+
+function bad(err) { return { status: 400, body: { error: err } }; }

--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -27,6 +27,7 @@
  */
 import { query } from "../db/pool.js";
 import { constantTimeEqual } from "./auth-utils.js";
+import { runArmPreflight } from "../services/limit-close-preflight.js";
 
 const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN || "";
 
@@ -167,6 +168,7 @@ export async function handleAgentLimitCloseArm(req) {
     `SELECT l.id, l.loan_id, l.status,
             l.original_loan_amount_lamports::text AS owed,
             l.collateral_mint,
+            l.collateral_amount::text AS collateral_amount_raw,
             u.id AS owner_user_id
        FROM loans l
        JOIN users u ON u.id = l.user_id
@@ -240,6 +242,50 @@ export async function handleAgentLimitCloseArm(req) {
     };
   }
 
+  // ── Pre-flight liquidity check (Layer 1) ─────────────────────
+  //
+  // Quote Jupiter at current state. If the order can't clear at the
+  // user's slippage right now, reject with a suggested slippage. This
+  // catches "you typed 1% but your collateral trades at 12% impact"
+  // BEFORE the user is armed and silently failing weeks later when
+  // their trigger hits.
+  //
+  // The check is fail-open on Jupiter outages (advisory) — the engine's
+  // runtime safety floor is the actual guarantee. Layer 2 (TWAP) and
+  // Layer 3 (intervention) handle the dynamic-liquidity case at fire
+  // time.
+  const preflightCap = autoEscalate ? delegation.max_slippage_bps : slippageBps;
+  const preflight = await runArmPreflight({
+    collateralMint: loan.collateral_mint,
+    collateralAmountRaw: loan.collateral_amount_raw,
+    sellDestination,
+    // Use the EFFECTIVE max we could ever clear at — that's the cap if
+    // auto-escalate is on, the literal slippage otherwise. Catches the
+    // case "even at the cap we can't fill" while NOT rejecting "you
+    // can't fill at 200 bps but you opted into escalating to 500".
+    slippageBps: preflightCap,
+    loanOwedLamports: loan.owed,
+    protocolFeeBps: 100,
+  });
+  if (!preflight.ok) {
+    return {
+      status: 409,
+      body: {
+        error: preflight.reason,
+        detail: preflight.detail,
+        suggested_slippage_bps: preflight.suggestedSlippageBps,
+        your_slippage_bps: preflight.yourSlippageBps,
+        cap_used_for_check_bps: preflightCap,
+      },
+    };
+  }
+  // Pre-flight passed (or advisory-passed when Jupiter unreachable).
+  // Persist what we saw so we can later detect "liquidity has gotten
+  // worse since arm" in the engine's failure-reason notes.
+  const preflightSlippageQuotedBps = preflight.advisory ? null : preflightCap;
+  const preflightProceedsLamports  = preflight.advisory ? null : (preflight.proceedsLamports || null);
+  const preflightQuotedAtIso       = preflight.advisory ? null : (preflight.quotedAtIso || new Date().toISOString());
+
   // ── INSERT — UNIQUE partial index catches dup-arm races ──────
   //
   // For auto-escalation we snapshot the borrower's delegation cap into
@@ -263,18 +309,22 @@ export async function handleAgentLimitCloseArm(req) {
           slippage_bps, sell_destination, expires_at,
           source, source_agent_pubkey, status, armed_at,
           auto_escalate_slippage, max_slippage_bps_cap, initial_slippage_bps,
+          preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at,
           notes)
        VALUES ($1, $2, $3, $4, $5, $6, $7,
                'agent_x402', $8, 'armed', NOW(),
                $9, $10, $11,
-               $12)
+               $12, $13, $14,
+               $15)
        RETURNING id, armed_at`,
       [delegation.user_id, loan.id, triggerKind, triggerValueMicro.toString(),
        slippageBps, sellDestination, expiresAt,
        agentPubkey,
        autoEscalate, capBps, slippageBps,
+       preflightSlippageQuotedBps, preflightProceedsLamports, preflightQuotedAtIso,
        `armed via x402 tx ${x402TxSignature.slice(0, 16)}...; ` +
-       `auto_escalate=${autoEscalate} cap=${capBps}bps`],
+       `auto_escalate=${autoEscalate} cap=${capBps}bps; ` +
+       `preflight=${preflight.advisory ? "advisory" : "passed"}`],
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message)) {

--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -23,12 +23,22 @@
  *
  * The agent never names the user by Telegram id or DB primary key —
  * it identifies the borrower by on-chain wallet pubkey, which is what
- * the user knew when they ran /agent-authorize.
+ * the user knew when they ran /agent_authorize.
  */
 import { query } from "../db/pool.js";
 import { constantTimeEqual } from "./auth-utils.js";
 
 const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN || "";
+
+// Operator kill switch — set LIMIT_CLOSE_AGENT_DISABLED=1 to disable
+// the x402 agent arm path WITHOUT affecting TG-armed orders or any
+// already-armed agent orders. The engine still processes armed
+// orders; this just refuses new ones from the x402 endpoint.
+// Read fresh on every request so flipping the env doesn't need a
+// process restart.
+function agentArmDisabled() {
+  return /^(1|true|yes|on)$/i.test(process.env.LIMIT_CLOSE_AGENT_DISABLED || "");
+}
 
 const MIN_LOAN_LAMPORTS = 1_000_000_000n; // 1 SOL eligibility floor (same as TG path)
 const MIN_TRIGGER_VALUE_MICRO = 1n;
@@ -69,6 +79,13 @@ export async function handleAgentLimitCloseArm(req) {
   }
   if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
     return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  if (agentArmDisabled()) {
+    // Operator kill switch — refuse new agent arms. TG-armed orders
+    // and already-armed agent orders continue to be processed by the
+    // engine. The x402 service surfaces this to the agent as a 503
+    // with reason, which they should treat as "retry later".
+    return { status: 503, body: { error: "agent_arm_disabled_by_operator" } };
   }
 
   let body;
@@ -127,7 +144,7 @@ export async function handleAgentLimitCloseArm(req) {
     return { status: 403, body: { error: "no_active_delegation" } };
   }
   if (delegation.expires_at && new Date(delegation.expires_at) < new Date()) {
-    // Best-effort cleanup; the next /agent-authorize will overwrite.
+    // Best-effort cleanup; the next /agent_authorize will overwrite.
     await query(
       `UPDATE agent_delegations SET status = 'expired', revoked_at = NOW(), revoked_by = 'system'
         WHERE id = $1`,
@@ -245,6 +262,29 @@ export async function handleAgentLimitCloseArm(req) {
   }
 
   const orderId = inserted.rows[0].id;
+
+  // Borrower wasn't the actor here — DM them so they know an
+  // authorized agent just armed an order on their loan. Best-effort:
+  // if the enqueue fails the order is still armed (correct), they
+  // just don't get the immediate ping.
+  try {
+    await query(
+      `INSERT INTO pending_notifications (user_id, channel, kind, payload, status)
+         VALUES ($1, 'tg', 'limit_close_armed', $2::jsonb, 'pending')`,
+      [delegation.user_id, JSON.stringify({
+        order_id: orderId,
+        loan_id_chain: loan.loan_id,
+        trigger_label: `${triggerKind}=${triggerValueMicro.toString()}`,
+        slippage_bps: slippageBps,
+        sell_destination: sellDestination,
+        source: "agent_x402",
+        source_agent_pubkey: agentPubkey,
+      })],
+    );
+  } catch (err) {
+    console.warn("[internal-agent-limitclose] arm-DM enqueue failed:", err.message?.slice(0, 200));
+  }
+
   return {
     status: 200,
     body: {
@@ -381,6 +421,90 @@ export async function handleAgentLimitCloseDelete(req, params) {
     return { status: 409, body: { error: "not_cancellable_or_not_found" } };
   }
   return { status: 200, body: { ok: true, cancelled_order_id: result.rows[0].id } };
+}
+
+/**
+ * GET /api/v1/internal/agent/limit-close/delegations?agent=<pubkey>
+ *
+ * The agent reads its OWN active grants — every (user_wallet, action,
+ * bounds) tuple that the borrower authorized to it. This is what an
+ * agent calls on startup to discover the surface it can operate over.
+ *
+ * Scoped strictly by agent_pubkey so one agent cannot enumerate
+ * another's delegations. Same INTERNAL_API_TOKEN gate as the other
+ * internal endpoints — the x402 service binds the agent_pubkey to
+ * the verified x402 payer before calling us, OR (for the free path)
+ * the x402 service requires the agent to assert its pubkey via the
+ * X-Agent-Pubkey header. Read-only and exposes only the bounds the
+ * agent itself agreed to, so no payer-binding is required.
+ */
+export async function handleAgentLimitCloseListDelegations(req, params) {
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  const agentPubkey = String(params.agent ?? "");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+
+  const { rows } = await query(
+    `SELECT user_wallet,
+            action,
+            max_per_order_lamports::text AS max_per_order_lamports,
+            max_active_orders,
+            max_slippage_bps,
+            granted_at,
+            expires_at
+       FROM agent_delegations
+      WHERE agent_pubkey = $1
+        AND status = 'active'
+        AND (expires_at IS NULL OR expires_at > NOW())
+      ORDER BY granted_at DESC
+      LIMIT 200`,
+    [agentPubkey],
+  );
+
+  // For each delegation also surface the agent's current armed-orders
+  // count against the cap — the agent needs this to know whether it
+  // has headroom to arm another order without round-tripping.
+  let activeByWallet = new Map();
+  if (rows.length > 0) {
+    const wallets = rows.map((r) => r.user_wallet);
+    const { rows: counts } = await query(
+      `SELECT w.public_key AS user_wallet, COUNT(*)::int AS active
+         FROM limit_close_orders lc
+         JOIN users u ON u.id = lc.user_id
+         JOIN wallets w ON w.user_id = u.id
+        WHERE lc.status = 'armed'
+          AND lc.source = 'agent_x402'
+          AND lc.source_agent_pubkey = $1
+          AND w.public_key = ANY($2::text[])
+        GROUP BY w.public_key`,
+      [agentPubkey, wallets],
+    );
+    activeByWallet = new Map(counts.map((c) => [c.user_wallet, c.active]));
+  }
+
+  return {
+    status: 200,
+    body: {
+      count: rows.length,
+      delegations: rows.map((r) => ({
+        user_wallet: r.user_wallet,
+        action: r.action,
+        bounds: {
+          max_per_order_lamports: r.max_per_order_lamports,
+          max_per_order_sol: Number(r.max_per_order_lamports) / 1e9,
+          max_active_orders: r.max_active_orders,
+          max_slippage_bps: r.max_slippage_bps,
+        },
+        usage: {
+          active_orders: activeByWallet.get(r.user_wallet) ?? 0,
+          headroom: r.max_active_orders - (activeByWallet.get(r.user_wallet) ?? 0),
+        },
+        granted_at: r.granted_at,
+        expires_at: r.expires_at,
+      })),
+    },
+  };
 }
 
 function bad(err) { return { status: 400, body: { error: err } }; }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1471,6 +1471,7 @@ const PUBLIC_ROUTES = new Set([
   "/api/v1/internal/agent/limit-close/arm",
   "/api/v1/internal/agent/limit-close",
   "/api/v1/internal/agent/limit-close/list",
+  "/api/v1/internal/agent/limit-close/delegations",
   // Admin routes are "public" at the HTTP layer but gate internally on
   // wallet === LENDER_PUBKEY, so any non-creator caller gets a 403.
   "/api/v1/admin/pool-stats",
@@ -1727,6 +1728,11 @@ async function router(req, res) {
       case "/api/v1/internal/agent/limit-close/list": {
         const { handleAgentLimitCloseList } = await import("./internal-agent-limitclose.js");
         result = await handleAgentLimitCloseList(req, Object.fromEntries(url.searchParams));
+        break;
+      }
+      case "/api/v1/internal/agent/limit-close/delegations": {
+        const { handleAgentLimitCloseListDelegations } = await import("./internal-agent-limitclose.js");
+        result = await handleAgentLimitCloseListDelegations(req, Object.fromEntries(url.searchParams));
         break;
       }
       case "/api/v1/internal/agent/limit-close": {

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1462,6 +1462,15 @@ const PUBLIC_ROUTES = new Set([
   // handler level (same pattern as the agent endpoints), so we list
   // it as "public" at the API-key layer to bypass the API-key gate.
   "/api/v1/internal/x402/record",
+  // Internal agent-limit-close arm/read/cancel — same INTERNAL_API_TOKEN
+  // model. The x402 service is the only legitimate caller; it has
+  // already verified the agent's x402 payment and proven (via the
+  // payer pubkey on-chain) the agent_pubkey it forwards. We trust
+  // the inbound agent_pubkey on this path BECAUSE the token gate
+  // proves it came from the x402 service.
+  "/api/v1/internal/agent/limit-close/arm",
+  "/api/v1/internal/agent/limit-close",
+  "/api/v1/internal/agent/limit-close/list",
   // Admin routes are "public" at the HTTP layer but gate internally on
   // wallet === LENDER_PUBKEY, so any non-creator caller gets a 403.
   "/api/v1/admin/pool-stats",
@@ -1708,6 +1717,25 @@ async function router(req, res) {
       case "/api/v1/internal/x402/record": {
         const { handleX402Record } = await import("./x402-metrics.js");
         result = await handleX402Record(req);
+        break;
+      }
+      case "/api/v1/internal/agent/limit-close/arm": {
+        const { handleAgentLimitCloseArm } = await import("./internal-agent-limitclose.js");
+        result = await handleAgentLimitCloseArm(req);
+        break;
+      }
+      case "/api/v1/internal/agent/limit-close/list": {
+        const { handleAgentLimitCloseList } = await import("./internal-agent-limitclose.js");
+        result = await handleAgentLimitCloseList(req, Object.fromEntries(url.searchParams));
+        break;
+      }
+      case "/api/v1/internal/agent/limit-close": {
+        const m = await import("./internal-agent-limitclose.js");
+        if (req.method === "DELETE") {
+          result = await m.handleAgentLimitCloseDelete(req, Object.fromEntries(url.searchParams));
+        } else {
+          result = await m.handleAgentLimitCloseGet(req, Object.fromEntries(url.searchParams));
+        }
         break;
       }
       case "/api/v1/tokens":

--- a/src/commands/agent-delegations.js
+++ b/src/commands/agent-delegations.js
@@ -1,0 +1,230 @@
+/**
+ * Agent delegations — TG commands.
+ *
+ *   /agent-authorize <agent_pubkey> limit_close [max_per_order_sol=10]
+ *                                                [max_active=5]
+ *                                                [max_slippage_bps=500]
+ *                                                [expires=30d]
+ *   /agent-revoke <agent_pubkey> [action]
+ *   /agent-list
+ *
+ * The user is the SOURCE OF TRUTH for what an agent can do on their
+ * behalf. Every constraint here flows into agent_delegations and is
+ * re-checked at every agent action — the x402 endpoint cannot exceed
+ * these bounds, the engine cannot exceed these bounds.
+ *
+ * Security:
+ *   - Ownership enforced on every read AND write (WHERE user_id = ctx.from.id)
+ *   - Pubkey validated as base58 + correct length before any write
+ *   - Schema CHECK constraints catch anything the parser missed
+ *   - Revocation is one-way (status='revoked' is terminal) so audit
+ *     trail is preserved
+ */
+import { PublicKey } from "@solana/web3.js";
+import { query } from "../db/pool.js";
+import { upsertUser } from "../services/users.js";
+import { ensureWallet } from "../services/wallet.js";
+
+const VALID_ACTIONS = new Set(["limit_close"]);
+const MIN_ORDER_LAMPORTS = BigInt(100_000_000n);          // 0.1 SOL floor
+const MAX_ORDER_LAMPORTS_HARD_CAP = BigInt(100_000_000_000n); // 100 SOL hard ceiling
+
+function isValidPubkey(s) {
+  if (typeof s !== "string") return false;
+  if (s.length < 32 || s.length > 44) return false;
+  try { new PublicKey(s); return true; } catch { return false; }
+}
+
+function parseDuration(s) {
+  // "30d" / "12h" / "7d"
+  const m = String(s).match(/^(\d+)([dh])$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  const ms = m[2] === "d" ? n * 86_400_000 : n * 3_600_000;
+  if (ms > 365 * 86_400_000) return null;
+  return new Date(Date.now() + ms).toISOString();
+}
+
+function parseSolToLamports(s) {
+  const n = Number(s);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return BigInt(Math.round(n * 1e9));
+}
+
+/* ─── /agent-authorize ─────────────────────────────────────────── */
+
+export async function handleAgentAuthorize(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const text = ctx.message?.text || "";
+  const tokens = text.trim().split(/\s+/).slice(1); // strip /agent-authorize
+  if (tokens.length < 2) {
+    return ctx.reply(
+      "Usage: `/agent-authorize <agent_pubkey> limit_close [max_per_order_sol=10] [max_active=5] [max_slippage_bps=500] [expires=30d]`",
+      { parse_mode: "Markdown" },
+    );
+  }
+  const agentPubkeyRaw = tokens[0];
+  const action = tokens[1];
+
+  if (!isValidPubkey(agentPubkeyRaw)) {
+    return ctx.reply("Invalid agent pubkey. Must be a valid Solana base58 pubkey.");
+  }
+  if (!VALID_ACTIONS.has(action)) {
+    return ctx.reply(`Unknown action \`${action}\`. Allowed: ${[...VALID_ACTIONS].join(", ")}`, { parse_mode: "Markdown" });
+  }
+
+  // Parse optional key=value bounds
+  let maxPerOrderLamports = BigInt(10_000_000_000n); // 10 SOL default
+  let maxActiveOrders = 5;
+  let maxSlippageBps = 500;
+  let expiresAt = null;
+  for (const t of tokens.slice(2)) {
+    const m = t.match(/^([a-z_]+)=(.+)$/i);
+    if (!m) return ctx.reply(`Unrecognized argument: \`${t}\``, { parse_mode: "Markdown" });
+    const k = m[1].toLowerCase();
+    const v = m[2];
+    if (k === "max_per_order_sol") {
+      const lamports = parseSolToLamports(v);
+      if (!lamports) return ctx.reply(`Invalid max_per_order_sol: \`${v}\``, { parse_mode: "Markdown" });
+      if (lamports < MIN_ORDER_LAMPORTS) {
+        return ctx.reply(`max_per_order_sol must be at least ${Number(MIN_ORDER_LAMPORTS) / 1e9} SOL.`);
+      }
+      if (lamports > MAX_ORDER_LAMPORTS_HARD_CAP) {
+        return ctx.reply(`max_per_order_sol cannot exceed ${Number(MAX_ORDER_LAMPORTS_HARD_CAP) / 1e9} SOL.`);
+      }
+      maxPerOrderLamports = lamports;
+    } else if (k === "max_active") {
+      const n = Number(v);
+      if (!Number.isInteger(n) || n < 1 || n > 50) {
+        return ctx.reply("max_active must be an integer between 1 and 50.");
+      }
+      maxActiveOrders = n;
+    } else if (k === "max_slippage_bps") {
+      const n = Number(v);
+      if (!Number.isInteger(n) || n < 10 || n > 1000) {
+        return ctx.reply("max_slippage_bps must be between 10 and 1000 (0.1% to 10%).");
+      }
+      maxSlippageBps = n;
+    } else if (k === "expires") {
+      const iso = parseDuration(v);
+      if (!iso) return ctx.reply("expires must be like `30d` or `12h` (max 365d).");
+      expiresAt = iso;
+    } else {
+      return ctx.reply(`Unknown option \`${k}=\`. Allowed: max_per_order_sol, max_active, max_slippage_bps, expires.`, { parse_mode: "Markdown" });
+    }
+  }
+
+  const user = await upsertUser(tgUser.id, tgUser.username);
+  const userWallet = await ensureWallet(user.id);
+
+  // UPSERT — overwriting existing active grant for same (wallet, agent, action).
+  // The UNIQUE partial index makes "two active grants for the same tuple"
+  // physically impossible. ON CONFLICT updates the bounds + extends expiry.
+  try {
+    await query(
+      `INSERT INTO agent_delegations
+         (user_id, user_wallet, agent_pubkey, action,
+          max_per_order_lamports, max_active_orders, max_slippage_bps,
+          status, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 'active', $8)
+       ON CONFLICT (user_wallet, agent_pubkey, action) WHERE status = 'active'
+       DO UPDATE SET
+         max_per_order_lamports = EXCLUDED.max_per_order_lamports,
+         max_active_orders      = EXCLUDED.max_active_orders,
+         max_slippage_bps       = EXCLUDED.max_slippage_bps,
+         expires_at             = EXCLUDED.expires_at,
+         notes                  = COALESCE(agent_delegations.notes, '') || '\nupdated via /agent-authorize ' || NOW()::text`,
+      [user.id, userWallet.publicKey, agentPubkeyRaw, action,
+       maxPerOrderLamports.toString(), maxActiveOrders, maxSlippageBps,
+       expiresAt],
+    );
+  } catch (err) {
+    console.error("[agent-authorize] insert failed:", err.message);
+    return ctx.reply(`Couldn't grant: ${err.message?.slice(0, 100)}`);
+  }
+
+  const expiryLabel = expiresAt ? `\nExpires: \`${expiresAt.slice(0, 10)}\`` : "";
+  await ctx.reply(
+    [
+      `*Agent authorized*`,
+      ``,
+      `Agent: \`${agentPubkeyRaw.slice(0, 8)}…\``,
+      `Action: \`${action}\``,
+      `Max per order: \`${(Number(maxPerOrderLamports) / 1e9).toFixed(2)} SOL\``,
+      `Max active orders: \`${maxActiveOrders}\``,
+      `Max slippage: \`${(maxSlippageBps / 100).toFixed(2)}%\``,
+      expiryLabel,
+      ``,
+      `The agent can now arm \`${action}\` orders on your custodial wallet within these bounds.`,
+      `Revoke any time: \`/agent-revoke ${agentPubkeyRaw.slice(0, 8)}…\``,
+    ].join("\n"),
+    { parse_mode: "Markdown" },
+  );
+}
+
+/* ─── /agent-revoke ───────────────────────────────────────────── */
+
+export async function handleAgentRevoke(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const text = ctx.message?.text || "";
+  const tokens = text.trim().split(/\s+/).slice(1);
+  if (tokens.length < 1) {
+    return ctx.reply("Usage: `/agent-revoke <agent_pubkey> [action]`", { parse_mode: "Markdown" });
+  }
+  const agentPubkey = tokens[0];
+  const action = tokens[1] || null;
+  if (!isValidPubkey(agentPubkey)) {
+    return ctx.reply("Invalid agent pubkey.");
+  }
+  if (action && !VALID_ACTIONS.has(action)) {
+    return ctx.reply(`Unknown action \`${action}\`.`, { parse_mode: "Markdown" });
+  }
+  const user = await upsertUser(tgUser.id, tgUser.username);
+
+  const result = await query(
+    `UPDATE agent_delegations
+        SET status = 'revoked',
+            revoked_at = NOW(),
+            revoked_by = 'user'
+      WHERE user_id = $1
+        AND agent_pubkey = $2
+        AND status = 'active'
+        AND ($3::text IS NULL OR action = $3)
+      RETURNING id, action`,
+    [user.id, agentPubkey, action],
+  );
+  if (result.rows.length === 0) {
+    return ctx.reply(`No active grant found for that agent.`);
+  }
+  const list = result.rows.map((r) => `\`${r.action}\``).join(", ");
+  await ctx.reply(`Revoked ${result.rows.length} grant(s) for agent \`${agentPubkey.slice(0, 8)}…\`: ${list}`, { parse_mode: "Markdown" });
+}
+
+/* ─── /agent-list ─────────────────────────────────────────────── */
+
+export async function handleAgentList(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const user = await upsertUser(tgUser.id, tgUser.username);
+  const { rows } = await query(
+    `SELECT agent_pubkey, action, max_per_order_lamports::text AS cap,
+            max_active_orders, max_slippage_bps, expires_at, granted_at
+       FROM agent_delegations
+      WHERE user_id = $1 AND status = 'active'
+      ORDER BY granted_at DESC`,
+    [user.id],
+  );
+  if (rows.length === 0) {
+    return ctx.reply("No active agent delegations. Grant one with `/agent-authorize`.", { parse_mode: "Markdown" });
+  }
+  const lines = [`*Active agent delegations* (${rows.length})`, ``];
+  for (const r of rows) {
+    const expiry = r.expires_at ? ` · expires ${new Date(r.expires_at).toISOString().slice(0, 10)}` : "";
+    const capSol = (Number(r.cap) / 1e9).toFixed(2);
+    lines.push(`\`${r.agent_pubkey.slice(0, 8)}…\`  ${r.action}  cap=${capSol} SOL  max_active=${r.max_active_orders}  slip≤${(r.max_slippage_bps / 100).toFixed(1)}%${expiry}`);
+  }
+  lines.push(``, `Revoke: \`/agent-revoke <agent_pubkey>\``);
+  await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
+}

--- a/src/commands/agent-delegations.js
+++ b/src/commands/agent-delegations.js
@@ -1,12 +1,12 @@
 /**
  * Agent delegations — TG commands.
  *
- *   /agent-authorize <agent_pubkey> limit_close [max_per_order_sol=10]
+ *   /agent_authorize <agent_pubkey> limit_close [max_per_order_sol=10]
  *                                                [max_active=5]
  *                                                [max_slippage_bps=500]
  *                                                [expires=30d]
- *   /agent-revoke <agent_pubkey> [action]
- *   /agent-list
+ *   /agent_revoke <agent_pubkey> [action]
+ *   /agent_list
  *
  * The user is the SOURCE OF TRUTH for what an agent can do on their
  * behalf. Every constraint here flows into agent_delegations and is
@@ -51,16 +51,16 @@ function parseSolToLamports(s) {
   return BigInt(Math.round(n * 1e9));
 }
 
-/* ─── /agent-authorize ─────────────────────────────────────────── */
+/* ─── /agent_authorize ─────────────────────────────────────────── */
 
 export async function handleAgentAuthorize(ctx) {
   const tgUser = ctx.from;
   if (!tgUser) return;
   const text = ctx.message?.text || "";
-  const tokens = text.trim().split(/\s+/).slice(1); // strip /agent-authorize
+  const tokens = text.trim().split(/\s+/).slice(1); // strip /agent_authorize
   if (tokens.length < 2) {
     return ctx.reply(
-      "Usage: `/agent-authorize <agent_pubkey> limit_close [max_per_order_sol=10] [max_active=5] [max_slippage_bps=500] [expires=30d]`",
+      "Usage: `/agent_authorize <agent_pubkey> limit_close [max_per_order_sol=10] [max_active=5] [max_slippage_bps=500] [expires=30d]`",
       { parse_mode: "Markdown" },
     );
   }
@@ -134,7 +134,7 @@ export async function handleAgentAuthorize(ctx) {
          max_active_orders      = EXCLUDED.max_active_orders,
          max_slippage_bps       = EXCLUDED.max_slippage_bps,
          expires_at             = EXCLUDED.expires_at,
-         notes                  = COALESCE(agent_delegations.notes, '') || '\nupdated via /agent-authorize ' || NOW()::text`,
+         notes                  = COALESCE(agent_delegations.notes, '') || '\nupdated via /agent_authorize ' || NOW()::text`,
       [user.id, userWallet.publicKey, agentPubkeyRaw, action,
        maxPerOrderLamports.toString(), maxActiveOrders, maxSlippageBps,
        expiresAt],
@@ -157,13 +157,13 @@ export async function handleAgentAuthorize(ctx) {
       expiryLabel,
       ``,
       `The agent can now arm \`${action}\` orders on your custodial wallet within these bounds.`,
-      `Revoke any time: \`/agent-revoke ${agentPubkeyRaw.slice(0, 8)}…\``,
+      `Revoke any time: \`/agent_revoke ${agentPubkeyRaw.slice(0, 8)}…\``,
     ].join("\n"),
     { parse_mode: "Markdown" },
   );
 }
 
-/* ─── /agent-revoke ───────────────────────────────────────────── */
+/* ─── /agent_revoke ───────────────────────────────────────────── */
 
 export async function handleAgentRevoke(ctx) {
   const tgUser = ctx.from;
@@ -171,7 +171,7 @@ export async function handleAgentRevoke(ctx) {
   const text = ctx.message?.text || "";
   const tokens = text.trim().split(/\s+/).slice(1);
   if (tokens.length < 1) {
-    return ctx.reply("Usage: `/agent-revoke <agent_pubkey> [action]`", { parse_mode: "Markdown" });
+    return ctx.reply("Usage: `/agent_revoke <agent_pubkey> [action]`", { parse_mode: "Markdown" });
   }
   const agentPubkey = tokens[0];
   const action = tokens[1] || null;
@@ -202,7 +202,7 @@ export async function handleAgentRevoke(ctx) {
   await ctx.reply(`Revoked ${result.rows.length} grant(s) for agent \`${agentPubkey.slice(0, 8)}…\`: ${list}`, { parse_mode: "Markdown" });
 }
 
-/* ─── /agent-list ─────────────────────────────────────────────── */
+/* ─── /agent_list ─────────────────────────────────────────────── */
 
 export async function handleAgentList(ctx) {
   const tgUser = ctx.from;
@@ -217,7 +217,7 @@ export async function handleAgentList(ctx) {
     [user.id],
   );
   if (rows.length === 0) {
-    return ctx.reply("No active agent delegations. Grant one with `/agent-authorize`.", { parse_mode: "Markdown" });
+    return ctx.reply("No active agent delegations. Grant one with `/agent_authorize`.", { parse_mode: "Markdown" });
   }
   const lines = [`*Active agent delegations* (${rows.length})`, ``];
   for (const r of rows) {
@@ -225,6 +225,6 @@ export async function handleAgentList(ctx) {
     const capSol = (Number(r.cap) / 1e9).toFixed(2);
     lines.push(`\`${r.agent_pubkey.slice(0, 8)}…\`  ${r.action}  cap=${capSol} SOL  max_active=${r.max_active_orders}  slip≤${(r.max_slippage_bps / 100).toFixed(1)}%${expiry}`);
   }
-  lines.push(``, `Revoke: \`/agent-revoke <agent_pubkey>\``);
+  lines.push(``, `Revoke: \`/agent_revoke <agent_pubkey>\``);
   await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
 }

--- a/src/commands/limit-close-intervention.js
+++ b/src/commands/limit-close-intervention.js
@@ -1,0 +1,193 @@
+/**
+ * Layer 3 — TG callback handler for limit-close intervention DMs.
+ *
+ * Callback data formats:
+ *   lcint:approve:<order_id>:<new_slippage_bps>
+ *   lcint:decline:<order_id>
+ *   lcint:cancel:<order_id>
+ *
+ * Security model:
+ *
+ *   1. Ownership — the order MUST belong to the user that pressed the
+ *      button. We re-derive user_id from ctx.from.id and require the
+ *      UPDATE to match. A leaked screenshot of a keyboard cannot be
+ *      replayed by a different account because the callback runs
+ *      WHERE user_id = ctx.from.id.
+ *
+ *   2. State-machine guard — the UPDATE only fires WHERE
+ *      status = 'awaiting_user' AND intervention_state = 'requested'.
+ *      If the order already advanced (engine consumed an earlier
+ *      approval; cron timed out; user pressed twice), the UPDATE is
+ *      a no-op and we tell the user "your decision already settled."
+ *
+ *   3. Slippage bounds — even though the engine computed the
+ *      suggested_slippage_bps and put it in the callback data, the
+ *      bot REVERIFIES against the engine's saved suggestion in the
+ *      row (intervention_suggested_slippage_bps) before applying.
+ *      A tampered callback payload (e.g. "approve:order:9999") gets
+ *      rejected because the value won't match.
+ *
+ *   4. Schema CHECK is the final backstop — slippage_bps is constrained
+ *      to (10, 1000). Even if 1 and 2 and 3 all failed, the DB UPDATE
+ *      with slippage_bps=5000 fails.
+ */
+import { query } from "../db/pool.js";
+
+const PATTERN = /^lcint:(approve|decline|cancel):(\d+)(?::(\d+))?$/;
+
+export function registerLimitCloseInterventionCallbacks(bot) {
+  bot.callbackQuery(/^lcint:/, async (ctx) => {
+    const data = ctx.callbackQuery?.data || "";
+    const m = data.match(PATTERN);
+    if (!m) {
+      await ctx.answerCallbackQuery({ text: "Invalid action.", show_alert: false });
+      return;
+    }
+    const [, action, orderIdStr, slippageStr] = m;
+    const orderId = Number(orderIdStr);
+    const tgUserId = ctx.from?.id;
+    if (!tgUserId || !Number.isInteger(orderId)) {
+      await ctx.answerCallbackQuery({ text: "Couldn't identify the order." });
+      return;
+    }
+
+    // Find the order + verify ownership in a single statement.
+    const { rows: [order] } = await query(
+      `SELECT lc.id, lc.status, lc.intervention_state, lc.user_id,
+              lc.slippage_bps, lc.max_slippage_bps_cap,
+              lc.intervention_suggested_slippage_bps,
+              u.telegram_id
+         FROM limit_close_orders lc
+         JOIN users u ON u.id = lc.user_id
+        WHERE lc.id = $1 AND u.telegram_id = $2`,
+      [orderId, String(tgUserId)],
+    );
+    if (!order) {
+      await ctx.answerCallbackQuery({ text: "Order not found or not yours.", show_alert: true });
+      return;
+    }
+    if (order.status !== "awaiting_user" || order.intervention_state !== "requested") {
+      await ctx.answerCallbackQuery({
+        text: "This decision already settled.",
+        show_alert: true,
+      });
+      try {
+        await ctx.editMessageReplyMarkup({});
+      } catch { /* keyboard already gone */ }
+      return;
+    }
+
+    if (action === "approve") {
+      const requested = Number(slippageStr);
+      // Defense-in-depth #3 — the suggested_slippage_bps in the callback
+      // must match what the engine wrote into the row at intervention
+      // request time. Catches a tampered keyboard payload.
+      if (
+        !Number.isInteger(requested) ||
+        requested !== order.intervention_suggested_slippage_bps
+      ) {
+        await ctx.answerCallbackQuery({
+          text: "Suggestion changed since this prompt was sent. Tap /limitorders to see current state.",
+          show_alert: true,
+        });
+        return;
+      }
+      // Hard ceiling guard, mirroring the engine's INTERVENTION_HARD_CEILING_BPS.
+      // The CHECK constraint on slippage_bps also enforces (10, 1000), so
+      // this is belt-and-suspenders.
+      if (requested < 10 || requested > 1000) {
+        await ctx.answerCallbackQuery({ text: "Out-of-range slippage." });
+        return;
+      }
+      // Apply: bump BOTH slippage_bps and max_slippage_bps_cap (cap
+      // widens to the same value — explicit borrower consent at this
+      // moment is what authorizes the widening). The state transition
+      // back to 'armed' will happen in the engine's
+      // consumeApprovedInterventions sweep.
+      const r = await query(
+        `UPDATE limit_close_orders
+            SET slippage_bps = $2,
+                max_slippage_bps_cap = GREATEST($2, COALESCE(max_slippage_bps_cap, $2)),
+                intervention_state = 'approved',
+                intervention_response = 'approve',
+                intervention_response_at = NOW()
+          WHERE id = $1
+            AND user_id = $3
+            AND status = 'awaiting_user'
+            AND intervention_state = 'requested'
+          RETURNING id`,
+        [orderId, requested, order.user_id],
+      );
+      if (r.rows.length === 0) {
+        await ctx.answerCallbackQuery({ text: "Couldn't apply (race). Tap /limitorders to see status.", show_alert: true });
+        return;
+      }
+      await ctx.answerCallbackQuery({ text: `Approved — will retry at ${(requested / 100).toFixed(1)}% slippage.` });
+      try {
+        await ctx.editMessageReplyMarkup({});
+        await ctx.editMessageText(
+          `Order #${orderId} — approved widening to *${(requested / 100).toFixed(2)}%*.\n\nThe engine will retry at the new slippage on its next tick.`,
+          { parse_mode: "Markdown" },
+        );
+      } catch { /* edit failed — not critical */ }
+      return;
+    }
+
+    if (action === "decline") {
+      const r = await query(
+        `UPDATE limit_close_orders
+            SET status = 'armed',
+                intervention_state = 'declined',
+                intervention_response = 'decline',
+                intervention_response_at = NOW()
+          WHERE id = $1
+            AND user_id = $2
+            AND status = 'awaiting_user'
+            AND intervention_state = 'requested'
+          RETURNING id`,
+        [orderId, order.user_id],
+      );
+      if (r.rows.length === 0) {
+        await ctx.answerCallbackQuery({ text: "Couldn't apply (race)." });
+        return;
+      }
+      await ctx.answerCallbackQuery({ text: "Will keep trying at your original cap." });
+      try {
+        await ctx.editMessageReplyMarkup({});
+        await ctx.editMessageText(
+          `Order #${orderId} — waiting for deeper liquidity at your original cap. I'll DM again if the same condition reappears.`,
+        );
+      } catch {}
+      return;
+    }
+
+    if (action === "cancel") {
+      const r = await query(
+        `UPDATE limit_close_orders
+            SET status = 'cancelled',
+                intervention_state = 'declined',
+                intervention_response = 'cancel',
+                intervention_response_at = NOW(),
+                cancellation_reason = 'user_intervention_cancel'
+          WHERE id = $1
+            AND user_id = $2
+            AND status = 'awaiting_user'
+            AND intervention_state = 'requested'
+          RETURNING id`,
+        [orderId, order.user_id],
+      );
+      if (r.rows.length === 0) {
+        await ctx.answerCallbackQuery({ text: "Couldn't cancel (race)." });
+        return;
+      }
+      await ctx.answerCallbackQuery({ text: "Order cancelled." });
+      try {
+        await ctx.editMessageReplyMarkup({});
+        await ctx.editMessageText(
+          `Order #${orderId} — cancelled. Your loan is unchanged.`,
+        );
+      } catch {}
+      return;
+    }
+  });
+}

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -26,6 +26,7 @@
  */
 import { query } from "../db/pool.js";
 import { upsertUser } from "../services/users.js";
+import { runArmPreflight } from "../services/limit-close-preflight.js";
 
 const MIN_LOAN_LAMPORTS = BigInt(1_000_000_000n); // 1 SOL eligibility floor
 const MAX_ACTIVE_ORDERS_PER_USER = 10;
@@ -207,7 +208,8 @@ export async function handleLimitClose(ctx) {
   const { rows: [loan] } = await query(
     `SELECT id, loan_id, status,
             original_loan_amount_lamports::text AS owed,
-            collateral_mint, collateral_amount::text AS coll_amount
+            collateral_mint, collateral_amount::text AS coll_amount,
+            collateral_amount::text AS collateral_amount_raw
        FROM loans
       WHERE user_id = $1 AND loan_id = $2`,
     [user.id, loan_id],
@@ -252,12 +254,51 @@ export async function handleLimitClose(ctx) {
     return ctx.reply(`You have ${activeCount.n} active limit orders (max ${MAX_ACTIVE_ORDERS_PER_USER}). Cancel one with /cancellimitorder first.`);
   }
 
-  // 4. Pre-arm "would-fire-immediately" check. Refuse trigger values <= current
-  //    market level. We DON'T fetch the live price here (cheaper to refuse only
-  //    obviously-bad values via the trigger_value_micro range gates); the
-  //    engine's pre-flight gate does the live-price re-check at fire time.
-  //    The schema CHECK constraint enforces > 0 already; this is just a UX
-  //    hint when the user clearly typed something wrong.
+  // 4. Pre-flight liquidity check (Layer 1).
+  //    Quote Jupiter at current state. If the order can't clear at the
+  //    user's slippage right now, refuse with a friendly suggestion.
+  //    Fail-open on Jupiter outages — advisory not gating.
+  const preflight = await runArmPreflight({
+    collateralMint: loan.collateral_mint,
+    collateralAmountRaw: loan.collateral_amount_raw,
+    sellDestination: dest,
+    slippageBps: slippage_bps,
+    loanOwedLamports: loan.owed,
+    protocolFeeBps: 100,
+  });
+  if (!preflight.ok) {
+    if (preflight.reason === "slippage_too_low" && preflight.suggestedSlippageBps) {
+      return ctx.reply(
+        [
+          `*Order would not fill right now.*`,
+          ``,
+          `At current liquidity, ${(slippage_bps / 100).toFixed(2)}% slippage can't cover the loan + fee.`,
+          `A setting of *${(preflight.suggestedSlippageBps / 100).toFixed(2)}%* would clear at current prices.`,
+          ``,
+          `Re-run with \`slip=${(preflight.suggestedSlippageBps / 100).toFixed(2)}%\` or wait for deeper liquidity.`,
+        ].join("\n"),
+        { parse_mode: "Markdown" },
+      );
+    }
+    if (preflight.reason === "liquidity_insufficient") {
+      return ctx.reply(
+        `*Can't arm this order.*\n\n` +
+        `Even at 10% slippage, current Jupiter routes can't cover the loan + fee. ` +
+        `Consider a smaller collateral position, lowering your trigger, or waiting for deeper liquidity.`,
+        { parse_mode: "Markdown" },
+      );
+    }
+    if (preflight.reason === "no_route_for_collateral") {
+      return ctx.reply(
+        `Jupiter can't route a swap for this collateral right now. ` +
+        `Wait a few minutes and try again.`,
+      );
+    }
+    return ctx.reply(
+      `Couldn't pre-check the order: ${preflight.reason}. Please try again.`,
+    );
+  }
+  const preflightAdvisory = !!preflight.advisory;
 
   // 5. Insert. The UNIQUE partial index on (loan_id WHERE status='armed')
   //    makes "two orders on the same loan" physically impossible at the
@@ -267,11 +308,19 @@ export async function handleLimitClose(ctx) {
     insertResult = await query(
       `INSERT INTO limit_close_orders
          (user_id, loan_id, trigger_kind, trigger_value_micro,
-          slippage_bps, sell_destination, expires_at, source, status, armed_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, 'tg', 'armed', NOW())
+          slippage_bps, sell_destination, expires_at, source, status, armed_at,
+          initial_slippage_bps,
+          preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 'tg', 'armed', NOW(),
+               $8,
+               $9, $10, $11)
        RETURNING id`,
       [user.id, loan.id, trigger_kind, trigger_value_micro.toString(),
-       slippage_bps, dest, expire_iso],
+       slippage_bps, dest, expire_iso,
+       slippage_bps,
+       preflightAdvisory ? null : slippage_bps,
+       preflightAdvisory ? null : (preflight.proceedsLamports || null),
+       preflightAdvisory ? null : (preflight.quotedAtIso || new Date().toISOString())],
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message)) {

--- a/src/index.js
+++ b/src/index.js
@@ -329,6 +329,14 @@ bot.command("crosspost", handleCommunityCrosspost);
   bot.command("limitclose", lc.handleLimitClose);
   bot.command("limitorders", lc.handleLimitOrders);
   bot.command("cancellimitorder", lc.handleCancelLimitOrder);
+
+  // Layer 3 — intervention callback handler (inline keyboard taps).
+  // Registers a bot.callbackQuery(/^lcint:/) handler that processes
+  // approve/decline/cancel taps from the intervention DMs the
+  // engine sends when single-block + TWAP both can't fit within
+  // the borrower's slippage cap.
+  const lci = await import("./commands/limit-close-intervention.js");
+  lci.registerLimitCloseInterventionCallbacks(bot);
 }
 // Agent delegations — Tier 2 (x402 agentic wrapper). Users authorize
 // agents to arm limit-close orders on their behalf within explicit

--- a/src/index.js
+++ b/src/index.js
@@ -330,6 +330,17 @@ bot.command("crosspost", handleCommunityCrosspost);
   bot.command("limitorders", lc.handleLimitOrders);
   bot.command("cancellimitorder", lc.handleCancelLimitOrder);
 }
+// Agent delegations — Tier 2 (x402 agentic wrapper). Users authorize
+// agents to arm limit-close orders on their behalf within explicit
+// bounds (max per order, max active, max slippage, expiry). The
+// magpie-x402 endpoint validates every agent request against these
+// rows BEFORE writing to limit_close_orders.
+{
+  const ad = await import("./commands/agent-delegations.js");
+  bot.command("agent_authorize", ad.handleAgentAuthorize);
+  bot.command("agent_revoke", ad.handleAgentRevoke);
+  bot.command("agent_list", ad.handleAgentList);
+}
 
 // Governance autopilot admin — operator-only commands gated inside each handler
 // via OPERATOR_TG_IDS env var. /gov-pause is the master kill switch.

--- a/src/services/limit-close-preflight.js
+++ b/src/services/limit-close-preflight.js
@@ -1,0 +1,227 @@
+/**
+ * Pre-flight liquidity check for limit-close orders.
+ *
+ * Before accepting an arm (TG or x402-agent), call this to verify
+ * that selling the loan's collateral at the user's slippage WOULD
+ * clear at current liquidity. Refuses orders that the market clearly
+ * cannot sustain at the chosen slippage, returning a suggested
+ * slippage that would have worked.
+ *
+ * Why this is a sanity check, NOT a guarantee:
+ *   The trigger fires at a FUTURE price level. Liquidity at that
+ *   future moment may be very different from now (deeper because of
+ *   hype; thinner because of dumping; gone because of token death).
+ *   We're catching the obvious "you typed 1% slippage and your token
+ *   trades at 12% impact" case at arm time so the user doesn't
+ *   discover it weeks later when their trigger hits.
+ *
+ *   For thin-liquidity collateral the call should be paired with
+ *   the engine's TWAP fallback (Layer 2) and intervention DM (Layer 3)
+ *   — those layers handle the runtime side.
+ *
+ * Security:
+ *   - Network failures fall through with allow=true + warning='quote_api_unreachable'.
+ *     Don't block users because Jupiter is having a bad day; the
+ *     engine's runtime safety floor is the actual guarantee.
+ *   - All numeric inputs are coerced to BigInt before arithmetic;
+ *     no float drift in the proceeds-vs-owed comparison.
+ *   - We never accept caller-supplied "skip preflight" flags. Every
+ *     arm goes through this gate. (Operator kill switch is separate.)
+ */
+import axios from "axios";
+
+const JUP_QUOTE_API = process.env.JUPITER_QUOTE_API || "https://lite-api.jup.ag/swap/v1/quote";
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+// Slippage levels we sweep when the user's setting doesn't clear,
+// looking for the lowest level that would have worked. Returned to
+// the user as a suggestion so they can re-arm with a realistic value.
+const SUGGESTION_SWEEP_BPS = [100, 200, 300, 500, 750, 1000];
+
+// Buffer above (owed + protocol_fee) we require for the order to be
+// considered "would clear." 50 bps = 0.5%. Smaller than the smallest
+// slippage step so a user setting exactly the floor doesn't get
+// rejected for a rounding error.
+const PROCEEDS_BUFFER_BPS = 50n;
+
+function isHttpUrl(s) {
+  return typeof s === "string" && /^https?:\/\//.test(s);
+}
+
+/**
+ * Fetch one Jupiter quote.
+ * Returns { ok, outAmountLamports: BigInt, route, raw } on success.
+ * Returns { ok: false, reason } on failure.
+ */
+async function fetchQuote({ inputMint, outputMint, amountRaw, slippageBps }) {
+  if (!isHttpUrl(JUP_QUOTE_API)) {
+    return { ok: false, reason: "jupiter_url_invalid" };
+  }
+  const url = `${JUP_QUOTE_API}?inputMint=${inputMint}&outputMint=${outputMint}` +
+              `&amount=${amountRaw}&slippageBps=${slippageBps}&onlyDirectRoutes=false`;
+  let res;
+  try {
+    res = await axios.get(url, { timeout: 4_000 });
+  } catch (err) {
+    return { ok: false, reason: "quote_api_unreachable", detail: err.message?.slice(0, 100) };
+  }
+  const data = res?.data;
+  if (!data || !data.outAmount || data.outAmount === "0") {
+    return { ok: false, reason: "no_route" };
+  }
+  let outAmountLamports;
+  try { outAmountLamports = BigInt(data.outAmount); }
+  catch { return { ok: false, reason: "non_numeric_out_amount" }; }
+  return { ok: true, outAmountLamports, raw: data };
+}
+
+/**
+ * Run the pre-flight check.
+ *
+ * Inputs (all required):
+ *   collateralMint              — string base58
+ *   collateralAmountRaw         — string of decimal raw units
+ *   sellDestination             — 'sol' | 'usdc'
+ *   slippageBps                 — integer 10..1000
+ *   loanOwedLamports            — BigInt or string
+ *   protocolFeeBps              — integer (default 100)
+ *
+ * Output:
+ *   {
+ *     ok: true,
+ *     proceedsLamports: <string>,
+ *     quotedAtIso: <string>,
+ *   }
+ *  OR
+ *   {
+ *     ok: false,
+ *     reason: <code>,
+ *     detail?: <string>,
+ *     suggestedSlippageBps?: <integer>,    // when reason='slippage_too_low'
+ *     wouldClearAt?: <string>,             // human label
+ *   }
+ *  OR (network failure → fail-open)
+ *   { ok: true, advisory: { reason, detail } }
+ */
+export async function runArmPreflight({
+  collateralMint,
+  collateralAmountRaw,
+  sellDestination,
+  slippageBps,
+  loanOwedLamports,
+  protocolFeeBps,
+}) {
+  // ── Shape coercion / validation ──────────────────────────────
+  if (!/^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(String(collateralMint || ""))) {
+    return { ok: false, reason: "invalid_collateral_mint" };
+  }
+  if (!/^\d{1,30}$/.test(String(collateralAmountRaw || ""))) {
+    return { ok: false, reason: "invalid_collateral_amount" };
+  }
+  const amountBI = BigInt(collateralAmountRaw);
+  if (amountBI <= 0n) return { ok: false, reason: "zero_collateral_amount" };
+  const dst = sellDestination === "usdc" ? USDC_MINT : SOL_MINT;
+  if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > 1000) {
+    return { ok: false, reason: "invalid_slippage" };
+  }
+  let owedBI;
+  try { owedBI = BigInt(loanOwedLamports); }
+  catch { return { ok: false, reason: "invalid_loan_owed" }; }
+  if (owedBI <= 0n) return { ok: false, reason: "zero_loan_owed" };
+  const feeBps = Number.isInteger(protocolFeeBps) ? protocolFeeBps : 100;
+  if (feeBps < 0 || feeBps > 1000) {
+    return { ok: false, reason: "invalid_protocol_fee_bps" };
+  }
+
+  // ── 1. Quote at user's slippage ──────────────────────────────
+  const primary = await fetchQuote({
+    inputMint: collateralMint,
+    outputMint: dst,
+    amountRaw: collateralAmountRaw,
+    slippageBps,
+  });
+
+  // Network / API failure — fail OPEN so a quote-API outage doesn't
+  // block legitimate arms. The engine's runtime proceeds check is
+  // the actual safety; this is just a friendlier pre-flight.
+  if (!primary.ok && primary.reason === "quote_api_unreachable") {
+    return {
+      ok: true,
+      advisory: { reason: "quote_api_unreachable", detail: primary.detail },
+    };
+  }
+
+  if (!primary.ok && primary.reason === "no_route") {
+    return { ok: false, reason: "no_route_for_collateral",
+             detail: "Jupiter cannot route a swap for this collateral right now." };
+  }
+
+  if (!primary.ok) {
+    return { ok: false, reason: primary.reason, detail: primary.detail };
+  }
+
+  // ── 2. Will proceeds cover (loan + fee + buffer)? ──────────────
+  // Compute the minimum-out the user would actually receive after
+  // slippage, then deduct the protocol fee, then compare to owed.
+  // We require strict gt with a small buffer so a price-feed wobble
+  // between arm and fire doesn't flip a marginal pass into a fail.
+  const slippageDenom = 10_000n;
+  const minOutLamports = (primary.outAmountLamports * (slippageDenom - BigInt(slippageBps))) / slippageDenom;
+  const feeOnMinOut = (minOutLamports * BigInt(feeBps)) / slippageDenom;
+  const proceedsAfterFee = minOutLamports - feeOnMinOut;
+  const requiredWithBuffer = owedBI + (owedBI * PROCEEDS_BUFFER_BPS) / slippageDenom;
+
+  if (proceedsAfterFee >= requiredWithBuffer) {
+    return {
+      ok: true,
+      proceedsLamports: primary.outAmountLamports.toString(),
+      minOutLamports: minOutLamports.toString(),
+      proceedsAfterFeeLamports: proceedsAfterFee.toString(),
+      requiredLamports: requiredWithBuffer.toString(),
+      quotedAtIso: new Date().toISOString(),
+    };
+  }
+
+  // ── 3. Sweep for a suggested slippage that WOULD clear ──────────
+  // Walk up the sweep table. First level that clears is our suggestion.
+  // We never suggest above 1000 (10%); above that we report
+  // "liquidity_insufficient" — the user should sell smaller pieces
+  // or rethink the order entirely.
+  let suggestedBps = null;
+  for (const trySlip of SUGGESTION_SWEEP_BPS) {
+    if (trySlip <= slippageBps) continue; // already tried lower or equal
+    const q = await fetchQuote({
+      inputMint: collateralMint,
+      outputMint: dst,
+      amountRaw: collateralAmountRaw,
+      slippageBps: trySlip,
+    });
+    if (!q.ok) continue;
+    const minOut = (q.outAmountLamports * (slippageDenom - BigInt(trySlip))) / slippageDenom;
+    const fee = (minOut * BigInt(feeBps)) / slippageDenom;
+    const after = minOut - fee;
+    if (after >= requiredWithBuffer) {
+      suggestedBps = trySlip;
+      break;
+    }
+  }
+
+  if (suggestedBps === null) {
+    return {
+      ok: false,
+      reason: "liquidity_insufficient",
+      detail: "Even at 10% slippage, current Jupiter routes won't cover the loan + fee. " +
+              "Consider a smaller collateral position, lowering your trigger, or waiting for deeper liquidity.",
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "slippage_too_low",
+    detail: `At current liquidity, ${slippageBps / 100}% slippage won't clear. ` +
+            `A setting of ${suggestedBps / 100}% would clear right now. Liquidity may improve by the time your trigger hits, but we recommend re-arming with at least ${suggestedBps / 100}%.`,
+    suggestedSlippageBps: suggestedBps,
+    yourSlippageBps: slippageBps,
+  };
+}

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -55,6 +55,29 @@ function agentAttribution(p) {
   return `Armed by your authorized agent \`${pk.slice(0, 8)}...${pk.slice(-4)}\`. Revoke with /agent_revoke if unexpected.`;
 }
 
+/**
+ * Render the Layer 3 intervention DM. The bot's send-tick wraps this
+ * with an inline keyboard since notification-sender is the only
+ * place we have the TG client.
+ */
+function renderLimitCloseIntervention(p) {
+  const agentLine = agentAttribution(p);
+  const suggestedPct = (p.suggested_slippage_bps / 100).toFixed(2);
+  const currentCapPct = (p.current_cap_bps / 100).toFixed(2);
+  return [
+    `*Limit-close needs your call* — order #${p.order_id}`,
+    ``,
+    `Trigger hit, but the swap can't fill within your cap.`,
+    `Current cap: \`${currentCapPct}%\` slippage`,
+    `Would clear at: \`${suggestedPct}%\` (current liquidity)`,
+    ``,
+    `Allow \`${suggestedPct}%\` to fill now, or wait for deeper liquidity.`,
+    `(Decision window: 1 hour.)`,
+    agentLine ? `` : null,
+    agentLine,
+  ].filter((s) => s !== null).join("\n");
+}
+
 function renderLimitCloseArmed(p) {
   const agentLine = agentAttribution(p);
   return [
@@ -113,10 +136,11 @@ function renderLimitCloseCancelled(p) {
 }
 
 const RENDERERS = {
-  limit_close_armed:     renderLimitCloseArmed,
-  limit_close_fired:     renderLimitCloseFired,
-  limit_close_failed:    renderLimitCloseFailed,
-  limit_close_cancelled: renderLimitCloseCancelled,
+  limit_close_armed:        renderLimitCloseArmed,
+  limit_close_fired:        renderLimitCloseFired,
+  limit_close_failed:       renderLimitCloseFailed,
+  limit_close_cancelled:    renderLimitCloseCancelled,
+  limit_close_intervention: renderLimitCloseIntervention,
 };
 
 function renderPayload(kind, payload) {
@@ -173,9 +197,28 @@ async function tick(bot) {
           if (!u?.telegram_id) {
             lastError = `user_has_no_telegram_id`;
           } else {
+            // Layer 3 — limit-close intervention needs an inline
+            // keyboard so the borrower can tap a response. Keyboard
+            // callback IDs encode the order id + the suggested
+            // slippage_bps to widen to so the callback handler can
+            // verify the action against the row.
+            let extra = {};
+            if (row.kind === "limit_close_intervention") {
+              const { InlineKeyboard } = await import("grammy");
+              const kb = new InlineKeyboard()
+                .text(`Allow ${(row.payload.suggested_slippage_bps / 100).toFixed(1)}%`,
+                      `lcint:approve:${row.payload.order_id}:${row.payload.suggested_slippage_bps}`)
+                .row()
+                .text("Wait",
+                      `lcint:decline:${row.payload.order_id}`)
+                .text("Cancel order",
+                      `lcint:cancel:${row.payload.order_id}`);
+              extra = { reply_markup: kb };
+            }
             await bot.api.sendMessage(Number(u.telegram_id), text, {
               parse_mode: "Markdown",
               disable_web_page_preview: true,
+              ...extra,
             });
             success = true;
           }

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -37,7 +37,26 @@ function fmtMcUsd(micros) {
   return `$${usd.toFixed(2)}`;
 }
 
+/**
+ * Render an "an agent did this" attribution line if the order's
+ * source is agent_x402. Borrower needs to know whether they (via TG)
+ * or an authorized agent took the action — and which agent, so they
+ * can revoke if it wasn't expected.
+ *
+ * If source is 'tg' (or missing — older orders predate the field),
+ * return null and let renderers omit the line entirely.
+ */
+function agentAttribution(p) {
+  if (p.source !== "agent_x402") return null;
+  const pk = p.source_agent_pubkey;
+  if (!pk || typeof pk !== "string" || pk.length < 12) {
+    return `Armed by an authorized agent.`;
+  }
+  return `Armed by your authorized agent \`${pk.slice(0, 8)}...${pk.slice(-4)}\`. Revoke with /agent_revoke if unexpected.`;
+}
+
 function renderLimitCloseArmed(p) {
+  const agentLine = agentAttribution(p);
   return [
     `*Limit-close armed* — order #${p.order_id}`,
     ``,
@@ -45,25 +64,31 @@ function renderLimitCloseArmed(p) {
     `Trigger: ${p.trigger_label}`,
     `Slippage: ${(p.slippage_bps / 100).toFixed(2)}%`,
     `Destination: ${p.sell_destination.toUpperCase()}`,
+    agentLine ? `` : null,
+    agentLine,
     ``,
     `I'll repay and sell automatically when the trigger fires.`,
-  ].join("\n");
+  ].filter((s) => s !== null).join("\n");
 }
 
 function renderLimitCloseFired(p) {
+  const agentLine = agentAttribution(p);
   return [
     `*Limit-close FIRED* — order #${p.order_id}`,
     ``,
-    `Trigger: ${p.trigger_label} ✓`,
+    `Trigger: ${p.trigger_label} hit`,
     `Repaid: ${fmtSol(p.loan_owed_lamports)} SOL · [tx](https://solscan.io/tx/${p.tx_repay})`,
     `Sold: ${p.collateral_sold_human} ${p.collateral_symbol} → ${fmtSol(p.proceeds_lamports)} ${p.dest.toUpperCase()} · [tx](https://solscan.io/tx/${p.tx_swap})`,
     `Fee: ${fmtSol(p.fee_lamports)} ${p.dest.toUpperCase()} (1%)`,
     ``,
     `Net to your wallet: *${fmtSol(p.net_to_user_lamports)} ${p.dest.toUpperCase()}*`,
-  ].join("\n");
+    agentLine ? `` : null,
+    agentLine,
+  ].filter((s) => s !== null).join("\n");
 }
 
 function renderLimitCloseFailed(p) {
+  const agentLine = agentAttribution(p);
   return [
     `*Limit-close FAILED* — order #${p.order_id}`,
     ``,
@@ -71,15 +96,20 @@ function renderLimitCloseFailed(p) {
     p.detail ? `Detail: ${p.detail}` : null,
     ``,
     `Your loan is *unchanged*. Set a new order with /limitclose or close manually with /repay.`,
-  ].filter(Boolean).join("\n");
+    agentLine ? `` : null,
+    agentLine,
+  ].filter((s) => s !== null).join("\n");
 }
 
 function renderLimitCloseCancelled(p) {
+  const agentLine = agentAttribution(p);
   return [
     `*Limit-close cancelled* — order #${p.order_id}`,
     ``,
     `Reason: ${p.reason}`,
-  ].join("\n");
+    agentLine ? `` : null,
+    agentLine,
+  ].filter((s) => s !== null).join("\n");
 }
 
 const RENDERERS = {


### PR DESCRIPTION
Bot-side counterpart to the magpie-x402 limit-close endpoint (separate PR coming on `magpiecapital/magpie-x402`).

## What this PR adds

| Method | Path | Purpose |
|---|---|---|
| POST | `/api/v1/internal/agent/limit-close/arm` | Arm an agent order (after x402 has verified payment + bound agent_pubkey) |
| GET | `/api/v1/internal/agent/limit-close?agent=&id=` | Read one order scoped to the calling agent |
| GET | `/api/v1/internal/agent/limit-close/list?agent=[&status=all]` | List orders armed by this agent |
| DELETE | `/api/v1/internal/agent/limit-close?agent=&id=` | Cancel an armed order |

All four are gated by `X-Internal-Token: $INTERNAL_API_TOKEN` — same model as `/api/v1/internal/x402/record`.

## Authorization model (defense in depth)

1. **Network** — `INTERNAL_API_TOKEN` constant-time compare. Only the x402 service has it.
2. **App** — `agent_delegations` row for `(user_wallet, agent_pubkey, action='limit_close', status='active')` must exist, not be expired, and bound every dimension of the requested order:
   - `max_per_order_lamports` ≥ `loan.original_loan_amount_lamports`
   - `max_active_orders` > current armed count for **this agent's** orders for **this user**
   - `max_slippage_bps` ≥ requested `slippage_bps`
3. **Storage** — the existing UNIQUE partial index `(loan_id WHERE status='armed')` physically blocks two armed orders against the same loan even if the app-layer check races with another path.

## Cross-wallet defense

The loan lookup joins on:
```sql
WHERE l.user_id = delegation.user_id
  AND w.public_key = body.user_wallet
```
so an agent authorized for wallet A cannot arm against a loan owned by wallet B — regardless of which `loan_id` they pass.

## Cancel race semantics

Cancel `WHERE status='armed'`. Once the engine flips the row to `firing`, the agent's cancel returns `not_cancellable_or_not_found` rather than corrupting an in-flight execution. Matches TG cancel semantics exactly.

## What happens downstream

Orders armed via this path land with `source='agent_x402'` and `source_agent_pubkey=<agent>`. The private engine (`magpiecapital/magpie-limitclose`) processes them identically to TG-armed orders — same atomic claim, same pre-flight gates, same proceeds safety floor. No engine changes required.

## Tests

- `node --check` clean on both files.
- Manual smoke: cURL with valid token + valid delegation arms; with invalid token returns 401; with non-existent delegation returns `no_active_delegation`; with over-cap notional returns `order_exceeds_delegation_cap`; with stranger wallet returns `loan_not_found_for_wallet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)