### PR TITLE
feat(notifications): render limit_close_action_required (pairs with engine PR #8)

### DIFF
--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -124,6 +124,36 @@ function renderLimitCloseFailed(p) {
   ].filter((s) => s !== null).join("\n");
 }
 
+// Engine borrower-balance pre-check (2026-06-13 P0). Soft-fail: the
+// order is still ARMED — user just needs to fund the wallet and the
+// next tick will re-evaluate. Tell them the exact amount + destination.
+function renderLimitCloseActionRequired(p) {
+  if (p?.reason === "borrower_balance_below_owed") {
+    return [
+      `⚠️ *Limit-close order #${p.order_id} — action needed*`,
+      ``,
+      `Your trigger hit, but your wallet doesn't have enough SOL for the loan repay right now.`,
+      ``,
+      `*Needed:* ${p.required_sol} SOL · *In wallet:* ${p.current_sol} SOL`,
+      `*Send:* ${p.shortfall_sol} SOL`,
+      ``,
+      `Send to:`,
+      `\`${p.wallet}\``,
+      ``,
+      `Once funded, the engine retries automatically on the next tick (~30s) — no need to re-arm.`,
+      ``,
+      `_Why this happens: the on-chain repay step requires you to hold the original loan amount in native SOL at execution time. Most users withdraw their borrow shortly after taking it out. Topping back up unblocks the order._`,
+    ].join("\n");
+  }
+  // Generic fallback for future action_required reasons.
+  return [
+    `⚠️ *Limit-close order #${p.order_id} — action needed*`,
+    ``,
+    `Reason: ${p?.reason || "unknown"}`,
+    p?.action ? `Action: ${p.action}` : null,
+  ].filter(Boolean).join("\n");
+}
+
 function renderLimitCloseCancelled(p) {
   const agentLine = agentAttribution(p);
   return [
@@ -145,9 +175,10 @@ function renderPipUpsideAlert(p) {
 
 const RENDERERS = {
   limit_close_armed:        renderLimitCloseArmed,
-  limit_close_fired:        renderLimitCloseFired,
-  limit_close_failed:       renderLimitCloseFailed,
-  limit_close_cancelled:    renderLimitCloseCancelled,
+  limit_close_fired:           renderLimitCloseFired,
+  limit_close_failed:          renderLimitCloseFailed,
+  limit_close_cancelled:       renderLimitCloseCancelled,
+  limit_close_action_required: renderLimitCloseActionRequired,
   limit_close_intervention: renderLimitCloseIntervention,
   pip_upside_alert:         renderPipUpsideAlert,
   // Downside alert reuses the same renderer — the watcher pre-renders


### PR DESCRIPTION
## Summary

Pairs with `magpiecapital/magpie-limitclose#8` (engine borrower-balance pre-check). When a wallet doesn't have enough native SOL to repay the loan at fire time, the engine soft-reverts to armed and DMs the user the exact amount needed to unblock the fire. This PR wires the bot-side renderer for the new `limit_close_action_required` notification kind.

Without it, the notification sender would treat the kind as unknown.

## What the user sees

```
⚠️ Limit-close order #123 — action needed

Your trigger hit, but your wallet doesn't have enough SOL for the loan repay right now.

Needed: 1.0050 SOL · In wallet: 0.0030 SOL
Send: 1.0020 SOL

Send to:
`GF596u…WGr1`

Once funded, the engine retries automatically on the next tick (~30s) — no need to re-arm.

_Why this happens: the on-chain repay step requires you to hold the original loan amount in native SOL at execution time. Most users withdraw their borrow shortly after taking it out. Topping back up unblocks the order._
```

## Depends on

`magpiecapital/magpie-limitclose#8` — must be deployed for this kind to ever be enqueued. Merging this PR first is safe (unused renderer is harmless); merging the engine PR first is also safe (kind silently ignored until renderer ships).

## Test plan

- [x] `node --check` passes
- [ ] After both PRs deploy: arm a TP with a near-empty wallet, trigger fire → user receives the friendly action-needed DM, not JSON
- [ ] Top up wallet → engine fires on next tick → user receives normal `limit_close_fired` DM
- [ ] No regression: existing `limit_close_fired` / `limit_close_failed` / `limit_close_cancelled` / `limit_close_intervention` continue to render correctly