### PR TITLE
fix(db): migration 031 — widen slippage CHECK to match PR #77

### DIFF
--- a/migrations/031_limit_close_slippage_check_widen.sql
+++ b/migrations/031_limit_close_slippage_check_widen.sql
@@ -1,0 +1,50 @@
+-- migration 031: widen slippage CHECK constraints to match PR #77 defaults.
+--
+-- PR #77 (feat/fill-guarantee-defaults) raised the application-side
+-- validation limits:
+--   - MAX_INITIAL_SLIPPAGE_BPS: 1000 -> 2500
+--   - DEFAULT_HARD_CAP_BPS:     1000 -> 5000
+--
+-- The DB CHECK constraints from migrations 025 + 027 still pin all three
+-- slippage columns at 1000 bps max, so any new INSERT with the new
+-- derived caps (e.g. cap=2500 on a default-slip arm) violates the CHECK
+-- and the INSERT rolls back. Result: arming silently broken in prod.
+--
+-- This migration relaxes the CHECKs to match the new application limits.
+-- The application is STILL the source of truth on the upper bound — the
+-- CHECK just stops being a regression source.
+--
+-- The bounds line up with arm-core's constants intentionally:
+--   slippage_bps         <= 2500  (matches MAX_INITIAL_SLIPPAGE_BPS)
+--   initial_slippage_bps <= 2500  (same — frozen copy of the initial)
+--   max_slippage_bps_cap <= 5000  (matches DEFAULT_HARD_CAP_BPS)
+--
+-- Lower bound of 10 bps preserved — it's a "did the caller mean to send
+-- a value at all" sanity floor, not a UX preference.
+
+-- 1. slippage_bps — the current working slippage; escalates up to the cap.
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_slippage_bps_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_slippage_bps_check
+  CHECK (slippage_bps >= 10 AND slippage_bps <= 5000);
+
+-- 2. initial_slippage_bps — frozen copy of what the order was armed with.
+-- Same upper bound as slippage_bps because the engine never writes a value
+-- here that isn't a valid past slippage_bps.
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_initial_slippage_in_range;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_initial_slippage_in_range
+  CHECK (
+    initial_slippage_bps IS NULL OR
+    (initial_slippage_bps >= 10 AND initial_slippage_bps <= 2500)
+  );
+
+-- 3. max_slippage_bps_cap — the borrower's stated ceiling. Highest of the
+-- three because the cap can be derived as slip * 8 (PR #77).
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_max_slippage_cap_in_range;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_max_slippage_cap_in_range
+  CHECK (
+    max_slippage_bps_cap IS NULL OR
+    (max_slippage_bps_cap >= 10 AND max_slippage_bps_cap <= 5000)
+  );


### PR DESCRIPTION
## Summary
- **CRITICAL hotfix** for PR #77 (already merged)
- Relaxes three DB CHECK constraints so the post-PR-77 default cap derivation can land:
  - \`slippage_bps\`         10..1000 -> 10..5000
  - \`initial_slippage_bps\` 10..1000 -> 10..2500
  - \`max_slippage_bps_cap\` 10..1000 -> 10..5000

## Why
PR #77 raised \`MAX_INITIAL_SLIPPAGE_BPS\` to 2500 and \`DEFAULT_HARD_CAP_BPS\` to 5000 in arm-core. The DB CHECKs from migs 025 + 027 still cap all three columns at 1000. **Every new TP arm with the new defaults will violate the CHECK on INSERT and silently fail.**

## Deploy
Land + deploy ASAP. Until this runs, the take-profit flow is broken for any user whose derived cap > 1000 bps (i.e. the default for everyone).

## Test plan
- [ ] Migration runner applies 031, schema_migrations ledger inserts
- [ ] \`/takeprofit 123 at 2x\` arms successfully with derived cap = 2500
- [ ] \`/takeprofit 123 at 2x slip=20%\` arms with cap = 5000
- [ ] Existing armed orders unaffected (their values are all <= 1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)