### PR TITLE
feat(lc-perf): engine_metrics_hourly + Engine activity section

### DIFF
--- a/migrations/045_engine_metrics_hourly.sql
+++ b/migrations/045_engine_metrics_hourly.sql
@@ -1,0 +1,57 @@
+-- migration 045: engine_metrics_hourly — per-tick engine activity rollups.
+--
+-- engine_heartbeats answers "is the engine alive right now?" and is
+-- a single-row (id=1) liveness signal. That doesn't tell the operator
+-- "how busy was the engine this week", "how often did Jupiter fail",
+-- or "how many fires were attempted vs succeeded".
+--
+-- This table is the historical view. Engine UPSERTs the row for the
+-- current hour bucket on every tick, accumulating counters. /lc-perf
+-- reads this for the "Engine activity (last 7d)" section.
+--
+-- Why hourly buckets (not per-tick rows): a 30s poll generates 2880
+-- rows/day per service. That's 86k rows/month per service. Hourly
+-- rollups are 24 rows/day = 720/month — three orders of magnitude
+-- smaller storage for the same operator-facing question. Sub-hourly
+-- granularity isn't useful for the kinds of questions /lc-perf
+-- answers (success rate over a window, average activity per day).
+--
+-- Counters are CUMULATIVE within the hour: the engine reads the
+-- existing row, adds its tick's delta, and UPSERTs back. RACE-FREE
+-- via the same atomic UPSERT pattern engine_heartbeats uses — single
+-- engine process per service today; if we ever scale horizontally,
+-- switch to `INSERT … ON CONFLICT (hour, service) DO UPDATE SET col =
+-- col + EXCLUDED.col` so two concurrent ticks accumulate safely.
+
+CREATE TABLE IF NOT EXISTS engine_metrics_hourly (
+  hour                     TIMESTAMPTZ NOT NULL,
+  service                  TEXT        NOT NULL,
+  ticks                    INTEGER     NOT NULL DEFAULT 0,
+  jupiter_probes_ok        INTEGER     NOT NULL DEFAULT 0,
+  jupiter_probes_failed    INTEGER     NOT NULL DEFAULT 0,
+  armed_orders_evaluated   INTEGER     NOT NULL DEFAULT 0,
+  fires_attempted          INTEGER     NOT NULL DEFAULT 0,
+  fires_succeeded          INTEGER     NOT NULL DEFAULT 0,
+  fires_failed             INTEGER     NOT NULL DEFAULT 0,
+  fires_reverted           INTEGER     NOT NULL DEFAULT 0,
+  errors                   INTEGER     NOT NULL DEFAULT 0,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (hour, service)
+);
+
+-- Hot-path read pattern for /lc-perf:
+--   SELECT ... FROM engine_metrics_hourly
+--    WHERE service = 'limit_close_watcher' AND hour > NOW() - INTERVAL '...'
+--    ORDER BY hour DESC
+-- The PK covers (hour, service) but the operator's filter starts with
+-- service. This index supports the desired access pattern.
+CREATE INDEX IF NOT EXISTS engine_metrics_hourly_service_hour_idx
+  ON engine_metrics_hourly(service, hour DESC);
+
+COMMENT ON TABLE engine_metrics_hourly IS
+  'Per-hour activity rollups for external engines (e.g.
+   limit_close_watcher). Engine UPSERTs the current hour bucket each
+   tick, accumulating counters. Read by /lc-perf for historical
+   activity. Hourly granularity caps row count; sub-hourly noise
+   isn''t useful at this surface.';

--- a/src/commands/lc-perf.js
+++ b/src/commands/lc-perf.js
@@ -160,6 +160,52 @@ async function showPerf(ctx, windowKey) {
       LIMIT 5`,
   );
 
+  // ── Engine activity (from engine_metrics_hourly) ──
+  // engine_metrics_hourly has the per-hour rollups the engine writes
+  // every tick. Without this, /lc-perf goes silent during quiet
+  // periods — even though the engine has been ticking faithfully.
+  // The "ticks" column is the proof-of-life number; jupiter probe
+  // success rate is the proof-of-health number.
+  let engineSummary = null;
+  try {
+    const engineWindow = win.interval
+      ? ` AND hour > NOW() - INTERVAL '${win.interval}'`
+      : "";
+    const { rows: [eng] } = await query(
+      `SELECT COALESCE(SUM(ticks), 0)::bigint::text                 AS ticks,
+              COALESCE(SUM(jupiter_probes_ok), 0)::bigint::text     AS jup_ok,
+              COALESCE(SUM(jupiter_probes_failed), 0)::bigint::text AS jup_fail,
+              COALESCE(SUM(armed_orders_evaluated), 0)::bigint::text AS evaluated,
+              COALESCE(SUM(fires_attempted), 0)::bigint::text       AS fires_attempted,
+              COALESCE(SUM(fires_succeeded), 0)::bigint::text       AS fires_succeeded,
+              COALESCE(SUM(fires_failed), 0)::bigint::text          AS fires_failed,
+              COALESCE(SUM(fires_reverted), 0)::bigint::text        AS fires_reverted,
+              COALESCE(SUM(errors), 0)::bigint::text                AS errors,
+              MIN(hour)                                              AS earliest_hour,
+              MAX(hour)                                              AS latest_hour
+         FROM engine_metrics_hourly
+        WHERE service = 'limit_close_watcher' ${engineWindow}`,
+    );
+    if (eng && Number(eng.ticks) > 0) {
+      const jupTotal = Number(eng.jup_ok) + Number(eng.jup_fail);
+      const jupRate  = jupTotal > 0
+        ? ((Number(eng.jup_ok) / jupTotal) * 100).toFixed(2)
+        : "—";
+      // Activity span — useful when the window straddles a deploy or restart.
+      let span = "n/a";
+      if (eng.earliest_hour && eng.latest_hour) {
+        const spanMs = new Date(eng.latest_hour).getTime() - new Date(eng.earliest_hour).getTime();
+        const spanH  = Math.max(1, Math.round(spanMs / 3_600_000));
+        span = spanH < 24 ? `${spanH}h` : `${Math.round(spanH / 24)}d`;
+      }
+      engineSummary = { eng, jupRate, span };
+    }
+  } catch (err) {
+    // engine_metrics_hourly may not exist yet on a fresh deploy — log
+    // and continue. /lc-perf still renders the order-driven sections.
+    console.warn("[lc-perf] engine_metrics_hourly read failed:", err.message?.slice(0, 80));
+  }
+
   const lines = [
     `*Limit-close performance — ${win.label}*`,
     "",
@@ -196,6 +242,19 @@ async function showPerf(ctx, windowKey) {
     lines.push("_/lc-perf failures for the full breakdown._");
   } else {
     lines.push("*No failures in this window.* ✓");
+  }
+
+  if (engineSummary) {
+    const { eng, jupRate, span } = engineSummary;
+    lines.push("");
+    lines.push(`*Engine activity (rollup span: ${span}):*`);
+    lines.push(`• Ticks:              ${Number(eng.ticks).toLocaleString()}`);
+    lines.push(`• Jupiter probe rate: *${jupRate}%* (${Number(eng.jup_ok)} ok / ${Number(eng.jup_fail)} failed)`);
+    lines.push(`• Orders evaluated:   ${Number(eng.evaluated).toLocaleString()}`);
+    lines.push(`• Fires attempted:    ${Number(eng.fires_attempted)} → ${Number(eng.fires_succeeded)} ok · ${Number(eng.fires_failed)} fail · ${Number(eng.fires_reverted)} revert`);
+    if (Number(eng.errors) > 0) {
+      lines.push(`• Tick errors:        ${Number(eng.errors)}`);
+    }
   }
 
   await ctx.reply(lines.join("\n"), { parse_mode: "Markdown", disable_web_page_preview: true });


### PR DESCRIPTION
Closes the lc-perf-goes-silent-during-quiet-periods gap. Migration adds engine_metrics_hourly table. /lc-perf renders new Engine activity section with ticks, Jupiter probe rate, fires breakdown. Hourly granularity caps row count (720/month/service vs 86k for per-tick). Engine-side writer lands in magpie-limitclose paired PR. Silently omits the section if the table is empty so it ships safely before the engine PR. Generated with Claude Code