### PR TITLE
feat(limit-close): fill-guarantee defaults — auto-escalate ON + wider cap

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -363,7 +363,10 @@ export async function handleSiteLimitCloseArm(req) {
   }
 
   const slippageBps = fields.Slippage ? Number(fields.Slippage) : 200;
-  if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > 1000) {
+  // Upper bound matches arm-core's MAX_INITIAL_SLIPPAGE_BPS (2500 = 25%) so
+  // moon-pump UX can request a wide initial slippage when the user knows the
+  // token is thin. Arm-core then auto-derives a wider cap on top.
+  if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > 2500) {
     return { status: 400, body: { error: "invalid_slippage" } };
   }
   const dest = (fields.Dest || "sol").toLowerCase();

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -229,8 +229,11 @@ function parseSlippage(s) {
     return { ok: false, error: `Invalid slippage: \`${s}\`` };
   }
   const bps = /bps$/i.test(s) ? Math.round(n) : Math.round(n * 100);
-  if (bps < 10 || bps > 1000) {
-    return { ok: false, error: "Slippage must be between 0.1% and 10%." };
+  // Upper bound matches arm-core's MAX_INITIAL_SLIPPAGE_BPS (25%). Thin-
+  // liquidity memecoin pumps regularly want a wider initial slippage so the
+  // first attempt fires; arm-core then derives an even wider cap on top.
+  if (bps < 10 || bps > 2500) {
+    return { ok: false, error: "Slippage must be between 0.1% and 25%." };
   }
   return { ok: true, bps };
 }
@@ -413,6 +416,12 @@ export async function handleLimitClose(ctx) {
   }
   const preflightAdvisory = !!preflight.advisory;
 
+  // Fill-guarantee defaults — match arm-core's derivation so TG orders
+  // get the same escalation headroom as site / agent paths. Operator
+  // mandate: "the order MUST execute." Cap = max(2500, slip * 8) capped
+  // at 5000 bps. Engine walks UNDER the cap on revert; never above.
+  const derivedCapBps = Math.min(5000, Math.max(2500, slippage_bps * 8));
+
   // 5. Insert. The UNIQUE partial index on (loan_id WHERE status='armed')
   //    makes "two orders on the same loan" physically impossible at the
   //    storage layer.
@@ -422,15 +431,15 @@ export async function handleLimitClose(ctx) {
       `INSERT INTO limit_close_orders
          (user_id, loan_id, trigger_kind, trigger_value_micro,
           slippage_bps, sell_destination, expires_at, source, status, armed_at,
-          initial_slippage_bps,
+          initial_slippage_bps, auto_escalate_slippage, max_slippage_bps_cap,
           preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7, 'tg', 'armed', NOW(),
-               $8,
-               $9, $10, $11)
+               $8, TRUE, $9,
+               $10, $11, $12)
        RETURNING id`,
       [user.id, loan.id, trigger_kind, trigger_value_micro.toString(),
        slippage_bps, dest, expire_iso,
-       slippage_bps,
+       slippage_bps, derivedCapBps,
        preflightAdvisory ? null : slippage_bps,
        preflightAdvisory ? null : (preflight.proceedsLamports || null),
        preflightAdvisory ? null : (preflight.quotedAtIso || new Date().toISOString())],

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -81,6 +81,19 @@ export async function resolveMultiplierToPrice(collateralMint, multiplier) {
  *
  * Returns { ok: true, orderId, loan, mint } or { ok: false, error, ... }.
  */
+// Fill-guarantee defaults. Operator-stated rule: "the order MUST execute or
+// it makes it look like we are advertising false promises." The prior
+// defaults (capBps = slippageBps, autoEscalate = false) were silently
+// preventing fills on thin-liquidity memecoin pumps — a 200 bps cap on a
+// 6% impact swap never clears. To honor the mandate every order ships with
+// escalation headroom by default. The borrower's stated initial slippage
+// is preserved as the FIRST attempt; the engine only walks UNDER the cap
+// when the first attempt would revert.
+const DEFAULT_HARD_CAP_BPS = 5000;        // 50% — absolute ceiling on any auto-widened cap
+const DEFAULT_CAP_FLOOR_BPS = 2500;       // 25% — every order gets at least this much room
+const DEFAULT_CAP_MULTIPLIER = 8;         // cap = max(floor, slip × 8) capped at hard cap
+const MAX_INITIAL_SLIPPAGE_BPS = 2500;    // 25% — allow aggressive initial for moon-pump UX
+
 export async function armOrder({
   userId,
   source,                  // 'tg' | 'site' | 'agent_x402'
@@ -91,9 +104,9 @@ export async function armOrder({
   slippageBps,
   sellDestination = "sol",
   expiresAt = null,
-  autoEscalate = false,
-  // For agent path the cap comes from delegation. For other paths
-  // capBps defaults to slippageBps (no escalation headroom).
+  autoEscalate = true,     // fill-guarantee default — overridable per call
+  // For agent path the cap comes from delegation. For other paths we
+  // derive the cap from slippage so every order has escalation room.
   capBps = null,
   preflightProtocolFeeBps = 100,
   armNote = null,
@@ -108,7 +121,7 @@ export async function armOrder({
   if (triggerBI < MIN_TRIGGER_VALUE_MICRO || triggerBI > MAX_TRIGGER_VALUE_MICRO) {
     return { ok: false, error: "trigger_value_out_of_range" };
   }
-  if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > 1000) {
+  if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > MAX_INITIAL_SLIPPAGE_BPS) {
     return { ok: false, error: "invalid_slippage_bps" };
   }
   if (!VALID_DESTINATIONS.has(sellDestination)) {
@@ -124,8 +137,16 @@ export async function armOrder({
     return { ok: false, error: "invalid_source" };
   }
 
-  const effectiveCap = Number.isInteger(capBps) ? capBps : slippageBps;
-  if (effectiveCap < slippageBps || effectiveCap > 1000) {
+  // Derive the cap: explicit caller-supplied value wins; otherwise default to
+  // max(floor, slip × multiplier) clamped to the hard ceiling. Even a 50 bps
+  // initial slippage gets at least 2500 bps of headroom under this rule, so
+  // the engine's escalation ladder always has somewhere to walk.
+  const derivedCap = Math.min(
+    DEFAULT_HARD_CAP_BPS,
+    Math.max(DEFAULT_CAP_FLOOR_BPS, slippageBps * DEFAULT_CAP_MULTIPLIER),
+  );
+  const effectiveCap = Number.isInteger(capBps) ? capBps : derivedCap;
+  if (effectiveCap < slippageBps || effectiveCap > DEFAULT_HARD_CAP_BPS) {
     return { ok: false, error: "invalid_cap_bps" };
   }
 


### PR DESCRIPTION
## Summary
- arm-core: \`autoEscalate\` defaults to TRUE (was FALSE) — orders escalate by default
- arm-core: \`capBps\` derived as \`max(2500, slip * 8)\` clamped to 5000 when caller omits it
- arm-core + TG + site: \`MAX_INITIAL_SLIPPAGE_BPS\` raised 1000 -> 2500 (25%)
- TG direct INSERT path now sets \`auto_escalate_slippage=TRUE\` + \`max_slippage_bps_cap\` to match

## Why
Operator mandate: the order MUST execute. Prior defaults silently prevented fills on thin-liquidity memecoin pumps — a 200 bps initial with a 200 bps cap = no escalation headroom = swap reverts forever at >2% price impact. New defaults give every order at least 2500 bps of headroom while preserving the borrower's stated initial slippage as the first attempt.

## What this does NOT change
- Engine's escalation ladder (1.5x toward cap on revert) — already implemented in execution.js
- TWAP fallback (Layer B) — already implemented
- Proceeds safety floor (user can never net below 0.005 SOL after fees) — unchanged
- The cap is an ABSOLUTE ceiling: the engine never widens it at runtime; it only walks under it

## Test plan
- [ ] /takeprofit on a thin token with default 2% slippage: confirm DB row has auto_escalate_slippage=true, max_slippage_bps_cap=2500
- [ ] Site arm with default 2% slippage: same DB shape
- [ ] Engine fires order, single-block reverts: confirm slippage escalates 200 -> 300 -> 450 -> ... up to cap
- [ ] /takeprofit with slip=20%: arm succeeds (previously rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)