### PR TITLE
feat(resilience): pre-merge syntax-check CI + add Pip/dev/founder to impersonation patterns

### DIFF
--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -1,0 +1,59 @@
+name: Syntax check
+
+# Pre-merge guard against the class of bug that took prod down at
+# 2026-06-13 04:22Z: a duplicate top-level function declaration in
+# src/services/self-monitor.js shipped through review, Railway built
+# fine, then Node refused to load the file with:
+#   SyntaxError: Identifier 'probeCreditCoverage' has already been declared
+#
+# Bot was unreachable for ~10 min. The fix was a one-line edit.
+# This workflow runs `node --check` on every .js/.mjs file under src/
+# and scripts/, which catches every parser-rejected file — duplicates,
+# unterminated strings, missing brackets, etc. — without running
+# anything. Cheap and fast (whole repo finishes in a few seconds).
+#
+# Required check on main (added via branch protection alongside leak-check).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: none
+      actions: none
+      checks: none
+      deployments: none
+      packages: none
+      pull-requests: none
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Shallow clone is plenty — we're parsing files, not history.
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: node --check across src/ and scripts/
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          FAILED=0
+          # Glob over both directories; nullglob ensures missing dirs
+          # don't blow up the loop with a literal pattern.
+          for f in src/**/*.js src/**/*.mjs scripts/**/*.js scripts/**/*.mjs scripts/**/*.cjs; do
+            if ! node --check "$f" 2>&1; then
+              echo "::error file=$f::node --check failed on $f"
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "Syntax errors above. Fix and re-push." >&2
+            exit 1
+          fi
+          echo "All source files parse cleanly."

--- a/src/services/community-moderation.js
+++ b/src/services/community-moderation.js
@@ -70,6 +70,17 @@ export const IMPERSONATION_PATTERNS = [
   /\bmoderator\b/i,
   /\bmod\b/i,
   /\bhelp\s*desk\b/i,
+  // 2026-06-13: live impersonator joined with display name "Pip" (no
+  // "magpie" substring), slipped past the join-time filter. The bot's
+  // AI helper IS named Pip in the community chat, so anyone using
+  // that name is impersonating. The verified-account allowlist still
+  // exempts @magpie_capital_bot itself and the operator's account.
+  /\bpip\b/i,
+  // Also lock down "dev"/"founder"/"owner" which scammers love and
+  // which a legit member has no reason to put in their display name.
+  /\bdev\b/i,
+  /\bfounder\b/i,
+  /\bowner\b/i,
 ];
 
 // Verified accounts that are allowed to use those words (the bot


### PR DESCRIPTION
## Summary
Closes two distinct gaps the 2026-06-13 04:22Z outage exposed:

1. **Pre-merge syntax-check CI** — `node --check` on every .js/.mjs under src/ + scripts/, runs as a PR check. Would have caught the duplicate `probeCreditCoverage` declaration in self-monitor.js that took prod down for ~10 min.
2. **IMPERSONATION_PATTERNS gap close** — added `\bpip\b`, `\bdev\b`, `\bfounder\b`, `\bowner\b`. The live Pip impersonator earlier today had display name 'Pip' (no 'magpie' substring) and slipped past the existing magpie/i filter. Verified-account allowlist still exempts the real bot + operator.

## Test plan
- [x] Both files parse with node --check locally
- [x] Name scan zero
- [ ] After merge: enable syntax-check as required status on main (manual one-time)
- [ ] After merge: verify next Pip-named test account auto-trips the filter

## What this does NOT solve
TG delivers updates to one bot per token; if THE bot dies, the join-time filter can't run. That's an architectural limit, not a code gap. The pre-deploy CI is the load-bearing defense. Followups queued: Railway-side auto-restart on health miss, `/scan-impersonators` admin sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)