### PR TITLE
feat(watchers): engine topup wallet balance alerts (P0 from engine audit)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,7 @@ import { startHolderDistributor } from "./services/magpie-holder-rewards.js";
 import { startLpLoyaltyDistributor } from "./services/lp-loyalty.js";
 import { startLoanReconciler } from "./services/loan-reconciler.js";
 import { startLenderBalanceWatcher } from "./services/lender-balance-watcher.js";
+import { startEngineTopupWatcher } from "./services/engine-topup-watcher.js";
 import { startAutoProtect } from "./services/auto-protect.js";
 import { startAiConversationDigest } from "./services/ai-conversation-digest.js";
 import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
@@ -766,6 +767,10 @@ bot.start({
     setTimeout(() => startPriceSnapshotter(), 80_000);
     // Overnight safety: DMs admin if lender wallet drops below safe thresholds
     setTimeout(() => startLenderBalanceWatcher(bot), 60_000);
+    // Same pattern for the limit-close engine topup wallet. P0 from
+    // LIMIT_CLOSE_ENGINE_AUDIT.md — if this drains, every engine fire
+    // reverts with topup_transfer_failed and no orders execute.
+    setTimeout(() => startEngineTopupWatcher(bot), 65_000);
     // Auto-Protect — opt-in anti-liquidation. Watches every 90s.
     setTimeout(() => startAutoProtect(bot), 50_000);
     // Conditional-borrow watcher — fires agent intents when their

--- a/src/services/engine-topup-watcher.js
+++ b/src/services/engine-topup-watcher.js
@@ -1,0 +1,115 @@
+/**
+ * Engine topup wallet balance monitor — P0 from LIMIT_CLOSE_ENGINE_AUDIT.md.
+ *
+ * The limit-close engine's ENGINE_TOPUP_KEYPAIR funds 0.03 SOL per fire
+ * to top up borrower wallets so they can pay tx fees. If this wallet
+ * drains overnight, the engine's ensureSolReserve fails on every fire
+ * and orders revert to armed with topup_transfer_failed reason. Users
+ * never get their fires; ops doesn't know until users complain.
+ *
+ * This watcher polls the topup wallet balance and DMs the operator
+ * when it crosses tiered thresholds, BEFORE the drain becomes a
+ * customer issue.
+ *
+ * Parallel to lender-balance-watcher.js but for the engine's wallet.
+ * Designed identically: same alert tiering, same anti-spam, same
+ * recovery semantics.
+ */
+import bs58 from "bs58";
+import { Keypair } from "@solana/web3.js";
+import { connection } from "../solana/connection.js";
+import { getAdminId } from "./admin-notify.js";
+
+const POLL_INTERVAL_MS = Number(process.env.ENGINE_TOPUP_WATCH_MS) || 30 * 60 * 1000; // 30 min
+
+// Tiered thresholds — alert once per tier crossing.
+// At 0.03 SOL per fire, the headroom translates to:
+//   5 SOL = ~150 fires before drain
+//   3 SOL = ~100 fires
+//   1 SOL = ~33 fires
+//   0.3 SOL = ~10 fires — emergency
+const THRESHOLDS = [
+  { lamports: 5_000_000_000n, level: "🟡 LOW",      action: "Top up within 24h" },
+  { lamports: 3_000_000_000n, level: "🟠 CRITICAL", action: "Top up within 6h — engine fires will start failing soon" },
+  { lamports: 1_000_000_000n, level: "🔴 EMERGENCY", action: "Engine fires WILL FAIL imminently. Send SOL to the topup wallet NOW." },
+];
+
+let lastAlertedAt = 0;
+let lastAlertedTier = null;
+
+function loadTopupPubkey() {
+  const secret = process.env.ENGINE_TOPUP_KEYPAIR;
+  if (!secret) return null;
+  try {
+    const kp = Keypair.fromSecretKey(bs58.decode(secret));
+    return kp.publicKey;
+  } catch (err) {
+    console.warn("[engine-topup-watch] keypair parse failed:", err.message?.slice(0, 80));
+    return null;
+  }
+}
+
+async function tick(bot) {
+  const adminTgId = getAdminId();
+  if (!adminTgId || !bot) return;
+
+  const topupPubkey = loadTopupPubkey();
+  if (!topupPubkey) return; // env not set on this deploy; engine fires not gated by this bot anyway
+
+  let lamports;
+  try {
+    lamports = BigInt(await connection.getBalance(topupPubkey));
+  } catch (err) {
+    console.warn("[engine-topup-watch] balance fetch failed:", err.message);
+    return;
+  }
+
+  const crossed = THRESHOLDS.find((t) => lamports < t.lamports);
+  if (!crossed) {
+    lastAlertedTier = null;
+    return;
+  }
+
+  // Same-tier dedupe — same pattern as lender-balance-watcher.
+  const now = Date.now();
+  const sinceLast = now - lastAlertedAt;
+  const tierEscalated = lastAlertedTier && THRESHOLDS.indexOf(crossed) > THRESHOLDS.indexOf(lastAlertedTier);
+  const enoughTimeElapsed = sinceLast > 12 * 60 * 60 * 1000;
+  if (lastAlertedTier === crossed && !tierEscalated && !enoughTimeElapsed) return;
+
+  const sol = (Number(lamports) / 1e9).toFixed(4);
+  const fires = Math.floor(Number(lamports) / 30_000_000); // ENGINE_TOPUP_LAMPORTS = 0.03 SOL
+  try {
+    await bot.api.sendMessage(
+      adminTgId,
+      [
+        `${crossed.level} *Engine topup wallet balance alert*`,
+        "",
+        `Current: \`${sol} SOL\` (~${fires} fires of headroom)`,
+        `Wallet: \`${topupPubkey.toBase58()}\``,
+        "",
+        `Action: ${crossed.action}`,
+        "",
+        `Purpose: this wallet funds 0.03 SOL per limit-close fire so the borrower can pay tx fees. If it drains, every fire reverts with topup_transfer_failed and no orders execute.`,
+        "",
+        `Top up: send SOL directly to \`${topupPubkey.toBase58()}\` from any wallet.`,
+      ].join("\n"),
+      { parse_mode: "Markdown" },
+    );
+    lastAlertedAt = now;
+    lastAlertedTier = crossed;
+  } catch (err) {
+    console.warn("[engine-topup-watch] DM failed:", err.message?.slice(0, 80));
+  }
+}
+
+export function startEngineTopupWatcher(bot) {
+  if (!process.env.ENGINE_TOPUP_KEYPAIR) {
+    console.log("[engine-topup-watch] ENGINE_TOPUP_KEYPAIR not set — watcher idle");
+    return;
+  }
+  console.log(`[engine-topup-watch] started; polling every ${POLL_INTERVAL_MS / 60_000}min`);
+  // Initial tick after a short delay so it doesn't block startup.
+  setTimeout(() => tick(bot).catch((e) => console.error("[engine-topup-watch] tick:", e.message)), 30_000);
+  setInterval(() => tick(bot).catch((e) => console.error("[engine-topup-watch] tick:", e.message)), POLL_INTERVAL_MS);
+}

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -124,6 +124,36 @@ function renderLimitCloseFailed(p) {
   ].filter((s) => s !== null).join("\n");
 }
 
+// Engine borrower-balance pre-check (2026-06-13 P0). Soft-fail: the
+// order is still ARMED — user just needs to fund the wallet and the
+// next tick will re-evaluate. Tell them the exact amount + destination.
+function renderLimitCloseActionRequired(p) {
+  if (p?.reason === "borrower_balance_below_owed") {
+    return [
+      `⚠️ *Limit-close order #${p.order_id} — action needed*`,
+      ``,
+      `Your trigger hit, but your wallet doesn't have enough SOL for the loan repay right now.`,
+      ``,
+      `*Needed:* ${p.required_sol} SOL · *In wallet:* ${p.current_sol} SOL`,
+      `*Send:* ${p.shortfall_sol} SOL`,
+      ``,
+      `Send to:`,
+      `\`${p.wallet}\``,
+      ``,
+      `Once funded, the engine retries automatically on the next tick (~30s) — no need to re-arm.`,
+      ``,
+      `_Why this happens: the on-chain repay step requires you to hold the original loan amount in native SOL at execution time. Most users withdraw their borrow shortly after taking it out. Topping back up unblocks the order._`,
+    ].join("\n");
+  }
+  // Generic fallback for future action_required reasons.
+  return [
+    `⚠️ *Limit-close order #${p.order_id} — action needed*`,
+    ``,
+    `Reason: ${p?.reason || "unknown"}`,
+    p?.action ? `Action: ${p.action}` : null,
+  ].filter(Boolean).join("\n");
+}
+
 function renderLimitCloseCancelled(p) {
   const agentLine = agentAttribution(p);
   return [
@@ -145,9 +175,10 @@ function renderPipUpsideAlert(p) {
 
 const RENDERERS = {
   limit_close_armed:        renderLimitCloseArmed,
-  limit_close_fired:        renderLimitCloseFired,
-  limit_close_failed:       renderLimitCloseFailed,
-  limit_close_cancelled:    renderLimitCloseCancelled,
+  limit_close_fired:           renderLimitCloseFired,
+  limit_close_failed:          renderLimitCloseFailed,
+  limit_close_cancelled:       renderLimitCloseCancelled,
+  limit_close_action_required: renderLimitCloseActionRequired,
   limit_close_intervention: renderLimitCloseIntervention,
   pip_upside_alert:         renderPipUpsideAlert,
   // Downside alert reuses the same renderer — the watcher pre-renders


### PR DESCRIPTION
## Summary

P0 from `LIMIT_CLOSE_ENGINE_AUDIT.md` (PR #115). Closes the silent-drain risk on the engine's topup wallet.

## What this prevents

The engine's `ENGINE_TOPUP_KEYPAIR` funds 0.03 SOL per fire so borrowers can pay tx fees. If it drains overnight without warning:

1. Every `ensureSolReserve` call returns `topup_transfer_failed`
2. Every order reverts to armed instead of firing
3. Users see no movement; ops doesn't know until users complain
4. Liquidations stack up because TPs/SLs that should fire don't

Same severity as the lender wallet draining — silent failure of a core protocol function.

## Behavior

Parallel to `lender-balance-watcher.js` but for the engine wallet:

| Threshold | Level | Headroom (~fires) | Action |
|---|---|---|---|
| < 5 SOL | 🟡 LOW | ~150 | Top up within 24h |
| < 3 SOL | 🟠 CRITICAL | ~100 | Top up within 6h |
| < 1 SOL | 🔴 EMERGENCY | ~33 | Top up NOW |

Poll: every 30 min (tunable via `ENGINE_TOPUP_WATCH_MS`).

Anti-spam: same-tier dedupe; don't re-spam unless 12h passed OR tier escalated.

Env-gated: idle no-op if `ENGINE_TOPUP_KEYPAIR` not set.

## Test plan

- [x] `node --check` passes
- [ ] After deploy with topup wallet at 3+ SOL: no alert (healthy)
- [ ] Drain topup wallet to <5 SOL: receive LOW alert within 30 min
- [ ] Top up to >5 SOL: alert tier resets; next drop re-alerts
- [ ] Same-tier dedupe: drain again within 12h doesn't re-spam