### PR TITLE
fix(api): tweetnacl ESM/CJS interop for site-limit-close

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -39,7 +39,11 @@
  */
 import { PublicKey } from "@solana/web3.js";
 import bs58 from "bs58";
-import { sign as naclSign } from "tweetnacl";
+// tweetnacl is a CommonJS module — the named-import form (`import { sign }`)
+// breaks under Node ESM in some environments. Use the default-import +
+// destructure pattern (same as src/api/credit-attest.js).
+import nacl from "tweetnacl";
+const { sign: naclSign } = nacl;
 import { query } from "../db/pool.js";
 import {
   armOrder, cancelOrder, enqueueArmedDm,


### PR DESCRIPTION
Site limit-close was 500'ing because of the named-import form of tweetnacl. Fix: default import + destructure (matches credit-attest pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)