### PR TITLE
feat(limit-close): bidirectional trigger_direction foundation (stop-loss schema)

### DIFF
--- a/migrations/039_limit_close_trigger_direction.sql
+++ b/migrations/039_limit_close_trigger_direction.sql
@@ -1,0 +1,42 @@
+-- migration 039: bidirectional limit-close (take-profit + stop-loss).
+--
+-- Before now every limit_close_orders row fired when current_price >=
+-- trigger_value (the take-profit semantic). Operator mandate:
+--   "completes the bidirectional proactive risk story"
+--   "make sure we are charging a 1% fee that goes back to the protocol
+--    not only on gains but for stop losses too"
+--
+-- Stop-loss fires when current_price <= trigger_value — locks in
+-- whatever value the user has left BEFORE a liquidation forces them
+-- out at the edge. The 1% protocol fee comes off proceeds regardless
+-- of direction (already direction-agnostic in the engine).
+--
+-- Implementation:
+--   - 'above' = take-profit (existing behavior; default for back-compat
+--     so every pre-migration row is treated as take-profit)
+--   - 'below' = stop-loss (new)
+--
+-- Engine's isTriggerHit reads this column and swaps >= for <= when
+-- direction='below'. Safety floor in safety.js bypasses the
+-- "proceeds_below_safety_floor" check for direction='below' since a
+-- stop-loss is exactly the case where the user WANTS out even with
+-- low net.
+--
+-- arm-core validates that trigger_value sits on the correct side of
+-- current price at arm time to prevent an immediate-fire arm. The
+-- engine re-checks at fire time as defense in depth.
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS trigger_direction TEXT NOT NULL DEFAULT 'above';
+
+ALTER TABLE limit_close_orders DROP CONSTRAINT IF EXISTS limit_close_orders_trigger_direction_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_trigger_direction_check
+  CHECK (trigger_direction IN ('above', 'below'));
+
+COMMENT ON COLUMN limit_close_orders.trigger_direction IS
+  'Direction the trigger fires from. ''above'' (default, take-profit):
+   fires when current_price >= trigger_value. ''below'' (stop-loss):
+   fires when current_price <= trigger_value. arm-core validates the
+   trigger_value sits on the correct side of current price at arm time.
+   1% protocol fee applies in BOTH directions — operator rule 2026-06-12.';

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -55,7 +55,7 @@ const MAX_TRIGGER_VALUE_MICRO = 1_000_000_000_000_000n; // 1e15 — sanity ceili
  * an optional `multiplier` field — if set, the caller must convert it
  * to a USD price using the live collateral price BEFORE inserting.
  */
-function parseLimitCloseArgs(text) {
+function parseLimitCloseArgs(text, direction = "above") {
   // strip command word, normalize "/cmd 1234 at 2x" or "/cmd 1234 sell at 2x"
   const raw = text.trim();
   const tokens = raw.split(/\s+/).slice(1); // drop the /command word
@@ -66,12 +66,17 @@ function parseLimitCloseArgs(text) {
   if (filtered.length < 2) {
     return {
       ok: false,
-      error:
-        "*Usage:*\n" +
-        "`/takeprofit <loan_id> at 2x`  (sell when price doubles)\n" +
-        "`/takeprofit <loan_id> at $150m`  (market cap target)\n" +
-        "`/takeprofit <loan_id> at $0.005 slip=3%`  (USD price target)\n\n" +
-        "Find your loan_id with /loans.",
+      error: direction === "below"
+        ? "*Usage:*\n" +
+          "`/stoploss <loan_id> at -30%`  (sell if price drops 30%)\n" +
+          "`/stoploss <loan_id> at 0.7x`  (sell at 70% of current price)\n" +
+          "`/stoploss <loan_id> at $0.002 slip=3%`  (USD price floor)\n\n" +
+          "Find your loan_id with /loans."
+        : "*Usage:*\n" +
+          "`/takeprofit <loan_id> at 2x`  (sell when price doubles)\n" +
+          "`/takeprofit <loan_id> at $150m`  (market cap target)\n" +
+          "`/takeprofit <loan_id> at $0.005 slip=3%`  (USD price target)\n\n" +
+          "Find your loan_id with /loans.",
     };
   }
   const loanIdRaw = filtered[0];
@@ -98,15 +103,38 @@ function parseLimitCloseArgs(text) {
     // Handle "at <value>" — consume i+1 too.
     if (t.toLowerCase() === "at" && i + 1 < filtered.length) {
       const v = filtered[i + 1];
-      // multiplier: "2x", "1.5x"
+      // Stop-loss percent: "-30%" / "-5%"
+      const mPct = v.match(/^-([0-9]+(?:\.[0-9]+)?)%$/);
+      if (mPct) {
+        if (direction !== "below") {
+          return { ok: false, error: "Percent-drop targets (e.g. `at -30%`) are only valid for /stoploss." };
+        }
+        const p = Number(mPct[1]);
+        if (!Number.isFinite(p) || p <= 0 || p >= 100) {
+          return { ok: false, error: "Stop-loss percent must be between 0% and 100% (e.g. `at -30%`)." };
+        }
+        multiplier = 1 - (p / 100); // 30% drop → 0.7x of current
+        trigger_kind = "price_usd";
+        i++; continue;
+      }
+      // multiplier: "2x", "1.5x" (TP) or "0.7x", "0.5x" (SL)
       const mMul = v.match(/^([0-9]+(?:\.[0-9]+)?)x$/i);
       if (mMul) {
         const n = Number(mMul[1]);
-        if (!Number.isFinite(n) || n <= 1) {
-          return { ok: false, error: "Multiplier must be > 1x (e.g. `at 2x`, `at 1.5x`)." };
+        if (!Number.isFinite(n) || n <= 0) {
+          return { ok: false, error: "Multiplier must be a positive number (e.g. `at 2x`, `at 0.7x`)." };
+        }
+        if (direction === "below") {
+          if (n >= 1) {
+            return { ok: false, error: "Stop-loss multiplier must be < 1x (e.g. `at 0.7x` = sell at 70% of current). Use /takeprofit for upside targets." };
+          }
+        } else {
+          if (n <= 1) {
+            return { ok: false, error: "Take-profit multiplier must be > 1x (e.g. `at 2x`). Use /stoploss for downside targets." };
+          }
         }
         multiplier = n;
-        trigger_kind = "price_usd"; // we'll resolve to actual USD value before INSERT
+        trigger_kind = "price_usd"; // resolved to actual USD value before INSERT
         i++; // consume value
         continue;
       }
@@ -269,12 +297,12 @@ function fmtTrigger(kind, value_micro) {
 
 /* ─── /limitclose ──────────────────────────────────────────────── */
 
-export async function handleLimitClose(ctx) {
+export async function handleLimitClose(ctx, direction = "above") {
   const tgUser = ctx.from;
   if (!tgUser) return;
   const text = ctx.message?.text ?? "";
 
-  const parseResult = parseLimitCloseArgs(text);
+  const parseResult = parseLimitCloseArgs(text, direction);
   if (!parseResult.ok) {
     return ctx.reply(parseResult.error, { parse_mode: "Markdown" });
   }
@@ -283,44 +311,42 @@ export async function handleLimitClose(ctx) {
 
   const user = await upsertUser(tgUser.id, tgUser.username);
 
-  // Multiplier path: resolve "at 2x" to a concrete USD micros price BEFORE
-  // calling armOrder. armOrder takes a concrete trigger_value_micro — the
-  // multiplier-to-price resolution is a TG-specific UX concern.
+  // Multiplier path: resolve "at 2x" / "at 0.7x" / "at -30%" to a concrete
+  // USD micros price BEFORE calling armOrder. armOrder takes a concrete
+  // trigger_value_micro — the multiplier-to-price resolution is a TG-specific
+  // UX concern.
   let multiplierContextLine = null;
   if (multiplier != null && trigger_value_micro == null) {
-    // We need the collateral mint to resolve. armOrder will re-fetch this
-    // anyway, but at this stage we only need a cheap loans-table lookup.
     const { rows: [loanForMint] } = await query(
       `SELECT collateral_mint FROM loans WHERE user_id = $1 AND loan_id = $2`,
       [user.id, loan_id],
     );
     if (!loanForMint) {
-      // armOrder will surface this same error anyway, but a friendly
-      // pre-emptive message reads better than the resolveMultiplier
-      // error.
       return ctx.reply(`Loan #${loan_id} not found in your account.`);
     }
-    const r = await resolveMultiplierToPrice(loanForMint.collateral_mint, multiplier);
+    const r = await resolveMultiplierToPrice(loanForMint.collateral_mint, multiplier, {
+      allowBelowOne: direction === "below",
+    });
     if (!r.ok) {
       return ctx.reply(r.error, { parse_mode: "Markdown" });
     }
     trigger_value_micro = r.triggerValueMicro;
     trigger_kind = "price_usd";
     const fmt = (n) => n < 0.01 ? n.toFixed(8) : n < 1 ? n.toFixed(6) : n.toFixed(4);
-    multiplierContextLine = `Current: $${fmt(r.currentUsd)} → target: $${fmt(r.targetUsd)} (${multiplier}×)`;
+    const arrow = direction === "below" ? "↓" : "↑";
+    multiplierContextLine = `Current: $${fmt(r.currentUsd)} ${arrow} target: $${fmt(r.targetUsd)} (${multiplier}×)`;
   }
 
-  // Hand off to arm-core. This consolidates loan ownership, mint
-  // allowlist + RWA exclusion, concurrency cap, fill-guarantee defaults
-  // (autoEscalate=true, derived cap), liquidity-aware initial bump,
-  // direction sanity check, INSERT, and the unique-index race guard.
-  // Any future hardening in arm-core lands here automatically.
+  // Hand off to arm-core. Direction-aware: arm-core's immediate-fire guard
+  // rejects an 'above' arm whose trigger is <= current, or a 'below' arm
+  // whose trigger is >= current.
   const armed = await armOrder({
     userId: user.id,
     source: "tg",
     loanIdChain: String(loan_id),
     triggerKind: trigger_kind,
     triggerValueMicro: trigger_value_micro.toString(),
+    triggerDirection: direction,
     slippageBps: slippage_bps,
     sellDestination: dest,
     expiresAt: expire_iso,
@@ -366,6 +392,12 @@ export async function handleLimitClose(ctx) {
         case "trigger_below_current":
         case "trigger_above_current":
           return `${armed.detail || "Trigger is on the wrong side of the current price."}`;
+        case "trigger_would_fire_immediately":
+          return direction === "below"
+            ? `Stop-loss target is already at or above the current price — the order would fire immediately. Set a lower target.`
+            : `Take-profit target is already at or below the current price — the order would fire immediately. Set a higher target.`;
+        case "invalid_trigger_direction":
+          return `Internal error — invalid trigger direction. Try again.`;
         default:
           console.error(`[limit-close] arm-core returned unrecognized error: ${armed.error}`, armed);
           return `Couldn't arm the order: ${armed.error}. Please try again.`;
@@ -389,9 +421,19 @@ export async function handleLimitClose(ctx) {
   const originalInitial = armed.initialSlippageBpsRequested ?? slippage_bps;
   const bumped = appliedInitial !== originalInitial;
 
+  const isStopLoss = direction === "below";
+  const headline = isStopLoss
+    ? `*Stop-loss armed* — order #${orderId}${expiryLabel}`
+    : `*Take-profit armed* — order #${orderId}${expiryLabel}`;
+  const triggerVerb = isStopLoss ? "drops to" : "hits";
+  const purpose = isStopLoss
+    ? `If ${symbol} ${triggerVerb} your floor, I'll cut the position before liquidation: repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`
+    : `When ${symbol} ${triggerVerb} your target, I'll repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`;
+  const listCmd = isStopLoss ? "/stoplosses" : "/takeprofitorders";
+
   await ctx.reply(
     [
-      `*Take-profit armed* — order #${orderId}${expiryLabel}`,
+      headline,
       ``,
       `Loan: #${loan.loan_id} (${symbol})`,
       `Trigger: ${triggerLabel}`,
@@ -403,13 +445,21 @@ export async function handleLimitClose(ctx) {
       }`,
       `Destination: ${dest.toUpperCase()}`,
       ``,
-      `When ${symbol} hits your target, I'll repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`,
-      `The 1% execution fee covers protocol operating costs.`,
+      purpose,
+      `The 1% execution fee applies in both directions and covers protocol operating costs.`,
       ``,
-      `/takeprofitorders to view all · /cancellimitorder ${orderId} to cancel`,
+      `${listCmd} to view all · /cancellimitorder ${orderId} to cancel`,
     ].filter(Boolean).join("\n"),
     { parse_mode: "Markdown" },
   );
+}
+
+/* ─── /stoploss ────────────────────────────────────────────────── */
+// Thin wrapper that delegates to handleLimitClose with direction='below'.
+// Shares every gate, fill-guarantee, and 1% fee — only the trigger
+// comparator flips at fire time (see magpie-limitclose isTriggerHit).
+export async function handleStopLoss(ctx) {
+  return handleLimitClose(ctx, "below");
 }
 
 /* ─── /limitorders ─────────────────────────────────────────────── */

--- a/src/index.js
+++ b/src/index.js
@@ -336,12 +336,22 @@ bot.command("crosspost", handleCommunityCrosspost);
   bot.command("takeprofit", lc.handleLimitClose);
   bot.command("tp", lc.handleLimitClose);
   bot.command("lo", lc.handleLimitClose);
+  // Stop-loss — same arm-core path, direction='below' flips the engine's
+  // trigger comparator from >= to <=. 1% protocol fee applies in BOTH
+  // directions (operator rule 2026-06-12). Cutting losses before the
+  // liquidation edge is the user's choice; the engine still charges
+  // the fee on proceeds either way.
+  bot.command("stoploss", lc.handleStopLoss);
+  bot.command("sl", lc.handleStopLoss);
   bot.command("limitorders", lc.handleLimitOrders);
   bot.command("takeprofitorders", lc.handleLimitOrders);
   bot.command("tps", lc.handleLimitOrders);
   bot.command("los", lc.handleLimitOrders);
+  bot.command("stoplosses", lc.handleLimitOrders);
+  bot.command("sls", lc.handleLimitOrders);
   bot.command("cancellimitorder", lc.handleCancelLimitOrder);
   bot.command("canceltp", lc.handleCancelLimitOrder);
+  bot.command("cancelsl", lc.handleCancelLimitOrder);
 
   // Layer 3 — intervention callback handler (inline keyboard taps).
   // Registers a bot.callbackQuery(/^lcint:/) handler that processes

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -50,6 +50,13 @@ export const MIN_TRIGGER_VALUE_MICRO = 1n;
 export const MAX_TRIGGER_VALUE_MICRO = 1_000_000_000_000_000n;
 export const VALID_TRIGGER_KINDS = new Set(["mc_usd", "price_usd", "price_sol"]);
 export const VALID_DESTINATIONS = new Set(["sol", "usdc"]);
+// Direction the trigger fires from:
+//   'above' (default) — take-profit: fires when current >= trigger
+//   'below'           — stop-loss:   fires when current <= trigger
+// arm-core validates that the trigger sits on the correct side of
+// current price at arm time so an immediate-fire arm is rejected.
+// 1% protocol fee applies in BOTH directions — operator rule 2026-06-12.
+export const VALID_TRIGGER_DIRECTIONS = new Set(["above", "below"]);
 
 /**
  * Resolve a multiplier ("at 2x" semantic) to a price_usd micros value
@@ -101,6 +108,7 @@ export async function armOrder({
   loanIdChain,             // string
   triggerKind,
   triggerValueMicro,       // BigInt or string
+  triggerDirection = "above", // 'above' = take-profit, 'below' = stop-loss
   slippageBps,
   sellDestination = "sol",
   expiresAt = null,
@@ -114,6 +122,9 @@ export async function armOrder({
   // ── Shape validation ─────────────────────────────────────────
   if (!VALID_TRIGGER_KINDS.has(triggerKind)) {
     return { ok: false, error: "invalid_trigger_kind" };
+  }
+  if (!VALID_TRIGGER_DIRECTIONS.has(triggerDirection)) {
+    return { ok: false, error: "invalid_trigger_direction" };
   }
   let triggerBI;
   try { triggerBI = BigInt(triggerValueMicro); }
@@ -223,6 +234,43 @@ export async function armOrder({
     appliedInitialBps = Math.min(liquidityFloorBps, effectiveCap);
   }
 
+  // ── Immediate-fire guard (best-effort) ──────────────────────
+  // Reject arms that would fire immediately:
+  //   - 'above' (TP)  with trigger <= current
+  //   - 'below' (SL)  with trigger >= current
+  // The engine re-checks at fire time so this is purely a UX guard;
+  // fail-open on any oracle hiccup so a transient price miss doesn't
+  // block a legitimate arm. Implemented for USD-denominated triggers
+  // (mc_usd, price_usd); price_sol skipped because the SOL denominator
+  // moves fast enough that a stale read can false-reject.
+  try {
+    if (triggerKind === "mc_usd" || triggerKind === "price_usd") {
+      const { getPriceInUsdCrossSourced } = await import("./price.js");
+      const currentUsdPerDisplayed = await getPriceInUsdCrossSourced(loan.collateral_mint);
+      if (currentUsdPerDisplayed && currentUsdPerDisplayed > 0) {
+        // For price_usd, trigger_value_micro is per displayed unit in USD micros.
+        // For mc_usd, multiply current price by circulating supply (best-effort —
+        // mintRow may not carry supply; skip if missing).
+        let currentMicros = null;
+        if (triggerKind === "price_usd") {
+          currentMicros = BigInt(Math.round(currentUsdPerDisplayed * 1e6));
+        } else if (triggerKind === "mc_usd" && mintRow.supply) {
+          currentMicros = BigInt(Math.round(currentUsdPerDisplayed * 1e6)) * BigInt(mintRow.supply);
+        }
+        if (currentMicros != null) {
+          if (triggerDirection === "above" && triggerBI <= currentMicros) {
+            return { ok: false, error: "trigger_would_fire_immediately",
+              detail: { direction: "above", currentMicros: currentMicros.toString(), triggerMicros: triggerBI.toString() } };
+          }
+          if (triggerDirection === "below" && triggerBI >= currentMicros) {
+            return { ok: false, error: "trigger_would_fire_immediately",
+              detail: { direction: "below", currentMicros: currentMicros.toString(), triggerMicros: triggerBI.toString() } };
+          }
+        }
+      }
+    }
+  } catch { /* fail-open: engine is the source of truth */ }
+
   // ── Per-user concurrency cap ────────────────────────────────
   const { rows: [activeCount] } = await query(
     `SELECT COUNT(*)::int AS n FROM limit_close_orders
@@ -259,18 +307,22 @@ export async function armOrder({
     inserted = await query(
       `INSERT INTO limit_close_orders
          (user_id, loan_id, trigger_kind, trigger_value_micro,
+          trigger_direction,
           slippage_bps, sell_destination, expires_at,
           source, source_agent_pubkey, status, armed_at,
           auto_escalate_slippage, max_slippage_bps_cap, initial_slippage_bps,
           preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at,
           notes)
-       VALUES ($1, $2, $3, $4, $5, $6, $7,
-               $8, $9, 'armed', NOW(),
-               $10, $11, $12,
-               $13, $14, $15,
-               $16)
+       VALUES ($1, $2, $3, $4,
+               $5,
+               $6, $7, $8,
+               $9, $10, 'armed', NOW(),
+               $11, $12, $13,
+               $14, $15, $16,
+               $17)
        RETURNING id, armed_at`,
       [userId, loan.id, triggerKind, triggerBI.toString(),
+       triggerDirection,
        appliedInitialBps, sellDestination, expiresAt,
        source, sourceAgentPubkey,
        autoEscalate, effectiveCap, appliedInitialBps,
@@ -279,8 +331,8 @@ export async function armOrder({
        advisory ? null : (preflight.quotedAtIso || new Date().toISOString()),
        armNote
          || (appliedInitialBps !== originalInitialBps
-           ? `armed via ${source}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
-           : `armed via ${source}`)],
+           ? `armed via ${source}; ${triggerDirection === "below" ? "STOP-LOSS" : "TP"}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
+           : `armed via ${source}; ${triggerDirection === "below" ? "STOP-LOSS" : "TP"}`)],
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message || "")) {
@@ -304,6 +356,7 @@ export async function armOrder({
     initialSlippageBpsApplied: appliedInitialBps,
     liquidityTierFloorBps: liquidityFloorBps,
     liquidityUsd: liqUsd,
+    triggerDirection,
   };
 }
 

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -66,9 +66,15 @@ export const VALID_TRIGGER_DIRECTIONS = new Set(["above", "below"]);
  * Returns { ok: true, triggerValueMicro: BigInt, currentUsd, targetUsd }
  * or { ok: false, error: string }.
  */
-export async function resolveMultiplierToPrice(collateralMint, multiplier) {
-  if (multiplier == null || !Number.isFinite(multiplier) || multiplier <= 1) {
+export async function resolveMultiplierToPrice(collateralMint, multiplier, { allowBelowOne = false } = {}) {
+  if (multiplier == null || !Number.isFinite(multiplier) || multiplier <= 0) {
+    return { ok: false, error: "Multiplier must be a positive number." };
+  }
+  if (!allowBelowOne && multiplier <= 1) {
     return { ok: false, error: "Multiplier must be > 1 (e.g. 2 for 2×)." };
+  }
+  if (allowBelowOne && multiplier >= 1) {
+    return { ok: false, error: "Stop-loss multiplier must be < 1 (e.g. 0.7 for 70% of current)." };
   }
   const { getPriceInUsdCrossSourced } = await import("./price.js");
   const currentUsd = await getPriceInUsdCrossSourced(collateralMint);


### PR DESCRIPTION
## Summary

Full bot-side enablement for bidirectional limit-close (take-profit + stop-loss). Schema, arm-core direction support, and the TG `/stoploss` command in one PR. Engine half ships in `magpiecapital/magpie-limitclose#7`.

## What ships

### Migration 039 — `trigger_direction` column
- `CHECK ('above','below')`, default `'above'` for back-compat
- Pre-migration rows treated as take-profit; new rows opt-in

### arm-core (`src/services/limit-close-arm-core.js`)
- `VALID_TRIGGER_DIRECTIONS` exported
- `triggerDirection` param on `armOrder()` (default `'above'`)
- Shape validation → `invalid_trigger_direction`
- **Immediate-fire guard**: rejects an arm whose trigger sits on the wrong side of current (UX-only; engine `isTriggerHit` at fire time is the source of truth — fails open on any oracle hiccup)
- `INSERT` writes `trigger_direction`; return value surfaces it
- `resolveMultiplierToPrice` gets optional `allowBelowOne` flag

### TG `/stoploss` command (`src/commands/limit-close.js` + `src/index.js`)
- `handleStopLoss` thin wrapper → `handleLimitClose(ctx, 'below')`
- `parseLimitCloseArgs` direction-aware:
  - `at -30%` / `at -5%` percent-drop syntax (SL only)
  - `at 0.7x` multiplier (<1 for SL, >1 for TP)
  - Explicit `$<usd>` / `mc=` works in both directions
- New commands: `/stoploss`, `/sl`, `/stoplosses`, `/sls`, `/cancelsl`
- Confirmation copy direction-aware: "Stop-loss armed" vs "Take-profit armed"; verb "drops to" vs "hits"; arrow ↓ vs ↑ on context line
- New error `trigger_would_fire_immediately` translated to friendly TG message

## Fee semantics

**1% protocol fee applies in BOTH directions** (operator rule 2026-06-12). Already direction-agnostic upstream — `feeLamports` is computed on PROCEEDS in `magpie-limitclose/src/execution.js` (lines 676 + 1075). No fee code changes needed.

## Pairs with

- `magpiecapital/magpie-limitclose#7` — engine `isTriggerHit` direction + `safety.js` floor exception

## Test plan

- [ ] Migration applies on prod via ledger insert (NOT raw `node -e`)
- [ ] Existing TP arms unchanged (no `triggerDirection` passed = `'above'`)
- [ ] `/stoploss <loan_id> at -30%` arms with `trigger_direction='below'`
- [ ] `/stoploss <loan_id> at 0.7x` arms with `trigger_direction='below'`
- [ ] `/stoploss <loan_id> at 2x` rejected ("must be < 1")
- [ ] `/takeprofit <loan_id> at 0.7x` rejected ("must be > 1")
- [ ] `/stoploss <loan_id> at $<above_current>` rejected by immediate-fire guard
- [ ] `/cancelsl <order_id>` cancels a stop-loss
- [ ] `/stoplosses` lists armed orders (shared handler — kind shown in display)