### PR TITLE
fix(intervention): raise callback ceiling 1000 -> 5000

### DIFF
--- a/src/commands/limit-close-intervention.js
+++ b/src/commands/limit-close-intervention.js
@@ -93,9 +93,9 @@ export function registerLimitCloseInterventionCallbacks(bot) {
         return;
       }
       // Hard ceiling guard, mirroring the engine's INTERVENTION_HARD_CEILING_BPS.
-      // The CHECK constraint on slippage_bps also enforces (10, 1000), so
-      // this is belt-and-suspenders.
-      if (requested < 10 || requested > 1000) {
+      // The CHECK constraint on slippage_bps is (10, 5000) post-mig 031, so
+      // this is belt-and-suspenders aligned with the post-PR-77 ceilings.
+      if (requested < 10 || requested > 5000) {
         await ctx.answerCallbackQuery({ text: "Out-of-range slippage." });
         return;
       }


### PR DESCRIPTION
Aligns bot callback's hard ceiling with migration 031's relaxed CHECK and the engine's updated `INTERVENTION_HARD_CEILING_BPS`. Without this fix, an intervention DM suggesting > 1000 bps would be silently rejected by the callback handler.

Depends on: PR #80 (migration 031) merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)