### PR TITLE
feat: agent eligible-loans discovery + Tier 2 end-to-end verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "eval-ai": "node scripts/eval-ai-support.js",
     "check-site": "node scripts/check-site.js",
     "test-signed": "node scripts/test-signed-endpoints.js",
-    "preflight": "npm run check-site && npm run test-signed"
+    "preflight": "npm run check-site && npm run test-signed",
+    "verify:tier2": "node scripts/verify-tier2/run.js"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/verify-tier2/run.js
+++ b/scripts/verify-tier2/run.js
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * Tier 2 (agentic limit-close via x402) end-to-end verification.
+ *
+ * Walks every step of the Tier 2 flow against the real prod stack
+ * WITHOUT touching the chain:
+ *
+ *   1. Insert a synthetic user (negative telegram_id so it can never
+ *      collide with a real TG user).
+ *   2. Insert a synthetic wallet for that user (uses the user's
+ *      "borrower wallet" string).
+ *   3. Insert a synthetic active loan against that wallet using a
+ *      KNOWN enabled memecoin so the eligibility checks would pass.
+ *   4. Insert a synthetic agent_delegations row authorizing a
+ *      synthetic agent pubkey.
+ *   5. Hit POST /api/v1/internal/agent/limit-close/arm with the
+ *      synthetic data + verify it INSERTs a `limit_close_orders` row
+ *      with source='agent_x402'.
+ *   6. Hit GET /api/v1/internal/agent/limit-close/eligible-loans
+ *      and verify the synthetic loan appears with the expected
+ *      eligibility/reasons across multiple scenarios.
+ *   7. Hit GET /api/v1/internal/agent/limit-close/delegations and
+ *      verify the synthetic delegation appears with correct usage.
+ *   8. Hit DELETE /api/v1/internal/agent/limit-close and verify the
+ *      armed order cancels.
+ *   9. Clean up every synthetic row in a finally{} block so a thrown
+ *      assertion never leaves test data in prod.
+ *
+ * The engine is NOT exercised — this is a control-plane test. The
+ * engine's own smoke test (`magpie-limitclose/scripts/smoke.js`)
+ * covers the data-plane / execution side.
+ *
+ * Exit codes:
+ *   0  — every check passed
+ *   1  — at least one assertion failed
+ *   2  — script-level error (DB unavailable, env missing, etc.)
+ *
+ * Required env:
+ *   DATABASE_URL                — same as the bot
+ *   BOT_INTERNAL_API_URL        — default http://127.0.0.1:3001
+ *   INTERNAL_API_TOKEN          — same as the bot's
+ *
+ * Usage:
+ *   DATABASE_URL=... INTERNAL_API_TOKEN=... \
+ *     node scripts/verify-tier2/run.js
+ */
+import { query } from "../../src/db/pool.js";
+
+const BOT_INTERNAL_API_URL =
+  process.env.BOT_INTERNAL_API_URL || "http://127.0.0.1:3001";
+const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN || "";
+const TEST_MARKER = "[tier2-verify]";
+
+// Track checks for a final summary
+let passes = 0;
+let fails = 0;
+let lastFail = null;
+
+function pass(label, extra = "") {
+  passes++;
+  console.log(`   OK  ${label}${extra ? `  (${extra})` : ""}`);
+}
+function fail(label, msg) {
+  fails++;
+  lastFail = `${label}: ${msg}`;
+  console.error(`\n  FAIL @ ${label}\n     ${msg}\n`);
+}
+
+async function assertHttp(method, path, opts = {}) {
+  const url = `${BOT_INTERNAL_API_URL}${path}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      "X-Internal-Token": INTERNAL_API_TOKEN,
+      ...(opts.body ? { "Content-Type": "application/json" } : {}),
+      ...(opts.headers || {}),
+    },
+    body: opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  let body;
+  try { body = await res.json(); } catch { body = {}; }
+  return { status: res.status, body };
+}
+
+// Synthetic identifiers — randomized per run so concurrent runs
+// don't collide.
+const RUN_ID = Math.random().toString(36).slice(2, 10);
+const TG_ID = -Date.now(); // negative so never collides with real TG IDs
+const SYNTHETIC = {
+  username: `tier2-verify-${RUN_ID}`,
+  // Fake borrower wallet — base58, 44 chars. The actual on-chain bytes
+  // don't matter because the internal arm endpoint validates shape
+  // (PublicKey constructor) but never reads the on-chain account.
+  borrowerWallet: "TestBorrower" + RUN_ID.padEnd(32, "X").slice(0, 32),
+  agentPubkey: "TestAgent" + RUN_ID.padEnd(35, "X").slice(0, 35),
+  // A real enabled memecoin mint — anything from supported_mints with
+  // category != 'stock'/'etf'/'metal'. Will be picked dynamically.
+  collateralMint: null,
+  // Fake loan_pda — also shape-only validated.
+  loanPda: "TestLoanPda" + RUN_ID.padEnd(33, "X").slice(0, 33),
+  loanId: Math.floor(Math.random() * 1e15) + 1e15,
+};
+
+let createdUserId = null;
+let createdLoanId = null;
+let createdDelegationId = null;
+let armedOrderId = null;
+
+async function main() {
+  console.log("Tier 2 (agentic limit-close) verification");
+  console.log("==========================================");
+  console.log("");
+
+  // ── Preflight ────────────────────────────────────────────────
+  if (!INTERNAL_API_TOKEN) {
+    console.error("FAIL: INTERNAL_API_TOKEN env not set");
+    process.exit(2);
+  }
+  pass("preflight: INTERNAL_API_TOKEN set");
+
+  // Pick a real enabled memecoin to use as collateral
+  try {
+    const { rows: [m] } = await query(
+      `SELECT mint, symbol FROM supported_mints
+        WHERE enabled = TRUE
+          AND category NOT IN ('stock','etf','metal')
+          AND mint != 'So11111111111111111111111111111111111111112'
+        ORDER BY RANDOM() LIMIT 1`,
+    );
+    if (!m) { fail("pick_collateral_mint", "no enabled memecoin found"); return; }
+    SYNTHETIC.collateralMint = m.mint;
+    pass("pick_collateral_mint", `${m.symbol}`);
+  } catch (err) {
+    fail("pick_collateral_mint", err.message);
+    return;
+  }
+
+  // ── 1. Synthetic user ────────────────────────────────────────
+  try {
+    const { rows: [u] } = await query(
+      `INSERT INTO users (telegram_id, telegram_username) VALUES ($1, $2) RETURNING id`,
+      [TG_ID, SYNTHETIC.username],
+    );
+    createdUserId = u.id;
+    pass("create_user", `id=${createdUserId}`);
+  } catch (err) { fail("create_user", err.message); return; }
+
+  // ── 2. Synthetic wallet ──────────────────────────────────────
+  try {
+    await query(
+      `INSERT INTO wallets (user_id, public_key, encrypted_secret, nonce, auth_tag, source, label, is_active)
+         VALUES ($1, $2, $3, $4, $5, 'verify-script', 'tier2-verify', TRUE)`,
+      [createdUserId, SYNTHETIC.borrowerWallet, "fake_enc", "fake_nonce", "fake_tag"],
+    );
+    pass("create_wallet", `wallet=${SYNTHETIC.borrowerWallet.slice(0, 12)}…`);
+  } catch (err) { fail("create_wallet", err.message); return; }
+
+  // ── 3. Synthetic active loan ─────────────────────────────────
+  try {
+    const startTs = new Date();
+    const dueTs = new Date(Date.now() + 7 * 86_400_000);
+    const { rows: [l] } = await query(
+      `INSERT INTO loans
+         (user_id, loan_id, loan_pda, collateral_mint, collateral_amount, status,
+          original_loan_amount_lamports, loan_amount_lamports,
+          ltv_percentage, duration_days, program_id,
+          borrower_wallet, start_timestamp, due_timestamp)
+       VALUES ($1, $2, $3, $4, $5, 'active', $6, $7, $8, $9, $10, $11, $12, $13)
+       RETURNING id`,
+      [createdUserId, SYNTHETIC.loanId, SYNTHETIC.loanPda, SYNTHETIC.collateralMint,
+       "10000000",       // 10 token-units of collateral
+       "1500000000",     // 1.5 SOL owed
+       "1500000000",
+       30, 7,
+       process.env.PROGRAM_ID || "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh",
+       SYNTHETIC.borrowerWallet,
+       startTs.toISOString(), dueTs.toISOString()],
+    );
+    createdLoanId = l.id;
+    pass("create_loan", `id=${createdLoanId} on-chain-id=${SYNTHETIC.loanId}`);
+  } catch (err) { fail("create_loan", err.message); return; }
+
+  // ── 4. Synthetic delegation ──────────────────────────────────
+  try {
+    const { rows: [d] } = await query(
+      `INSERT INTO agent_delegations
+         (user_id, user_wallet, agent_pubkey, action,
+          max_per_order_lamports, max_active_orders, max_slippage_bps,
+          status)
+       VALUES ($1, $2, $3, 'limit_close', $4, $5, $6, 'active')
+       RETURNING id`,
+      [createdUserId, SYNTHETIC.borrowerWallet, SYNTHETIC.agentPubkey,
+       "10000000000",  // 10 SOL per-order cap (way above the 1.5 SOL loan)
+       5, 500],
+    );
+    createdDelegationId = d.id;
+    pass("create_delegation", `id=${createdDelegationId}`);
+  } catch (err) { fail("create_delegation", err.message); return; }
+
+  // ── 5. /api/v1/internal/agent/limit-close/eligible-loans ─────
+  // Pre-arm: verify the synthetic loan shows up as ELIGIBLE.
+  try {
+    const r = await assertHttp(
+      "GET",
+      `/api/v1/internal/agent/limit-close/eligible-loans?agent=${encodeURIComponent(SYNTHETIC.agentPubkey)}`,
+    );
+    if (r.status !== 200) throw new Error(`http ${r.status}: ${JSON.stringify(r.body).slice(0, 200)}`);
+    if (r.body.delegations_count !== 1) throw new Error(`expected 1 delegation, got ${r.body.delegations_count}`);
+    if (r.body.eligible_loans_count !== 1) throw new Error(`expected 1 eligible loan, got ${r.body.eligible_loans_count}`);
+    const w = r.body.by_wallet.find((x) => x.user_wallet === SYNTHETIC.borrowerWallet);
+    if (!w) throw new Error("synthetic wallet not in by_wallet response");
+    const loan = w.loans.find((x) => String(x.loan_id) === String(SYNTHETIC.loanId));
+    if (!loan) throw new Error("synthetic loan not in wallet's loans");
+    if (!loan.is_eligible) throw new Error(`expected eligible, got reasons=${JSON.stringify(loan.ineligibility_reasons)}`);
+    pass("eligible_loans_pre_arm", `1 eligible loan visible`);
+  } catch (err) { fail("eligible_loans_pre_arm", err.message); }
+
+  // ── 6. /api/v1/internal/agent/limit-close/delegations ────────
+  try {
+    const r = await assertHttp(
+      "GET",
+      `/api/v1/internal/agent/limit-close/delegations?agent=${encodeURIComponent(SYNTHETIC.agentPubkey)}`,
+    );
+    if (r.status !== 200) throw new Error(`http ${r.status}`);
+    if (r.body.count !== 1) throw new Error(`expected 1 delegation, got ${r.body.count}`);
+    const d = r.body.delegations[0];
+    if (d.user_wallet !== SYNTHETIC.borrowerWallet) throw new Error("wallet mismatch");
+    if (d.bounds.max_active_orders !== 5) throw new Error("bounds mismatch");
+    if (d.usage.headroom !== 5) throw new Error(`expected headroom 5, got ${d.usage.headroom}`);
+    pass("delegations_lookup", `headroom=5/5`);
+  } catch (err) { fail("delegations_lookup", err.message); }
+
+  // ── 7. ARM via internal endpoint ─────────────────────────────
+  try {
+    const r = await assertHttp(
+      "POST",
+      `/api/v1/internal/agent/limit-close/arm`,
+      {
+        body: {
+          user_wallet: SYNTHETIC.borrowerWallet,
+          agent_pubkey: SYNTHETIC.agentPubkey,
+          loan_id: String(SYNTHETIC.loanId),
+          trigger_kind: "mc_usd",
+          trigger_value_micro: "1000000000", // $1k MC (way above current, will never fire)
+          slippage_bps: 200,
+          sell_destination: "sol",
+          x402_tx_signature: `synthetic_tx_${RUN_ID}`,
+        },
+      },
+    );
+    if (r.status !== 200 || !r.body.ok) throw new Error(`status=${r.status} body=${JSON.stringify(r.body).slice(0, 200)}`);
+    armedOrderId = r.body.order_id;
+    if (r.body.source !== "agent_x402") throw new Error(`expected source=agent_x402, got ${r.body.source}`);
+    if (r.body.source_agent_pubkey !== SYNTHETIC.agentPubkey) throw new Error("agent attribution mismatch");
+    pass("arm_via_internal", `order_id=${armedOrderId} source=agent_x402`);
+  } catch (err) { fail("arm_via_internal", err.message); }
+
+  // ── 8. eligible-loans POST-arm: SAME loan now ineligible ─────
+  // Loan should now show 'loan_already_has_active_order' as the reason
+  // because the UNIQUE partial index would block a second arm.
+  if (armedOrderId) {
+    try {
+      const r = await assertHttp(
+        "GET",
+        `/api/v1/internal/agent/limit-close/eligible-loans?agent=${encodeURIComponent(SYNTHETIC.agentPubkey)}`,
+      );
+      const loan = r.body.by_wallet[0]?.loans.find((x) => String(x.loan_id) === String(SYNTHETIC.loanId));
+      if (!loan) throw new Error("loan disappeared from response");
+      if (loan.is_eligible) throw new Error("loan still eligible after arm — UNIQUE-index check failed");
+      if (!loan.ineligibility_reasons.includes("loan_already_has_active_order")) {
+        throw new Error(`expected loan_already_has_active_order in reasons, got ${JSON.stringify(loan.ineligibility_reasons)}`);
+      }
+      // Also verify the agent's headroom dropped to 4
+      const usage = r.body.by_wallet[0]?.delegation;
+      if (usage.headroom !== 4) throw new Error(`expected headroom 4 after arm, got ${usage.headroom}`);
+      pass("eligible_loans_post_arm", `dedup + headroom both correctly reflect armed order`);
+    } catch (err) { fail("eligible_loans_post_arm", err.message); }
+
+    // ── 9. Try to arm SAME loan again — should 409 ─────────────
+    try {
+      const r = await assertHttp("POST", `/api/v1/internal/agent/limit-close/arm`, {
+        body: {
+          user_wallet: SYNTHETIC.borrowerWallet,
+          agent_pubkey: SYNTHETIC.agentPubkey,
+          loan_id: String(SYNTHETIC.loanId),
+          trigger_kind: "mc_usd", trigger_value_micro: "2000000000",
+          slippage_bps: 200, sell_destination: "sol",
+          x402_tx_signature: `synthetic_tx2_${RUN_ID}`,
+        },
+      });
+      if (r.status !== 409) throw new Error(`expected 409, got ${r.status}`);
+      if (r.body.error !== "loan_already_has_active_order") throw new Error(`expected loan_already_has_active_order, got ${r.body.error}`);
+      pass("double_arm_blocked", `409 + correct error code`);
+    } catch (err) { fail("double_arm_blocked", err.message); }
+
+    // ── 10. Try to arm from a DIFFERENT agent against same wallet
+    //         WITHOUT a delegation — should 403 no_active_delegation
+    try {
+      const r = await assertHttp("POST", `/api/v1/internal/agent/limit-close/arm`, {
+        body: {
+          user_wallet: SYNTHETIC.borrowerWallet,
+          agent_pubkey: "DifferentAgent" + RUN_ID.padEnd(30, "Y").slice(0, 30),
+          loan_id: String(SYNTHETIC.loanId),
+          trigger_kind: "mc_usd", trigger_value_micro: "2000000000",
+          slippage_bps: 200, sell_destination: "sol",
+          x402_tx_signature: `synthetic_tx3_${RUN_ID}`,
+        },
+      });
+      if (r.status !== 403) throw new Error(`expected 403, got ${r.status}`);
+      if (r.body.error !== "no_active_delegation") throw new Error(`expected no_active_delegation, got ${r.body.error}`);
+      pass("undelegated_agent_blocked", `403 + no_active_delegation`);
+    } catch (err) { fail("undelegated_agent_blocked", err.message); }
+
+    // ── 11. DELETE — agent cancels its order ────────────────────
+    try {
+      const r = await assertHttp(
+        "DELETE",
+        `/api/v1/internal/agent/limit-close?id=${armedOrderId}&agent=${encodeURIComponent(SYNTHETIC.agentPubkey)}`,
+      );
+      if (r.status !== 200 || !r.body.ok) throw new Error(`status=${r.status} body=${JSON.stringify(r.body).slice(0, 200)}`);
+      if (r.body.cancelled_order_id !== armedOrderId) throw new Error("cancellation mismatch");
+      pass("cancel_via_internal", `order ${armedOrderId} cancelled`);
+    } catch (err) { fail("cancel_via_internal", err.message); }
+
+    // ── 12. Verify DB: order is now status='cancelled', not 'armed'
+    try {
+      const { rows: [o] } = await query(
+        `SELECT status, cancellation_reason FROM limit_close_orders WHERE id = $1`,
+        [armedOrderId],
+      );
+      if (o.status !== "cancelled") throw new Error(`expected status=cancelled, got ${o.status}`);
+      if (o.cancellation_reason !== "agent_cancel_via_x402") throw new Error(`expected agent_cancel_via_x402, got ${o.cancellation_reason}`);
+      pass("final_db_state", `status=cancelled reason=agent_cancel_via_x402`);
+    } catch (err) { fail("final_db_state", err.message); }
+  }
+
+  // ── Auth check: missing/invalid INTERNAL_API_TOKEN → 401 ──────
+  try {
+    const url = `${BOT_INTERNAL_API_URL}/api/v1/internal/agent/limit-close/delegations?agent=${encodeURIComponent(SYNTHETIC.agentPubkey)}`;
+    const res = await fetch(url, {
+      headers: { "X-Internal-Token": "wrong_token" },
+    });
+    if (res.status !== 401) throw new Error(`expected 401 for bad token, got ${res.status}`);
+    pass("auth_reject_bad_token", `401 OK`);
+  } catch (err) { fail("auth_reject_bad_token", err.message); }
+}
+
+(async () => {
+  try {
+    await main();
+  } catch (err) {
+    console.error("\nFATAL:", err.message);
+    process.exitCode = 2;
+  } finally {
+    // ── Cleanup — always runs ─────────────────────────────────
+    console.log("\n   cleaning up synthetic rows…");
+    try {
+      if (armedOrderId) await query(`DELETE FROM limit_close_orders WHERE id = $1`, [armedOrderId]);
+      if (createdDelegationId) await query(`DELETE FROM agent_delegations WHERE id = $1`, [createdDelegationId]);
+      if (createdLoanId) await query(`DELETE FROM loans WHERE id = $1`, [createdLoanId]);
+      // Wallets first (FK on user_id), then user
+      await query(`DELETE FROM wallets WHERE user_id = $1`, [createdUserId]);
+      if (createdUserId) await query(`DELETE FROM users WHERE id = $1 AND telegram_username = $2`, [createdUserId, SYNTHETIC.username]);
+      console.log("   cleanup OK");
+    } catch (err) {
+      console.warn(`   cleanup encountered: ${err.message?.slice(0, 200)}`);
+      console.warn(`   manual recovery: DELETE FROM users WHERE telegram_username = '${SYNTHETIC.username}';`);
+    }
+
+    console.log("\n==========================================");
+    console.log(`Result: ${passes} passed, ${fails} failed`);
+    if (fails > 0) {
+      console.error(`FAIL: last failure was — ${lastFail}`);
+      process.exitCode = 1;
+    } else {
+      console.log("ALL CHECKS PASSED — Tier 2 wiring is intact.");
+    }
+    process.exit(process.exitCode || 0);
+  }
+})();

--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -588,4 +588,241 @@ export async function handleAgentLimitCloseListDelegations(req, params) {
   };
 }
 
+/**
+ * GET /api/v1/internal/agent/limit-close/eligible-loans?agent=<pubkey>
+ *
+ * The agent's complete actionable surface — every (wallet, loan) tuple
+ * they could arm a limit-close against, with explicit eligibility for
+ * each so the agent doesn't have to encode protocol invariants on
+ * their side.
+ *
+ * Returns ONE shaped object containing:
+ *   - by_wallet: array, one entry per active delegation
+ *       - user_wallet
+ *       - delegation: bounds + current usage (active orders, headroom)
+ *       - loans: every loan owned by that wallet, with:
+ *           - loan metadata (loan_id, collateral_mint+symbol, amount, status, due)
+ *           - is_eligible: true/false
+ *           - ineligibility_reasons: an explicit array; empty if eligible
+ *
+ * The endpoint surfaces INELIGIBLE loans too (not just eligible) — agents
+ * can use the reasons to display "this loan is too small to limit-close"
+ * or "the collateral type isn't supported" to the user in their UI.
+ *
+ * Free. X-Internal-Token gated (only the x402 service calls this); the
+ * x402 service has already proven the agent's pubkey via the X-Agent-
+ * Pubkey header binding before forwarding.
+ *
+ * Defense in depth:
+ *   - Strictly scoped to wallets where (user_wallet, agent_pubkey,
+ *     action='limit_close') has an ACTIVE non-expired delegation. An
+ *     agent CANNOT discover loans on wallets that haven't authorized them.
+ *   - Eligibility checks mirror the arm endpoint exactly (single source
+ *     of truth via the same set of constants + queries) so the agent
+ *     can never see a loan as "eligible" that the arm endpoint would
+ *     subsequently reject. Drift between these two paths would be
+ *     a serious UX bug.
+ *   - Loan size, collateral category, existing-armed-order checks are
+ *     all applied. Agent's per-wallet active-order count is applied to
+ *     the delegation's max_active_orders cap.
+ *   - Hard cap of 500 loans across all wallets in one response. An
+ *     agent with delegations on many wallets gets the most-recent
+ *     loans for each.
+ */
+export async function handleAgentLimitCloseEligibleLoans(req, params) {
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  const agentPubkey = String(params.agent ?? "");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+
+  // ── Active delegations for this agent ──────────────────────────
+  const { rows: delegations } = await query(
+    `SELECT id,
+            user_wallet,
+            user_id,
+            max_per_order_lamports::text AS max_per_order_lamports,
+            max_active_orders,
+            max_slippage_bps,
+            granted_at,
+            expires_at
+       FROM agent_delegations
+      WHERE agent_pubkey = $1
+        AND action = 'limit_close'
+        AND status = 'active'
+        AND (expires_at IS NULL OR expires_at > NOW())
+      ORDER BY granted_at DESC
+      LIMIT 100`,
+    [agentPubkey],
+  );
+  if (delegations.length === 0) {
+    return {
+      status: 200,
+      body: {
+        agent_pubkey: agentPubkey,
+        delegations_count: 0,
+        eligible_loans_count: 0,
+        by_wallet: [],
+      },
+    };
+  }
+
+  // ── For each delegation, fetch the wallet's loans + agent's
+  //    existing active orders against THIS user (for cap math) ──
+  // We do the fetch in two batched queries to keep round-trips at O(1)
+  // regardless of delegation count — important if an agent has many
+  // delegations.
+  const userIds = delegations.map((d) => d.user_id);
+  const wallets = delegations.map((d) => d.user_wallet);
+
+  const [{ rows: allLoans }, { rows: activeOrderCounts }, { rows: activeLimitOrders }] =
+    await Promise.all([
+      query(
+        `SELECT l.id, l.loan_id::text AS loan_id, l.loan_pda,
+                l.collateral_mint, l.collateral_amount::text AS collateral_amount,
+                l.original_loan_amount_lamports::text AS owed_lamports,
+                l.status, l.due_timestamp, l.start_timestamp,
+                l.borrower_wallet, l.user_id,
+                sm.symbol AS collateral_symbol, sm.category AS collateral_category,
+                sm.enabled AS collateral_enabled, sm.decimals
+           FROM loans l
+           LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+          WHERE l.user_id = ANY($1::bigint[])
+            AND l.borrower_wallet = ANY($2::text[])
+            AND l.status = 'active'
+          ORDER BY l.start_timestamp DESC
+          LIMIT 500`,
+        [userIds, wallets],
+      ),
+      // Per-(user, agent) active-orders counter — used to compute headroom
+      // against delegation.max_active_orders. Counts ONLY orders this
+      // agent armed for this user (other agents' counts don't deplete
+      // this agent's headroom).
+      query(
+        `SELECT user_id, COUNT(*)::int AS active_orders
+           FROM limit_close_orders
+          WHERE status = 'armed'
+            AND source = 'agent_x402'
+            AND source_agent_pubkey = $1
+            AND user_id = ANY($2::bigint[])
+          GROUP BY user_id`,
+        [agentPubkey, userIds],
+      ),
+      // Set of loan_ids that ALREADY have an active limit-close order
+      // (from ANY source — TG, agent, etc). Loans in this set are
+      // ineligible regardless of who would try to arm them, because
+      // the UNIQUE partial index physically prevents two armed orders
+      // on the same loan.
+      query(
+        `SELECT DISTINCT loan_id
+           FROM limit_close_orders
+          WHERE status = 'armed'
+            AND loan_id = ANY(
+              SELECT id FROM loans
+               WHERE user_id = ANY($1::bigint[])
+            )`,
+        [userIds],
+      ),
+    ]);
+
+  const activeByUser = new Map(
+    activeOrderCounts.map((r) => [Number(r.user_id), r.active_orders]),
+  );
+  const loanIdsWithActiveOrder = new Set(
+    activeLimitOrders.map((r) => Number(r.loan_id)),
+  );
+
+  // Group loans by user_wallet for the response shape.
+  const loansByWallet = new Map();
+  for (const l of allLoans) {
+    const key = l.borrower_wallet;
+    if (!loansByWallet.has(key)) loansByWallet.set(key, []);
+    loansByWallet.get(key).push(l);
+  }
+
+  // ── Build per-wallet response, applying eligibility per loan ───
+  let totalEligible = 0;
+  const byWallet = delegations.map((d) => {
+    const wLoans = loansByWallet.get(d.user_wallet) || [];
+    const userId = Number(d.user_id);
+    const activeOrders = activeByUser.get(userId) ?? 0;
+    const headroom = d.max_active_orders - activeOrders;
+    const maxPerOrder = BigInt(d.max_per_order_lamports);
+
+    const loans = wLoans.map((l) => {
+      const reasons = [];
+      const owedBI = BigInt(l.owed_lamports);
+
+      // Mirror the arm endpoint's checks EXACTLY. Keep this list aligned
+      // with handleAgentLimitCloseArm.
+      if (l.status !== "active") reasons.push("loan_not_active");
+      if (owedBI < MIN_LOAN_LAMPORTS) reasons.push("loan_below_minimum_size");
+      if (!l.collateral_enabled) reasons.push("collateral_not_enabled");
+      if (["stock", "etf", "metal"].includes(l.collateral_category)) {
+        reasons.push("rwa_collateral_not_supported_in_v1");
+      }
+      if (loanIdsWithActiveOrder.has(Number(l.id))) {
+        reasons.push("loan_already_has_active_order");
+      }
+      if (owedBI > maxPerOrder) {
+        reasons.push("loan_exceeds_delegation_per_order_cap");
+      }
+      if (headroom <= 0) {
+        reasons.push("agent_concurrency_cap_reached");
+      }
+
+      const isEligible = reasons.length === 0;
+      if (isEligible) totalEligible++;
+
+      return {
+        loan_id: l.loan_id,
+        loan_pda: l.loan_pda,
+        collateral_mint: l.collateral_mint,
+        collateral_symbol: l.collateral_symbol,
+        collateral_category: l.collateral_category,
+        collateral_amount_raw: l.collateral_amount,
+        collateral_decimals: l.decimals,
+        owed_lamports: l.owed_lamports,
+        owed_sol: Number(l.owed_lamports) / 1e9,
+        status: l.status,
+        start_at: l.start_timestamp,
+        due_at: l.due_timestamp,
+        is_eligible: isEligible,
+        ineligibility_reasons: reasons,
+      };
+    });
+
+    return {
+      user_wallet: d.user_wallet,
+      delegation: {
+        max_per_order_lamports: d.max_per_order_lamports,
+        max_per_order_sol: Number(d.max_per_order_lamports) / 1e9,
+        max_active_orders: d.max_active_orders,
+        max_slippage_bps: d.max_slippage_bps,
+        active_orders_used: activeOrders,
+        headroom,
+        granted_at: d.granted_at,
+        expires_at: d.expires_at,
+      },
+      loans_total: loans.length,
+      loans_eligible: loans.filter((x) => x.is_eligible).length,
+      loans,
+    };
+  });
+
+  return {
+    status: 200,
+    body: {
+      agent_pubkey: agentPubkey,
+      delegations_count: delegations.length,
+      eligible_loans_count: totalEligible,
+      // generated_at gives the agent a freshness signal — they can
+      // cache this for a short window without worrying about staleness
+      // making them try-and-fail on an arm.
+      generated_at: new Date().toISOString(),
+      by_wallet: byWallet,
+    },
+  };
+}
+
 function bad(err) { return { status: 400, body: { error: err } }; }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1472,6 +1472,7 @@ const PUBLIC_ROUTES = new Set([
   "/api/v1/internal/agent/limit-close",
   "/api/v1/internal/agent/limit-close/list",
   "/api/v1/internal/agent/limit-close/delegations",
+  "/api/v1/internal/agent/limit-close/eligible-loans",
   // Pre-borrow price refresh. Site calls this BEFORE buildBorrowTransaction
   // so the on-chain feed is fresh by the time the wallet simulates the
   // tx — closes the window where Phantom rejects with StalePriceAttestation
@@ -1738,6 +1739,11 @@ async function router(req, res) {
       case "/api/v1/internal/agent/limit-close/delegations": {
         const { handleAgentLimitCloseListDelegations } = await import("./internal-agent-limitclose.js");
         result = await handleAgentLimitCloseListDelegations(req, Object.fromEntries(url.searchParams));
+        break;
+      }
+      case "/api/v1/internal/agent/limit-close/eligible-loans": {
+        const { handleAgentLimitCloseEligibleLoans } = await import("./internal-agent-limitclose.js");
+        result = await handleAgentLimitCloseEligibleLoans(req, Object.fromEntries(url.searchParams));
         break;
       }
       case "/api/v1/internal/agent/limit-close": {


### PR DESCRIPTION
Two new pieces of Tier 2 (agentic limit-close via x402):

## 1. `GET /api/v1/internal/agent/limit-close/eligible-loans`

The agent's complete actionable surface. Closes the biggest UX gap: agents previously had no way to enumerate which loans they could arm against — borrowers had to ferry `loan_id`s off-band.

**Now an agent can:**
1. `/delegations` → discover authorized wallets + bounds
2. `/eligible-loans` → enumerate every loan with eligibility
3. `POST /arm` → arm an eligible loan

Returns every (wallet, loan) tuple where the agent has an active delegation, with explicit `is_eligible: bool` + `ineligibility_reasons: string[]` per loan. Agents can show users 'this loan is too small to limit-close' or 'this collateral type isn't supported' from the reasons directly.

**Eligibility checks MIRROR the arm endpoint exactly** — same constants, same query patterns. An `is_eligible: true` here cannot be reverted by a subsequent arm without real state change (loan flip, new order from another agent, etc).

**Defense in depth:**
- Scoped strictly to wallets where (user_wallet, agent_pubkey, action='limit_close') has an ACTIVE non-expired delegation
- Hard cap 500 loans across all wallets
- Per-(user, agent) active-orders counter — headroom math correct even when other agents have armed orders for the same user

## 2. `npm run verify:tier2` — end-to-end verification script

Walks 12 distinct checks against a real deployed bot:
- Real enabled memecoin picked as collateral
- Synthetic user / wallet / loan / delegation inserted
- eligible-loans pre-arm shows loan as eligible
- delegations reports correct headroom (5/5)
- Arm via internal endpoint, source='agent_x402'
- eligible-loans post-arm dedups (loan_already_has_active_order)
- Headroom drops to 4 after arm
- Double-arm returns 409
- Undelegated agent gets 403 no_active_delegation
- Cancel via internal endpoint, status=cancelled
- DB shows cancellation_reason=agent_cancel_via_x402
- Bad INTERNAL_API_TOKEN returns 401

Every synthetic row cleaned up in `finally{}`. RUN_ID randomization avoids concurrent-run collisions. Does NOT exercise the engine — that's the engine's own smoke test.

x402 forwarder in magpiecapital/magpie-x402 (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)