### PR TITLE
security(admin): audit log every admin command attempt (audit F-4)

### DIFF
--- a/migrations/041_admin_command_log.sql
+++ b/migrations/041_admin_command_log.sql
@@ -1,0 +1,50 @@
+-- migration 041: admin command audit log
+--
+-- Security audit finding F-4 (2026-06-12, MEDIUM severity): every admin
+-- command — /enablemint, /disablemint, /pause, /resume, /announcement,
+-- /broadcast, /ban_user, etc. — runs behind a single env-var gate
+-- (ADMIN_TELEGRAM_IDS). No logging, no forensic trail.
+--
+-- A SIM-swap or social-engineering compromise of an admin TG account
+-- gives the attacker:
+--   /pause                  → freeze borrowing → ransom
+--   /enablemint <rug>       → drain pool against attacker-controlled rug
+--   /announcement <phish>   → DM the entire user base with malicious links
+--   /ban_user <legit user>  → grief
+--
+-- With no log, the operator wouldn't know which actions to undo, when,
+-- or by whom.
+--
+-- This migration creates the append-only log. The log writer is
+-- src/services/admin-audit.js logAdminCommand(). Reader is /admincmds.
+--
+-- Future: pair with admin_command_approvals (separate migration) for the
+-- multi-step approval workflow on sensitive commands.
+
+CREATE TABLE IF NOT EXISTS admin_command_log (
+  id              BIGSERIAL    PRIMARY KEY,
+  admin_tg_id     BIGINT       NOT NULL,
+  admin_username  TEXT,
+  command         TEXT         NOT NULL,
+  args_redacted   TEXT,
+  outcome         TEXT         NOT NULL CHECK (outcome IN ('success', 'denied', 'error')),
+  error_excerpt   TEXT,
+  chat_id         BIGINT,
+  chat_type       TEXT,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_command_log_created_at
+  ON admin_command_log (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_command_log_admin_tg_id
+  ON admin_command_log (admin_tg_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_command_log_command
+  ON admin_command_log (command, created_at DESC);
+
+COMMENT ON TABLE admin_command_log IS
+  'Append-only forensic log of every admin command attempt. Written by
+   src/services/admin-audit.js logAdminCommand(); read by /admincmds.
+   args_redacted strips secrets/long-form content; never store full
+   pubkeys or signatures here. outcome=denied means isAdmin() rejected;
+   that case is the most important to log — captures unauthorized attempts
+   that would otherwise be invisible.';

--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -9,9 +9,25 @@ import { query } from "../db/pool.js";
 import { connection } from "../solana/connection.js";
 import { estimateCostUsd } from "../services/ai-support.js";
 import { getHealthSnapshot } from "../services/infra-health.js";
+import { logAdminCommand, recentAdminCommands, countDeniedAttempts } from "../services/admin-audit.js";
 
-async function requireAdmin(ctx) {
+// requireAdmin takes the command name so we can log every denied attempt
+// to admin_command_log. Unauthorized attempts are the highest-signal
+// security event — a sustained pattern of denied calls means someone is
+// probing admin commands without the right TG ID (recon, social-engineered
+// admin account, or a previously-removed admin still trying old credentials).
+// cmdName falls back to parsing the first slash-token if not passed,
+// so older callsites that didn't pass it still log meaningfully rather
+// than as "unknown".
+async function requireAdmin(ctx, cmdName) {
   if (!isAdmin(ctx.from?.id)) {
+    let name = cmdName;
+    if (!name) {
+      const txt = ctx?.message?.text || "";
+      const m = txt.match(/^\/([a-z0-9_]+)/i);
+      name = m ? m[1] : "unknown";
+    }
+    await logAdminCommand(ctx, name, { outcome: "denied" });
     await ctx.reply("❌ Not authorized.");
     return false;
   }
@@ -19,19 +35,21 @@ async function requireAdmin(ctx) {
 }
 
 export async function handlePause(ctx) {
-  if (!(await requireAdmin(ctx))) return;
+  if (!(await requireAdmin(ctx, "pause"))) return;
   pauseBorrowing();
+  await logAdminCommand(ctx, "pause", { outcome: "success" });
   await ctx.reply("⏸ Borrowing paused. Existing loans unaffected.");
 }
 
 export async function handleResume(ctx) {
-  if (!(await requireAdmin(ctx))) return;
+  if (!(await requireAdmin(ctx, "resume"))) return;
   resumeBorrowing();
+  await logAdminCommand(ctx, "resume", { outcome: "success" });
   await ctx.reply("▶️ Borrowing resumed.");
 }
 
 export async function handleAdminStatus(ctx) {
-  if (!(await requireAdmin(ctx))) return;
+  if (!(await requireAdmin(ctx, "admin"))) return;
   const { getGlobalSiteState } = await import("../services/site-global.js");
   const [{ rows }, siteState, lockedRow] = await Promise.all([
     query(
@@ -62,7 +80,7 @@ export async function handleAdminStatus(ctx) {
 }
 
 export async function handleEnableMint(ctx) {
-  if (!(await requireAdmin(ctx))) return;
+  if (!(await requireAdmin(ctx, "enablemint"))) return;
   const parts = ctx.message.text.split(/\s+/);
   // /enablemint <mint> <symbol> <decimals> [name]
   if (parts.length < 4) {
@@ -98,25 +116,35 @@ export async function handleEnableMint(ctx) {
     );
   }
   const name = nameParts.join(" ") || null;
-  await query(
-    `INSERT INTO supported_mints (mint, symbol, name, decimals, enabled)
-     VALUES ($1, $2, $3, $4, TRUE)
-     ON CONFLICT (mint) DO UPDATE
-       SET symbol = EXCLUDED.symbol,
-           name = COALESCE(EXCLUDED.name, supported_mints.name),
-           decimals = EXCLUDED.decimals,
-           enabled = TRUE`,
-    [mint, symbol.toUpperCase(), name, decimals],
-  );
-  await ctx.reply(`✅ ${symbol.toUpperCase()} enabled (decimals=${decimals}, verified on-chain).`);
+  try {
+    await query(
+      `INSERT INTO supported_mints (mint, symbol, name, decimals, enabled)
+       VALUES ($1, $2, $3, $4, TRUE)
+       ON CONFLICT (mint) DO UPDATE
+         SET symbol = EXCLUDED.symbol,
+             name = COALESCE(EXCLUDED.name, supported_mints.name),
+             decimals = EXCLUDED.decimals,
+             enabled = TRUE`,
+      [mint, symbol.toUpperCase(), name, decimals],
+    );
+    await logAdminCommand(ctx, "enablemint", { outcome: "success", args: `${symbol.toUpperCase()} ${mint}` });
+    await ctx.reply(`✅ ${symbol.toUpperCase()} enabled (decimals=${decimals}, verified on-chain).`);
+  } catch (err) {
+    await logAdminCommand(ctx, "enablemint", { outcome: "error", args: `${symbol} ${mint}`, error: err.message });
+    throw err;
+  }
 }
 
 export async function handleBroadcast(ctx) {
-  if (!(await requireAdmin(ctx))) return;
+  if (!(await requireAdmin(ctx, "broadcast"))) return;
   const text = ctx.message.text.replace(/^\/broadcast(\s+|$)/, "").trim();
   if (!text) {
     return ctx.reply("Usage: `/broadcast <message>`", { parse_mode: "Markdown" });
   }
+  // Log the broadcast BEFORE sending — even partial sends are recorded
+  // so the operator can see what the broadcast contained without scanning
+  // every user's DMs.
+  await logAdminCommand(ctx, "broadcast", { outcome: "success", args: text });
   const { rows } = await query(`SELECT telegram_id FROM users`);
   let ok = 0;
   let fail = 0;
@@ -136,7 +164,7 @@ export async function handleBroadcast(ctx) {
 }
 
 export async function handleDisableMint(ctx) {
-  if (!(await requireAdmin(ctx))) return;
+  if (!(await requireAdmin(ctx, "disablemint"))) return;
   const arg = ctx.message.text.split(/\s+/)[1];
   if (!arg) return ctx.reply("Usage: `/disablemint <symbol or mint>`", { parse_mode: "Markdown" });
   const { rowCount } = await query(
@@ -144,7 +172,62 @@ export async function handleDisableMint(ctx) {
      WHERE UPPER(symbol) = UPPER($1) OR mint = $1`,
     [arg],
   );
+  await logAdminCommand(ctx, "disablemint", {
+    outcome: rowCount > 0 ? "success" : "error",
+    args: arg,
+    error: rowCount > 0 ? null : "mint not found",
+  });
   await ctx.reply(rowCount > 0 ? `✅ ${arg} disabled.` : `❌ ${arg} not found.`);
+}
+
+/**
+ * /admincmds [N] — read the most recent N admin command attempts from
+ * the audit log. Default 25, max 200. Admin-only (logging this read is
+ * itself logged as 'admincmds' so an attacker can't quietly inspect
+ * recent commands without leaving a trace).
+ *
+ * Usage:
+ *   /admincmds              — last 25
+ *   /admincmds 50           — last 50
+ *   /admincmds enablemint   — filter by command
+ *   /admincmds denied       — recent unauthorized attempts only
+ */
+export async function handleAdminCmds(ctx) {
+  if (!(await requireAdmin(ctx, "admincmds"))) return;
+  const parts = (ctx.message?.text || "").trim().split(/\s+/).slice(1);
+  let limit = 25;
+  let command = null;
+  let deniedOnly = false;
+  for (const p of parts) {
+    if (/^\d+$/.test(p)) limit = Number(p);
+    else if (p.toLowerCase() === "denied") deniedOnly = true;
+    else command = p;
+  }
+  let rows;
+  if (deniedOnly) {
+    rows = await recentAdminCommands({ limit });
+    rows = rows.filter((r) => r.outcome === "denied");
+  } else {
+    rows = await recentAdminCommands({ limit, command });
+  }
+  const deniedCount = await countDeniedAttempts({ hours: 24 });
+  await logAdminCommand(ctx, "admincmds", { outcome: "success", args: parts.join(" ") || null });
+  if (rows.length === 0) {
+    return ctx.reply(`No matching admin commands.\n\n*Denied attempts last 24h:* ${deniedCount}`, {
+      parse_mode: "Markdown",
+    });
+  }
+  const lines = rows.map((r) => {
+    const when = r.created_at.toISOString().replace("T", " ").slice(0, 19);
+    const marker = r.outcome === "denied" ? "🚫" : r.outcome === "error" ? "⚠️" : "✓";
+    const who = r.admin_username ? `@${r.admin_username}` : `tg:${r.admin_tg_id}`;
+    const args = r.args_redacted ? ` ${r.args_redacted}` : "";
+    return `${marker} ${when}  ${who}  /${r.command}${args}`;
+  });
+  const body = lines.join("\n");
+  const header = `*Admin command log* (last ${rows.length}${command ? ` for /${command}` : ""}${deniedOnly ? ", denied only" : ""})`;
+  const footer = `\n\n*Denied attempts last 24h:* ${deniedCount}`;
+  await ctx.reply(`${header}\n\`\`\`\n${body}\n\`\`\`${footer}`, { parse_mode: "Markdown" });
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ import {
   handleAiStats,
   handleInfraHealth,
   handleHolderPool,
+  handleAdminCmds,
 } from "./commands/admin.js";
 import { rateLimit } from "./middleware/rate-limit.js";
 import { startDepositWatcher } from "./services/deposit-watcher.js";
@@ -237,10 +238,12 @@ bot.command("distributions", handleDistributions);
 bot.command("distribution", handleDistributions); // alias
 bot.command("mydistributions", handleDistributions); // alias
 
-// Admin commands (authorization enforced in handlers)
+// Admin commands (authorization enforced in handlers — every gate now
+// logs success + denied attempts to admin_command_log per audit F-4).
 bot.command("pause", handlePause);
 bot.command("resume", handleResume);
 bot.command("adminstatus", handleAdminStatus);
+bot.command(["admincmds", "adminlog"], handleAdminCmds);
 bot.command("siteops", handleSiteOps);
 bot.command(["protocolfees", "protocol-fees"], handleProtocolFees);
 bot.command("ban_user", handleBanUser);

--- a/src/services/admin-audit.js
+++ b/src/services/admin-audit.js
@@ -1,0 +1,130 @@
+/**
+ * Admin command audit log writer + reader.
+ *
+ * Security audit F-4 (2026-06-12, MEDIUM): every admin command must be
+ * recorded so a TG-account compromise leaves a forensic trail. Two-step
+ * approval for the most sensitive commands is a separate follow-up; this
+ * module ships the foundation (logging + reader) that approval will build on.
+ *
+ * Usage at a handler:
+ *
+ *   import { logAdminCommand } from "../services/admin-audit.js";
+ *
+ *   bot.command("enablemint", async (ctx) => {
+ *     if (!isAdmin(ctx.from?.id)) {
+ *       await logAdminCommand(ctx, "enablemint", { outcome: "denied" });
+ *       return ctx.reply("admin only");
+ *     }
+ *     try {
+ *       await doEnable(...);
+ *       await logAdminCommand(ctx, "enablemint", { outcome: "success", args: mint });
+ *     } catch (err) {
+ *       await logAdminCommand(ctx, "enablemint", { outcome: "error", error: err.message });
+ *       throw err;
+ *     }
+ *   });
+ *
+ * The log is append-only; never UPDATE/DELETE rows here. Operator-facing
+ * /admincmds reads the most recent N rows.
+ */
+import { query } from "../db/pool.js";
+
+const ARGS_MAX_LEN = 200;
+
+/**
+ * Strip known-secret patterns + cap length. We never want a full pubkey,
+ * signature, or long base58 blob in the log — too useful to an attacker
+ * who later gains DB read access, and too privacy-invasive even for
+ * routine ops.
+ */
+function redactArgs(args) {
+  if (args == null) return null;
+  let s = String(args);
+  // Solana pubkeys / signatures are 32-88 char base58. Replace anything
+  // 32+ chars of [1-9A-HJ-NP-Za-km-z] with a short hash-marker.
+  s = s.replace(/[1-9A-HJ-NP-Za-km-z]{32,}/g, (m) => `<base58:${m.slice(0, 4)}…${m.slice(-4)}>`);
+  // Long hex blobs (signatures, hashes).
+  s = s.replace(/[0-9a-fA-F]{40,}/g, (m) => `<hex:${m.slice(0, 4)}…${m.slice(-4)}>`);
+  if (s.length > ARGS_MAX_LEN) s = s.slice(0, ARGS_MAX_LEN - 1) + "…";
+  return s;
+}
+
+/**
+ * Record an admin command attempt. Never throws — logging failures must
+ * not break the command flow.
+ *
+ * outcome ∈ {'success', 'denied', 'error'}
+ *   - 'success': command authorized + executed without error
+ *   - 'denied' : isAdmin() rejected the caller (UNAUTHORIZED ATTEMPT)
+ *   - 'error'  : authorized but execution threw
+ */
+export async function logAdminCommand(ctx, command, opts = {}) {
+  const outcome = opts.outcome || "success";
+  if (!["success", "denied", "error"].includes(outcome)) {
+    console.warn(`[admin-audit] bad outcome "${outcome}" for command "${command}"`);
+    return;
+  }
+  try {
+    await query(
+      `INSERT INTO admin_command_log
+         (admin_tg_id, admin_username, command, args_redacted, outcome, error_excerpt, chat_id, chat_type)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        Number(ctx?.from?.id) || 0,
+        ctx?.from?.username || null,
+        String(command).slice(0, 64),
+        redactArgs(opts.args),
+        outcome,
+        opts.error ? String(opts.error).slice(0, 200) : null,
+        ctx?.chat?.id ? Number(ctx.chat.id) : null,
+        ctx?.chat?.type || null,
+      ],
+    );
+  } catch (err) {
+    // Log to stderr only — never break the command.
+    console.error(`[admin-audit] write failed for ${command}/${outcome}: ${err.message}`);
+  }
+}
+
+/**
+ * Read the most recent N command attempts. Returns rows in reverse
+ * chronological order. Default 25; cap at 200.
+ */
+export async function recentAdminCommands({ limit = 25, command = null, adminTgId = null } = {}) {
+  const cappedLimit = Math.max(1, Math.min(200, Number(limit) || 25));
+  const params = [];
+  let where = "WHERE 1=1";
+  if (command) {
+    params.push(String(command).slice(0, 64));
+    where += ` AND command = $${params.length}`;
+  }
+  if (adminTgId) {
+    params.push(Number(adminTgId));
+    where += ` AND admin_tg_id = $${params.length}`;
+  }
+  params.push(cappedLimit);
+  const { rows } = await query(
+    `SELECT id, admin_tg_id, admin_username, command, args_redacted, outcome, error_excerpt, chat_id, chat_type, created_at
+       FROM admin_command_log
+       ${where}
+       ORDER BY created_at DESC
+       LIMIT $${params.length}`,
+    params,
+  );
+  return rows;
+}
+
+/**
+ * Count unauthorized attempts (outcome=denied) in the last N hours.
+ * Useful for proactive alerting on a recon-style probe pattern.
+ */
+export async function countDeniedAttempts({ hours = 24 } = {}) {
+  const { rows: [r] } = await query(
+    `SELECT COUNT(*)::int AS n
+       FROM admin_command_log
+      WHERE outcome = 'denied'
+        AND created_at > NOW() - ($1 || ' hours')::interval`,
+    [String(hours)],
+  );
+  return r?.n || 0;
+}


### PR DESCRIPTION
## Summary

MEDIUM-severity finding from the 2026-06-12 V1/V2 security audit. Ships the foundation for admin command forensics.

## The risk this closes

Every admin command (`/pause`, `/resume`, `/enablemint`, `/disablemint`, `/broadcast`, `/ban_user`, etc.) runs behind a single env-var gate (`ADMIN_TELEGRAM_IDS`) with **no logging**. A SIM-swap or social-engineering compromise of an admin TG account lets the attacker:

- `/pause` → freeze borrowing → ransom
- `/enablemint <rug>` → drain pool against attacker-controlled rug token
- `/broadcast <phishing>` → DM the entire user base with malicious links
- `/ban_user <legit user>` → grief

With no log, the operator wouldn't know what to undo, when, or by whom.

## What ships

### `migrations/041_admin_command_log.sql`
- Append-only `admin_command_log` table
- Indexed on `(created_at)`, `(admin_tg_id)`, `(command)`
- `outcome ∈ {success, denied, error}` — `denied` is the highest-signal event (unauthorized probe / compromised account)

### `src/services/admin-audit.js` (new)
- `logAdminCommand(ctx, cmd, {outcome, args, error})` — never throws
- `recentAdminCommands({limit, command, adminTgId})` — operator reader
- `countDeniedAttempts({hours})` — proactive alert primitive
- Built-in redaction: base58/hex blobs ≥32 chars get shortened to `<base58:abcd…wxyz>`; args cap 200 chars

### `src/commands/admin.js`
- `requireAdmin(ctx, cmdName)` takes optional command name; logs denied attempts
- Falls back to parsing the slash-prefix from `ctx.message.text` so older callsites still log meaningfully
- Sensitive handlers instrumented for success + error: `/pause`, `/resume`, `/enablemint`, `/disablemint`, `/broadcast`, `/admin`
- New `/admincmds [N|command|denied]` reader — same admin gate, logs its own access

### `src/index.js`
- `/admincmds` + `/adminlog` alias wired

## Usage examples

```
/admincmds              → last 25 admin command attempts
/admincmds 50           → last 50
/admincmds enablemint   → filter by command
/admincmds denied       → recent unauthorized attempts only
```

## Out of scope (follow-up PRs)

1. **Multi-step approval workflow** for `/enablemint`, `/disablemint`, `/broadcast` — second-admin must approve within 5 min before execution. The audit's full F-4 recommendation.
2. Instrument the remaining ~10 admin handlers (bans, fund_pool, distribute, reconcile, exempt_*, ticket_pulse, set_token_cap, etc.) with success/error logging. Mechanical; same pattern.
3. Alert pipeline: WARN to ops if `countDeniedAttempts(1h) > N` — automated detection of recon-style probing.

## Test plan

- [x] `node --check` passes on every changed file
- [ ] After deploy: migration 041 applies via `schema_migrations` ledger
- [ ] An admin runs `/pause` → row appears in `admin_command_log` with `outcome=success`
- [ ] Non-admin runs `/pause` → row with `outcome=denied`, admin sees in `/admincmds`
- [ ] An admin runs `/admincmds denied` after a denied attempt → row visible
- [ ] Errors during `/enablemint` (e.g., decimals mismatch) → row with `outcome=error`