### PR TITLE
feat(lc-status): engine sub-pane reads heartbeat + activity rollups

### DIFF
--- a/src/commands/lc-status.js
+++ b/src/commands/lc-status.js
@@ -196,20 +196,79 @@ async function showFailed(ctx) {
 }
 
 async function showEngine(ctx) {
-  // Watcher heartbeats + topup wallet balance + RPC health probe.
-  // Most engine state lives in the magpie-limitclose service, not this
-  // bot, so we report indirect signals: when did orders last transition,
-  // and is the price-attestor still ticking (sister service we DO own).
+  // Operator-facing snapshot of every engine signal we know about.
+  // The engine itself runs in magpie-limitclose; we surface the
+  // DB-mediated signals here so the operator can answer "is it alive
+  // and healthy" without leaving Telegram.
   const { rows: [recentArm] } = await query(
     `SELECT MAX(armed_at) AS last_arm FROM limit_close_orders`,
   );
   const { rows: [recentTransition] } = await query(
     `SELECT MAX(updated_at) AS last_transition FROM limit_close_orders`,
   );
+
+  // Heartbeat row (proof-of-life; the bot's heartbeat-watcher alerts
+  // off this same row but here we just render it).
+  let heartbeatLine = "_heartbeat row missing — engine never wrote, or migration not applied_";
+  try {
+    const { rows: [hb] } = await query(
+      `SELECT last_tick_at, last_tick_status, armed_count
+         FROM engine_heartbeats
+        WHERE id = 1 AND service = 'limit_close_watcher'`,
+    );
+    if (hb) {
+      const statusBadge = hb.last_tick_status === "ok" ? "ok" : `*${hb.last_tick_status}*`;
+      heartbeatLine = `${ageStr(hb.last_tick_at)} ago · status=${statusBadge} · ${hb.armed_count} armed`;
+    }
+  } catch { /* table may not exist yet on a brand-new deploy */ }
+
+  // engine_metrics_hourly recent rollups — last hour + last 24h
+  let metricsLines = [];
+  try {
+    const { rows: [last1h] } = await query(
+      `SELECT COALESCE(SUM(ticks), 0)::int                  AS ticks,
+              COALESCE(SUM(jupiter_probes_ok), 0)::int      AS jup_ok,
+              COALESCE(SUM(jupiter_probes_failed), 0)::int  AS jup_fail,
+              COALESCE(SUM(fires_attempted), 0)::int        AS fires_attempted,
+              COALESCE(SUM(fires_succeeded), 0)::int        AS fires_succeeded,
+              COALESCE(SUM(fires_failed), 0)::int           AS fires_failed,
+              COALESCE(SUM(errors), 0)::int                 AS errors
+         FROM engine_metrics_hourly
+        WHERE service = 'limit_close_watcher'
+          AND hour > NOW() - INTERVAL '1 hour'`,
+    );
+    const { rows: [last24h] } = await query(
+      `SELECT COALESCE(SUM(ticks), 0)::int                  AS ticks,
+              COALESCE(SUM(jupiter_probes_ok), 0)::int      AS jup_ok,
+              COALESCE(SUM(jupiter_probes_failed), 0)::int  AS jup_fail,
+              COALESCE(SUM(fires_attempted), 0)::int        AS fires_attempted,
+              COALESCE(SUM(fires_succeeded), 0)::int        AS fires_succeeded
+         FROM engine_metrics_hourly
+        WHERE service = 'limit_close_watcher'
+          AND hour > NOW() - INTERVAL '24 hours'`,
+    );
+    const jup1h    = last1h.jup_ok + last1h.jup_fail;
+    const jup24h   = last24h.jup_ok + last24h.jup_fail;
+    const jup1hPct = jup1h > 0
+      ? `${((last1h.jup_ok / jup1h) * 100).toFixed(1)}%`
+      : "n/a";
+    const jup24hPct = jup24h > 0
+      ? `${((last24h.jup_ok / jup24h) * 100).toFixed(1)}%`
+      : "n/a";
+    if (last1h.ticks > 0 || last24h.ticks > 0) {
+      metricsLines = [
+        "",
+        "*Activity rollups:*",
+        `1h:  ${last1h.ticks} ticks · jup ${jup1hPct} · fires ${last1h.fires_attempted}→${last1h.fires_succeeded}ok${last1h.errors ? ` · err ${last1h.errors}` : ""}`,
+        `24h: ${last24h.ticks} ticks · jup ${jup24hPct} · fires ${last24h.fires_attempted}→${last24h.fires_succeeded}ok`,
+      ];
+    }
+  } catch { /* table may not exist yet */ }
+
   // Topup wallet balance (operator funds for fee/repay topup).
   let topupBalance = "—";
   try {
-    const { Connection, PublicKey, Keypair } = await import("@solana/web3.js");
+    const { Connection, Keypair } = await import("@solana/web3.js");
     const bs58 = (await import("bs58")).default;
     const secret = process.env.ENGINE_TOPUP_KEYPAIR;
     if (secret) {
@@ -221,14 +280,17 @@ async function showEngine(ctx) {
   } catch (err) {
     topupBalance = `error: ${err.message?.slice(0, 60)}`;
   }
+
   const lines = [
-    "🔧 *Engine state*",
+    "*Engine state*",
     "",
+    `Heartbeat:       ${heartbeatLine}`,
     `Last arm:        ${recentArm?.last_arm ? `${ageStr(recentArm.last_arm)} ago` : "*never*"}`,
     `Last transition: ${recentTransition?.last_transition ? `${ageStr(recentTransition.last_transition)} ago` : "*never*"}`,
     `Topup wallet:    ${topupBalance}`,
+    ...metricsLines,
     "",
-    "_Engine itself runs in the `magpie-limitclose` Railway service. SSH there for tick-level watcher logs._",
+    "_Run `/lc-perf` for full historical analytics. Engine itself runs in `magpie-limitclose` Railway service._",
   ];
   await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
 }


### PR DESCRIPTION
/lc-status engine now surfaces engine_heartbeats (last_tick_at + status + armed count) and engine_metrics_hourly 1h/24h rollups (ticks/jup probes/fires). Operator's quick-look becomes: /lc-status (current state) + /lc-status engine (live + healthy?) + /lc-perf (historical trend). Graceful fallbacks if tables don't exist yet. Generated with Claude Code