### PR TITLE
feat(tiers): wire loan-tier-resolver into reborrow / api/agent / price (#103 follow-up)

### DIFF
--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -81,13 +81,35 @@ import { Keypair } from "@solana/web3.js";
 const LENDER_PUBKEY = new PublicKey(process.env.LENDER_PUBKEY);
 const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN || "";
 
-// Tier index → (LTV%, duration days, fee bps). Matches the on-chain
-// program's TIER_LTV_BPS / TIER_DURATION_DAYS / TIER_FEE_BPS.
+// Legacy memecoin tier map — kept for back-compat callers that still
+// import TIERS directly. NEW code should use the category-aware
+// resolveTierForAgent helper below, which picks the right schedule
+// (memecoin vs RWA) based on the collateral's supported_mints.category.
+//
+// On-chain program's TIER_LTV_BPS / TIER_DURATION_DAYS / TIER_FEE_BPS
+// were derived from these defaults at v1; RWA borrows on V2 use the
+// resolver so the higher 50/60/70% RWA tiers flow through correctly.
 export const TIERS = {
-  0: { ltv: 30, days: 2, feeBps: 300 }, // express
-  1: { ltv: 25, days: 3, feeBps: 200 }, // quick
-  2: { ltv: 20, days: 7, feeBps: 150 }, // standard
+  0: { ltv: 30, days: 2, feeBps: 300 }, // express (memecoin)
+  1: { ltv: 25, days: 3, feeBps: 200 }, // quick (memecoin)
+  2: { ltv: 20, days: 7, feeBps: 150 }, // standard (memecoin)
 };
+
+import { getTierByOption } from "../services/loan-tier-resolver.js";
+
+/**
+ * Resolve a tier from (category, option). Returns shape compatible with
+ * the legacy TIERS map entries: { ltv, days, feeBps }. RWA categories
+ * route to rwa_loan_tiers; memecoin path matches the legacy TIERS map.
+ *
+ * Used by buildBorrowTx so x402 agent borrows respect the same
+ * category-aware tier schedule as TG /borrow.
+ */
+export async function resolveTierForAgent({ category, option }) {
+  const tier = await getTierByOption({ category, option });
+  if (!tier) return null;
+  return { ltv: tier.ltv, days: tier.days, feeBps: tier.feeBps };
+}
 
 /**
  * Deterministic synthetic telegram_id for a wallet pubkey.
@@ -145,7 +167,14 @@ export async function buildBorrowTx({
   userId,                // already resolved
   mintRow,               // already resolved from supported_mints
 }) {
-  const tierCfg = TIERS[Number(tier)];
+  // Category-aware tier resolution. RWA mints get the higher-LTV
+  // schedule out of rwa_loan_tiers; memecoin falls back to TIERS.
+  // Defense-in-depth: if resolver returns null (bad option), surface
+  // an error rather than silently picking the wrong tier.
+  const tierCfg = (await resolveTierForAgent({ category: mintRow?.category, option: Number(tier) })) ?? TIERS[Number(tier)];
+  if (!tierCfg) {
+    return { blocked: true, status: 400, body: { error: "invalid_tier", detail: `tier ${tier} not available for category ${mintRow?.category}` } };
+  }
   const collateralMintStr = collateralMintPk.toBase58();
   const borrowerWalletStr = borrowerPk.toBase58();
 

--- a/src/commands/price.js
+++ b/src/commands/price.js
@@ -1,5 +1,6 @@
 import { query } from "../db/pool.js";
 import { getPriceInSol } from "../services/price.js";
+import { getEligibleTiers } from "../services/loan-tier-resolver.js";
 
 export async function handlePrice(ctx) {
   const arg = ctx.message?.text?.split(/\s+/)[1];
@@ -7,9 +8,12 @@ export async function handlePrice(ctx) {
     return ctx.reply("Usage: `/price <symbol or mint>`", { parse_mode: "Markdown" });
   }
 
-  // Look up by symbol or by mint address.
+  // Look up by symbol or by mint address. Category drives the loan-tier
+  // resolver — RWA mints (stock/etf/metal) get the higher-LTV / longer-
+  // term / higher-fee schedule out of rwa_loan_tiers; memecoin and
+  // uncategorized fall through to the legacy MEMECOIN_TIERS.
   const { rows } = await query(
-    `SELECT mint, symbol, name, decimals FROM supported_mints
+    `SELECT mint, symbol, name, decimals, category FROM supported_mints
      WHERE enabled = TRUE AND (UPPER(symbol) = UPPER($1) OR mint = $1)
      LIMIT 1`,
     [arg],
@@ -25,11 +29,7 @@ export async function handlePrice(ctx) {
   const token = rows[0];
   try {
     const priceSol = await getPriceInSol(token.mint);
-    const tiers = [
-      { ltv: 30, days: 2, feeBps: 300, label: "Express" },
-      { ltv: 25, days: 3, feeBps: 200, label: "Quick" },
-      { ltv: 20, days: 7, feeBps: 150, label: "Standard" },
-    ];
+    const tiers = await getEligibleTiers({ category: token.category });
     const lines = [
       `💰 *${token.symbol}* — ${token.name ?? ""}`,
       `\`${token.mint}\``,
@@ -40,7 +40,11 @@ export async function handlePrice(ctx) {
     ];
     for (const t of tiers) {
       const loanPerToken = priceSol * (t.ltv / 100) * (1 - t.feeBps / 10_000);
-      lines.push(`• ${t.label} (${t.ltv}% / ${t.days}d / ${t.feeBps / 100}% fee): ${loanPerToken.toFixed(9)} SOL`);
+      // Resolver-supplied label already includes LTV/days/fee for RWA;
+      // memecoin label is just "Express"/"Quick"/"Standard". Compose
+      // consistently either way.
+      const stub = t.label.includes("LTV") ? t.label : `${t.label} (${t.ltv}% / ${t.days}d / ${(t.feeBps / 100).toFixed(1)}% fee)`;
+      lines.push(`• ${stub}: ${loanPerToken.toFixed(9)} SOL`);
     }
 
     await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });

--- a/src/commands/reborrow.js
+++ b/src/commands/reborrow.js
@@ -14,12 +14,7 @@ import { incrementBorrowed } from "../services/reputation.js";
 import { query } from "../db/pool.js";
 import { filterLoansForWallet } from "../services/wallet-scoped-loans.js";
 import { translateTxError, errorActionKeyboard } from "../services/tx-error-translator.js";
-
-const LTV_TIERS = [
-  { option: 0, ltv: 30, days: 2, feeBps: 300, label: "Express" },
-  { option: 1, ltv: 25, days: 3, feeBps: 200, label: "Quick" },
-  { option: 2, ltv: 20, days: 7, feeBps: 150, label: "Standard" },
-];
+import { getEligibleTiers } from "../services/loan-tier-resolver.js";
 
 function fmtSol(lamports) {
   return (Number(lamports) / 1e9).toFixed(4);
@@ -70,8 +65,24 @@ export async function handleReborrow(ctx) {
     );
   }
 
-  // Use same tier as last loan
-  const tier = LTV_TIERS.find((t) => t.ltv === lastLoan.ltv_percentage) || LTV_TIERS[2];
+  // Resolve the tier set for THIS specific mint's category. RWA mints
+  // pull from rwa_loan_tiers; memecoin (and uncategorized) get
+  // MEMECOIN_TIERS. We need the category from supported_mints — the
+  // loans table doesn't carry it, and the user could have re-borrowed
+  // across categories.
+  const { rows: [mintRow] } = await query(
+    `SELECT category FROM supported_mints WHERE mint = $1`,
+    [match.mint],
+  );
+  const tiers = await getEligibleTiers({ category: mintRow?.category });
+  // Match by LTV percentage to keep the "same tier as last loan" UX, but
+  // pull from the category-correct set. If no exact LTV match (e.g. user
+  // last borrowed at 30% memecoin, then transferred RWA — RWA Express is
+  // 50%), fall back to the most conservative tier (longest term, lowest LTV)
+  // — preserves the "safe default" intent of the original `|| LTV_TIERS[2]`.
+  const tier =
+    tiers.find((t) => t.ltv === lastLoan.ltv_percentage) ||
+    tiers[tiers.length - 1];
 
   // Use same amount or full balance (whichever is smaller)
   const lastRaw = BigInt(lastLoan.collateral_amount);


### PR DESCRIPTION
## Summary

Follow-up to PR #103 (RWA loan tiers). #103 wired the resolver into `src/commands/borrow.js` only. This PR covers three more callsites that had their own hardcoded `MEMECOIN_TIERS` arrays and would have shown wrong numbers for RWA collateral once the `rwa_loan_tiers` seed lands.

## What ships

### `src/commands/reborrow.js`
- Was: `const LTV_TIERS = [...memecoin]; pick by ltv_percentage match`
- Now: query `supported_mints.category` for the specific mint, resolve via `getEligibleTiers`, match by LTV on the right set. If no exact match (e.g. user re-borrowing RWA after a memecoin loan with different LTV grid), fall back to the most conservative tier in the resolved set — preserves the safe-default intent of the original `|| LTV_TIERS[2]`.

### `src/api/agent.js` (x402 agent borrow path)
- Was: `const TIERS = {...memecoin}; tierCfg = TIERS[option]`
- Now: new `resolveTierForAgent({ category, option })` helper that calls the resolver. `buildBorrowTx` uses it with the `mintRow.category` already in scope. Legacy `TIERS` export preserved as fallback + back-compat for any other importer.
- Defensive: if resolver returns null (bad option for category), returns `blocked: true` with `invalid_tier` error rather than crashing later on undefined dereferences.

### `src/commands/price.js`
- `/price <symbol>` "Max loan per token" rows now reflect the right tier set. The `supported_mints` SELECT now includes `category`.
- Label formatting handles both styles: memecoin labels are just "Express"/"Quick"/"Standard" → we compose LTV/days/fee around them. RWA labels from `rwa_loan_tiers` already include the numbers → we use them verbatim.

## Still out of scope (low blast radius, follow-up)

- `commands/simulate.js` — generic simulator with no mint context
- `commands/unlock.js` — generic teaser; same as simulate
- `services/community-pip.js` — Pip's hardcoded copy mentioning the legacy tier numbers; needs a copy refresh + dynamic-from-DB lookup in Pip's system prompt assembly

## Fee flow

**Unchanged across every callsite.** The resolver returns the same `feeBps` shape and `recordLoan` continues to feed it into the 70-10-10-10 distribution to `4JSSSaG3...`.

## Test plan

- [x] `node --check` passes on every changed file
- [ ] After PR #103 + this PR deploy: `/reborrow` after a `$TSLAx` loan → tier set shown is RWA (50/60/70%), not memecoin (30/25/20%)
- [ ] x402 agent borrow against `$SPCX` builds tx with RWA Express LTV (50%), not memecoin Express (30%)
- [ ] `/price SPCX` shows RWA-tier max loan numbers
- [ ] `/price BONK` still shows memecoin numbers (no regression)