### PR TITLE
fix: support-vigil listener init + upside-watcher price-throw spam

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ import { startLenderBalanceWatcher } from "./services/lender-balance-watcher.js"
 import { startAutoProtect } from "./services/auto-protect.js";
 import { startAiConversationDigest } from "./services/ai-conversation-digest.js";
 import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
+import { registerSupportVigilCallbacks } from "./services/support-vigil.js";
 import { startInfraHealth } from "./services/infra-health.js";
 import { startNeonSync } from "./services/neon-sync.js";
 import { registerTxErrorCallbacks } from "./services/tx-error-callbacks.js";
@@ -407,6 +408,11 @@ bot.command("nomination_review", handleNominationReview);
 registerImportCallbacks(bot);
 registerSupportCallbacks(bot);
 registerMyTicketsCallbacks(bot);
+// Support vigil callbacks must register BEFORE bot.start — Grammy
+// throws if listeners are added during another listener's execution.
+// The vigil's timer starts later via startSupportVigil() from inside
+// the runtime startup section.
+registerSupportVigilCallbacks(bot);
 registerAutoProtectCallbacks(bot);
 registerCalendarCallbacks(bot);
 registerUnlockCallbacks(bot);

--- a/src/services/support-vigil.js
+++ b/src/services/support-vigil.js
@@ -249,6 +249,12 @@ export function registerSupportVigilCallbacks(bot) {
 
 let _timer = null;
 
+// Timer-only startup. Callback registration MUST happen separately via
+// registerSupportVigilCallbacks(bot) at top-level index.js init — Grammy
+// throws if listeners are registered from inside another listener
+// execution (e.g. from inside a dynamic-import .then() handler called
+// during bot startup). Splitting timer + callbacks lets the runtime
+// init flow do the right thing in the right order.
 export function startSupportVigil(bot) {
   if (_timer) return;
   console.log(`[support-vigil] armed — probing every ${TICK_MS / 60_000}m`);
@@ -256,7 +262,6 @@ export function startSupportVigil(bot) {
     tick(bot).catch(() => {});
     _timer = setInterval(() => tick(bot).catch(() => {}), TICK_MS);
   }, 120_000);
-  registerSupportVigilCallbacks(bot);
 }
 
 export function stopSupportVigil() {

--- a/src/services/upside-watcher.js
+++ b/src/services/upside-watcher.js
@@ -56,28 +56,29 @@ let _timer = null;
  * historical price marker are skipped (we don't guess).
  */
 async function computeAppreciation(loan) {
+  // getPriceInUsdCrossSourced THROWS when no price is available (thin
+  // pump.fun tokens, Jupiter outages, DexScreener gaps). For the
+  // watcher's purposes "no price" == "skip this loan, try next tick" —
+  // we never want a missing price to log-spam or crash the tick. Both
+  // price lookups are wrapped + swallowed silently.
   const decimals = loan.decimals ?? 9;
-  const currentUsdPerToken = await getPriceInUsdCrossSourced(loan.collateral_mint);
+  let currentUsdPerToken;
+  try {
+    currentUsdPerToken = await getPriceInUsdCrossSourced(loan.collateral_mint);
+  } catch { return null; }
   if (!currentUsdPerToken || currentUsdPerToken <= 0) return null;
   const collateralWhole = Number(loan.collateral_amount) / 10 ** decimals;
   const currentValueUsd = collateralWhole * currentUsdPerToken;
-  // Loan-open value: original_loan_amount_lamports was the SOL disbursed
-  // at LTV ratio against the collateral at THAT moment. We back out the
-  // collateral USD value from the loan amount + LTV. This is more reliable
-  // than relying on a historical price oracle (which we'd have to store).
-  // If ltv_percentage is missing/zero, we cannot reason about appreciation.
   const ltv = Number(loan.ltv_percentage);
   if (!ltv || ltv <= 0) return null;
-  // SOL borrowed (lamports) → SOL borrowed (whole)
   const solBorrowed = Number(loan.original_loan_amount_lamports) / 1e9;
-  // SOL/USD reference: use the current SOL price as a stable denominator.
-  // The watcher's accuracy is tier-based ("did we cross 40%?"), so
-  // using current SOL/USD for both sides is consistent — drift in SOL
-  // price affects both legs equally.
-  const solUsd = await getPriceInUsdCrossSourced("So11111111111111111111111111111111111111112");
+  let solUsd;
+  try {
+    solUsd = await getPriceInUsdCrossSourced("So11111111111111111111111111111111111111112");
+  } catch { return null; }
   if (!solUsd || solUsd <= 0) return null;
   const borrowedUsd = solBorrowed * solUsd;
-  const borrowValueUsd = borrowedUsd / (ltv / 100);  // back out collateral USD at open
+  const borrowValueUsd = borrowedUsd / (ltv / 100);
   if (borrowValueUsd <= 0) return null;
   const pct = ((currentValueUsd - borrowValueUsd) / borrowValueUsd) * 100;
   return { pct, currentValueUsd, borrowValueUsd, currentUsdPerToken };


### PR DESCRIPTION
Two prod fixes for the failed deploys after PRs #88 and #89. Move support-vigil callback registration to top-level index.js (grammY memory-leak protection), wrap upside-watcher price lookups in try/catch (price service throws on missing data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)