### PR TITLE
fix(anti-exploit): honor premium_tier_whitelist cap before computeTokenTier

### DIFF
--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -344,15 +344,25 @@ export async function preBorrowAntiExploitCheck(opts) {
 
   try {
     // 0. PER_TOKEN_CAP — refuse if total open loans against this mint
-    // already exceed the cap. Three-step cap resolution:
+    // already exceed the cap. Four-step cap resolution:
     //   1. supported_mints.max_open_lamports override (operator-set):
     //        NULL → fall through to step 2
     //        0    → unlimited (no cap)
     //        N    → cap is N lamports
-    //   2. computeTokenTier(metadata) → tier-based cap (bluechip/large/
+    //   2. premium_tier_whitelist.max_open_lamports (operator-approved RWA):
+    //        If the mint is in the premium tier whitelist AND enabled, its
+    //        cap takes precedence over the metadata-driven tiering. This
+    //        matters specifically because tokenized stocks (xStocks) live
+    //        with mint+freeze authorities ON by design (the issuer needs
+    //        them for compliance), which would otherwise trip the hard-
+    //        demotion-to-small branch in computeTokenTier. The whitelist
+    //        is the operator's explicit "I know about the auth keys; here's
+    //        the conservative cap I'm comfortable with" signal — so honor
+    //        it for cap math even when the metadata says small.
+    //   3. computeTokenTier(metadata) → tier-based cap (bluechip/large/
     //      mid → 30/25/15 SOL). Larger + older + more-distributed tokens
     //      that pass the screener earn a proportionally larger cap.
-    //   3. Fallback PER_TOKEN_OPEN_LAMPORTS_CAP (small tier, 10 SOL).
+    //   4. Fallback PER_TOKEN_OPEN_LAMPORTS_CAP (small tier, 10 SOL).
     //
     // Defends against many-borrower parallel attacks on one token even
     // if no individual borrower trips other gates. Higher tiers raise
@@ -361,18 +371,30 @@ export async function preBorrowAntiExploitCheck(opts) {
     // account, imported-wallet, TWAP, etc.).
     {
       const { rows: capRows } = await query(
-        `SELECT max_open_lamports, liquidity_usd, holder_count, token_age_hours,
-                top10_holder_pct, has_mint_authority, has_freeze_authority, lp_burned,
-                symbol
-           FROM supported_mints WHERE mint = $1 LIMIT 1`,
+        `SELECT sm.max_open_lamports, sm.liquidity_usd, sm.holder_count, sm.token_age_hours,
+                sm.top10_holder_pct, sm.has_mint_authority, sm.has_freeze_authority, sm.lp_burned,
+                sm.symbol, sm.market_cap_usd,
+                pt.max_open_lamports::text AS pt_cap,
+                pt.enabled AS pt_enabled,
+                pt.symbol AS pt_symbol
+           FROM supported_mints sm
+           LEFT JOIN premium_tier_whitelist pt ON pt.mint = sm.mint
+          WHERE sm.mint = $1 LIMIT 1`,
         [String(collateralMint)],
       );
       const mintRow = capRows[0];
       const override = mintRow?.max_open_lamports;
+      const ptCap = mintRow?.pt_enabled === true && mintRow?.pt_cap != null
+        ? BigInt(String(mintRow.pt_cap))
+        : null;
       let cap;
       let tierLabel = "override";
       if (override !== null && override !== undefined) {
         cap = BigInt(String(override));
+      } else if (ptCap !== null) {
+        // Operator-approved RWA whitelist cap.
+        cap = ptCap;
+        tierLabel = "premium_rwa";
       } else {
         const tierInfo = computeTokenTier(mintRow);
         cap = tierInfo.capLamports;


### PR DESCRIPTION
## Summary

SPCX (Backpack xStocks SpaceX) was operator-approved at a 40 SOL aggregate cap via `premium_tier_whitelist`. But the V1 borrow path's `per_token_cap` gate only consulted `supported_mints.max_open_lamports` → fell through to `computeTokenTier` → SPCX (xStocks mint+freeze authorities live by issuer-design) hard-demoted to "small" tier (10 SOL). The dashboard surfaced "11.88 of 10 SOL borrowed protocol-wide" and the operator's 40 SOL approval was invisible to the gate.

## Fix

Cap resolution now follows a 4-step ladder that adds the premium whitelist as a second-tier override **before** `computeTokenTier`:

1. `supported_mints.max_open_lamports` (explicit per-mint override)
2. `premium_tier_whitelist.max_open_lamports` (operator-approved RWA) ← new
3. `computeTokenTier` (metadata-driven bluechip/large/mid/small)
4. `PER_TOKEN_OPEN_LAMPORTS_CAP` fallback (10 SOL)

The whitelist is the operator's explicit "I know about the auth keys, here's the conservative cap I'm comfortable with" signal — so honor it for cap math even when metadata says small. Per-borrower gates that fire BELOW the per-token-cap (rapid-fire, new-account, imported-wallet, TWAP) are unchanged.

## Immediate prod unblock

Already shipped via direct DB UPDATE on `supported_mints.max_open_lamports` → 40 SOL so the operator can borrow SPCX right now while this PR works through review. This PR is the proper code fix so future operator-approved RWA tokens don't fall into the same trap.

## Test plan

- [x] `node --check` passes
- [ ] Borrow against SPCX shows correct 40 SOL cap on dashboard after deploy
- [ ] Borrow against a non-premium token still uses `computeTokenTier` (no regression)
- [ ] Borrow against a token with explicit `supported_mints.max_open_lamports` still takes the override (no regression)