### PR TITLE
feat(arm): liquidity-aware initial slippage for thin tokens

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -444,7 +444,17 @@ export async function handleSiteLimitCloseArm(req) {
       collateral_symbol: armed.mint?.symbol || null,
       trigger_kind: triggerKind,
       trigger_value_micro: triggerValueMicro.toString(),
-      slippage_bps: slippageBps,
+      // The applied initial slippage AFTER any liquidity-aware bump.
+      slippage_bps: armed.initialSlippageBpsApplied ?? slippageBps,
+      // Surface the bump so the site can render "we armed at 5% instead
+      // of 2% because $TOKEN is thin." Only present when a bump landed.
+      ...(armed.initialSlippageBpsApplied !== armed.initialSlippageBpsRequested
+        ? {
+            slippage_bps_requested: armed.initialSlippageBpsRequested,
+            liquidity_floor_bps: armed.liquidityTierFloorBps,
+            liquidity_usd: armed.liquidityUsd,
+          }
+        : {}),
       sell_destination: dest,
       expires_at: expiresAt,
       multiplier: multiplierUsed,

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -422,6 +422,24 @@ export async function handleLimitClose(ctx) {
   // at 5000 bps. Engine walks UNDER the cap on revert; never above.
   const derivedCapBps = Math.min(5000, Math.max(2500, slippage_bps * 8));
 
+  // Liquidity-aware initial slippage — mirrors arm-core. Bumps the
+  // INITIAL up to a token-liquidity-appropriate floor for thin tokens
+  // so the engine's first attempt is more likely to fill (saves a 30s
+  // retry cycle on auto-escalation). Treats liquidity_usd <= 0 as
+  // UNKNOWN (no bump) — bumping on missing screener data would surprise
+  // the user. Cap is unchanged.
+  const liqUsd = Number(mintRow.liquidity_usd ?? 0);
+  let liquidityFloorBps = 0;
+  if (liqUsd <= 0) liquidityFloorBps = 0;
+  else if (liqUsd >= 100_000) liquidityFloorBps = 0;
+  else if (liqUsd >= 25_000) liquidityFloorBps = 300;
+  else if (liqUsd >= 5_000) liquidityFloorBps = 500;
+  else liquidityFloorBps = 1000;
+  const originalInitialBps = slippage_bps;
+  const appliedInitialBps = liquidityFloorBps > 0 && slippage_bps < liquidityFloorBps
+    ? Math.min(liquidityFloorBps, derivedCapBps)
+    : slippage_bps;
+
   // 5. Insert. The UNIQUE partial index on (loan_id WHERE status='armed')
   //    makes "two orders on the same loan" physically impossible at the
   //    storage layer.
@@ -432,17 +450,21 @@ export async function handleLimitClose(ctx) {
          (user_id, loan_id, trigger_kind, trigger_value_micro,
           slippage_bps, sell_destination, expires_at, source, status, armed_at,
           initial_slippage_bps, auto_escalate_slippage, max_slippage_bps_cap,
-          preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at)
+          preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at,
+          notes)
        VALUES ($1, $2, $3, $4, $5, $6, $7, 'tg', 'armed', NOW(),
                $8, TRUE, $9,
-               $10, $11, $12)
+               $10, $11, $12, $13)
        RETURNING id`,
       [user.id, loan.id, trigger_kind, trigger_value_micro.toString(),
-       slippage_bps, dest, expire_iso,
-       slippage_bps, derivedCapBps,
-       preflightAdvisory ? null : slippage_bps,
+       appliedInitialBps, dest, expire_iso,
+       appliedInitialBps, derivedCapBps,
+       preflightAdvisory ? null : appliedInitialBps,
        preflightAdvisory ? null : (preflight.proceedsLamports || null),
-       preflightAdvisory ? null : (preflight.quotedAtIso || new Date().toISOString())],
+       preflightAdvisory ? null : (preflight.quotedAtIso || new Date().toISOString()),
+       appliedInitialBps !== originalInitialBps
+         ? `armed via tg; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
+         : "armed via tg"],
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message)) {
@@ -465,7 +487,11 @@ export async function handleLimitClose(ctx) {
       `Loan: #${loan.loan_id} (${symbol})`,
       `Trigger: ${triggerLabel}`,
       multiplierContextLine ? `_${multiplierContextLine}_` : null,
-      `Slippage: ${(slippage_bps / 100).toFixed(2)}%`,
+      `Slippage: ${(appliedInitialBps / 100).toFixed(2)}%${
+        appliedInitialBps !== originalInitialBps
+          ? ` _(bumped from ${(originalInitialBps / 100).toFixed(2)}% — ${symbol} has thin liquidity)_`
+          : ""
+      }`,
       `Destination: ${dest.toUpperCase()}`,
       ``,
       `When ${symbol} hits your target, I'll repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`,

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -171,12 +171,56 @@ export async function armOrder({
 
   // ── Collateral allowlist ────────────────────────────────────
   const { rows: [mintRow] } = await query(
-    `SELECT enabled, category, symbol FROM supported_mints WHERE mint = $1`,
+    `SELECT enabled, category, symbol, liquidity_usd FROM supported_mints WHERE mint = $1`,
     [loan.collateral_mint],
   );
   if (!mintRow || !mintRow.enabled) return { ok: false, error: "collateral_not_enabled" };
   if (["stock", "etf", "metal"].includes(mintRow.category)) {
     return { ok: false, error: "rwa_collateral_not_supported_in_v1" };
+  }
+
+  // ── Liquidity-aware initial slippage adjustment ─────────────
+  // Operator mandate: "the order MUST execute." The arm-time INITIAL
+  // slippage is what the engine tries FIRST. For thin tokens, a default
+  // 200 bps initial means the first attempt almost certainly reverts and
+  // we waste a tick before auto-escalation kicks in. Bumping the initial
+  // up to a token-liquidity-appropriate floor saves that round-trip.
+  //
+  // Exploit surface analysis:
+  //   - liquidity_usd is screener-vetted and operator-controlled (slow
+  //     cadence). Not manipulable per-arm — an attacker cannot create a
+  //     fake low-liquidity reading right before an arm to force a wider
+  //     initial. The CAP is the actual ceiling (5000 bps absolute via
+  //     DEFAULT_HARD_CAP_BPS), and this code never touches the cap.
+  //   - Hard floor on the bump: never bump initial ABOVE the user's
+  //     stated cap. If the bump would exceed the cap, clamp to cap.
+  //   - User's stated cap (effectiveCap) is unchanged.
+  //
+  // Tiers (bps floors):
+  //   deep      (>= $100k liquidity_usd) : no bump
+  //   mid       ($25k-$100k)             : 300 bps floor (3%)
+  //   thin      ($5k-$25k)               : 500 bps floor (5%)
+  //   very_thin (< $5k)                  : 1000 bps floor (10%)
+  const liqUsd = Number(mintRow.liquidity_usd ?? 0);
+  let liquidityFloorBps = 0;
+  // Treat liquidity_usd <= 0 as UNKNOWN (screener data missing or stale)
+  // rather than as "very thin". Bumping to 10% on a token that may have
+  // real $1M liquidity (just unscanned) would be a surprise to the user.
+  // The engine's auto-escalation still walks UP from the initial when the
+  // first attempt fails, so the user is still protected against thin
+  // liquidity at fire time — we just don't preemptively widen on data we
+  // don't have.
+  if (liqUsd <= 0) liquidityFloorBps = 0;
+  else if (liqUsd >= 100_000) liquidityFloorBps = 0;
+  else if (liqUsd >= 25_000) liquidityFloorBps = 300;
+  else if (liqUsd >= 5_000) liquidityFloorBps = 500;
+  else liquidityFloorBps = 1000;
+  const originalInitialBps = slippageBps;
+  let appliedInitialBps = slippageBps;
+  if (liquidityFloorBps > 0 && slippageBps < liquidityFloorBps) {
+    // Clamp to user's stated cap so the bump never widens past what
+    // they already accepted as the worst case for this order.
+    appliedInitialBps = Math.min(liquidityFloorBps, effectiveCap);
   }
 
   // ── Per-user concurrency cap ────────────────────────────────
@@ -227,13 +271,16 @@ export async function armOrder({
                $16)
        RETURNING id, armed_at`,
       [userId, loan.id, triggerKind, triggerBI.toString(),
-       slippageBps, sellDestination, expiresAt,
+       appliedInitialBps, sellDestination, expiresAt,
        source, sourceAgentPubkey,
-       autoEscalate, effectiveCap, slippageBps,
+       autoEscalate, effectiveCap, appliedInitialBps,
        advisory ? null : effectiveCap,
        advisory ? null : (preflight.proceedsLamports || null),
        advisory ? null : (preflight.quotedAtIso || new Date().toISOString()),
-       armNote || `armed via ${source}`],
+       armNote
+         || (appliedInitialBps !== originalInitialBps
+           ? `armed via ${source}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
+           : `armed via ${source}`)],
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message || "")) {
@@ -250,6 +297,13 @@ export async function armOrder({
     loan,
     mint: mintRow,
     preflightAdvisory: advisory,
+    // Surfacing the bump lets callers (TG cmd, site UI, agent response)
+    // tell the user "you asked for 2%, we armed at 5% because $TOKEN
+    // is thin." Cap is unchanged either way.
+    initialSlippageBpsRequested: originalInitialBps,
+    initialSlippageBpsApplied: appliedInitialBps,
+    liquidityTierFloorBps: liquidityFloorBps,
+    liquidityUsd: liqUsd,
   };
 }
 


### PR DESCRIPTION
Bumps the initial slippage at arm time to a liquidity-appropriate floor when the token is thin, so the engine's first attempt is more likely to fill. Cap is unchanged. Bump is clamped to the cap so worst case is the same. Liquidity_usd from supported_mints (screener-vetted, not spot — exploit-resistant). Unknown liquidity = no bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)