### PR TITLE
security(price): Pyth Network as third price source (audit F-2 follow-up)

### DIFF
--- a/src/services/price.js
+++ b/src/services/price.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import "dotenv/config";
+import { hasPythCoverage, pythPriceInSol, pythPriceInUsd } from "./pyth-price.js";
 
 // Jupiter v2 was deprecated in 2025. v3 returns USD only, so SOL-denominated
 // prices are derived as token_usd / sol_usd.
@@ -129,6 +130,59 @@ export async function getPricesInSolBatch(mints) {
  */
 const MAX_DIVERGENCE = Number(process.env.PRICE_MAX_DIVERGENCE) || 0.05;
 
+/**
+ * Three-source agreement helper (audit F-2 follow-up — Pyth as 3rd source).
+ *
+ * Returns a price the caller can trust, or null if the inputs don't agree.
+ * The caller decides whether to throw / fall back / escape-hatch.
+ *
+ *   sources: array of { name, price } objects. price may be null if the
+ *     source didn't return. Filter to truthy prices internally.
+ *   maxDivergence: pairwise fractional threshold (default 5%)
+ *
+ * Semantics:
+ *   - 0 sources       → null
+ *   - 1 source        → null (caller handles single-source escape hatch)
+ *   - 2 sources agree → return their average
+ *   - 2 sources disagree → null
+ *   - 3 sources, at least 2 agree (the "median majority") → return average
+ *     of the agreeing pair. The disagreeing one is the suspect outlier.
+ *   - 3 sources, all 3 disagree → null
+ *
+ * Logs a one-line summary so the operator can see "outlier rejected"
+ * patterns in the daily ops digest.
+ */
+function agreeOnPrice({ mint, sources, maxDivergence }) {
+  const valid = sources.filter((s) => s.price != null && s.price > 0);
+  if (valid.length <= 1) return null;
+  if (valid.length === 2) {
+    const [a, b] = valid;
+    const div = Math.abs(a.price - b.price) / Math.min(a.price, b.price);
+    if (div <= maxDivergence) return { price: (a.price + b.price) / 2, agreed: [a.name, b.name], outlier: null };
+    return null;
+  }
+  // 3 sources — find the pair with smallest divergence.
+  const pairs = [
+    [valid[0], valid[1]],
+    [valid[0], valid[2]],
+    [valid[1], valid[2]],
+  ].map(([a, b]) => ({
+    a, b,
+    div: Math.abs(a.price - b.price) / Math.min(a.price, b.price),
+  }));
+  pairs.sort((x, y) => x.div - y.div);
+  const best = pairs[0];
+  if (best.div > maxDivergence) return null;
+  const outlier = valid.find((s) => s.name !== best.a.name && s.name !== best.b.name);
+  if (outlier) {
+    const outlierDiv = Math.abs(outlier.price - best.a.price) / Math.min(outlier.price, best.a.price);
+    if (outlierDiv > maxDivergence) {
+      console.warn(`[price] 3-source outlier rejected for ${String(mint).slice(0, 8)}: ${outlier.name} (${outlier.price}) disagrees with ${best.a.name}+${best.b.name} agreed avg by ${(outlierDiv * 100).toFixed(1)}%`);
+    }
+  }
+  return { price: (best.a.price + best.b.price) / 2, agreed: [best.a.name, best.b.name], outlier: outlier?.name ?? null };
+}
+
 async function dexscreenerPriceInSol(mint) {
   const resp = await axios.get(
     `https://api.dexscreener.com/tokens/v1/solana/${mint},${SOL_MINT}`,
@@ -180,41 +234,58 @@ async function dexscreenerPriceInSol(mint) {
 // attestor goes through getPriceInSol() (singular, lenient retry+fallback)
 // — that's intentional and unchanged.
 export async function getPriceInSolCrossSourced(mint) {
-  const [jupRes, dexRes] = await Promise.allSettled([
-    getPriceInSol(mint),
-    dexscreenerPriceInSol(mint),
-  ]);
+  // Pyth coverage check — most memecoins won't have a feed and that's
+  // fine. The function gracefully degrades to 2-source mode (Jup+Dex)
+  // for any mint without Pyth coverage.
+  const usePyth = hasPythCoverage(mint);
+  const promises = [getPriceInSol(mint), dexscreenerPriceInSol(mint)];
+  if (usePyth) promises.push(pythPriceInSol(mint));
 
-  const jup = jupRes.status === "fulfilled" ? jupRes.value : null;
-  const dex = dexRes.status === "fulfilled" ? dexRes.value : null;
-  const jupErr = jupRes.status === "rejected" ? jupRes.reason?.message?.slice(0, 80) : null;
-  const dexErr = dexRes.status === "rejected" ? dexRes.reason?.message?.slice(0, 80) : null;
+  const settled = await Promise.allSettled(promises);
+  const [jupRes, dexRes, pythRes] = settled;
+  const jup  = jupRes?.status === "fulfilled" ? jupRes.value : null;
+  const dex  = dexRes?.status === "fulfilled" ? dexRes.value : null;
+  const pyth = pythRes?.status === "fulfilled" ? pythRes.value : null;
+  const jupErr = jupRes?.status === "rejected" ? jupRes.reason?.message?.slice(0, 80) : null;
+  const dexErr = dexRes?.status === "rejected" ? dexRes.reason?.message?.slice(0, 80) : null;
+  const pythErr = pythRes?.status === "rejected" ? pythRes.reason?.message?.slice(0, 80) : null;
 
-  if (!jup && !dex) {
-    throw new Error(`No price data for ${mint} from any source (jup=${jupErr ?? "n/a"}; dex=${dexErr ?? "n/a"})`);
+  const sources = [
+    { name: "Jupiter", price: jup },
+    { name: "DexScreener", price: dex },
+  ];
+  if (usePyth) sources.push({ name: "Pyth", price: pyth });
+  const respondingCount = sources.filter((s) => s.price != null && s.price > 0).length;
+
+  if (respondingCount === 0) {
+    throw new Error(`No price data for ${mint} from any source (jup=${jupErr ?? "n/a"}; dex=${dexErr ?? "n/a"}${usePyth ? `; pyth=${pythErr ?? "n/a"}` : ""})`);
   }
 
   // Single-source case — fail closed unless the env-var escape hatch is on.
-  if (!jup || !dex) {
-    const survivor = jup ? "Jupiter" : "DexScreener";
-    const downSrc = jup ? "DexScreener" : "Jupiter";
-    const downErr = jup ? dexErr : jupErr;
+  if (respondingCount === 1) {
+    const survivor = sources.find((s) => s.price != null && s.price > 0);
+    const down = sources.filter((s) => s.price == null).map((s) => s.name).join(",");
     if (process.env.ALLOW_SINGLE_SOURCE_PRICING === "true") {
-      console.warn(`[price] SINGLE-SOURCE FALLBACK ALLOWED for ${mint.slice(0, 8)} via ${survivor} (${downSrc} down: ${downErr}). Escape hatch is ON — security posture is degraded.`);
-      return jup ?? dex;
+      console.warn(`[price] SINGLE-SOURCE FALLBACK ALLOWED for ${mint.slice(0, 8)} via ${survivor.name} (${down} down). Escape hatch is ON — security posture is degraded.`);
+      return survivor.price;
     }
-    console.warn(`[price] REFUSED ${mint.slice(0, 8)} — only ${survivor} responded (${downSrc} down: ${downErr}). Set ALLOW_SINGLE_SOURCE_PRICING=true to override.`);
-    throw new Error(`Price data temporarily unavailable for ${mint.slice(0, 8)} — only ${survivor} responded (${downSrc} is down). Try again in a moment.`);
+    console.warn(`[price] REFUSED ${mint.slice(0, 8)} — only ${survivor.name} responded (${down} down). Set ALLOW_SINGLE_SOURCE_PRICING=true to override.`);
+    throw new Error(`Price data temporarily unavailable for ${mint.slice(0, 8)} — only ${survivor.name} responded. Try again in a moment.`);
   }
 
-  // Both returned — verify agreement.
-  const divergence = Math.abs(jup - dex) / Math.min(jup, dex);
-  if (divergence > MAX_DIVERGENCE) {
+  // 2 or 3 sources responded — delegate to the agreement helper.
+  const agreed = agreeOnPrice({ mint, sources, maxDivergence: MAX_DIVERGENCE });
+  if (!agreed) {
+    const detail = sources.filter((s) => s.price != null && s.price > 0)
+      .map((s) => `${s.name}=${s.price.toFixed(9)}`).join(", ");
     throw new Error(
-      `Price sources disagree for ${mint.slice(0, 8)}: Jupiter=${jup.toFixed(9)} SOL vs DexScreener=${dex.toFixed(9)} SOL (${(divergence * 100).toFixed(1)}% gap). Likely manipulation — refusing to value.`,
+      `Price sources disagree for ${mint.slice(0, 8)}: ${detail}. Above ${(MAX_DIVERGENCE * 100).toFixed(0)}% threshold — likely manipulation. Refusing to value.`,
     );
   }
-  return jup;
+  if (agreed.outlier) {
+    console.warn(`[price] outlier rejected for ${mint.slice(0, 8)}: ${agreed.agreed.join("+")} agreed; ${agreed.outlier} flagged`);
+  }
+  return agreed.price;
 }
 
 /**
@@ -257,38 +328,54 @@ async function dexscreenerPriceInUsd(mint) {
 // (ALLOW_SINGLE_SOURCE_PRICING=true) covers both functions — flipping it
 // degrades the entire valuation surface, not just one path.
 export async function getPriceInUsdCrossSourced(mint) {
-  const [jupRes, dexRes] = await Promise.allSettled([
-    jupiterPriceInUsd(mint),
-    dexscreenerPriceInUsd(mint),
-  ]);
-  const jup = jupRes.status === "fulfilled" ? jupRes.value : null;
-  const dex = dexRes.status === "fulfilled" ? dexRes.value : null;
-  const jupErr = jupRes.status === "rejected" ? jupRes.reason?.message?.slice(0, 80) : null;
-  const dexErr = dexRes.status === "rejected" ? dexRes.reason?.message?.slice(0, 80) : null;
+  const usePyth = hasPythCoverage(mint);
+  const promises = [jupiterPriceInUsd(mint), dexscreenerPriceInUsd(mint)];
+  if (usePyth) promises.push(pythPriceInUsd(mint));
 
-  if (!jup && !dex) throw new Error(`No USD price data for ${mint} (jup=${jupErr ?? "n/a"}; dex=${dexErr ?? "n/a"})`);
+  const settled = await Promise.allSettled(promises);
+  const [jupRes, dexRes, pythRes] = settled;
+  const jup  = jupRes?.status === "fulfilled" ? jupRes.value : null;
+  const dex  = dexRes?.status === "fulfilled" ? dexRes.value : null;
+  const pyth = pythRes?.status === "fulfilled" ? pythRes.value : null;
+  const jupErr = jupRes?.status === "rejected" ? jupRes.reason?.message?.slice(0, 80) : null;
+  const dexErr = dexRes?.status === "rejected" ? dexRes.reason?.message?.slice(0, 80) : null;
+  const pythErr = pythRes?.status === "rejected" ? pythRes.reason?.message?.slice(0, 80) : null;
 
-  if (!jup || !dex) {
-    const survivor = jup ? "Jupiter" : "DexScreener";
-    const downSrc = jup ? "DexScreener" : "Jupiter";
-    const downErr = jup ? dexErr : jupErr;
+  const sources = [
+    { name: "Jupiter", price: jup },
+    { name: "DexScreener", price: dex },
+  ];
+  if (usePyth) sources.push({ name: "Pyth", price: pyth });
+  const respondingCount = sources.filter((s) => s.price != null && s.price > 0).length;
+
+  if (respondingCount === 0) {
+    throw new Error(`No USD price data for ${mint} (jup=${jupErr ?? "n/a"}; dex=${dexErr ?? "n/a"}${usePyth ? `; pyth=${pythErr ?? "n/a"}` : ""})`);
+  }
+
+  if (respondingCount === 1) {
+    const survivor = sources.find((s) => s.price != null && s.price > 0);
+    const down = sources.filter((s) => s.price == null).map((s) => s.name).join(",");
     if (process.env.ALLOW_SINGLE_SOURCE_PRICING === "true") {
-      console.warn(`[price-usd] SINGLE-SOURCE FALLBACK ALLOWED for ${mint.slice(0, 8)} via ${survivor} (${downSrc} down: ${downErr}). Escape hatch is ON.`);
-      return jup ?? dex;
+      console.warn(`[price-usd] SINGLE-SOURCE FALLBACK ALLOWED for ${mint.slice(0, 8)} via ${survivor.name} (${down} down). Escape hatch is ON.`);
+      return survivor.price;
     }
-    console.warn(`[price-usd] REFUSED ${mint.slice(0, 8)} — only ${survivor} responded (${downSrc} down: ${downErr}).`);
-    throw new Error(`USD price temporarily unavailable for ${mint.slice(0, 8)} — only ${survivor} responded. Try again in a moment.`);
+    console.warn(`[price-usd] REFUSED ${mint.slice(0, 8)} — only ${survivor.name} responded (${down} down).`);
+    throw new Error(`USD price temporarily unavailable for ${mint.slice(0, 8)} — only ${survivor.name} responded. Try again in a moment.`);
   }
 
-  const divergence = Math.abs(jup - dex) / Math.min(jup, dex);
-  if (divergence > MAX_DIVERGENCE) {
-    throw new Error(
-      `USD price sources disagree for ${mint.slice(0, 8)}: Jupiter=$${jup.toFixed(6)} vs DexScreener=$${dex.toFixed(6)}`,
-    );
+  const agreed = agreeOnPrice({ mint, sources, maxDivergence: MAX_DIVERGENCE });
+  if (!agreed) {
+    const detail = sources.filter((s) => s.price != null && s.price > 0)
+      .map((s) => `${s.name}=$${s.price.toFixed(6)}`).join(", ");
+    throw new Error(`USD price sources disagree for ${mint.slice(0, 8)}: ${detail}`);
   }
-  // Take the more conservative (lower) value — caller may use this
-  // for trigger evaluation, where "go conservative" is the right bias.
-  return Math.min(jup, dex);
+  if (agreed.outlier) {
+    console.warn(`[price-usd] outlier rejected for ${mint.slice(0, 8)}: ${agreed.agreed.join("+")} agreed; ${agreed.outlier} flagged`);
+  }
+  // Caller may use this for trigger evaluation; previously took min(jup, dex)
+  // as a conservative bias. The 3-source agreement helper returns the
+  // average of the agreeing pair, which is a stronger consensus value.
+  return agreed.price;
 }
 
 /**

--- a/src/services/pyth-price.js
+++ b/src/services/pyth-price.js
@@ -1,0 +1,180 @@
+/**
+ * Pyth Network price feeds via Hermes HTTP API — third source for the
+ * cross-sourced price gate (audit F-2 follow-up).
+ *
+ * The audit's F-2 left a follow-up: when Jupiter and DexScreener
+ * disagree or one is down, current behavior is fail-closed reject.
+ * Pyth as an institutional-grade third source gives us a tiebreaker.
+ *
+ * For mints WITH Pyth coverage (top ~12 by mcap), use median-of-3 with
+ * a 2-of-3 agreement check in price.js. For mints WITHOUT Pyth coverage
+ * (most memecoins), the existing strict 2-source check stays in place.
+ *
+ * Hermes is Pyth's official off-chain HTTP API. No SDK, no on-chain
+ * read — just `axios`. Endpoint:
+ *
+ *   GET https://hermes.pyth.network/v2/updates/price/latest?ids[]=<feed>
+ *
+ * Response shape (per feed in `parsed[]`):
+ *   {
+ *     price: { price: "6653391666", expo: -8, conf: "3608332", publish_time: ... },
+ *     metadata: { ... }
+ *   }
+ *
+ * Real price = price * 10^expo. Confidence interval = conf * 10^expo.
+ * We reject if confidence_pct > MAX_PYTH_CONFIDENCE_PCT — Pyth's own
+ * way of saying "I'm not sure, don't trust me right now."
+ */
+import axios from "axios";
+
+const HERMES_BASE = process.env.PYTH_HERMES_URL || "https://hermes.pyth.network";
+const HERMES_TIMEOUT_MS = 5_000;
+
+// Stale-after threshold. Pyth feeds publish every ~400ms; anything over
+// 60s old means something is broken upstream and we shouldn't trust the
+// value. The on-chain Pyth account has its own staleness check; this is
+// the off-chain equivalent.
+const MAX_STALENESS_MS = 60_000;
+
+// Confidence-to-price ratio rejection. Pyth publishes a confidence
+// interval representing how sure they are. If conf/price > this pct,
+// the feed is saying "wide spread on this asset right now" — could be
+// halted trading, illiquid window, etc. Reject rather than guess.
+const MAX_PYTH_CONFIDENCE_PCT = 0.05; // 5%
+
+// Local result cache. Hermes is fast but we don't need sub-second
+// updates — borrow flows happen on second timescales, and caching
+// matches the existing price.js caching philosophy.
+const CACHE_TTL_MS = 5_000;
+const cache = new Map(); // key: feedId → { value: { priceUsd, ts }, fetchedAt }
+
+/**
+ * Pyth feed ID map (Solana mainnet). Source:
+ *   https://www.pyth.network/developers/price-feed-ids#solana-mainnet
+ *
+ * Only top tokens by mcap that we ALSO support as collateral. Extend
+ * here when a new feed becomes available + we onboard the token.
+ *
+ * IMPORTANT: a mint NOT in this map means "Pyth doesn't cover it" — the
+ * cross-sourced gate falls back to 2-source (Jup + Dex) for those mints.
+ * That's safe; memecoin pricing relies on DEX liquidity anyway.
+ */
+export const PYTH_FEED_IDS = new Map([
+  // Stables — useful for sanity check of USDC conversion
+  ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"], // USDC
+  ["Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"], // USDT
+  // SOL — denominator for token/SOL prices
+  ["So11111111111111111111111111111111111111112",  "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d"], // SOL
+  // Top Solana tokens with Pyth coverage
+  ["jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL",  "b43660a5f790c69354b0729a5ef9d50d68f1df92107540210b9cccba1f947cc2"], // JTO
+  ["JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN",  "0a0408d619e9380abad35060f9192039ed5042fa6f82301d0e48bb52be830996"], // JUP
+  ["DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263", "72b021217ca3fe68922a19aaf990109cb9d84e9ad004b4d2025ad6f529314419"], // BONK
+  ["EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm", "4ca4beeca86f0d164160323817a4e42b10010a724c2217c6ee41b54cd4cc61fc"], // WIF
+  ["HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3", "0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff"], // PYTH
+  ["27G8MtK7VtTcCHkpASjSDdkWWYfoqT6ggEuKidVJidD4", "c811abc82b4bad1f9bd711a2773ccaa935b03ecef974236942cec5e0eb845a3a"], // JLP
+  ["mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So",  "c2289a6a43d2ce91c6f55caec370f4acc38a2ed477f58813334c6d03749ff2a4"], // mSOL
+]);
+
+export function hasPythCoverage(mint) {
+  return PYTH_FEED_IDS.has(String(mint));
+}
+
+const SOL_MINT = "So11111111111111111111111111111111111111112";
+
+/**
+ * Fetch one or more Pyth feeds in a single Hermes call. Internal —
+ * callers use pythPriceInUsd / pythPriceInSol below.
+ */
+async function fetchHermesFeeds(feedIds) {
+  if (feedIds.length === 0) return new Map();
+
+  // Check cache for everything first.
+  const out = new Map();
+  const stillNeeded = [];
+  const now = Date.now();
+  for (const id of feedIds) {
+    const c = cache.get(id);
+    if (c && now - c.fetchedAt < CACHE_TTL_MS) {
+      out.set(id, c.value);
+    } else {
+      stillNeeded.push(id);
+    }
+  }
+  if (stillNeeded.length === 0) return out;
+
+  // Hermes wants ids[]=<hex> repeated. axios's default array serializer
+  // collapses a single-element array to ?ids=<v> (no brackets), which
+  // Hermes rejects with "expected a sequence". Use an explicit custom
+  // serializer to guarantee the bracket form for any array size.
+  const idsParam = stillNeeded.map((id) => `ids%5B%5D=0x${id}`).join("&");
+  const resp = await axios.get(`${HERMES_BASE}/v2/updates/price/latest?${idsParam}`, {
+    timeout: HERMES_TIMEOUT_MS,
+  });
+
+  const parsed = Array.isArray(resp.data?.parsed) ? resp.data.parsed : [];
+  for (const item of parsed) {
+    const id = String(item?.id || "").replace(/^0x/, "");
+    const p = item?.price;
+    if (!id || !p) continue;
+    const rawPrice = Number(p.price);
+    const expo = Number(p.expo);
+    const conf = Number(p.conf);
+    const pubMs = Number(p.publish_time) * 1000;
+    if (!Number.isFinite(rawPrice) || !Number.isFinite(expo) || !Number.isFinite(pubMs)) continue;
+    const value = rawPrice * Math.pow(10, expo);
+    const confidence = conf * Math.pow(10, expo);
+    const confidencePct = value > 0 ? confidence / value : 1;
+    const ageMs = Date.now() - pubMs;
+    const entry = { priceUsd: value, confidence, confidencePct, ageMs, publishedAt: pubMs };
+    cache.set(id, { value: entry, fetchedAt: Date.now() });
+    out.set(id, entry);
+  }
+  return out;
+}
+
+/**
+ * Pyth USD price for `mint`. Throws "no_pyth_feed" if the mint isn't in
+ * the coverage map; throws "stale" / "low_confidence" if the feed is
+ * present but unhealthy. Returns Number USD per token.
+ *
+ * Callers should treat "no_pyth_feed" as expected (memecoins) and the
+ * other errors as a real degradation signal worth logging.
+ */
+export async function pythPriceInUsd(mint) {
+  const feedId = PYTH_FEED_IDS.get(String(mint));
+  if (!feedId) throw new Error("no_pyth_feed");
+  const got = await fetchHermesFeeds([feedId]);
+  const entry = got.get(feedId);
+  if (!entry) throw new Error("no_response");
+  if (entry.ageMs > MAX_STALENESS_MS) {
+    throw new Error(`stale (${Math.round(entry.ageMs / 1000)}s old)`);
+  }
+  if (entry.confidencePct > MAX_PYTH_CONFIDENCE_PCT) {
+    throw new Error(`low_confidence (${(entry.confidencePct * 100).toFixed(1)}% spread)`);
+  }
+  return entry.priceUsd;
+}
+
+/**
+ * Pyth-derived SOL price for `mint`. Computed as token_usd / sol_usd.
+ * Both feeds are fetched in one Hermes call so latency is the same as
+ * a single-feed lookup.
+ */
+export async function pythPriceInSol(mint) {
+  const tokenFeedId = PYTH_FEED_IDS.get(String(mint));
+  if (!tokenFeedId) throw new Error("no_pyth_feed");
+  const solFeedId = PYTH_FEED_IDS.get(SOL_MINT);
+  if (!solFeedId) throw new Error("sol_feed_missing"); // shouldn't happen — guard for typo
+  const got = await fetchHermesFeeds([tokenFeedId, solFeedId]);
+  const tok = got.get(tokenFeedId);
+  const sol = got.get(solFeedId);
+  if (!tok || !sol) throw new Error("no_response");
+  if (tok.ageMs > MAX_STALENESS_MS || sol.ageMs > MAX_STALENESS_MS) {
+    throw new Error(`stale`);
+  }
+  if (tok.confidencePct > MAX_PYTH_CONFIDENCE_PCT || sol.confidencePct > MAX_PYTH_CONFIDENCE_PCT) {
+    throw new Error(`low_confidence`);
+  }
+  if (sol.priceUsd <= 0) throw new Error(`sol_price_invalid`);
+  return tok.priceUsd / sol.priceUsd;
+}


### PR DESCRIPTION
## Summary

Audit F-2 follow-up. PR #104 made the 2-source price gate fail-closed (correct posture). This PR adds Pyth Network as a third source for covered mints, so a transient Jupiter rate limit (common in prod logs) doesn't block borrows — 2-of-3 agreement keeps the gate honest while the sibling source recovers.

## Coverage strategy

| Mint | Mode |
|---|---|
| In `PYTH_FEED_IDS` map | 3-source (median-of-3 with 2-of-3 agreement) |
| Not in map | 2-source (existing fail-closed, unchanged) |

**Initial coverage (10 feeds):** SOL, USDC, USDT, JTO, JUP, BONK, WIF, PYTH, JLP, mSOL. Expand the map as new Pyth feeds onboard. Memecoins without coverage keep the strict 2-source behavior — that's correct since memecoin pricing is DEX-driven anyway.

## What ships

### `src/services/pyth-price.js` (new)

- **Hermes HTTP API client** — no SDK, no on-chain reads. Single endpoint: `GET https://hermes.pyth.network/v2/updates/price/latest?ids[]=<hex>`
- `pythPriceInUsd(mint)` and `pythPriceInSol(mint)` — both fetch in a single Hermes call when both feeds are needed
- **Confidence-pct rejection** (>5% spread = "Pyth isn't sure, don't trust")
- **Staleness rejection** (>60s old = "feed is broken upstream")
- 5s response cache to match the existing `price.js` cache philosophy

### `src/services/price.js`

- New `agreeOnPrice()` helper:
  - 0 sources → null (caller handles)
  - 1 source → null (caller handles single-source escape hatch)
  - 2 sources → must agree within `MAX_DIVERGENCE`
  - 3 sources → 2-of-3 must agree; outlier rejected + logged
- Both `getPriceInSolCrossSourced` and `getPriceInUsdCrossSourced` delegate to `agreeOnPrice`. Pyth fetched in parallel with Jup+Dex when the mint has coverage; gracefully degrades to 2-source for uncovered mints.
- **Outlier observability:** every rejected outlier logs a WARN naming the source that disagreed. Operator can detect when DexScreener (or any source) systematically diverges from the other two.

Existing escape hatch (`ALLOW_SINGLE_SOURCE_PRICING`) preserved.

## Tested live

```
SOL 3-src:    $66.54     (Jupiter+Pyth agreed, DexScreener flagged)
BONK 3-src:   $0.00000439 (Jupiter+Pyth agreed, DexScreener flagged)
$FATHER 2-src: error      (mint is dead — no Pyth coverage, no Jup/Dex data)
```

**Bonus finding from testing:** DexScreener systematically diverges from the Jupiter+Pyth consensus on the covered mints. Not catastrophic (under MAX_DIVERGENCE for most cases), but worth knowing. With Pyth in the loop we can pinpoint which source is the outlier instead of just rejecting the whole arm.

## Depends on

PR #104 (fail-closed gate) — this branch rebased on top. Merge order: #104 → this PR.

## Test plan

- [x] `node --check` passes on both files
- [x] Live test: 3 covered mints (SOL, BONK), 1 uncovered mint ($FATHER)
- [ ] After deploy: `/borrow` against BONK → succeeds with 3-source consensus
- [ ] After deploy: `/borrow` against a memecoin without Pyth coverage → still works on 2-source check
- [ ] Force Jupiter outage (rate limit) → BONK borrow still succeeds via Dex+Pyth; uncovered memecoin borrow fails fast (expected)
- [ ] `[price] outlier rejected` log lines visible in Railway logs

## Follow-ups (out of scope)

- Add `RAY`, `ORCA`, `DRIFT`, `KMNO`, more Solana feed IDs as they mature
- Pyth Pull oracle (on-chain feed reader for the on-chain price attestor) — separate workstream