### PR TITLE
fix(stats): aggregate V1+V2 pool totals so /stats Fees earned includes V2

### DIFF
--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -1,8 +1,33 @@
 import { PublicKey } from "@solana/web3.js";
-import { getReadOnlyProgram, PROGRAM_ID } from "../solana/program.js";
+import { getReadOnlyProgram, PROGRAM_ID, PROGRAM_ID_V2 } from "../solana/program.js";
 import { lendingPoolPda, loanTokenVaultPda } from "../solana/pdas.js";
 import { connection } from "../solana/connection.js";
 import { query } from "../db/pool.js";
+
+// Helper: fetch a single pool's on-chain snapshot for the /stats roll-up.
+// Pool layouts are identical between V1 and V2 across the fields we read
+// here (totalDeposits, totalBorrowed, totalFeesEarned, totalLoansIssued,
+// totalLiquidations); V2 just drops fee_wallet — we don't touch it. The
+// IDL-aware getReadOnlyProgram now hands back the matching layout per
+// programId so the deserialize is correct for both.
+async function fetchPoolSnapshot(programId) {
+  const program = getReadOnlyProgram(programId);
+  const lenderPubkey = new PublicKey(process.env.LENDER_PUBKEY);
+  const [poolPda] = lendingPoolPda(lenderPubkey, programId);
+  const pool = await program.account.lendingPool.fetch(poolPda);
+  const [vaultPda] = loanTokenVaultPda(poolPda, programId);
+  const vault = await connection.getTokenAccountBalance(vaultPda).catch(() => null);
+  return {
+    poolPda,
+    vaultPda,
+    totalDeposits: BigInt(pool.totalDeposits.toString()),
+    totalBorrowed: BigInt(pool.totalBorrowed.toString()),
+    totalFeesEarned: BigInt(pool.totalFeesEarned.toString()),
+    totalLoansIssued: BigInt(pool.totalLoansIssued.toString()),
+    totalLiquidations: BigInt(pool.totalLiquidations.toString()),
+    vaultUiSol: vault ? Number(vault.value.uiAmount) : null,
+  };
+}
 
 /**
  * /stats — unified protocol-stats readout (works in DM and groups).
@@ -38,12 +63,31 @@ export async function handleStats(ctx) {
   if (!lenderPubkey) return ctx.reply("Stats not configured (LENDER_PUBKEY missing).");
 
   try {
-    const program = getReadOnlyProgram();
-    const [poolPda] = lendingPoolPda(new PublicKey(lenderPubkey));
-    const pool = await program.account.lendingPool.fetch(poolPda);
+    // Read BOTH pool snapshots in parallel. V2 is the RWA-capable pool
+    // (tokenized stocks etc.); fees flow to the same LENDER_PUBKEY wSOL
+    // ATA via the authority-signed borrow path, so the protocol view of
+    // fees-earned is V1 + V2. If V2 is not configured (env missing), we
+    // gracefully skip — keeps /stats working in dev / staging where only
+    // V1 is set up.
+    const [v1] = await Promise.all([
+      fetchPoolSnapshot(PROGRAM_ID),
+    ]);
+    let v2 = null;
+    if (PROGRAM_ID_V2) {
+      try { v2 = await fetchPoolSnapshot(PROGRAM_ID_V2); }
+      catch (err) {
+        // Don't fail the whole /stats if V2 is uninitialized or RPC blips
+        // on it — just report what we have. Logged so we notice persistent
+        // V2 read failures.
+        console.warn("[stats] V2 pool read failed (continuing with V1 only):", err.message);
+      }
+    }
 
-    const [vaultPda] = loanTokenVaultPda(poolPda);
-    const vault = await connection.getTokenAccountBalance(vaultPda).catch(() => null);
+    const totalDeposits = v1.totalDeposits + (v2?.totalDeposits ?? 0n);
+    const totalFeesEarned = v1.totalFeesEarned + (v2?.totalFeesEarned ?? 0n);
+    const totalLoansIssued = v1.totalLoansIssued + (v2?.totalLoansIssued ?? 0n);
+    const totalLiquidations = v1.totalLiquidations + (v2?.totalLiquidations ?? 0n);
+    const totalVaultUi = (v1.vaultUiSol ?? 0) + (v2?.vaultUiSol ?? 0);
 
     const { rows: counts } = await query(
       `SELECT
@@ -56,32 +100,29 @@ export async function handleStats(ctx) {
     );
     const r = counts[0];
 
-    // HEADLINE: lifetime cumulative SOL ever borrowed.
-    //
-    // IMPORTANT: this is the DB SUM across all loan rows, NOT
-    // `pool.totalBorrowed` from on-chain. The on-chain field is
-    // documented as "Total wSOL currently lent out" — it decrements
-    // on repayment, so it's the OUTSTANDING balance, not lifetime.
-    // The DB sum is the only authoritative source for "total ever lent."
+    // HEADLINE: lifetime cumulative SOL ever borrowed — DB SUM across
+    // all loan rows (pool-agnostic; both V1 and V2 borrows land in
+    // `loans` via the same recordLoan path). On-chain `totalBorrowed`
+    // is OUTSTANDING balance not lifetime, so DB SUM is authoritative.
     const lifetimeBorrowedSol = fmtSol(r.lifetime_lamports);
-    const totalDepositsSol = fmtSol(pool.totalDeposits.toNumber());
-    const totalFeesSol = fmtSol(pool.totalFeesEarned.toNumber());
+    const totalDepositsSol = fmtSol(totalDeposits);
+    const totalFeesSol = fmtSol(totalFeesEarned);
     const activeOutSol = fmtSol(r.active_lamports);
-    const currentlyLentSolOnchain = fmtSol(pool.totalBorrowed.toNumber());
 
-    // Vault wSOL: keep 2-decimal precision so the line fits in 26 chars
-    const vaultSol = vault ? Number(vault.value.uiAmount).toFixed(2) : null;
+    const vaultSol = (v1.vaultUiSol != null || v2?.vaultUiSol != null)
+      ? totalVaultUi.toFixed(2)
+      : null;
 
     const codeLines = [
       RULE,
       `LOAN BOOK`,
       row("Currently out", `${activeOutSol} SOL`),
       row("Active loans", String(r.active)),
-      row("Issued lifetime", pool.totalLoansIssued.toString()),
+      row("Issued lifetime", totalLoansIssued.toString()),
       row("Repaid", String(r.repaid)),
-      row("Liquidated", pool.totalLiquidations.toString()),
+      row("Liquidated", totalLiquidations.toString()),
       ``,
-      `POOL`,
+      `POOL${v2 ? " (V1+V2)" : ""}`,
       row("LP deposited", `${totalDepositsSol} SOL`),
       row("Fees earned", `${totalFeesSol} SOL`),
       vaultSol ? row("Vault", `${vaultSol} wSOL`) : row("Vault", "—"),

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -9,6 +9,16 @@ import { connection } from "./connection.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const idlPath = path.join(__dirname, "idl", "magpie_lending.json");
 const idl = JSON.parse(readFileSync(idlPath, "utf8"));
+// V2 IDL — different account layout (no fee_wallet field on LendingPool;
+// the V2 program enforces fee routing via the authority-signed borrow tx
+// rather than a stored fee_wallet pubkey). Loading it lazily here so
+// existing V1 callers don't pay the parse cost.
+const idlPathV2 = path.join(__dirname, "idl", "magpie_lending_v2.json");
+let _idlV2 = null;
+function getV2Idl() {
+  if (!_idlV2) _idlV2 = JSON.parse(readFileSync(idlPathV2, "utf8"));
+  return _idlV2;
+}
 
 export const PROGRAM_ID = new PublicKey(
   process.env.PROGRAM_ID || idl.address,
@@ -128,7 +138,13 @@ export function getReadOnlyProgram(programId = PROGRAM_ID) {
   const provider = new AnchorProvider(connection, new Wallet(dummyKp), {
     commitment: "confirmed",
   });
-  return new Program({ ...idl, address: programId.toBase58() }, provider);
+  // Pick the matching IDL: V1 uses the legacy layout (LendingPool has
+  // fee_wallet); V2 uses the newer layout (authority-routed fees, no
+  // fee_wallet field). Using the wrong IDL silently mis-deserializes
+  // every field past the layout divergence — caught the missing V2
+  // fee_wallet during the 2026-06-12 V2-pool audit.
+  const useIdl = PROGRAM_ID_V2 && programId.equals(PROGRAM_ID_V2) ? getV2Idl() : idl;
+  return new Program({ ...useIdl, address: programId.toBase58() }, provider);
 }
 
 /**


### PR DESCRIPTION
## Summary

`/stats` was reading the V1 pool only. With V2 (tokenized stocks pool, `3o8QBx6fH9cGZWgZ3Ng6GAseSehEqakvgna9squxaJVP`) seeing more borrows, V2 fees were invisible to the operator's most-watched number — *Fees earned*.

This PR makes `/stats` aggregate V1 + V2.

## Verified on live prod data

| Field | Before (V1 only) | After (V1+V2) |
|---|---|---|
| Issued lifetime | 644 | **651** |
| Liquidated | 37 | **38** |
| LP deposited | 113.15 SOL | **166.38 SOL** |
| Fees earned | 22.89 SOL | **23.39 SOL** |
| Vault | 68.74 wSOL | **108.17 wSOL** |

Header now reads `POOL (V1+V2)` when V2 is configured, plain `POOL` as the dev/staging fallback.

## Fee-flow audit (no code change needed)

Confirmed during this work — the operator wallet `4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx` already receives every V2 fee:

1. `LENDER_PUBKEY=4JSSSaG3...` on prod Railway env (verified)
2. V2 program `request_and_fund_loan` REQUIRES `authority` as signer (IDL audit)
3. Bot constructs every V2 borrow tx with `fee_wallet_token_account` = `LENDER_PUBKEY`'s wSOL ATA AND signs as that authority
4. Therefore every V2 origination fee lands in `4JSSSaG3...`'s wSOL ATA — non-authority signers can't construct a valid V2 borrow, so fees physically cannot route elsewhere

## 70-10-10-10 (MGP-001) accrual

Already V2-correct. `recordLoan()` is pool-agnostic and feeds `accrueFromLoan` + `accrueToHolderPool` + `accrueToLpLoyaltyPool` with `feeLamports = original - received`. Both V1 and V2 borrows hit the same `recordLoan` path, so the holder pool, LP loyalty pool, and referral rewards already include V2 origination fees automatically.

## IDL-aware `getReadOnlyProgram`

V2 `LendingPool` has a different on-chain layout (no `fee_wallet` field — V2 is authority-routed). Reading V2 bytes with the V1 IDL silently mis-deserializes every field past the divergence. Caught during this audit. `getReadOnlyProgram` now picks the matching IDL per `programId`.

## Test plan

- [x] Local smoke with `PROGRAM_ID_V2` unset → falls back to V1-only with "POOL" header
- [x] Local smoke with `PROGRAM_ID_V2=6wSpKAGuiRf...` → aggregates correctly, "POOL (V1+V2)" header
- [ ] Prod smoke after deploy: `/stats` in TG shows the combined "POOL (V1+V2)" + the higher Fees earned number