### PR TITLE
feat(loans): differentiated RWA loan tiers (50/60/70% LTV, 7/15/30d, 2.5/3.5/5.0% fees)

### DIFF
--- a/migrations/040_rwa_loan_tiers.sql
+++ b/migrations/040_rwa_loan_tiers.sql
@@ -1,0 +1,74 @@
+-- migration 040: differentiated loan tiers for RWA collateral
+-- (tokenized stocks, ETFs, metals).
+--
+-- Until now every borrow — memecoin or stock — used the same hard-
+-- coded LTV_TIERS in src/commands/borrow.js (and a few other callsites):
+--
+--   Express : 30% LTV · 2d  · 3.0% fee
+--   Quick   : 25% LTV · 3d  · 2.0% fee
+--   Standard: 20% LTV · 7d  · 1.5% fee
+--
+-- That's conservative for a token whose collateral can move 30% in
+-- an hour. For SPYx / QQQx / NVDAx / TSLAx (Backpack xStocks) the
+-- intraday vol is 1–3% and the holder profile is closer to traditional
+-- investors than memecoin traders. The protocol can safely offer
+-- significantly higher LTVs, longer terms, and a higher fee — leaving
+-- value on the table both for the borrower (more SOL out per $1 of
+-- collateral, longer to repay) and for the protocol (higher fee that
+-- flows to 4JSSSaG3 via the existing 70-10-10-10 split).
+--
+-- Operator-proposed initial numbers (TUNE BEFORE MERGE if these don't
+-- match what you want):
+--
+--   RWA Express : 50% LTV · 7d  · 2.5% fee
+--   RWA Quick   : 60% LTV · 15d · 3.5% fee
+--   RWA Standard: 70% LTV · 30d · 5.0% fee
+--
+-- Fee semantics: same as memecoin — origination fee is deducted up
+-- front from the loan proceeds, accrued by recordLoan(), and routed
+-- through the 70-10-10-10 split via accrueFromLoan +
+-- accrueToHolderPool + accrueToLpLoyaltyPool. Protocol slice lands
+-- in the 4JSSSaG3 wallet.
+--
+-- Safety guards that ride alongside the higher LTV:
+--   * per-mint aggregate cap stays enforced via premium_tier_whitelist
+--     (operator-set, 25–50 SOL per mint today)
+--   * fee schedule is per-tier (option), NOT per-mint; the operator
+--     can promote/demote individual mints by adjusting their
+--     premium_tier_whitelist cap rather than per-mint LTV
+--   * the resolver in src/services/loan-tier-resolver.js picks the
+--     RWA set when category ∈ {stock, etf, metal}, falls back to the
+--     memecoin set otherwise — so the existing memecoin path is
+--     untouched
+--
+-- The on-chain V2 program does NOT enforce LTV on chain; the bot's
+-- src/api/cosign-borrow.js computes loan_amount = collateral_value *
+-- LTV / 100 and the program just accepts it as long as authority co-signs.
+-- That means this migration alone is enough to ship higher LTVs — no
+-- on-chain redeploy needed.
+
+CREATE TABLE IF NOT EXISTS rwa_loan_tiers (
+  option            INTEGER     PRIMARY KEY,
+  ltv_pct           INTEGER     NOT NULL CHECK (ltv_pct > 0 AND ltv_pct <= 90),
+  duration_days     INTEGER     NOT NULL CHECK (duration_days > 0 AND duration_days <= 90),
+  fee_bps           INTEGER     NOT NULL CHECK (fee_bps >= 0 AND fee_bps <= 1000),
+  label             TEXT        NOT NULL,
+  enabled           BOOLEAN     NOT NULL DEFAULT TRUE,
+  notes             TEXT
+);
+
+INSERT INTO rwa_loan_tiers (option, ltv_pct, duration_days, fee_bps, label, notes)
+VALUES
+  (0, 50, 7,  250, 'RWA Express',  'short-term cash, conservative LTV buffer'),
+  (1, 60, 15, 350, 'RWA Quick',    'NEW — 15-day term for tokenized stocks'),
+  (2, 70, 30, 500, 'RWA Standard', 'NEW — 30-day term, premium fee, highest LTV for RWA-only')
+ON CONFLICT (option) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_rwa_loan_tiers_enabled
+  ON rwa_loan_tiers(enabled, option);
+
+COMMENT ON TABLE rwa_loan_tiers IS
+  'Loan tier schedule for RWA collateral (stock/etf/metal). Resolved
+   via src/services/loan-tier-resolver.js based on supported_mints.category.
+   Memecoin path keeps hardcoded LTV_TIERS unchanged. Operator-tunable
+   per row — adjust ltv_pct / duration_days / fee_bps without code change.';

--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -13,11 +13,15 @@ import { renderRiskBlock } from "../services/token-risk-preview.js";
 import { preBorrowBanCheck } from "../services/bans.js";
 import { preBorrowAntiExploitCheck } from "../services/anti-exploit.js";
 
-const LTV_TIERS = [
-  { option: 0, ltv: 30, days: 2, feeBps: 300, label: "30% LTV · 2d · 3% fee (Express)" },
-  { option: 1, ltv: 25, days: 3, feeBps: 200, label: "25% LTV · 3d · 2% fee (Quick)" },
-  { option: 2, ltv: 20, days: 7, feeBps: 150, label: "20% LTV · 7d · 1.5% fee (Standard)" },
-];
+// Tier schedule is category-aware as of 2026-06-12 migration 040.
+// Memecoins use the legacy 30/25/20 LTV ladder; RWA collateral
+// (stock/etf/metal) uses the higher-LTV / longer-term / higher-fee
+// schedule seeded into rwa_loan_tiers. See ../services/loan-tier-resolver.js.
+//
+// LTV_TIERS kept here as a synchronous fallback for the rare path that
+// can't await (currently none); resolver returns an equivalent set for
+// memecoin category, so both paths agree on the memecoin numbers.
+import { getEligibleTiers, getTierByOption, MEMECOIN_TIERS as LTV_TIERS } from "../services/loan-tier-resolver.js";
 
 // In-memory pending state per Telegram chat; fine for MVP, move to DB for prod.
 const pending = new Map();
@@ -223,8 +227,12 @@ export function registerBorrowCallbacks(bot) {
     state.quotedAt = Date.now();
     pending.set(ctx.chat.id, state);
 
+    // Resolve tier schedule based on the selected mint's category.
+    // RWA collateral (stock/etf/metal) lands the higher-LTV ladder
+    // out of rwa_loan_tiers; memecoin (and uncategorized) get MEMECOIN_TIERS.
+    const tiers = await getEligibleTiers({ category: state.selected.category });
     const kb = new InlineKeyboard();
-    for (const t of LTV_TIERS) {
+    for (const t of tiers) {
       const loanSol = ((valueLamports * t.ltv) / 100) / 1e9;
       const fee = loanSol * (t.feeBps / 10_000);
       const receive = loanSol - fee;
@@ -275,8 +283,10 @@ export function registerBorrowCallbacks(bot) {
     state.quotedAt = Date.now();
     pending.set(ctx.chat.id, state);
 
+    // Same category-aware tier resolution as the prior flow.
+    const tiers = await getEligibleTiers({ category: state.selected.category });
     const kb = new InlineKeyboard();
-    for (const t of LTV_TIERS) {
+    for (const t of tiers) {
       const loanSol = ((valueLamports * t.ltv) / 100) / 1e9;
       const fee = loanSol * (t.feeBps / 10_000);
       const receive = loanSol - fee;
@@ -307,8 +317,9 @@ export function registerBorrowCallbacks(bot) {
 
   bot.callbackQuery(/^borrow:tier:(\d+)$/, async (ctx) => {
     const option = Number(ctx.match[1]);
-    const tier = LTV_TIERS.find((t) => t.option === option);
     const state = pending.get(ctx.chat.id);
+    // Resolve from the same tier set the user picked from — by category.
+    const tier = await getTierByOption({ category: state?.selected?.category, option });
     if (!state || !tier) {
       await ctx.answerCallbackQuery("Session expired");
       return;

--- a/src/services/deposits.js
+++ b/src/services/deposits.js
@@ -32,7 +32,7 @@ export async function getSupportedBalances(walletPubkey) {
 
   const mints = [...byMint.keys()];
   const { rows } = await query(
-    `SELECT mint, symbol, name, decimals FROM supported_mints
+    `SELECT mint, symbol, name, decimals, category FROM supported_mints
      WHERE enabled = TRUE AND mint = ANY($1)`,
     [mints],
   );
@@ -44,6 +44,10 @@ export async function getSupportedBalances(walletPubkey) {
       symbol: r.symbol,
       name: r.name,
       decimals: r.decimals,
+      // category drives loan-tier-resolver: RWA mints get the higher-LTV
+      // / longer-term / higher-fee tier schedule from rwa_loan_tiers,
+      // memecoin (and uncategorized) get the existing MEMECOIN_TIERS.
+      category: r.category,
       rawAmount: bal.rawAmount.toString(),
       humanAmount: Number(bal.rawAmount) / 10 ** r.decimals,
     };

--- a/src/services/loan-tier-resolver.js
+++ b/src/services/loan-tier-resolver.js
@@ -1,0 +1,120 @@
+/**
+ * Loan tier resolver — picks the right tier set per collateral category.
+ *
+ * Until 2026-06-12 every callsite imported a hardcoded LTV_TIERS array
+ * (30% / 25% / 20% with 2d / 3d / 7d terms and 3% / 2% / 1.5% fees) and
+ * used it for every borrow regardless of collateral type. Tokenized
+ * stocks (xStocks) have meaningfully lower volatility than memecoins,
+ * so the protocol can safely offer higher LTVs, longer terms, and a
+ * higher fee — but only on the RWA path.
+ *
+ * This module is the single source of truth that:
+ *   - returns the hardcoded MEMECOIN_TIERS for memecoin/non-categorized
+ *     collateral (unchanged from prior behavior)
+ *   - returns the RWA tiers (read live from rwa_loan_tiers table) when
+ *     category ∈ {stock, etf, metal}
+ *
+ * Callsites (src/commands/borrow.js, reborrow.js, simulate.js,
+ * unlock.js, price.js, api/agent.js, services/community-pip.js) should
+ * resolve via this module rather than embedding their own LTV_TIERS
+ * array. That way, when the operator tunes the RWA numbers via the DB
+ * (UPDATE rwa_loan_tiers SET ...) every surface picks up the change
+ * without a code redeploy.
+ *
+ * Fee semantics are unchanged regardless of source: feeBps is applied
+ * up front against loan_amount_pre_fee in recordLoan, and the resulting
+ * feeLamports feeds the 70-10-10-10 accrual pipeline. Protocol slice
+ * lands in 4JSSSaG3 via the existing PROTOCOL_FEE_DESTINATION flow.
+ */
+import { query } from "../db/pool.js";
+
+// Same MEMECOIN_TIERS that has been used since v1. Kept as a constant
+// here (not in DB) because (a) the memecoin path is stable and changing
+// these is a much bigger product decision than tuning the RWA numbers,
+// and (b) it lets the memecoin path be totally DB-independent.
+export const MEMECOIN_TIERS = [
+  { option: 0, ltv: 30, days: 2, feeBps: 300, label: "30% LTV · 2d · 3% fee (Express)" },
+  { option: 1, ltv: 25, days: 3, feeBps: 200, label: "25% LTV · 3d · 2% fee (Quick)" },
+  { option: 2, ltv: 20, days: 7, feeBps: 150, label: "20% LTV · 7d · 1.5% fee (Standard)" },
+];
+
+// Categories that route to the RWA tier set. Source of truth for the
+// vocabulary lives in src/solana/program.js (RWA_CATEGORIES); we mirror
+// it here to avoid circular imports between solana + services layers.
+const RWA_CATEGORIES = new Set(["stock", "etf", "metal"]);
+
+// Short cache so a borrow flow that touches getEligibleTiers multiple
+// times within the same tick doesn't re-query the DB. 30s is well below
+// the cadence at which the operator would realistically tune the table.
+const CACHE_TTL_MS = 30_000;
+let cachedRwaTiers = null;
+let cachedAt = 0;
+
+async function getRwaTiersFromDb() {
+  const now = Date.now();
+  if (cachedRwaTiers && now - cachedAt < CACHE_TTL_MS) return cachedRwaTiers;
+  try {
+    const { rows } = await query(
+      `SELECT option, ltv_pct, duration_days, fee_bps, label, notes
+         FROM rwa_loan_tiers
+        WHERE enabled = TRUE
+        ORDER BY option ASC`,
+    );
+    if (rows.length === 0) {
+      // Defensive: if migration 040 hasn't applied yet OR the operator
+      // disabled every row, fall back to the memecoin tiers so RWA
+      // borrows don't fail outright. They just don't get the favorable
+      // RWA-specific economics until the DB is set up.
+      return MEMECOIN_TIERS;
+    }
+    cachedRwaTiers = rows.map((r) => ({
+      option: r.option,
+      ltv: r.ltv_pct,
+      days: r.duration_days,
+      feeBps: r.fee_bps,
+      label: `${r.ltv_pct}% LTV · ${r.duration_days}d · ${(r.fee_bps / 100).toFixed(1)}% fee (${r.label})`,
+      notes: r.notes,
+    }));
+    cachedAt = now;
+    return cachedRwaTiers;
+  } catch (err) {
+    // Same defensive fallback: never let a bad DB query nuke the
+    // borrow flow. Memecoin tiers are guaranteed to clear; we'd rather
+    // a worse-economics borrow succeed than block legitimate RWA
+    // borrowers.
+    console.warn(`[loan-tier-resolver] rwa tier read failed, falling back to memecoin tiers: ${err.message}`);
+    return MEMECOIN_TIERS;
+  }
+}
+
+/**
+ * Pick the right tier set for the borrow. category is the value of
+ * supported_mints.category (string).
+ *
+ * Returns an array of tier objects: { option, ltv, days, feeBps, label }.
+ */
+export async function getEligibleTiers({ category }) {
+  if (category && RWA_CATEGORIES.has(category)) {
+    return await getRwaTiersFromDb();
+  }
+  return MEMECOIN_TIERS;
+}
+
+/**
+ * Look up a tier by option index for a given category. Same defaulting
+ * as getEligibleTiers. Returns undefined if option is out of range.
+ */
+export async function getTierByOption({ category, option }) {
+  const tiers = await getEligibleTiers({ category });
+  return tiers.find((t) => t.option === Number(option));
+}
+
+/**
+ * Clear the in-memory cache. The operator-facing /reload-tiers admin
+ * command can call this after tuning the rwa_loan_tiers table to skip
+ * the 30s TTL.
+ */
+export function clearTierCache() {
+  cachedRwaTiers = null;
+  cachedAt = 0;
+}


### PR DESCRIPTION
## ⚠️ Operator review requested — tune numbers in seed before merging

This PR ships the RWA-differentiated tier infrastructure with the proposed defaults from the 2026-06-12 conversation:

| Tier | LTV | Term | Fee |
|---|---|---|---|
| RWA Express | 50% | 7 days | 2.5% |
| RWA Quick | 60% | 15 days | 3.5% |
| RWA Standard | 70% | 30 days | 5.0% |

**These are tuned in `migrations/040_rwa_loan_tiers.sql` (the INSERT block).** Edit those numbers BEFORE merging if you want different values, or update the seed with conservative numbers first and tune up later via `UPDATE rwa_loan_tiers SET ...` (no code change needed — the resolver re-reads on a 30s TTL).

## Background

Every borrow today (memecoin or stock) uses the same hardcoded `LTV_TIERS` in `src/commands/borrow.js` — 30/25/20% LTV, 2/3/7d, 3.0/2.0/1.5% fees. That's conservative for SPYx/QQQx/NVDAx (intraday vol 1–3%, traditional investor profile). The protocol can safely offer higher LTVs, longer terms, and a higher fee on the RWA path — leaving value on the table both for borrowers and for the 70-10-10-10 distribution to `4JSSSaG3...`.

## What ships

### `migrations/040_rwa_loan_tiers.sql`
- New `rwa_loan_tiers` table with operator-tunable rows
- CHECK constraints bound LTV 1–90%, term 1–90d, fee 0–10%
- Operator can UPDATE rows post-deploy with no code change

### `src/services/loan-tier-resolver.js` (new)
- `getEligibleTiers({ category })` → `MEMECOIN_TIERS` for memecoin / uncategorized; RWA tiers from DB when `category ∈ {stock, etf, metal}`
- `getTierByOption({ category, option })` → look up a single tier
- 30s in-memory cache; `clearTierCache()` exposed for an admin reload command
- **Fail-safe:** DB read failure OR empty/disabled `rwa_loan_tiers` falls back to `MEMECOIN_TIERS` so a borrow never errors out due to bad seed

### `src/services/deposits.js`
- `getSupportedBalances` now returns `category` so callers can resolve the right tier set without a second DB roundtrip

### `src/commands/borrow.js`
- Replaces hardcoded `LTV_TIERS` const with the resolver
- All three tier-render / lookup callsites now read category from `state.selected` and resolve via `getEligibleTiers` / `getTierByOption`

## Fee flow

**Unchanged.** `feeBps` is applied up front against `loan_amount_pre_fee` in `recordLoan`, `feeLamports` feeds the 70-10-10-10 split via `accrueFromLoan` + `accrueToHolderPool` + `accrueToLpLoyaltyPool`. Protocol slice routes to `4JSSSaG3...` through the existing `PROTOCOL_FEE_DESTINATION` env. Higher RWA fee = bigger absolute slice to all three pools + protocol reserve.

## On-chain implications

**None.** V2 program doesn't enforce LTV on chain — bot's `src/api/cosign-borrow.js` does the math and authority co-signs. So this migration is enough to ship higher RWA LTVs; no V2 program redeploy.

## Out of scope for this PR (follow-ups if you want them aligned)

- `src/commands/reborrow.js` still uses hardcoded LTV_TIERS
- `src/commands/simulate.js`, `unlock.js`, `price.js` show memecoin tiers
- `src/api/agent.js` uses its own inline tier map
- `src/services/community-pip.js` mentions hardcoded numbers in Pip copy

I can ship these as a follow-up PR once you've signed off on the numbers — they're mechanical caller updates against the same resolver.

## Test plan

- [x] `node --check` passes on every changed file
- [ ] Migration 040 applies via schema_migrations ledger on next bot deploy
- [ ] `/borrow` flow with a memecoin shows 30/25/20% LTV ladder (unchanged)
- [ ] `/borrow` flow with $SPCX/$TSLAx/etc. shows the new 50/60/70% RWA ladder
- [ ] Borrowing an RWA at RWA Standard tier successfully completes the full request_and_fund_loan tx
- [ ] Fee flows to `4JSSSaG3...` (existing accrual pipeline) — confirmed in `/stats` Fees earned rolling up