### PR TITLE
fix: loan-health alert clarity — collateral symbol + wallet attribution + deep link

### DIFF
--- a/src/services/health-watcher.js
+++ b/src/services/health-watcher.js
@@ -177,22 +177,53 @@ async function checkLoan(bot, row) {
       .text("⏱ Extend", `extend:loan:${row.id}`);
   }
 
+  // ── Build the alert with clearer surface ──
+  // 1. Symbol on the loan line so the user immediately sees WHICH token
+  //    is at risk (operator complaint 2026-06-11 — alert didn't say
+  //    what token).
+  // 2. Loan number is a Markdown link that drops the user directly on
+  //    the loan card in the dashboard. The dashboard reads ?loan=<id>
+  //    on mount and scrolls + highlights that card.
+  // 3. If the user has multiple wallets we surface which one this loan
+  //    belongs to. Single-wallet users see no wallet line.
+  const symbol = row.symbol || row.collateral_mint?.slice(0, 4) + "…";
+  // Deep link to the dashboard with the on-chain loan_id. The site
+  // reads ?loan= and scrolls to the card with matching loan_id.
+  const dashUrl = `https://magpie.capital/dashboard?loan=${encodeURIComponent(row.loan_id)}`;
+  const loanLine = `[Loan #${row.loan_id}](${dashUrl}) — ${symbol} — health *${ratio.toFixed(2)}x*`;
+
+  // Wallet line — only for multi-wallet users.
+  let walletLine = null;
+  if ((row.wallet_count ?? 1) > 1) {
+    const label = row.wallet_label || "Magpie wallet";
+    const shortPk = row.borrower_wallet
+      ? `${row.borrower_wallet.slice(0, 4)}…${row.borrower_wallet.slice(-4)}`
+      : null;
+    walletLine = shortPk
+      ? `Wallet: \`${label} (${shortPk})\``
+      : `Wallet: \`${label}\``;
+  }
+
   const msg = [
     `${alert.emoji} *Loan health alert*`,
     "",
     `${alert.label}`,
     "",
-    `Loan #${row.loan_id} — health *${ratio.toFixed(2)}x*`,
+    loanLine,
+    walletLine,
     `Collateral value: \`${(valueLamports / 1e9).toFixed(4)} SOL\``,
     `Owed: \`${(owed / 1e9).toFixed(4)} SOL\``,
     "",
     rec ? `*Recommended:* ${rec.text}` : "Options: /repay · /partialrepay · /topup collateral · /extend",
-  ].join("\n");
+  ].filter((s) => s !== null).join("\n");
 
   try {
     await bot.api.sendMessage(row.telegram_id, msg, {
       parse_mode: "Markdown",
       reply_markup: kb,
+      // Suppress the big card from the magpie.capital dashboard link
+      // so the alert stays compact.
+      disable_web_page_preview: true,
     });
     await query(`UPDATE loans SET last_health_alert = $2 WHERE id = $1`, [
       row.id,
@@ -212,12 +243,25 @@ export function startHealthWatcher(bot) {
     running = true;
     try {
       const { rows } = await query(
+        // wallet_count + wallet_label / wallet_pubkey: lets the alert say
+        // which wallet a loan belongs to when the user has more than one.
+        // For multi-wallet users we surface either the user-set label OR
+        // (when labels are all the default 'Magpie wallet') a short pubkey
+        // prefix so they can tell wallets apart. Single-wallet users see
+        // no wallet line — would be noise.
+        // sm.symbol: collateral token symbol so the user can immediately
+        // see what's at risk without having to look up the mint.
         `SELECT l.id, l.loan_id, l.user_id, l.collateral_mint, l.collateral_amount,
                 l.original_loan_amount_lamports, l.last_health_alert,
-                u.telegram_id, sm.decimals
+                l.borrower_wallet,
+                u.telegram_id,
+                sm.decimals, sm.symbol,
+                w.label AS wallet_label,
+                (SELECT COUNT(*)::int FROM wallets ww WHERE ww.user_id = u.id) AS wallet_count
          FROM loans l
          JOIN users u ON u.id = l.user_id
          LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+         LEFT JOIN wallets w ON w.user_id = u.id AND w.public_key = l.borrower_wallet
          WHERE l.status = 'active'`,
       );
       // Serialise per-loan checks so we don't hammer the price API.


### PR DESCRIPTION
Operator received a health alert that said 'Loan #1781162209894 health 1.46x' with no indication of which token was at risk, which wallet the loan was on, or how to jump to the loan on the dashboard. This PR fixes all three.

## Changes

1. **Collateral symbol on the loan line** — JOIN supported_mints.symbol; falls back to mint-prefix.
2. **Wallet attribution for multi-wallet users** — JOIN wallets + wallet_count subquery. Single-wallet users see no extra line (would be noise). Multi-wallet users see `Wallet: <label> (<pk_prefix>)`.
3. **Clickable Loan #** that opens the dashboard directly on the matching loan. Markdown link to `magpie.capital/dashboard?loan=<id>`. Site PR (paired) handles the scroll + highlight.

`disable_web_page_preview` keeps the link from generating a big card in TG.

## Before / after

**Before:**
```
Loan health alert
Heads up — your loan health dipped below 1.5x.
Loan #1781162209894 — health 1.46x
Collateral value: 7.3236 SOL
Owed: 5.0055 SOL
```

**After:**
```
Loan health alert
Heads up — your loan health dipped below 1.5x.
[Loan #1781162209894](https://magpie.capital/dashboard?loan=1781162209894) — $WIF — health 1.46x
Wallet: `Magpie wallet (5hsZ…oA8)`        (only if user has > 1 wallet)
Collateral value: 7.3236 SOL
Owed: 5.0055 SOL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)