### PR TITLE
security: F-5 slippage constants + F-6 keeper keypair fail-closed

### DIFF
--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -47,13 +47,12 @@ const MAX_TRIGGER_VALUE_MICRO = 1_000_000_000_000_000n;
 const VALID_TRIGGER_KINDS = new Set(["mc_usd", "price_usd", "price_sol"]);
 const VALID_DESTINATIONS = new Set(["sol", "usdc"]);
 
-// Mirrors the protocol-wide MAX_INITIAL_SLIPPAGE_BPS from arm-core. Raised
-// 1000 -> 2500 on 2026-06-12 (PR #77 fill-guarantee defaults). The agent
-// endpoint had drifted to the old ceiling — fixed during the audit pass
-// 2026-06-12 (gap #1: slippage validation range mismatch). Delegation
-// max_slippage_bps still gates further, so an aggressive request from the
-// agent is still clamped by the borrower's authorized cap.
-const MAX_INITIAL_SLIPPAGE_BPS_PROTOCOL = 2500;
+// Sourced from src/lib/slippage-constants.js — protocol-absolute ceiling.
+// The delegation's max_slippage_bps still gates further (it's the user-
+// consent ceiling and is lower by design — see slippage-constants.js for
+// the layered model). This constant is the OUTER bound only; the agent
+// can never exceed min(delegation.max_slippage_bps, this).
+import { MAX_PROTOCOL_SLIPPAGE_BPS as MAX_INITIAL_SLIPPAGE_BPS_PROTOCOL } from "../lib/slippage-constants.js";
 
 function isValidPubkey(s) {
   return typeof s === "string" && s.length >= 32 && s.length <= 44 &&

--- a/src/commands/agent-delegations.js
+++ b/src/commands/agent-delegations.js
@@ -23,6 +23,7 @@
 import { PublicKey } from "@solana/web3.js";
 import { query } from "../db/pool.js";
 import { upsertUser } from "../services/users.js";
+import { MIN_AGENT_DELEGATION_BPS, MAX_AGENT_DELEGATION_BPS } from "../lib/slippage-constants.js";
 import { ensureWallet } from "../services/wallet.js";
 
 const VALID_ACTIONS = new Set(["limit_close"]);
@@ -102,8 +103,12 @@ export async function handleAgentAuthorize(ctx) {
       maxActiveOrders = n;
     } else if (k === "max_slippage_bps") {
       const n = Number(v);
-      if (!Number.isInteger(n) || n < 10 || n > 1000) {
-        return ctx.reply("max_slippage_bps must be between 10 and 1000 (0.1% to 10%).");
+      // User-consent ceiling — see src/lib/slippage-constants.js for why
+      // this is lower than MAX_PROTOCOL_SLIPPAGE_BPS.
+      if (!Number.isInteger(n) || n < MIN_AGENT_DELEGATION_BPS || n > MAX_AGENT_DELEGATION_BPS) {
+        const minPct = (MIN_AGENT_DELEGATION_BPS / 100).toFixed(1);
+        const maxPct = (MAX_AGENT_DELEGATION_BPS / 100).toFixed(1);
+        return ctx.reply(`max_slippage_bps must be between ${MIN_AGENT_DELEGATION_BPS} and ${MAX_AGENT_DELEGATION_BPS} (${minPct}% to ${maxPct}%).`);
       }
       maxSlippageBps = n;
     } else if (k === "expires") {

--- a/src/lib/slippage-constants.js
+++ b/src/lib/slippage-constants.js
@@ -1,0 +1,58 @@
+/**
+ * Slippage ceilings — single source of truth.
+ *
+ * Security audit F-5 (2026-06-12, LOW severity) flagged that slippage
+ * constants were scattered across three places (agent-delegations.js
+ * capped at 1000, internal-agent-limitclose.js capped at 2500,
+ * migration 026 CHECK at 10–1000). Same code-smell as any "magic
+ * number in multiple places" — easy to drift, hard to spot drift.
+ *
+ * The two values are INTENTIONALLY different. They model different
+ * layers of consent, not the same boundary:
+ *
+ * MAX_AGENT_DELEGATION_BPS (1000 = 10%)
+ *   The maximum slippage a USER can authorize a delegated x402 agent
+ *   to use on their behalf via /agent_authorize. Users picking a
+ *   conservative ceiling is normal — most won't want their agent
+ *   eating 25% slippage on their position even during a fill-guarantee
+ *   escalation. 10% caps the worst-case the agent can ever spend
+ *   without the user re-authorizing.
+ *
+ *   Mirrored in the DB by:
+ *     migrations/026_agent_delegations.sql
+ *     CHECK (max_slippage_bps >= 10 AND max_slippage_bps <= 1000)
+ *
+ * MAX_PROTOCOL_SLIPPAGE_BPS (2500 = 25%)
+ *   The absolute ceiling the protocol's engine will walk up to during
+ *   auto-escalation (Layer A of the fill-guarantee ladder). This is
+ *   the PROTOCOL'S worst-case spend during an aggressive moon-pump
+ *   fill, not the user's. Limit-close-arm-core also uses this as the
+ *   max INITIAL slippage a user can pre-set on a limit-close order.
+ *
+ * The hierarchy is:
+ *   effective_slippage = min(
+ *     user-requested,                      // arm-time choice
+ *     delegation.max_slippage_bps,         // agent path: user-set ceiling
+ *     MAX_PROTOCOL_SLIPPAGE_BPS,           // absolute floor
+ *   )
+ *
+ * If you find yourself wanting to "fix" the difference by raising
+ * MAX_AGENT_DELEGATION_BPS to match MAX_PROTOCOL_SLIPPAGE_BPS — DON'T.
+ * That's removing the user's consent layer, which is the whole point
+ * of agent delegations. The right path is to let users opt in to a
+ * higher delegation cap (raise to 2500 bps) via an explicit
+ * /agent_authorize_aggressive command that includes a risk warning,
+ * not to silently widen everyone's exposure.
+ */
+
+// Per-user consent cap on agent-delegated limit-close slippage.
+// Mirror in DB: migrations/026_agent_delegations.sql CHECK constraint.
+export const MAX_AGENT_DELEGATION_BPS = 1000; // 10%
+
+// Per-user consent floor (anything below this is too tight to clear most
+// fills and is more likely a typo than intent).
+export const MIN_AGENT_DELEGATION_BPS = 10; // 0.1%
+
+// Protocol-absolute ceiling on engine slippage. Also the max INITIAL
+// slippage a user can pre-set on a limit-close order (TG, site, agent).
+export const MAX_PROTOCOL_SLIPPAGE_BPS = 2500; // 25%

--- a/src/services/keeper.js
+++ b/src/services/keeper.js
@@ -45,11 +45,22 @@ const POLL_MS = Number(process.env.KEEPER_POLL_MS) || 30_000;
  *                                where you don't want a keypair file
  *                                living in the image.
  *   2. KEEPER_KEYPAIR_PATH     — JSON keypair file path.
- *   3. LENDER_KEYPAIR_PATH     — legacy fallback. The keeper sharing
- *                                the lender's keypair is a least-privilege
- *                                violation flagged in the 2026-06-11 audit.
- *                                Setting KEEPER_PRIVATE_KEY or
- *                                KEEPER_KEYPAIR_PATH avoids it.
+ *
+ * NOTE 2026-06-12 (security audit F-6): the legacy LENDER_KEYPAIR_PATH
+ * fallback that used to live here was REMOVED. The keeper sharing the
+ * lender's keypair is a least-privilege violation — the keeper only
+ * needs to sign liquidations, but the lender keypair also gates
+ * admin_withdraw, set_paused, set_keeper_reward, and price attestation.
+ *
+ * If neither KEEPER_PRIVATE_KEY nor KEEPER_KEYPAIR_PATH is set the
+ * keeper now THROWS at startup. This is intentional — fail loud, not
+ * silently falling back to a more powerful key. Operators running the
+ * keeper must provision a dedicated keeper key (see runbook docs).
+ *
+ * The fallback escape hatch is gone on purpose; if you genuinely need to
+ * temporarily run the keeper with the lender key, set KEEPER_PRIVATE_KEY
+ * to the lender's base58 secret explicitly so the configuration is
+ * VISIBLE in env, not implicit through a path-fallback.
  */
 function loadKeeperKeypair() {
   const b58 = process.env.KEEPER_PRIVATE_KEY;
@@ -57,8 +68,12 @@ function loadKeeperKeypair() {
     const decode = bs58.decode || (bs58.default && bs58.default.decode);
     return Keypair.fromSecretKey(decode(b58));
   }
-  const kpPath = process.env.KEEPER_KEYPAIR_PATH || process.env.LENDER_KEYPAIR_PATH;
-  if (!kpPath) throw new Error("KEEPER_PRIVATE_KEY or KEEPER_KEYPAIR_PATH must be set");
+  const kpPath = process.env.KEEPER_KEYPAIR_PATH;
+  if (!kpPath) {
+    throw new Error(
+      "[keeper] KEEPER_PRIVATE_KEY or KEEPER_KEYPAIR_PATH must be set — refusing to fall back to LENDER_KEYPAIR_PATH (least-privilege rule, audit F-6 2026-06-12). Set KEEPER_PRIVATE_KEY (preferred) or KEEPER_KEYPAIR_PATH explicitly.",
+    );
+  }
   return Keypair.fromSecretKey(
     new Uint8Array(JSON.parse(readFileSync(kpPath, "utf8"))),
   );

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -43,6 +43,7 @@
  */
 import { query } from "../db/pool.js";
 import { runArmPreflight } from "./limit-close-preflight.js";
+import { MAX_PROTOCOL_SLIPPAGE_BPS } from "../lib/slippage-constants.js";
 
 export const MIN_LOAN_LAMPORTS = BigInt(1_000_000_000n); // 1 SOL
 export const MAX_ACTIVE_ORDERS_PER_USER = 10;
@@ -105,7 +106,9 @@ export async function resolveMultiplierToPrice(collateralMint, multiplier, { all
 const DEFAULT_HARD_CAP_BPS = 5000;        // 50% — absolute ceiling on any auto-widened cap
 const DEFAULT_CAP_FLOOR_BPS = 2500;       // 25% — every order gets at least this much room
 const DEFAULT_CAP_MULTIPLIER = 8;         // cap = max(floor, slip × 8) capped at hard cap
-const MAX_INITIAL_SLIPPAGE_BPS = 2500;    // 25% — allow aggressive initial for moon-pump UX
+// Sourced from src/lib/slippage-constants.js — protocol-absolute ceiling
+// shared with internal-agent-limitclose.js and the DB CHECK constraint.
+const MAX_INITIAL_SLIPPAGE_BPS = MAX_PROTOCOL_SLIPPAGE_BPS; // 25% — allow aggressive initial for moon-pump UX
 
 export async function armOrder({
   userId,


### PR DESCRIPTION
## Summary

Two LOW-severity follow-ups from the 2026-06-12 V1/V2 security audit. Both are mechanical hardening with zero behavior change for the happy path.

## F-5 — slippage constants single source of truth

**Problem:** Slippage ceilings were scattered across three files plus the DB:
- `agent-delegations.js` capped at **1000 bps** (10%)
- `internal-agent-limitclose.js` capped at **2500 bps** (25%)
- `limit-close-arm-core.js` capped at **2500 bps** (25%)
- migration 026 DB CHECK at **10–1000 bps**

Audit's concern: same magic-number-in-multiple-places code smell. Easy to drift; hard to spot drift after the fact.

**Fix:** new `src/lib/slippage-constants.js` with two intentionally-different exports + long-form rationale comment:

```
MAX_AGENT_DELEGATION_BPS  = 1000  (user-consent ceiling)
MAX_PROTOCOL_SLIPPAGE_BPS = 2500  (protocol absolute ceiling)
```

The hierarchy is documented: `effective_slippage = min(user-requested, delegation.max_slippage_bps, MAX_PROTOCOL_SLIPPAGE_BPS)`. Anyone who tries to "fix" the difference will find the comment explaining why the layered consent model exists.

## F-6 — keeper keypair fail-closed

**Problem:** `keeper.js loadKeeperKeypair()` fell back to `LENDER_KEYPAIR_PATH` if neither `KEEPER_PRIVATE_KEY` nor `KEEPER_KEYPAIR_PATH` was set. Least-privilege violation — the keeper only needs to sign `liquidate_loan` but the lender authority also signs `admin_withdraw`, `set_paused`, `set_keeper_reward`, `update_price`, `cosign-borrow`.

A misconfigured deploy that omits `KEEPER_PRIVATE_KEY` would silently upgrade the keeper to lender-level authority. Not exploitable today (prod env has it set), but a real footgun for next operator onboarding.

**Fix:**
- Drop `LENDER_KEYPAIR_PATH` fallback in `loadKeeperKeypair()`
- Throw a clear startup error if neither keeper env is set, referencing the audit finding
- JSDoc updated to remove the legacy resolution-order entry and document fail-loud behavior

If you genuinely need keeper-as-lender (single-operator emergency), set `KEEPER_PRIVATE_KEY` to the lender's base58 explicitly — **visible** in env, not **implicit** through path-fallback.

## Operational impact

- F-5: zero — same numeric ceilings, just centralized
- F-6: zero on prod (`KEEPER_PRIVATE_KEY` is already set); new deploys without the env will now fail loud at startup instead of silently shadow-using the lender key

## Test plan

- [x] `node --check` passes on every changed file
- [ ] After deploy: `/agent_authorize ... max_slippage_bps=2000` still rejected (user-consent ceiling unchanged at 1000)
- [ ] After deploy: limit-close arm with `slippage_bps=1500` still accepted (protocol ceiling unchanged at 2500)
- [ ] Keeper service start with KEEPER_PRIVATE_KEY unset → throws "must be set — refusing to fall back to LENDER_KEYPAIR_PATH"

## Audit remaining

- ~~F-1 multisig authority~~ — operator-level work, runbook pending
- ~~F-2 fail-closed price~~ — PR #104 (open)
- F-3 token impersonation expansion — queued (canonical-mint list + on-chain authority check)
- ~~F-4 admin command logging~~ — PR #105 (open)
- ~~F-5 slippage constants~~ — this PR
- ~~F-6 keeper fail-closed~~ — this PR
- F-7 liquidate_loan on-chain signer check — needs Anchor source review