### PR TITLE
feat(watchers): engine heartbeat watcher + migration (pairs engine PR #9)

### DIFF
--- a/migrations/043_engine_heartbeats.sql
+++ b/migrations/043_engine_heartbeats.sql
@@ -1,0 +1,28 @@
+-- migration 043: engine_heartbeats table for cross-service liveness signal
+--
+-- Pairs with magpiecapital/magpie-limitclose PR #9. The engine writes
+-- one row per tick (UPSERT id=1). The bot polls and DMs the operator
+-- if last_tick_at goes stale > 5 min.
+--
+-- Single-row design (id=1) instead of an append-only log: we only need
+-- "alive in the last few seconds?" — historical heartbeats are noise.
+-- If the engine ships multiple watcher kinds in the future, each gets
+-- a distinct id + service name.
+--
+-- LIMIT_CLOSE_ENGINE_AUDIT.md section 3 flagged this as missing.
+
+CREATE TABLE IF NOT EXISTS engine_heartbeats (
+  id                INTEGER     PRIMARY KEY,
+  service           TEXT        NOT NULL,
+  last_tick_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_tick_status  TEXT        NOT NULL DEFAULT 'ok',
+  armed_count       INTEGER     NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE engine_heartbeats IS
+  'Liveness signal for external engines (e.g. limit_close_watcher in
+   magpiecapital/magpie-limitclose). Engine UPSERTs id=1 each tick;
+   bot watcher reads last_tick_at and alerts if stale > 5 min. Single
+   row per service — historical heartbeats are noise, this is purely
+   the "are you alive?" check.';

--- a/src/index.js
+++ b/src/index.js
@@ -152,6 +152,7 @@ import { startLoanReconciler } from "./services/loan-reconciler.js";
 import { startLenderBalanceWatcher } from "./services/lender-balance-watcher.js";
 import { startEngineTopupWatcher } from "./services/engine-topup-watcher.js";
 import { startLcOperatorAlerts } from "./services/lc-operator-alerts.js";
+import { startEngineHeartbeatWatcher } from "./services/engine-heartbeat-watcher.js";
 import { startAutoProtect } from "./services/auto-protect.js";
 import { startAiConversationDigest } from "./services/ai-conversation-digest.js";
 import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
@@ -777,6 +778,10 @@ bot.start({
     // operator. Critical for "perfected" demo readiness — operator sees
     // every fire + failure in real time.
     setTimeout(() => startLcOperatorAlerts(bot), 70_000);
+    // Engine heartbeat — DMs operator with WARN/CRITICAL/EMERGENCY tiers
+    // if the limit-close engine stops ticking. Pairs with the engine's
+    // tick-time writeHeartbeat() in magpie-limitclose PR #9.
+    setTimeout(() => startEngineHeartbeatWatcher(bot), 75_000);
     // Auto-Protect — opt-in anti-liquidation. Watches every 90s.
     setTimeout(() => startAutoProtect(bot), 50_000);
     // Conditional-borrow watcher — fires agent intents when their

--- a/src/services/engine-heartbeat-watcher.js
+++ b/src/services/engine-heartbeat-watcher.js
@@ -1,0 +1,115 @@
+/**
+ * Engine heartbeat watcher — detect when the limit-close engine
+ * service goes silent.
+ *
+ * Pairs with magpiecapital/magpie-limitclose PR #9 (engine-side
+ * heartbeat writer). The engine UPSERTs into engine_heartbeats id=1
+ * every tick. This watcher polls last_tick_at and DMs the operator
+ * with severity-tiered alerts if the engine stops ticking.
+ *
+ * LIMIT_CLOSE_ENGINE_AUDIT.md flagged this as P0 observability for the
+ * "PERFECTED" mandate — if the engine dies, no orders fire and the
+ * operator must hear about it BEFORE a user complains.
+ *
+ * Severity tiers:
+ *   - 5 min  stale   WARN     "Engine hasn't ticked in 5+ min. Check Railway."
+ *   - 15 min stale   CRITICAL "Engine still silent at 15 min. Probably down."
+ *   - 30 min stale   EMERGENCY "Engine has been down 30+ min. Orders are dead."
+ *
+ * Anti-spam: same-tier dedupe (don't re-spam unless 6h passed OR severity
+ * escalated). Recovery clears alert state so the next outage re-alerts.
+ *
+ * Poll interval: 60s. Tunable via ENGINE_HEARTBEAT_WATCH_MS.
+ */
+import { query } from "../db/pool.js";
+import { getAdminId } from "./admin-notify.js";
+
+const POLL_INTERVAL_MS = Number(process.env.ENGINE_HEARTBEAT_WATCH_MS) || 60_000;
+
+const TIERS = [
+  { stale_ms:  5 * 60_000, level: "🟡 WARN",      action: "Engine hasn't ticked in 5+ min. Check Railway logs on the magpie-limitclose service." },
+  { stale_ms: 15 * 60_000, level: "🟠 CRITICAL",  action: "Engine still silent at 15+ min. Likely crashed or in a restart loop." },
+  { stale_ms: 30 * 60_000, level: "🔴 EMERGENCY", action: "Engine has been DOWN 30+ min. Armed orders are not being processed. Restart the service NOW." },
+];
+
+let lastAlertedAt = 0;
+let lastAlertedTier = null;
+
+async function tick(bot) {
+  const adminTgId = getAdminId();
+  if (!adminTgId || !bot) return;
+
+  let row;
+  try {
+    const r = await query(
+      `SELECT last_tick_at, armed_count
+         FROM engine_heartbeats
+        WHERE id = 1 AND service = 'limit_close_watcher'`,
+    );
+    row = r.rows[0];
+  } catch (err) {
+    console.warn("[engine-heartbeat-watch] read failed:", err.message);
+    return;
+  }
+
+  if (!row) {
+    // Table exists (migration applied) but engine hasn't written yet —
+    // could be brand-new deploy. Skip alerting until first write lands.
+    return;
+  }
+
+  const staleMs = Date.now() - new Date(row.last_tick_at).getTime();
+  // Find the most severe tier we've crossed.
+  const crossed = [...TIERS].reverse().find((t) => staleMs >= t.stale_ms);
+  if (!crossed) {
+    // Healthy — clear alert state so a future outage re-alerts.
+    if (lastAlertedTier) {
+      // Recovery DM (low-noise; only fires once per recovery)
+      try {
+        await bot.api.sendMessage(
+          adminTgId,
+          `✅ Engine back online — last tick ${Math.round(staleMs / 1000)}s ago, ${row.armed_count} armed.`,
+          { parse_mode: "Markdown" },
+        );
+      } catch { /* noop */ }
+      lastAlertedTier = null;
+    }
+    return;
+  }
+
+  // Dedupe — don't re-spam same tier within 6h unless escalated.
+  const now = Date.now();
+  const sinceLast = now - lastAlertedAt;
+  const tierEscalated = lastAlertedTier && TIERS.indexOf(crossed) > TIERS.indexOf(lastAlertedTier);
+  const enoughTimeElapsed = sinceLast > 6 * 60 * 60 * 1000;
+  if (lastAlertedTier === crossed && !tierEscalated && !enoughTimeElapsed) return;
+
+  const ageMin = Math.round(staleMs / 60_000);
+  try {
+    await bot.api.sendMessage(
+      adminTgId,
+      [
+        `${crossed.level} *Engine heartbeat stale*`,
+        "",
+        `Service: \`limit_close_watcher\` (magpie-limitclose)`,
+        `Last tick: ${ageMin} min ago`,
+        `Armed orders at last tick: ${row.armed_count}`,
+        "",
+        `Action: ${crossed.action}`,
+        "",
+        `When the engine recovers, you'll get a one-shot ✅ "Engine back online" DM.`,
+      ].join("\n"),
+      { parse_mode: "Markdown" },
+    );
+    lastAlertedAt = now;
+    lastAlertedTier = crossed;
+  } catch (err) {
+    console.warn("[engine-heartbeat-watch] DM failed:", err.message?.slice(0, 80));
+  }
+}
+
+export function startEngineHeartbeatWatcher(bot) {
+  console.log(`[engine-heartbeat-watch] started; polling every ${POLL_INTERVAL_MS / 1000}s`);
+  setTimeout(() => tick(bot).catch((e) => console.error("[engine-heartbeat-watch] tick:", e.message)), 60_000);
+  setInterval(() => tick(bot).catch((e) => console.error("[engine-heartbeat-watch] tick:", e.message)), POLL_INTERVAL_MS);
+}


### PR DESCRIPTION
## Summary

Pairs with `magpiecapital/magpie-limitclose#9` (engine heartbeat writer). The engine writes a heartbeat row each tick; this watcher polls it and DMs the operator with severity-tiered alerts if the engine goes silent.

`LIMIT_CLOSE_ENGINE_AUDIT.md` flagged this as P0 observability for the "PERFECTED" mandate. Without it, an overnight engine crash means zero fires and no notification until a user complains hours later.

## What ships

### `migrations/043_engine_heartbeats.sql`

Single-row design (id=1 per service). Engine UPSERTs each tick. Stores `last_tick_at`, `last_tick_status`, `armed_count`. Historical heartbeats are noise — purely a liveness check.

### `src/services/engine-heartbeat-watcher.js` (new)

| Stale | Alert |
|---|---|
| 5 min | 🟡 WARN — "Check Railway logs" |
| 15 min | 🟠 CRITICAL — "Likely crashed or restart loop" |
| 30 min | 🔴 EMERGENCY — "Armed orders not processing. Restart NOW." |

- Polls every 60s (tunable via `ENGINE_HEARTBEAT_WATCH_MS`)
- Same-tier dedupe (no re-spam unless 6h passed OR severity escalated)
- Recovery: one-shot ✅ "Engine back online" DM when last_tick_at goes fresh again
- Returns silently when no row exists yet (brand-new deploy before engine writes first heartbeat) — doesn't false-alert

## Test plan

- [x] `node --check` passes
- [ ] Apply migration on bot deploy
- [ ] After engine PR #9 deploys: `SELECT * FROM engine_heartbeats` shows id=1 with `last_tick_at` updating every poll interval
- [ ] Stop engine: WARN DM lands at ~5 min
- [ ] Continue silence: CRITICAL at 15 min, EMERGENCY at 30 min
- [ ] Restart engine: ✅ recovery DM lands, alert state clears