### PR TITLE
feat(limit-close): SL solvency floor — refuse arms that would fire into insolvency

### DIFF
--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -398,6 +398,18 @@ export async function handleLimitClose(ctx, direction = "above") {
             : `Take-profit target is already at or below the current price — the order would fire immediately. Set a higher target.`;
         case "invalid_trigger_direction":
           return `Internal error — invalid trigger direction. Try again.`;
+        case "sl_below_solvency": {
+          // arm-core returned the math; surface it to the user clearly.
+          const d = armed.detail || {};
+          return [
+            `*Stop-loss target is too low — would leave you owing more than the sale covers.*`,
+            ``,
+            `At that trigger, the engine estimates your collateral sells for about *${d.estimated_proceeds_at_trigger_sol} SOL*, but the loan repay needs *${d.required_proceeds_sol} SOL* (owed ${d.owed_sol} SOL + 5% safety buffer).`,
+            `Shortfall: *${d.shortfall_sol} SOL*.`,
+            ``,
+            `Raise your stop-loss target so estimated proceeds cover the repay, OR repay part of the loan first to lower what you owe.`,
+          ].join("\n");
+        }
         default:
           console.error(`[limit-close] arm-core returned unrecognized error: ${armed.error}`, armed);
           return `Couldn't arm the order: ${armed.error}. Please try again.`;

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -243,15 +243,23 @@ export async function armOrder({
     appliedInitialBps = Math.min(liquidityFloorBps, effectiveCap);
   }
 
-  // ── Immediate-fire guard (best-effort) ──────────────────────
-  // Reject arms that would fire immediately:
-  //   - 'above' (TP)  with trigger <= current
-  //   - 'below' (SL)  with trigger >= current
-  // The engine re-checks at fire time so this is purely a UX guard;
+  // ── Immediate-fire + SL solvency guards (best-effort) ──────
+  // Two checks combined:
+  //   1. Immediate-fire: reject arms that would fire immediately:
+  //      - 'above' (TP)  with trigger <= current
+  //      - 'below' (SL)  with trigger >= current
+  //   2. SL solvency (2026-06-13): reject SL arms where expected
+  //      proceeds at trigger < owed + buffer. The engine's repay step
+  //      requires the borrower wallet to hold `owed` lamports in
+  //      native SOL — if the sale proceeds can't cover that, the user
+  //      goes negative and the engine eats the shortfall. Better to
+  //      refuse the arm than to fire into insolvency.
+  // The engine re-checks at fire time so these are purely UX guards;
   // fail-open on any oracle hiccup so a transient price miss doesn't
   // block a legitimate arm. Implemented for USD-denominated triggers
   // (mc_usd, price_usd); price_sol skipped because the SOL denominator
   // moves fast enough that a stale read can false-reject.
+  let currentMicrosForLater = null;
   try {
     if (triggerKind === "mc_usd" || triggerKind === "price_usd") {
       const { getPriceInUsdCrossSourced } = await import("./price.js");
@@ -267,6 +275,7 @@ export async function armOrder({
           currentMicros = BigInt(Math.round(currentUsdPerDisplayed * 1e6)) * BigInt(mintRow.supply);
         }
         if (currentMicros != null) {
+          currentMicrosForLater = currentMicros;
           if (triggerDirection === "above" && triggerBI <= currentMicros) {
             return { ok: false, error: "trigger_would_fire_immediately",
               detail: { direction: "above", currentMicros: currentMicros.toString(), triggerMicros: triggerBI.toString() } };
@@ -309,6 +318,51 @@ export async function armOrder({
     };
   }
   const advisory = !!preflight.advisory;
+
+  // ── SL solvency floor (2026-06-13) ──────────────────────────
+  // The engine's repay step requires the borrower wallet to hold the
+  // OWED amount in native SOL — the on-chain program's repay_loan ix
+  // wraps `owed` lamports into wSOL and burns them. For SL where
+  // collateral has dropped, expected sale proceeds may be below owed
+  // and the user would go negative.
+  //
+  // For TP this is never a concern (proceeds always > owed by the
+  // very nature of "I want to sell at a profit"). For SL it's the
+  // central risk.
+  //
+  // What we check: estimated proceeds AT TRIGGER >= owed * 1.05 (5%
+  // buffer). The buffer accounts for swap slippage eating proceeds +
+  // price moving past trigger before the engine catches the cross.
+  //
+  // What we DON'T check (yet): the borrower's actual wallet balance
+  // at fire time. That belongs in the engine's pre-flight gates and
+  // is covered by the engine's existing ensureSolReserve topup, which
+  // tops gas but not the owed amount. Sell-first-then-repay is the
+  // proper fix; awaits a program-level change.
+  //
+  // Fail-open if we couldn't compute the trigger:current ratio (e.g.
+  // price_sol triggers or oracle hiccup) — the engine's own runtime
+  // safety check at fire time backstops.
+  if (triggerDirection === "below" && preflight.proceedsLamports != null && currentMicrosForLater != null && currentMicrosForLater > 0n) {
+    // Scale current proceeds to trigger-time proceeds estimate.
+    // triggerProceeds ≈ currentProceeds * (trigger / current)
+    // BigInt math: (current_proceeds * trigger_micros) / current_micros
+    const triggerProceedsEstimate = (BigInt(preflight.proceedsLamports) * triggerBI) / currentMicrosForLater;
+    const ownedBI = BigInt(loan.owed);
+    const owedWithBuffer = (ownedBI * 105n) / 100n; // 5% buffer
+    if (triggerProceedsEstimate < owedWithBuffer) {
+      return {
+        ok: false,
+        error: "sl_below_solvency",
+        detail: {
+          owed_sol: (Number(ownedBI) / 1e9).toFixed(4),
+          required_proceeds_sol: (Number(owedWithBuffer) / 1e9).toFixed(4),
+          estimated_proceeds_at_trigger_sol: (Number(triggerProceedsEstimate) / 1e9).toFixed(4),
+          shortfall_sol: (Number(owedWithBuffer - triggerProceedsEstimate) / 1e9).toFixed(4),
+        },
+      };
+    }
+  }
 
   // ── INSERT ──
   let inserted;


### PR DESCRIPTION
## Summary

Operator escalated 2026-06-12: limit-close must be PERFECTED. PR #113 shipped `/lc-status` observability. This PR closes the biggest correctness gap on the stop-loss path — arms that would fire into a state where sale proceeds can't cover the loan repay.

## The architectural constraint

The engine's on-chain repay step transfers `owed` lamports of NATIVE SOL from the borrower wallet into the wSOL ATA and burns it via `repay_loan`. **The borrower must hold `owed` SOL at fire time.**

For take-profit this is never a problem — proceeds > owed by definition. For stop-loss it's the central risk:

1. Collateral drops, user sets SL to "cut me out at -30%"
2. At trigger, proceeds from swapping the dropped collateral come in below the original owed amount
3. Engine's repay tries to debit native SOL the borrower doesn't have
4. Tx fails; engine retries until failure_count exceeds the budget; user's SL never executes

## What ships

### `src/services/limit-close-arm-core.js`

New SL solvency check after the preflight Jupiter quote:

```
triggerProceedsEstimate = preflight.proceedsLamports * (trigger / current)
if triggerProceedsEstimate < owed * 1.05: REJECT
```

- Scales current proceeds estimate to trigger-time by the trigger:current ratio
- 5% safety buffer covers swap slippage + price overshoot past trigger before the engine catches the cross
- Only fires for `triggerDirection='below'` (stop-loss). Take-profit unaffected.
- Only fires for USD-denominated triggers (price_usd, mc_usd). price_sol arms skipped — SOL denominator shifts fast enough that a stale read could false-reject.
- Fail-open on any oracle hiccup. Engine's runtime safety checks backstop.

### `src/commands/limit-close.js`

New `sl_below_solvency` error case with concrete shortfall numbers:

> *Stop-loss target is too low — would leave you owing more than the sale covers.*
>
> At that trigger, the engine estimates your collateral sells for about **0.85 SOL**, but the loan repay needs **1.05 SOL** (owed 1.00 SOL + 5% safety buffer).
> Shortfall: **0.20 SOL**.
>
> Raise your stop-loss target so estimated proceeds cover the repay, OR repay part of the loan first to lower what you owe.

## What this doesn't fix

The fundamental "borrower must hold `owed` SOL at fire time" constraint. That's a sell-first-then-repay pattern requiring an on-chain program change (covered in the engine architecture audit doc — next PR tonight).

This PR keeps the protocol safe today by refusing arms that would deterministically fail. Users who want stop-loss below solvency will be guided to either raise their trigger or partial-repay first.

## Test plan

- [x] `node --check` passes
- [ ] After deploy: `/stoploss <loan> at -10%` on a healthy loan succeeds
- [ ] `/stoploss <loan> at -90%` on a loan near liquidation gets the new error with concrete shortfall math
- [ ] `/takeprofit <loan> at 2x` unaffected
- [ ] `/stoploss <loan> at $0.001` with explicit USD target → solvency check fires correctly
- [ ] Existing `trigger_would_fire_immediately` still fires for "set SL at current price" (no regression)