### PR TITLE
feat(x402): /api/v1/internal/agent/limit-close/preflight — free dry-run for agents

### DIFF
--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -441,6 +441,205 @@ export async function handleAgentLimitCloseGet(req, params) {
 }
 
 /**
+ * POST /api/v1/internal/agent/limit-close/preflight
+ *
+ * Same body shape as /arm. Runs every gate armOrder runs (collateral
+ * allowlist, runArmPreflight, immediate-fire guard, SL solvency floor,
+ * liquidity bump derivation) but does NOT INSERT a row and does NOT
+ * count against the per-user concurrency cap.
+ *
+ * Why this exists: agents pay x402 per /arm call. A rejected /arm
+ * burns the agent's fee with no value back. /preflight is FREE (no
+ * x402 ladder on the magpie-x402 side) and lets the agent ask "would
+ * this exact arm succeed right now?" — economically rational for
+ * agents to call before paying.
+ *
+ * Returns the same { ok: true, ... } shape as /arm on success and the
+ * same error codes on failure. The only difference is dryRun=true is
+ * surfaced in the response so the agent can distinguish a preflight
+ * result from a real arm.
+ *
+ * The preflight check is a strong hint, not a contractual reservation.
+ * Liquidity can shift between preflight and arm, so a successful
+ * preflight does NOT guarantee a subsequent arm will succeed. Agents
+ * should still be prepared to handle arm-time rejections.
+ */
+export async function handleAgentLimitClosePreflight(req) {
+  if (!INTERNAL_API_TOKEN) {
+    return { status: 503, body: { error: "service_not_configured" } };
+  }
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  // No agentArmDisabled() check here — preflight is read-only and
+  // returning useful info even while the kill switch is on lets
+  // agents know to back off cleanly.
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch {
+    return { status: 400, body: { error: "Invalid JSON body" } };
+  }
+
+  // Same shape parsing as /arm. Default direction 'above' for back-compat.
+  const userWallet       = String(body?.user_wallet ?? "");
+  const agentPubkey      = String(body?.agent_pubkey ?? "");
+  const loanIdRaw        = String(body?.loan_id ?? "");
+  const triggerKind      = String(body?.trigger_kind ?? "");
+  const triggerDirection = String(body?.trigger_direction ?? "above");
+  const triggerValueMicroRaw = String(body?.trigger_value_micro ?? "");
+  const slippageBpsRaw   = body?.slippage_bps;
+  const sellDestination  = String(body?.sell_destination ?? "sol").toLowerCase();
+  const expiresAt        = body?.expires_at ? String(body.expires_at) : null;
+  const autoEscalateRaw  = body?.auto_escalate_slippage;
+  const autoEscalate     = autoEscalateRaw === true;
+
+  // Shape validation (same set as /arm)
+  if (!isValidPubkey(userWallet))  return bad("invalid_user_wallet");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+  if (!/^\d+$/.test(loanIdRaw))    return bad("invalid_loan_id");
+  if (!VALID_TRIGGER_KINDS.has(triggerKind)) return bad("invalid_trigger_kind");
+  if (!VALID_TRIGGER_DIRECTIONS.has(triggerDirection)) return bad("invalid_trigger_direction");
+  if (!/^\d+$/.test(triggerValueMicroRaw))   return bad("invalid_trigger_value");
+  let triggerValueMicro;
+  try { triggerValueMicro = BigInt(triggerValueMicroRaw); } catch { return bad("invalid_trigger_value"); }
+  if (triggerValueMicro < MIN_TRIGGER_VALUE_MICRO || triggerValueMicro > MAX_TRIGGER_VALUE_MICRO) {
+    return bad("trigger_value_out_of_range");
+  }
+  if (!Number.isInteger(slippageBpsRaw) || slippageBpsRaw < 10 || slippageBpsRaw > MAX_INITIAL_SLIPPAGE_BPS_PROTOCOL) {
+    return bad("invalid_slippage_bps");
+  }
+  const slippageBps = slippageBpsRaw;
+  if (!VALID_DESTINATIONS.has(sellDestination)) return bad("invalid_sell_destination");
+  if (expiresAt && Number.isNaN(Date.parse(expiresAt))) return bad("invalid_expires_at");
+
+  // Delegation lookup (same auth model as /arm)
+  const { rows: [delegation] } = await query(
+    `SELECT id,
+            max_per_order_lamports::text AS max_per_order_lamports,
+            max_active_orders,
+            max_slippage_bps,
+            expires_at,
+            user_id
+       FROM agent_delegations
+      WHERE user_wallet = $1
+        AND agent_pubkey = $2
+        AND action = 'limit_close'
+        AND status = 'active'`,
+    [userWallet, agentPubkey],
+  );
+  if (!delegation) {
+    return { status: 403, body: { error: "no_active_delegation" } };
+  }
+  if (delegation.expires_at && new Date(delegation.expires_at) < new Date()) {
+    return { status: 403, body: { error: "delegation_expired" } };
+  }
+
+  // Wallet binding + loan owed lookup (same as /arm)
+  const { rows: [walletGuard] } = await query(
+    `SELECT l.loan_id::text AS loan_id_chain,
+            l.original_loan_amount_lamports::text AS owed
+       FROM loans l
+       JOIN wallets w ON w.user_id = l.user_id AND w.public_key = $1
+      WHERE l.user_id = $2 AND l.loan_id = $3`,
+    [userWallet, delegation.user_id, loanIdRaw],
+  );
+  if (!walletGuard) {
+    return { status: 404, body: { error: "loan_not_found_for_wallet" } };
+  }
+
+  // Delegation BOUNDS (same as /arm)
+  if (BigInt(walletGuard.owed) > BigInt(delegation.max_per_order_lamports)) {
+    return {
+      status: 403,
+      body: {
+        error: "order_exceeds_delegation_cap",
+        loan_owed_lamports: walletGuard.owed,
+        max_per_order_lamports: delegation.max_per_order_lamports,
+      },
+    };
+  }
+  if (slippageBps > delegation.max_slippage_bps) {
+    return {
+      status: 403,
+      body: {
+        error: "slippage_exceeds_delegation_cap",
+        requested_bps: slippageBps,
+        max_allowed_bps: delegation.max_slippage_bps,
+      },
+    };
+  }
+  // Note: per-agent concurrency cap is INTENTIONALLY skipped on preflight
+  // for the same reason armOrder skips user concurrency in dryRun — a
+  // preflight is a question, not a slot commitment.
+
+  // Hand off to armOrder() in dryRun mode
+  const capBps = autoEscalate ? delegation.max_slippage_bps : slippageBps;
+  const armResult = await armOrder({
+    userId: delegation.user_id,
+    source: "agent_x402",
+    sourceAgentPubkey: agentPubkey,
+    loanIdChain: loanIdRaw,
+    triggerKind,
+    triggerValueMicro,
+    triggerDirection,
+    slippageBps,
+    sellDestination,
+    expiresAt,
+    autoEscalate,
+    capBps,
+    preflightProtocolFeeBps: 100,
+    dryRun: true,
+  });
+
+  if (!armResult.ok) {
+    const status = ARM_ERROR_STATUS[armResult.error] || 409;
+    return {
+      status,
+      body: {
+        ok: false,
+        preflight: true,
+        error: armResult.error,
+        ...(armResult.detail != null ? { detail: armResult.detail } : {}),
+        ...(armResult.suggestedSlippageBps != null
+          ? { suggested_slippage_bps: armResult.suggestedSlippageBps,
+              your_slippage_bps: armResult.yourSlippageBps,
+              cap_used_for_check_bps: capBps }
+          : {}),
+      },
+    };
+  }
+
+  const appliedInitialBps   = armResult.initialSlippageBpsApplied;
+  const originalRequestedBps = armResult.initialSlippageBpsRequested;
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      preflight: true,
+      would_arm: true,
+      loan_id: walletGuard.loan_id_chain,
+      trigger_kind: triggerKind,
+      trigger_value_micro: triggerValueMicro.toString(),
+      slippage_bps: appliedInitialBps,
+      sell_destination: sellDestination,
+      auto_escalate_slippage: autoEscalate,
+      max_slippage_bps_cap: capBps,
+      initial_slippage_bps: appliedInitialBps,
+      // Same liquidity-bump surfacing as /arm
+      ...(appliedInitialBps !== originalRequestedBps
+        ? {
+            slippage_bps_requested: originalRequestedBps,
+            liquidity_floor_bps: armResult.liquidityTierFloorBps,
+            liquidity_usd: armResult.liquidityUsd,
+          }
+        : {}),
+    },
+  };
+}
+
+/**
  * GET /api/v1/internal/agent/limit-close/list?agent=<pubkey>&status=<armed|all>
  *
  * List orders armed by this agent. Default status filter is 'armed'

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1470,6 +1470,7 @@ const PUBLIC_ROUTES = new Set([
   // the inbound agent_pubkey on this path BECAUSE the token gate
   // proves it came from the x402 service.
   "/api/v1/internal/agent/limit-close/arm",
+  "/api/v1/internal/agent/limit-close/preflight",
   "/api/v1/internal/agent/limit-close",
   "/api/v1/internal/agent/limit-close/list",
   "/api/v1/internal/agent/limit-close/delegations",
@@ -1737,6 +1738,11 @@ async function router(req, res) {
       case "/api/v1/internal/agent/limit-close/arm": {
         const { handleAgentLimitCloseArm } = await import("./internal-agent-limitclose.js");
         result = await handleAgentLimitCloseArm(req);
+        break;
+      }
+      case "/api/v1/internal/agent/limit-close/preflight": {
+        const { handleAgentLimitClosePreflight } = await import("./internal-agent-limitclose.js");
+        result = await handleAgentLimitClosePreflight(req);
         break;
       }
       case "/api/v1/internal/agent/limit-close/list": {

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -127,6 +127,16 @@ export async function armOrder({
   capBps = null,
   preflightProtocolFeeBps = 100,
   armNote = null,
+  // dryRun: run every validation and gate but skip the INSERT and
+  // skip the per-user concurrency cap (a dry-run is a question, not
+  // a commitment of a slot). Used by the agent x402 preflight
+  // endpoint so agents can confirm an arm would succeed before
+  // paying. Returns the same ok/error shape as a real arm —
+  // callers can treat dryRun success exactly like a live arm
+  // would-have-succeeded. Setting dryRun=true does NOT enqueue
+  // notifications either (none happen in armOrder anyway today,
+  // but the contract holds).
+  dryRun = false,
 }) {
   // ── Shape validation ─────────────────────────────────────────
   if (!VALID_TRIGGER_KINDS.has(triggerKind)) {
@@ -290,13 +300,18 @@ export async function armOrder({
   } catch { /* fail-open: engine is the source of truth */ }
 
   // ── Per-user concurrency cap ────────────────────────────────
-  const { rows: [activeCount] } = await query(
-    `SELECT COUNT(*)::int AS n FROM limit_close_orders
-       WHERE user_id = $1 AND status = 'armed'`,
-    [userId],
-  );
-  if (activeCount.n >= MAX_ACTIVE_ORDERS_PER_USER) {
-    return { ok: false, error: "user_concurrency_cap_reached", detail: { active: activeCount.n, cap: MAX_ACTIVE_ORDERS_PER_USER } };
+  // Skipped in dryRun mode — a preflight is a question not a slot
+  // commitment, and the agent might be running this to decide which
+  // of several candidate orders to actually arm.
+  if (!dryRun) {
+    const { rows: [activeCount] } = await query(
+      `SELECT COUNT(*)::int AS n FROM limit_close_orders
+         WHERE user_id = $1 AND status = 'armed'`,
+      [userId],
+    );
+    if (activeCount.n >= MAX_ACTIVE_ORDERS_PER_USER) {
+      return { ok: false, error: "user_concurrency_cap_reached", detail: { active: activeCount.n, cap: MAX_ACTIVE_ORDERS_PER_USER } };
+    }
   }
 
   // ── Pre-flight Jupiter quote ────────────────────────────────
@@ -364,7 +379,31 @@ export async function armOrder({
     }
   }
 
-  // ── INSERT ──
+  // ── INSERT (skipped in dryRun) ──
+  // In dryRun mode all the gates above passed and we return ok=true
+  // without persisting any state. The caller (typically the agent
+  // preflight endpoint) treats this as "yes, a real arm with these
+  // exact params would succeed right now." Note that 'right now' is
+  // a momentary fact — liquidity can shift between preflight and
+  // arm. Agents should treat preflight as a strong hint, not a
+  // contractual reservation.
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      orderId: null,
+      armedAt: null,
+      loan,
+      mint: mintRow,
+      preflightAdvisory: advisory,
+      initialSlippageBpsRequested: originalInitialBps,
+      initialSlippageBpsApplied: appliedInitialBps,
+      liquidityTierFloorBps: liquidityFloorBps,
+      liquidityUsd: liqUsd,
+      triggerDirection,
+    };
+  }
+
   let inserted;
   try {
     inserted = await query(


### PR DESCRIPTION
Free preflight endpoint for x402 agents. Runs every gate /arm runs in dryRun mode and returns 200 with would_arm=true if a real arm would succeed, or the same error codes on failure. Saves agents x402 fees on rejected arms. armOrder() gained a dryRun flag. Generated with Claude Code