### PR TITLE
feat(tiers): wire loan-tier-resolver into simulate + unlock (#108 follow-up)

### DIFF
--- a/src/commands/simulate.js
+++ b/src/commands/simulate.js
@@ -6,12 +6,7 @@
  */
 import { query } from "../db/pool.js";
 import { getPriceInSol } from "../services/price.js";
-
-const TIERS = {
-  1: { ltv: 30, days: 2, feeBps: 300, label: "Express" },
-  2: { ltv: 25, days: 3, feeBps: 200, label: "Quick" },
-  3: { ltv: 20, days: 7, feeBps: 150, label: "Standard" },
-};
+import { getEligibleTiers } from "../services/loan-tier-resolver.js";
 
 function usage(ctx) {
   return ctx.reply(
@@ -30,7 +25,7 @@ export async function handleSimulate(ctx) {
   if (!Number.isFinite(amount) || amount <= 0) return usage(ctx);
 
   const { rows } = await query(
-    `SELECT mint, symbol, name, decimals FROM supported_mints
+    `SELECT mint, symbol, name, decimals, category FROM supported_mints
      WHERE enabled = TRUE AND (UPPER(symbol) = UPPER($1) OR mint = $1)
      LIMIT 1`,
     [arg],
@@ -61,6 +56,16 @@ export async function handleSimulate(ctx) {
 
   const collateralValueSol = amount * priceSol;
 
+  // Resolve tier set by category. RWA (stock/etf/metal) returns the
+  // higher-LTV / longer-term / higher-fee schedule out of rwa_loan_tiers;
+  // memecoin (and uncategorized) gets MEMECOIN_TIERS. Same resolver as
+  // borrow.js so /simulate previews match what /borrow will actually offer.
+  const resolved = await getEligibleTiers({ category: token.category });
+  // User-facing tier picker is 1-indexed; resolver returns option-indexed.
+  // Build the same lookup shape simulate.js historically used: {1, 2, 3}.
+  const TIERS = {};
+  resolved.forEach((t, i) => { TIERS[String(i + 1)] = t; });
+
   const tierList = tierStr ? [TIERS[tierStr]].filter(Boolean) : Object.values(TIERS);
   if (tierList.length === 0) return usage(ctx);
 
@@ -78,8 +83,13 @@ export async function handleSimulate(ctx) {
     const fee = gross * (t.feeBps / 10_000);
     const receive = gross - fee;
     const liquidationPriceSol = (gross / 1.1) / amount; // price at which ratio drops to 1.1x
+    // Resolver-built labels for RWA already include LTV/days/fee; strip
+    // them out of the header line so we don't double-print.
+    const headerLabel = (t.label && t.label.includes("LTV"))
+      ? t.label.replace(/.*\(([^)]+)\).*/, "$1") || t.label
+      : t.label;
     lines.push(
-      `*${t.ltv}% LTV · ${t.days}d (${t.label})*`,
+      `*${t.ltv}% LTV · ${t.days}d (${headerLabel})*`,
       `  Receive:     ${receive.toFixed(6)} SOL`,
       `  Repay:       ${gross.toFixed(6)} SOL`,
       `  Liq. price:  ${liquidationPriceSol.toFixed(9)} SOL/token`,
@@ -94,8 +104,9 @@ export async function handleSimulate(ctx) {
   // Estimated memecoin sell slippage: assume 2% as a conservative midpoint.
   // (Long-tail tokens often 5%+, larger ones <1%; 2% is fair averaged.)
   const ESTIMATED_SELL_SLIPPAGE_PCT = 2.0;
-  // Hardest tier (Standard 20% LTV / 1.5% fee) for the comparison
-  const standardTier = TIERS["3"];
+  // "Hardest" tier — last in the resolved set (typically longest-term + lowest LTV
+  // for memecoin = Standard; for RWA = RWA Standard at 70% LTV / 30d / 5% fee).
+  const standardTier = resolved[resolved.length - 1];
   const standardGross = collateralValueSol * (standardTier.ltv / 100);
   const standardFee = standardGross * (standardTier.feeBps / 10_000);
   const sellSlippageCost = collateralValueSol * (ESTIMATED_SELL_SLIPPAGE_PCT / 100);

--- a/src/commands/unlock.js
+++ b/src/commands/unlock.js
@@ -16,14 +16,18 @@ import { ensureWallet } from "../services/wallet.js";
 import { getSupportedBalances } from "../services/deposits.js";
 import { collateralValueLamports } from "../services/price.js";
 import { getLoanLimits } from "../services/loan-limits.js";
+import { getEligibleTiers, MEMECOIN_TIERS } from "../services/loan-tier-resolver.js";
 
-const TIERS = [
-  { name: "Express",  ltv: 30, days: 2, feeBps: 300 },
-  { name: "Quick",    ltv: 25, days: 3, feeBps: 200 },
-  { name: "Standard", ltv: 20, days: 7, feeBps: 150 },
-];
-
-const STANDARD = TIERS[2]; // safest recommended tier
+// Memecoin-tier shape for the headline "Standard tier" framing. Mixed-
+// category holdings (some memecoin, some RWA) get headlined as memecoin
+// Standard since that's the conservative case; per-holding lines below
+// resolve each token's correct tier set.
+const STANDARD = {
+  name: MEMECOIN_TIERS[2].label.split(" ")[0] || "Standard",
+  ltv: MEMECOIN_TIERS[2].ltv,
+  days: MEMECOIN_TIERS[2].days,
+  feeBps: MEMECOIN_TIERS[2].feeBps,
+};
 
 function fmtSol(n) {
   if (n < 0.001) return "<0.001";
@@ -71,7 +75,10 @@ export async function handleUnlock(ctx) {
     );
   }
 
-  // Compute borrow potential for each token
+  // Compute borrow potential for each token. Resolve per-token tiers so
+  // RWA holdings show their higher-LTV ladder while memecoins show the
+  // existing 30/25/20 ladder. getSupportedBalances exposes `category`
+  // since the tier-resolver wiring (PR #108).
   const enriched = await Promise.all(balances.map(async (b) => {
     let valueLamports = null;
     try {
@@ -82,35 +89,43 @@ export async function handleUnlock(ctx) {
       );
     } catch { /* fall through */ }
     const valueSol = valueLamports != null ? Number(valueLamports) / 1e9 : null;
+    const tierSet = await getEligibleTiers({ category: b.category });
     return {
       ...b,
       valueSol,
+      tierSet,
       // Borrow at each tier (post-fee receive)
       tiers: valueSol != null
-        ? TIERS.map((t) => {
+        ? tierSet.map((t) => {
             const gross = valueSol * (t.ltv / 100);
             const fee = gross * (t.feeBps / 10_000);
-            return { ...t, receiveSol: gross - fee, repaySol: gross };
+            return {
+              name: t.label.split(" ")[0] || t.label,
+              ltv: t.ltv, days: t.days, feeBps: t.feeBps,
+              receiveSol: gross - fee, repaySol: gross,
+            };
           })
         : null,
     };
   }));
 
-  // Rank by Standard-tier receive (the safest recommended)
+  // Rank by last-tier-in-set (safest = lowest LTV for memecoin, highest
+  // for RWA — both represent the longest-term "safest" option per category).
+  const safestIdx = (e) => e.tiers ? e.tiers.length - 1 : 0;
   enriched.sort((a, b) => {
-    const av = a.tiers ? a.tiers[2].receiveSol : -1;
-    const bv = b.tiers ? b.tiers[2].receiveSol : -1;
+    const av = a.tiers ? a.tiers[safestIdx(a)].receiveSol : -1;
+    const bv = b.tiers ? b.tiers[safestIdx(b)].receiveSol : -1;
     return bv - av;
   });
 
-  // Total potential on Standard tier (with per-wallet limits respected)
+  // Total potential on each holding's last tier (with per-wallet limits respected)
   const limits = await getLoanLimits(user.id);
   const maxOutstandingSol = Number(limits.maxOutstanding) / 1e9;
   const availableSol = Number(limits.availableToBorrow) / 1e9;
 
   const totalPotentialSol = enriched.reduce((acc, e) => {
     if (!e.tiers) return acc;
-    return acc + e.tiers[2].receiveSol;
+    return acc + e.tiers[safestIdx(e)].receiveSol;
   }, 0);
   // What they could ACTUALLY borrow given limits
   const realisticPotentialSol = Math.min(totalPotentialSol, availableSol);
@@ -140,12 +155,14 @@ export async function handleUnlock(ctx) {
       shown++;
       continue;
     }
-    const std = t.tiers[2];
+    // Use first + last in the resolved set so the line works for both
+    // memecoin (Express/Standard) and RWA (RWA Express/RWA Standard).
+    const std = t.tiers[t.tiers.length - 1];
     if (std.receiveSol < 0.001) continue; // skip dust
     const expr = t.tiers[0];
     lines.push(
       `• *${t.symbol}* — \`${t.humanAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}\` tokens`,
-      `  → Up to \`${fmtSol(std.receiveSol)} SOL\` (Standard) · \`${fmtSol(expr.receiveSol)} SOL\` (Express)`,
+      `  → Up to \`${fmtSol(std.receiveSol)} SOL\` (${std.name}) · \`${fmtSol(expr.receiveSol)} SOL\` (${expr.name})`,
     );
     shown++;
   }


### PR DESCRIPTION
## Summary

Closes task #150 from the earlier todo. PR #108 wired the loan-tier-resolver into `borrow.js`, `api/agent.js`, and `commands/price.js`. This PR covers the last two callsites that still showed hardcoded memecoin tiers for RWA holdings.

## What ships

### `src/commands/simulate.js`

- `/simulate <symbol> <amount> [tier]` previewer
- Now resolves the token's category from `supported_mints` and uses `getEligibleTiers` to build the tier-picker map
- "Why borrow instead of sell?" wedge now uses the resolver's LAST tier (memecoin Standard 20% / RWA Standard 70%) so the comparison reflects the actual best tier the user could pick

### `src/commands/unlock.js`

- `/unlock` "what could I borrow against my bags?" lister
- **Per-holding resolution** — each balance's category drives its tier set, so a wallet with mixed memecoin + RWA holdings shows accurate potential for each
- Sort + total still use "last tier" but per-holding (no global hardcoded index 2 anymore)
- Display labels now come from the resolved tier (e.g. "RWA Standard" vs "Standard")
- Headline "Standard tier" framing kept for the memecoin-conservative case; per-holding lines below show the actual resolved tier per token

## Out of scope

`services/community-pip.js` system prompt copy mentions hardcoded numbers. Pip's prompt assembly would need a dynamic-from-DB lookup. Defer to a Pip-prompt iteration.

## Test plan

- [x] `node --check` passes on both files
- [ ] After deploy: `/simulate BONK 1000` shows memecoin Express/Quick/Standard ladder (unchanged)
- [ ] `/simulate SPCX 0.5` shows RWA Express/Quick/Standard ladder once RWA tiers seeded
- [ ] `/unlock` for a wallet with mixed BONK + SPCX shows BONK at memecoin Standard and SPCX at RWA Standard
- [ ] `/unlock` empty-wallet path unchanged