### PR TITLE
fix: security audit fixes for fill-guarantee (cooldown + TWAP counter)

### DIFF
--- a/migrations/029_limit_close_security_audit.sql
+++ b/migrations/029_limit_close_security_audit.sql
@@ -1,0 +1,30 @@
+-- limit_close_orders — fixes from security audit on the three-layer
+-- fill-guarantee shipped in migrations 025-028.
+--
+-- 1. twap_consecutive_failures — a dedicated counter for TWAP-chunk
+--    failures, separate from the order-lifetime failure_count. The
+--    engine compares this against TWAP_MAX_CHUNK_RETRIES to decide
+--    whether to escalate to user intervention. Without a dedicated
+--    counter, an order entering TWAP with failure_count=5 from prior
+--    single-block escalations would trigger intervention on the FIRST
+--    chunk failure (5 >= 2) — false-positive intervention DMs.
+--
+-- 2. intervention_decline_cooldown_until — when a user taps Wait on
+--    an intervention DM, the engine puts the order back to armed and
+--    re-evaluates. Without a cooldown the same failure condition
+--    triggers another intervention DM within 30 seconds — DM spam.
+--    This timestamp gates re-requests so the engine only DMs again
+--    after the cooldown window passes.
+--
+-- 3. NB: 'awaiting_user' + 'twap_in_progress' need to be picked up by
+--    the expireOldOrders watchdog so orders past expires_at don't
+--    linger in those states. That's a code change in the engine
+--    repo (watcher.js) — no schema change needed; just listing here
+--    for completeness.
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS twap_consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS intervention_decline_cooldown_until TIMESTAMPTZ;
+
+-- Backfill is not needed — both default to 0 / NULL which is what the
+-- engine treats as "no prior TWAP failures, no cooldown active."

--- a/src/commands/limit-close-intervention.js
+++ b/src/commands/limit-close-intervention.js
@@ -134,12 +134,20 @@ export function registerLimitCloseInterventionCallbacks(bot) {
     }
 
     if (action === "decline") {
+      // Set a cooldown so the engine doesn't re-request intervention
+      // within the next 15 minutes. The engine's requestIntervention
+      // WHERE clause checks intervention_decline_cooldown_until — a
+      // future timestamp here blocks re-requests until it elapses.
+      // Without this guard, the same failure condition reappearing
+      // 30s later (next watcher tick) would fire ANOTHER DM, then
+      // another, then another — DM-spam loop.
       const r = await query(
         `UPDATE limit_close_orders
             SET status = 'armed',
                 intervention_state = 'declined',
                 intervention_response = 'decline',
-                intervention_response_at = NOW()
+                intervention_response_at = NOW(),
+                intervention_decline_cooldown_until = NOW() + INTERVAL '15 minutes'
           WHERE id = $1
             AND user_id = $2
             AND status = 'awaiting_user'


### PR DESCRIPTION
Caught during post-merge security audit of Layer 1-3 fill-guarantee. Bot side of a paired PR with engine repo.

## Fixes

| # | Severity | Issue |
|---|---|---|
| 1 | HIGH | DM-spam loop after user taps Wait — engine re-prompts every 30s with no cooldown |
| 2 | HIGH (engine repo) | Stale `failure_count` in TWAP processor — escalates to intervention on first chunk failure if order entered TWAP with high prior failure_count |
| 3 | HIGH (engine repo) | `expireOldOrders` only handled `armed` — `twap_in_progress` and `awaiting_user` lingered past expires_at forever |
| 4 | MEDIUM (engine repo) | TWAP processor missing wallet-binding check that the primary path has |
| 5 | MEDIUM (engine repo) | N×2 Jupiter calls per tick when multiple orders share a mint |

## What's in this PR (bot)

- **Migration 029** — adds `twap_consecutive_failures` (dedicated counter the engine uses for TWAP_MAX_CHUNK_RETRIES) and `intervention_decline_cooldown_until` (timestamp the bot callback sets when user taps Wait).
- **`limit-close-intervention.js`** — Wait handler now sets `intervention_decline_cooldown_until = NOW() + INTERVAL '15 minutes'`. Engine's `requestIntervention` checks this in its WHERE clause.

## What's in the paired engine PR

Engine repo (`magpiecapital/magpie-limitclose`) PR has the matching code:
- TWAP processor uses `UPDATE RETURNING` to read fresh `twap_consecutive_failures`
- `recordChunk` resets the counter on success
- `requestIntervention` respects cooldown + `MAX_INTERVENTION_REQUESTS=3`
- `expireOldOrders` extends to `twap_in_progress` + `awaiting_user`
- TWAP processor adds wallet binding check
- Per-tick price cache in watcher

## Worst-case behavior after fixes

3 intervention DMs total per order, spread ~45 minutes apart, then the order goes silent and waits for either:
1. Trigger condition to clear naturally (price moves enough that proceeds fit at original cap)
2. User to take manual action via `/limitorders`
3. `expires_at` to elapse → marked expired

No path now leads to perpetual DM spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)