### PR TITLE
HOTFIX: bot took down site/Pip — make migrations idempotent + non-fatal

### DIFF
--- a/migrations/027_limit_close_auto_escalate.sql
+++ b/migrations/027_limit_close_auto_escalate.sql
@@ -34,24 +34,33 @@ ALTER TABLE limit_close_orders
   ADD COLUMN IF NOT EXISTS initial_slippage_bps   INTEGER,
   ADD COLUMN IF NOT EXISTS slippage_escalations   INTEGER NOT NULL DEFAULT 0;
 
--- Cap must be within the global allowable range AND must be ≥ the
--- order's current slippage. Engine never reads max_slippage_bps_cap
--- without checking it's > current slippage_bps, but we belt-and-suspenders
--- this at the schema layer.
-ALTER TABLE limit_close_orders
-  ADD CONSTRAINT limit_close_orders_cap_in_range
-  CHECK (
-    max_slippage_bps_cap IS NULL OR
-    (max_slippage_bps_cap >= 10 AND max_slippage_bps_cap <= 1000)
-  );
+-- Cap must be within the global allowable range. Wrapped in
+-- DO $$ … EXCEPTION block so the migration is idempotent — re-running
+-- on a DB where the constraint already exists is a clean no-op
+-- instead of a fatal "constraint already exists" error. Postgres
+-- doesn't support `ADD CONSTRAINT IF NOT EXISTS` for CHECK
+-- constraints, so this DO block is the canonical workaround.
+DO $$ BEGIN
+  ALTER TABLE limit_close_orders
+    ADD CONSTRAINT limit_close_orders_cap_in_range
+    CHECK (
+      max_slippage_bps_cap IS NULL OR
+      (max_slippage_bps_cap >= 10 AND max_slippage_bps_cap <= 1000)
+    );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
 
--- Initial slippage, if recorded, must match schema bounds too.
-ALTER TABLE limit_close_orders
-  ADD CONSTRAINT limit_close_orders_initial_slippage_in_range
-  CHECK (
-    initial_slippage_bps IS NULL OR
-    (initial_slippage_bps >= 10 AND initial_slippage_bps <= 1000)
-  );
+DO $$ BEGIN
+  ALTER TABLE limit_close_orders
+    ADD CONSTRAINT limit_close_orders_initial_slippage_in_range
+    CHECK (
+      initial_slippage_bps IS NULL OR
+      (initial_slippage_bps >= 10 AND initial_slippage_bps <= 1000)
+    );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
 
 -- Backfill — for any existing armed orders we set initial_slippage_bps
 -- = slippage_bps so audit trails make sense. We leave auto_escalate_slippage

--- a/src/index.js
+++ b/src/index.js
@@ -605,8 +605,37 @@ bot.start({
           console.log(`[migrations] applied ${res.applied.length} new migration(s): ${res.applied.join(", ")}`);
         }
       } catch (err) {
-        console.error("[bot] migrations FAILED — crashing:", err.message);
-        process.exit(1);
+        // CHANGED 2026-06-11: previously we process.exit(1) on migration
+        // failure, the reasoning being "a half-migrated DB is worse than
+        // a visibly-down bot." That trade-off ate us at 21:04Z when a
+        // ledger desync caused 027 to re-run + ADD CONSTRAINT fail; the
+        // bot crashloop took the whole site + Pip down for ~30 minutes
+        // while users couldn't /borrow or /repay anything.
+        //
+        // New trade-off: log + alert operator + KEEP SERVING the API.
+        // The API server already started at line 553, and the previous
+        // schema is functional for everything that was working before
+        // the failed migration. The only thing that breaks is what the
+        // NEW migration was supposed to add — which is feature work,
+        // not core functionality.
+        //
+        // We page the operator via the security-alerts DM so they know
+        // a migration is stuck and can intervene. We also set a process
+        // env flag DB_MIGRATIONS_FAILED so admin commands can check it.
+        console.error("[bot] migrations FAILED — CONTINUING in degraded mode:", err.message);
+        process.env.DB_MIGRATIONS_FAILED = err.message?.slice(0, 500) || "unknown";
+        try {
+          const { sendSecurityAlert } = await import("./services/security-alerts.js");
+          await sendSecurityAlert(
+            `🚨 BOT MIGRATIONS FAILED on boot — running in DEGRADED mode.\n\n` +
+            `error: ${err.message?.slice(0, 300)}\n\n` +
+            `Core /borrow + /repay + site still serving the EXISTING schema.\n` +
+            `Investigate the migration manually: Railway shell -> psql -> check the failing migration's SQL.\n` +
+            `Then either fix the file + redeploy, or run the SQL + INSERT INTO schema_migrations.`,
+          );
+        } catch (alertErr) {
+          console.error("[bot] couldn't even DM the migration alert:", alertErr.message);
+        }
       }
       try {
         const pool = await import("./db/pool.js");


### PR DESCRIPTION
## What happened

At 21:04Z the bot's Railway service crashed and entered crashloop. Site dashboard, all bot API endpoints, and Pip went down for ~30 minutes. Users couldn't /borrow, /repay, or use the site dashboard.

## Root cause

1. Migrations 027/028/029 were applied to prod DB during development via direct `node -e` calls, which executed the SQL but **did not insert rows into `schema_migrations` ledger**.
2. After PR #67 merged + Railway redeployed, the migrations runner saw 027 as 'pending' (not in ledger) → tried to re-run.
3. Migration 027's `ADD CONSTRAINT` lacks idempotency protection → 'constraint already exists' → migrations runner throws.
4. `index.js` had `process.exit(1)` on migration failure → instant crashloop → Railway exponential backoff → total outage.

## Fixes

### 027 idempotency
`ADD CONSTRAINT` wrapped in `DO 11175 ... EXCEPTION WHEN duplicate_object` blocks. Re-running is now a clean no-op.

### index.js degraded-mode startup
Migration failure no longer crashes the bot. New behavior:
- Loud error log
- Set `process.env.DB_MIGRATIONS_FAILED`
- Security-alert DM to operator
- **Continue serving the API on previous schema**

Previous trade-off ('crash visibly rather than serve from half-migrated DB') optimized for the case where migration actually creates inconsistent state. Didn't optimize for the much more common case where a migration just fails idempotently. **Degraded > down.**

### Ledger
Backfilled manually for 027/028/029 before this PR so next bot restart finds them applied + skips. DO-block is belt-and-suspenders.

## Follow-up

Operator asked for proactive recovery — coming in next PR: external watchdog (Vercel cron) that pings the bot every 60s and DMs operator directly via Telegram API (bypassing the bot) if the bot is down for 2+ consecutive pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)