### PR TITLE
harden: support ALERT_BOT_TOKEN — separate Telegram bot for watchdog DMs

### DIFF
--- a/.github/workflows/uptime-watchdog.yml
+++ b/.github/workflows/uptime-watchdog.yml
@@ -78,11 +78,17 @@ jobs:
       - name: Send Telegram alert on failure
         if: steps.probe.outputs.ok == 'false'
         env:
-          TG_BOT_TOKEN: ${{ secrets.MAGPIE_BOT_TOKEN }}
+          # Prefer the dedicated alert bot's token. Falls back to the
+          # production bot's token if ALERT_BOT_TOKEN isn't set yet.
+          # See magpie-site PR for rationale: isolate Vercel/GitHub
+          # secret surface from the production bot's custodial keys.
+          TG_BOT_TOKEN_ALERT: ${{ secrets.ALERT_BOT_TOKEN }}
+          TG_BOT_TOKEN_PROD: ${{ secrets.MAGPIE_BOT_TOKEN }}
           TG_CHAT_ID: ${{ secrets.OPERATOR_TG_CHAT_ID }}
         run: |
+          TG_BOT_TOKEN="${TG_BOT_TOKEN_ALERT:-$TG_BOT_TOKEN_PROD}"
           if [ -z "$TG_BOT_TOKEN" ] || [ -z "$TG_CHAT_ID" ]; then
-            echo "::warning::watchdog secrets not configured — set MAGPIE_BOT_TOKEN + OPERATOR_TG_CHAT_ID in repo secrets to enable alerts"
+            echo "::warning::watchdog secrets not configured — set ALERT_BOT_TOKEN (preferred) or MAGPIE_BOT_TOKEN + OPERATOR_TG_CHAT_ID in repo secrets to enable alerts"
             exit 0
           fi
           STATUS="${{ steps.probe.outputs.status }}"


### PR DESCRIPTION
Backward-compatible support for a dedicated alert bot. Prefers `ALERT_BOT_TOKEN` if set, falls back to existing `MAGPIE_BOT_TOKEN` otherwise.

Operator steps to fully transition (~3 min):
1. DM @BotFather → `/newbot` → name it 'Magpie Alerts' → username `@magpie_alerts_bot` (or similar) → copy token
2. Open the new bot, hit Start (mandatory so it can DM you)
3. Set `ALERT_BOT_TOKEN` on Vercel + GitHub repo secrets
4. (Optional) Remove `MAGPIE_BOT_TOKEN` from both

After step 4, if Vercel or GitHub secrets are ever compromised, the attacker only has access to the alert bot (no commands, no users, no funds) — not the production bot that holds users' encrypted custodial keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)