### PR TITLE
security(admin): multi-step approval workflow (audit F-4 follow-up)

### DIFF
--- a/migrations/042_admin_command_approvals.sql
+++ b/migrations/042_admin_command_approvals.sql
@@ -1,0 +1,76 @@
+-- migration 042: multi-step admin command approval (audit F-4 follow-up)
+--
+-- PR #105 shipped the audit-log foundation. This migration ships the
+-- second-admin approval workflow for the most sensitive commands
+-- (/enablemint, /disablemint, /broadcast by default; tunable via
+-- ADMIN_COMMAND_APPROVAL_REQUIRED env var).
+--
+-- Threat model: a SIM-swap or social-engineering compromise of an
+-- admin TG account. With single-admin auth, the attacker can
+-- unilaterally /enablemint a rug token and drain the pool. With
+-- second-admin approval, they need to compromise TWO independent
+-- admin accounts within a 5-minute window before the pending request
+-- expires.
+--
+-- Flow:
+--   1. Admin A types `/enablemint <mint> <symbol> <decimals>`
+--      → row inserted into admin_command_approvals with status='pending'
+--      → bot DMs every OTHER admin "request #N: /enablemint ..."
+--   2. Admin B types `/approve <N>` within 5 min
+--      → row's status → 'approved', approved_by_tg_id + approved_at set
+--      → executor reads stored args_json and runs the real handler
+--   3. OR Admin B types `/deny <N>` → status='denied', no action
+--   4. OR 5 min passes → status='expired' on next sweep, no action
+--
+-- Same-admin self-approval is explicitly REJECTED at the application
+-- layer (audit log captures the attempt as outcome='denied'); the
+-- CHECK constraint here just guards data shape.
+--
+-- Solo-admin case: when ADMIN_TELEGRAM_IDS has exactly one entry, the
+-- approval gate short-circuits to execute immediately and logs as
+-- outcome='solo_admin_bypass' so the operator can see those events.
+-- The DB enforces nothing here — that's an app-layer policy decision.
+
+CREATE TABLE IF NOT EXISTS admin_command_approvals (
+  id                   BIGSERIAL    PRIMARY KEY,
+  command              TEXT         NOT NULL,
+  args_json            JSONB        NOT NULL,
+  requester_tg_id      BIGINT       NOT NULL,
+  requester_username   TEXT,
+  requester_chat_id    BIGINT,
+  requested_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  expires_at           TIMESTAMPTZ  NOT NULL,
+  status               TEXT         NOT NULL DEFAULT 'pending'
+                       CHECK (status IN ('pending','approved','denied','expired','executed')),
+  approver_tg_id       BIGINT,
+  approver_username    TEXT,
+  approved_at          TIMESTAMPTZ,
+  denied_at            TIMESTAMPTZ,
+  executed_at          TIMESTAMPTZ,
+  execute_error        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_command_approvals_status_expires
+  ON admin_command_approvals (status, expires_at);
+CREATE INDEX IF NOT EXISTS idx_admin_command_approvals_requester
+  ON admin_command_approvals (requester_tg_id, requested_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_command_approvals_pending
+  ON admin_command_approvals (id) WHERE status = 'pending';
+
+-- Expand the admin_command_log outcome enum to cover the two new states
+-- this migration introduces:
+--   solo_admin_bypass — single-admin operator; gate short-circuited
+--   pending_approval  — request enqueued, awaiting second admin
+-- migration 041 originally allowed only success/denied/error; both new
+-- values are forensic events the operator wants visible in /admincmds.
+ALTER TABLE admin_command_log DROP CONSTRAINT IF EXISTS admin_command_log_outcome_check;
+ALTER TABLE admin_command_log
+  ADD CONSTRAINT admin_command_log_outcome_check
+  CHECK (outcome IN ('success','denied','error','solo_admin_bypass','pending_approval'));
+
+COMMENT ON TABLE admin_command_approvals IS
+  'Two-step approval queue for sensitive admin commands (audit F-4).
+   Requester creates a row with status=pending; a DIFFERENT admin must
+   /approve or /deny within expires_at. Solo-admin operators bypass
+   the gate but the bypass is logged via admin_command_log
+   (outcome=solo_admin_bypass).';

--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -9,7 +9,20 @@ import { query } from "../db/pool.js";
 import { connection } from "../solana/connection.js";
 import { estimateCostUsd } from "../services/ai-support.js";
 import { getHealthSnapshot } from "../services/infra-health.js";
-import { logAdminCommand, recentAdminCommands, countDeniedAttempts } from "../services/admin-audit.js";
+import {
+  logAdminCommand,
+  recentAdminCommands,
+  countDeniedAttempts,
+  isApprovalGated,
+  isSoloAdmin,
+  otherAdminTgIds,
+  requestApproval,
+  approveAndClaim,
+  denyApproval,
+  getPendingApproval,
+  listPendingApprovals,
+  markExecuted,
+} from "../services/admin-audit.js";
 
 // requireAdmin takes the command name so we can log every denied attempt
 // to admin_command_log. Unauthorized attempts are the highest-signal
@@ -79,6 +92,34 @@ export async function handleAdminStatus(ctx) {
   await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
 }
 
+/**
+ * Pure executor for enablemint — given validated args, performs the
+ * INSERT/UPDATE and replies on the supplied ctx (which may be the
+ * SECOND admin who /approve'd, not the original requester). Used
+ * both for the solo-admin direct path AND for /approve dispatch.
+ */
+async function executeEnableMint(ctx, args) {
+  const { mint, symbol, decimals, name } = args;
+  try {
+    await query(
+      `INSERT INTO supported_mints (mint, symbol, name, decimals, enabled)
+       VALUES ($1, $2, $3, $4, TRUE)
+       ON CONFLICT (mint) DO UPDATE
+         SET symbol = EXCLUDED.symbol,
+             name = COALESCE(EXCLUDED.name, supported_mints.name),
+             decimals = EXCLUDED.decimals,
+             enabled = TRUE`,
+      [mint, symbol.toUpperCase(), name, decimals],
+    );
+    await logAdminCommand(ctx, "enablemint", { outcome: "success", args: `${symbol.toUpperCase()} ${mint}` });
+    await ctx.reply(`✅ ${symbol.toUpperCase()} enabled (decimals=${decimals}, verified on-chain).`);
+    return { ok: true };
+  } catch (err) {
+    await logAdminCommand(ctx, "enablemint", { outcome: "error", args: `${symbol} ${mint}`, error: err.message });
+    return { ok: false, error: err.message };
+  }
+}
+
 export async function handleEnableMint(ctx) {
   if (!(await requireAdmin(ctx, "enablemint"))) return;
   const parts = ctx.message.text.split(/\s+/);
@@ -116,34 +157,17 @@ export async function handleEnableMint(ctx) {
     );
   }
   const name = nameParts.join(" ") || null;
-  try {
-    await query(
-      `INSERT INTO supported_mints (mint, symbol, name, decimals, enabled)
-       VALUES ($1, $2, $3, $4, TRUE)
-       ON CONFLICT (mint) DO UPDATE
-         SET symbol = EXCLUDED.symbol,
-             name = COALESCE(EXCLUDED.name, supported_mints.name),
-             decimals = EXCLUDED.decimals,
-             enabled = TRUE`,
-      [mint, symbol.toUpperCase(), name, decimals],
-    );
-    await logAdminCommand(ctx, "enablemint", { outcome: "success", args: `${symbol.toUpperCase()} ${mint}` });
-    await ctx.reply(`✅ ${symbol.toUpperCase()} enabled (decimals=${decimals}, verified on-chain).`);
-  } catch (err) {
-    await logAdminCommand(ctx, "enablemint", { outcome: "error", args: `${symbol} ${mint}`, error: err.message });
-    throw err;
-  }
+  const args = { mint, symbol: symbol.toUpperCase(), decimals, name };
+
+  // ── Approval gate (audit F-4) ──────────────────────────────────
+  // /enablemint is approval-gated by default. If solo-admin OR the
+  // gate is disabled via env, execute immediately and log the bypass.
+  // Otherwise create a pending row + DM the other admins.
+  await requireApprovalOrExecute(ctx, "enablemint", args, executeEnableMint);
 }
 
-export async function handleBroadcast(ctx) {
-  if (!(await requireAdmin(ctx, "broadcast"))) return;
-  const text = ctx.message.text.replace(/^\/broadcast(\s+|$)/, "").trim();
-  if (!text) {
-    return ctx.reply("Usage: `/broadcast <message>`", { parse_mode: "Markdown" });
-  }
-  // Log the broadcast BEFORE sending — even partial sends are recorded
-  // so the operator can see what the broadcast contained without scanning
-  // every user's DMs.
+async function executeBroadcast(ctx, args) {
+  const text = String(args?.text || "");
   await logAdminCommand(ctx, "broadcast", { outcome: "success", args: text });
   const { rows } = await query(`SELECT telegram_id FROM users`);
   let ok = 0;
@@ -157,27 +181,215 @@ export async function handleBroadcast(ctx) {
     } catch {
       fail++;
     }
-    // Telegram rate-limits ~30 msgs/s; pacing keeps us safe.
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((rr) => setTimeout(rr, 50));
   }
   await ctx.reply(`✅ Sent to ${ok}, failed ${fail}.`);
+  return { ok: true };
+}
+
+export async function handleBroadcast(ctx) {
+  if (!(await requireAdmin(ctx, "broadcast"))) return;
+  const text = ctx.message.text.replace(/^\/broadcast(\s+|$)/, "").trim();
+  if (!text) {
+    return ctx.reply("Usage: `/broadcast <message>`", { parse_mode: "Markdown" });
+  }
+  await requireApprovalOrExecute(ctx, "broadcast", { text }, executeBroadcast);
+}
+
+async function executeDisableMint(ctx, args) {
+  const target = String(args?.target || "");
+  const { rowCount } = await query(
+    `UPDATE supported_mints SET enabled = FALSE
+     WHERE UPPER(symbol) = UPPER($1) OR mint = $1`,
+    [target],
+  );
+  await logAdminCommand(ctx, "disablemint", {
+    outcome: rowCount > 0 ? "success" : "error",
+    args: target,
+    error: rowCount > 0 ? null : "mint not found",
+  });
+  await ctx.reply(rowCount > 0 ? `✅ ${target} disabled.` : `❌ ${target} not found.`);
+  return { ok: rowCount > 0 };
 }
 
 export async function handleDisableMint(ctx) {
   if (!(await requireAdmin(ctx, "disablemint"))) return;
   const arg = ctx.message.text.split(/\s+/)[1];
   if (!arg) return ctx.reply("Usage: `/disablemint <symbol or mint>`", { parse_mode: "Markdown" });
-  const { rowCount } = await query(
-    `UPDATE supported_mints SET enabled = FALSE
-     WHERE UPPER(symbol) = UPPER($1) OR mint = $1`,
-    [arg],
-  );
-  await logAdminCommand(ctx, "disablemint", {
-    outcome: rowCount > 0 ? "success" : "error",
-    args: arg,
-    error: rowCount > 0 ? null : "mint not found",
+  await requireApprovalOrExecute(ctx, "disablemint", { target: arg }, executeDisableMint);
+}
+
+/* ════════════════════════════════════════════════════════════════
+ *  APPROVAL GATE (audit F-4, migration 042)
+ * ════════════════════════════════════════════════════════════════ */
+
+// Map of approval-gated command → executor. /approve dispatches into this
+// at execution time. Pure functions; they handle their own ctx replies
+// and audit logging.
+const APPROVAL_EXECUTORS = {
+  enablemint:  executeEnableMint,
+  disablemint: executeDisableMint,
+  broadcast:   executeBroadcast,
+};
+
+/**
+ * Shared gate. If the command isn't gated (env or solo-admin), executes
+ * immediately. Otherwise creates a pending row, DMs the other admins
+ * with `/approve <id>` instructions, and tells the requester the
+ * request is pending.
+ */
+async function requireApprovalOrExecute(ctx, command, args, executeFn) {
+  const requesterTgId = Number(ctx?.from?.id) || 0;
+
+  // Bypass if (a) operator disabled the gate via env, (b) command isn't
+  // in the gated set, or (c) solo admin (no second approver exists).
+  if (!isApprovalGated(command)) {
+    return executeFn(ctx, args);
+  }
+  if (isSoloAdmin(requesterTgId)) {
+    await logAdminCommand(ctx, command, {
+      outcome: "solo_admin_bypass",
+      args: JSON.stringify(args).slice(0, 200),
+    });
+    return executeFn(ctx, args);
+  }
+
+  // Create the pending approval row.
+  const { approvalId, expiresAt } = await requestApproval({
+    command,
+    args,
+    requesterCtx: ctx,
   });
-  await ctx.reply(rowCount > 0 ? `✅ ${arg} disabled.` : `❌ ${arg} not found.`);
+
+  // DM the other admins. Best-effort; failures don't block the request.
+  const others = otherAdminTgIds(requesterTgId);
+  const ttlMin = Math.max(1, Math.round((new Date(expiresAt).getTime() - Date.now()) / 60_000));
+  const summary = `\`${command}\` ${JSON.stringify(args).slice(0, 120)}`;
+  const requesterTag = ctx?.from?.username ? `@${ctx.from.username}` : `tg:${requesterTgId}`;
+  const dmText = [
+    `🔐 *Admin command pending your approval*`,
+    ``,
+    `Request #${approvalId}`,
+    `Command: ${summary}`,
+    `Requested by: ${requesterTag}`,
+    `Expires in: ${ttlMin} min`,
+    ``,
+    `Reply with \`/approve ${approvalId}\` to execute, or \`/deny ${approvalId}\` to reject.`,
+    ``,
+    `_Audit F-4 second-admin approval — same admin cannot self-approve._`,
+  ].join("\n");
+  for (const otherTgId of others) {
+    try {
+      await ctx.api.sendMessage(otherTgId, dmText, { parse_mode: "Markdown" });
+    } catch (err) {
+      console.warn(`[admin-approval] DM to admin ${otherTgId} failed: ${err.message?.slice(0, 100)}`);
+    }
+  }
+
+  await logAdminCommand(ctx, command, {
+    outcome: "pending_approval",
+    args: `approval_id=${approvalId}`,
+  });
+  await ctx.reply(
+    [
+      `🔐 *Approval requested — request #${approvalId}*`,
+      ``,
+      `Sent to ${others.length} other admin${others.length === 1 ? "" : "s"} for sign-off.`,
+      `Expires in ${ttlMin} min.`,
+      ``,
+      others.length === 0
+        ? `_No other admins configured. Add one to ADMIN_TELEGRAM_IDS to receive notifications._`
+        : `Approver runs \`/approve ${approvalId}\` to execute.`,
+    ].join("\n"),
+    { parse_mode: "Markdown" },
+  );
+}
+
+/**
+ * /approve <id> — second-admin sign-off on a pending sensitive command.
+ * Same-admin self-approval is blocked. Dispatches to the stored command's
+ * executor with the requester's args, replying on the approver's ctx
+ * so the approver sees the success/error message.
+ */
+export async function handleApprove(ctx) {
+  if (!(await requireAdmin(ctx, "approve"))) return;
+  const idStr = (ctx.message?.text || "").trim().split(/\s+/)[1];
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return ctx.reply("Usage: `/approve <id>`", { parse_mode: "Markdown" });
+  }
+  const claim = await approveAndClaim({ approvalId: id, approverCtx: ctx });
+  if (!claim.ok) {
+    const reasons = {
+      not_found_or_not_pending: "Request not found or no longer pending.",
+      self_approval_blocked: "You can't approve a request you submitted yourself.",
+      expired: "Request expired — ask the requester to re-submit.",
+      race_lost_or_invalid: "Another admin already actioned this request.",
+    };
+    await logAdminCommand(ctx, "approve", { outcome: "denied", args: `id=${id}`, error: claim.reason });
+    return ctx.reply(`❌ ${reasons[claim.reason] || claim.reason}`);
+  }
+  const exec = APPROVAL_EXECUTORS[claim.row.command];
+  if (!exec) {
+    await markExecuted(id, `no_executor_for_${claim.row.command}`);
+    return ctx.reply(`❌ Internal error: no executor registered for \`${claim.row.command}\`.`, { parse_mode: "Markdown" });
+  }
+  try {
+    const result = await exec(ctx, claim.row.args_json);
+    await markExecuted(id, result?.ok === false ? result.error : null);
+    await logAdminCommand(ctx, "approve", { outcome: "success", args: `id=${id} cmd=${claim.row.command}` });
+  } catch (err) {
+    await markExecuted(id, err.message);
+    await logAdminCommand(ctx, "approve", { outcome: "error", args: `id=${id}`, error: err.message });
+    await ctx.reply(`❌ Execute failed: ${err.message?.slice(0, 150)}`);
+  }
+}
+
+/**
+ * /deny <id> — reject a pending sensitive command. Either admin can deny.
+ */
+export async function handleDeny(ctx) {
+  if (!(await requireAdmin(ctx, "deny"))) return;
+  const idStr = (ctx.message?.text || "").trim().split(/\s+/)[1];
+  const id = Number(idStr);
+  if (!Number.isInteger(id) || id <= 0) {
+    return ctx.reply("Usage: `/deny <id>`", { parse_mode: "Markdown" });
+  }
+  const res = await denyApproval({ approvalId: id, denierCtx: ctx });
+  if (!res.ok) {
+    await logAdminCommand(ctx, "deny", { outcome: "denied", args: `id=${id}`, error: res.reason });
+    return ctx.reply(`❌ Request not found or no longer pending.`);
+  }
+  await logAdminCommand(ctx, "deny", { outcome: "success", args: `id=${id} cmd=${res.row.command}` });
+
+  // Notify the requester.
+  try {
+    await ctx.api.sendMessage(
+      Number(res.row.requester_tg_id),
+      `🔐 Your request #${id} (\`${res.row.command}\`) was denied by @${ctx.from?.username || `tg:${ctx.from?.id}`}.`,
+      { parse_mode: "Markdown" },
+    );
+  } catch { /* requester may have blocked the bot */ }
+  await ctx.reply(`🚫 Request #${id} denied.`);
+}
+
+/**
+ * /pending — list currently-pending approval requests.
+ */
+export async function handlePendingApprovals(ctx) {
+  if (!(await requireAdmin(ctx, "pending"))) return;
+  const rows = await listPendingApprovals({ limit: 25 });
+  if (rows.length === 0) {
+    return ctx.reply("No pending approval requests.");
+  }
+  const lines = rows.map((r) => {
+    const ageMin = Math.round((Date.now() - new Date(r.requested_at).getTime()) / 60_000);
+    const ttlMin = Math.max(0, Math.round((new Date(r.expires_at).getTime() - Date.now()) / 60_000));
+    const requester = r.requester_username ? `@${r.requester_username}` : `tg:${r.requester_tg_id}`;
+    return `#${r.id} /${r.command} — ${requester}, ${ageMin}m ago, ${ttlMin}m left`;
+  });
+  await logAdminCommand(ctx, "pending", { outcome: "success" });
+  await ctx.reply(`*Pending approvals* (${rows.length})\n\`\`\`\n${lines.join("\n")}\n\`\`\``, { parse_mode: "Markdown" });
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,9 @@ import {
   handleInfraHealth,
   handleHolderPool,
   handleAdminCmds,
+  handleApprove,
+  handleDeny,
+  handlePendingApprovals,
 } from "./commands/admin.js";
 import { rateLimit } from "./middleware/rate-limit.js";
 import { startDepositWatcher } from "./services/deposit-watcher.js";
@@ -244,6 +247,13 @@ bot.command("pause", handlePause);
 bot.command("resume", handleResume);
 bot.command("adminstatus", handleAdminStatus);
 bot.command(["admincmds", "adminlog"], handleAdminCmds);
+// F-4 multi-step approval — second-admin sign-off for sensitive commands.
+// Default gated commands: enablemint, disablemint, broadcast (tunable via
+// ADMIN_COMMAND_APPROVAL_REQUIRED env var). Solo-admin operators bypass
+// transparently — the bypass is logged via admin_command_log.
+bot.command("approve", handleApprove);
+bot.command("deny", handleDeny);
+bot.command(["pending", "pending_approvals"], handlePendingApprovals);
 bot.command("siteops", handleSiteOps);
 bot.command(["protocolfees", "protocol-fees"], handleProtocolFees);
 bot.command("ban_user", handleBanUser);

--- a/src/services/admin-audit.js
+++ b/src/services/admin-audit.js
@@ -128,3 +128,212 @@ export async function countDeniedAttempts({ hours = 24 } = {}) {
   );
   return r?.n || 0;
 }
+
+/* ════════════════════════════════════════════════════════════════
+ *  MULTI-STEP APPROVAL (audit F-4, migration 042)
+ * ════════════════════════════════════════════════════════════════
+ *
+ * Sensitive admin commands route through requireApproval(). When two
+ * admins are configured, the first admin's invocation creates a
+ * pending row + DMs the others; a different admin executes the action
+ * via /approve <id>. Solo-admin deployments bypass the gate (no second
+ * admin exists) and the bypass is logged for visibility.
+ *
+ * Default commands gated:
+ *   enablemint, disablemint, broadcast
+ *
+ * Tunable via ADMIN_COMMAND_APPROVAL_REQUIRED env var
+ * (comma-separated). Empty value disables the gate entirely.
+ */
+
+const APPROVAL_TTL_MS = Number(process.env.ADMIN_APPROVAL_TTL_MS || 5 * 60_000);
+
+// Parse the gated-command list once at import. Empty string OR "none"
+// disables the gate entirely (useful for staging).
+function gatedCommandSet() {
+  const env = process.env.ADMIN_COMMAND_APPROVAL_REQUIRED;
+  if (env === undefined || env === null) {
+    return new Set(["enablemint", "disablemint", "broadcast"]);
+  }
+  if (env === "" || env.toLowerCase() === "none") return new Set();
+  return new Set(env.split(",").map((s) => s.trim()).filter(Boolean));
+}
+
+export function isApprovalGated(command) {
+  return gatedCommandSet().has(String(command));
+}
+
+/**
+ * Snapshot the configured admin IDs at call time. Mirrors how
+ * src/services/admin.js builds its in-memory Set, but re-reads env so a
+ * mid-session ADMIN_TELEGRAM_IDS change is honored without a restart.
+ */
+function adminTgIds() {
+  return new Set(
+    (process.env.ADMIN_TELEGRAM_IDS || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number),
+  );
+}
+
+/**
+ * Create a pending approval row + return its id. Caller is responsible
+ * for DM'ing the other admins (we don't import grammy here to keep
+ * this module bot-framework-free).
+ *
+ * args object is stored verbatim as JSONB. It MUST contain everything
+ * the executor needs to replay the command — the original ctx is gone
+ * by the time the second admin approves.
+ */
+export async function requestApproval({ command, args, requesterCtx }) {
+  const expiresAt = new Date(Date.now() + APPROVAL_TTL_MS);
+  const { rows: [row] } = await query(
+    `INSERT INTO admin_command_approvals
+       (command, args_json, requester_tg_id, requester_username, requester_chat_id, expires_at)
+     VALUES ($1, $2::jsonb, $3, $4, $5, $6)
+     RETURNING id, expires_at`,
+    [
+      String(command).slice(0, 64),
+      JSON.stringify(args || {}),
+      Number(requesterCtx?.from?.id) || 0,
+      requesterCtx?.from?.username || null,
+      requesterCtx?.chat?.id ? Number(requesterCtx.chat.id) : null,
+      expiresAt,
+    ],
+  );
+  return { approvalId: Number(row.id), expiresAt: row.expires_at };
+}
+
+/**
+ * Look up a pending approval by id, with full row fields. Returns null
+ * if not found OR if the row's status is no longer pending.
+ */
+export async function getPendingApproval(approvalId) {
+  const { rows: [row] } = await query(
+    `SELECT id, command, args_json, requester_tg_id, requester_username,
+            requested_at, expires_at, status
+       FROM admin_command_approvals
+      WHERE id = $1 AND status = 'pending'`,
+    [Number(approvalId)],
+  );
+  return row || null;
+}
+
+/**
+ * Mark a pending approval as approved by approverTgId. Rejects:
+ *   - id not found / not pending
+ *   - approver is the same admin who requested it (self-approval block)
+ *   - expired (status → 'expired' as a side-effect)
+ *
+ * Returns { ok: true, row } on success or { ok: false, reason } on reject.
+ * The row return is the post-update state so the caller can dispatch
+ * to the executor with the original args_json.
+ */
+export async function approveAndClaim({ approvalId, approverCtx }) {
+  const approverTgId = Number(approverCtx?.from?.id) || 0;
+  const approverUsername = approverCtx?.from?.username || null;
+
+  // Read first to validate same-admin + expiry. A bad actor could try to
+  // race the UPDATE so we follow with a CAS-like conditional UPDATE that
+  // only succeeds if the row is still pending AND not expired AND not
+  // requested by the approver.
+  const pending = await getPendingApproval(approvalId);
+  if (!pending) return { ok: false, reason: "not_found_or_not_pending" };
+  if (Number(pending.requester_tg_id) === approverTgId) {
+    return { ok: false, reason: "self_approval_blocked" };
+  }
+  if (new Date(pending.expires_at) < new Date()) {
+    // Lazy expiry: mark expired so /pending doesn't show it again.
+    await query(
+      `UPDATE admin_command_approvals SET status='expired' WHERE id=$1 AND status='pending'`,
+      [Number(approvalId)],
+    );
+    return { ok: false, reason: "expired" };
+  }
+  const { rows: [updated] } = await query(
+    `UPDATE admin_command_approvals
+        SET status='approved', approver_tg_id=$2, approver_username=$3, approved_at=NOW()
+      WHERE id = $1
+        AND status = 'pending'
+        AND expires_at > NOW()
+        AND requester_tg_id <> $2
+      RETURNING id, command, args_json, requester_tg_id`,
+    [Number(approvalId), approverTgId, approverUsername],
+  );
+  if (!updated) return { ok: false, reason: "race_lost_or_invalid" };
+  return { ok: true, row: updated };
+}
+
+/**
+ * Mark a pending approval as denied. Same validation as approve except
+ * we allow self-deny (an admin can cancel their own pending request —
+ * useful if they realize they typo'd before another admin sees it).
+ */
+export async function denyApproval({ approvalId, denierCtx }) {
+  const { rows: [updated] } = await query(
+    `UPDATE admin_command_approvals
+        SET status='denied', denied_at=NOW(),
+            approver_tg_id=$2, approver_username=$3
+      WHERE id = $1 AND status = 'pending'
+      RETURNING id, command, requester_tg_id`,
+    [
+      Number(approvalId),
+      Number(denierCtx?.from?.id) || 0,
+      denierCtx?.from?.username || null,
+    ],
+  );
+  if (!updated) return { ok: false, reason: "not_found_or_not_pending" };
+  return { ok: true, row: updated };
+}
+
+/**
+ * Mark an approved request as executed. Caller invokes after the real
+ * command finishes; passes any error message for forensic logging.
+ */
+export async function markExecuted(approvalId, errorMessage = null) {
+  await query(
+    `UPDATE admin_command_approvals
+        SET status='executed', executed_at=NOW(), execute_error=$2
+      WHERE id = $1 AND status = 'approved'`,
+    [Number(approvalId), errorMessage ? String(errorMessage).slice(0, 200) : null],
+  );
+}
+
+/**
+ * List pending approvals. Cap 50.
+ */
+export async function listPendingApprovals({ limit = 25 } = {}) {
+  const cappedLimit = Math.max(1, Math.min(50, Number(limit) || 25));
+  const { rows } = await query(
+    `SELECT id, command, args_json, requester_tg_id, requester_username,
+            requested_at, expires_at
+       FROM admin_command_approvals
+      WHERE status = 'pending' AND expires_at > NOW()
+      ORDER BY requested_at DESC
+      LIMIT $1`,
+    [cappedLimit],
+  );
+  return rows;
+}
+
+/**
+ * Operator-facing helper used by the approval gate. Returns the list of
+ * admin TG ids EXCLUDING the requester — that's who should be DM'd.
+ */
+export function otherAdminTgIds(requesterTgId) {
+  const all = adminTgIds();
+  all.delete(Number(requesterTgId));
+  return [...all];
+}
+
+/**
+ * Solo-admin? Returns true when there's exactly ONE configured admin
+ * AND that admin is the requester. In that case, the approval gate
+ * cannot meaningfully require a second approver, so we short-circuit.
+ */
+export function isSoloAdmin(requesterTgId) {
+  const all = adminTgIds();
+  return all.size <= 1 && all.has(Number(requesterTgId));
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #105 (admin command logging). Ships the second half of audit F-4: **second-admin approval for sensitive commands** (default: `/enablemint`, `/disablemint`, `/broadcast`). Closes the MEDIUM-severity finding about single-admin-account compromise.

## Threat model this closes

A SIM-swap or social-engineering compromise of one admin TG account. With single-admin auth:

- `/pause` → freeze borrowing → ransom
- `/enablemint <rug>` → drain pool against attacker-controlled rug token
- `/broadcast <phishing>` → DM the entire user base with malicious links

After this PR the attacker has to compromise **two** independent admin accounts within a 5-minute window. That's a meaningful step-up.

## Flow

```
Admin A: /enablemint <mint> <symbol> <decimals>
   → DB row inserted (status=pending, expires_at = NOW() + 5 min)
   → bot DMs every OTHER admin: "Request #N pending"
   → requester sees: "Approval requested — request #N"

Admin B: /approve N    (within 5 min, must be different admin)
   → row → approved
   → executor dispatches with the args Admin A submitted
   → success/error reply lands on Admin B's chat

OR Admin B: /deny N    → row → denied, requester DM'd the rejection
OR 5 min passes        → next /approve marks expired
```

## Same-admin self-approval = blocked

Enforced both in app (`approveAndClaim` checks `requester_tg_id !== approver_tg_id`) AND via a CAS-style conditional UPDATE so a TOCTOU race can't slip through. The denied attempt is logged as `outcome='denied'` with reason `self_approval_blocked`.

## Solo-admin case

When `ADMIN_TELEGRAM_IDS` has exactly one entry, the gate transparently short-circuits and executes immediately. Bypass is logged as `outcome='solo_admin_bypass'` so the operator sees those events in `/admincmds`. No security regression — there's literally no second admin to ask.

## What ships

| File | Change |
|---|---|
| `migrations/042_admin_command_approvals.sql` | New `admin_command_approvals` table + ALTER to expand `admin_command_log.outcome` enum |
| `src/services/admin-audit.js` | `requestApproval`, `getPendingApproval`, `approveAndClaim`, `denyApproval`, `markExecuted`, `listPendingApprovals` + `isApprovalGated`, `isSoloAdmin`, `otherAdminTgIds` |
| `src/commands/admin.js` | Split `handleEnableMint`/`DisableMint`/`Broadcast` into pure executors + handler-with-gate. New `handleApprove`, `handleDeny`, `handlePendingApprovals` |
| `src/index.js` | `/approve`, `/deny`, `/pending`, `/pending_approvals` wired |

## Tuning

- `ADMIN_COMMAND_APPROVAL_REQUIRED` — comma-separated list. Default: `enablemint,disablemint,broadcast`. Empty string or `"none"` disables the gate entirely (staging).
- `ADMIN_APPROVAL_TTL_MS` — defaults to 5 min.

## Test plan

- [x] `node --check` passes on every changed file
- [ ] After deploy: solo admin runs `/enablemint ... ... ...` → executes immediately, `/admincmds` shows `outcome=solo_admin_bypass`
- [ ] Two-admin setup: Admin A runs `/enablemint ... ... ...` → Admin B receives DM, sees `Request #N pending`
- [ ] Admin A tries `/approve N` on their own request → rejected with "can't approve a request you submitted yourself"
- [ ] Admin B runs `/approve N` within 5 min → mint enabled, requester sees confirmation
- [ ] Admin B runs `/deny N` → requester DM'd the rejection
- [ ] Request older than 5 min → `/approve N` returns "Request expired"
- [ ] `/pending` lists currently-pending requests with age + TTL
- [ ] Disabling via `ADMIN_COMMAND_APPROVAL_REQUIRED=` reverts to immediate execution

## Depends on

PR #105 (admin command audit log) — this PR is rebased on top. Merge order: #105 → #107.