### PR TITLE
feat(canary): engine_canary_runs migration + bot watcher

### DIFF
--- a/migrations/046_engine_canary_runs.sql
+++ b/migrations/046_engine_canary_runs.sql
@@ -1,0 +1,52 @@
+-- migration 046: engine_canary_runs — periodic end-to-end engine validation.
+--
+-- Why this exists
+-- The engine's boot-time preflight validates dependencies once. The
+-- per-tick Jupiter probe validates the price oracle. But there's no
+-- ongoing validation that the FULL fire path (price reads + Jupiter
+-- quote sizing + cross-source agreement + borrower-balance math +
+-- SL-solvency floor + program reachability) actually works end-to-
+-- end against current market conditions.
+--
+-- This table receives one row per canary run. Engine writes; bot
+-- watcher reads. Without it the operator only finds out the engine
+-- is broken when a real fire fails — exactly the "find out from a
+-- user" pattern the operator banned.
+--
+-- Each row captures the OUTCOME of one synthetic fire-path run:
+-- which checks passed/failed, computed numbers, total duration. No
+-- on-chain action is taken — this is pure read-side simulation.
+--
+-- Bot's canary-watcher polls this table and DMs the operator if
+-- consecutive runs fail. Distinct from engine_heartbeats (liveness)
+-- and engine_metrics_hourly (activity rollups) — canary is the
+-- "would a fire succeed RIGHT NOW" signal.
+
+CREATE TABLE IF NOT EXISTS engine_canary_runs (
+  id                BIGSERIAL    PRIMARY KEY,
+  run_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  service           TEXT         NOT NULL,
+  overall_ok        BOOLEAN      NOT NULL,
+  duration_ms       INTEGER      NOT NULL,
+  -- Per-check results: name → { ok, detail, ms? }. JSONB so the
+  -- check set can grow without schema changes.
+  checks            JSONB        NOT NULL,
+  -- Convenience top-level columns for the most-watched signals so
+  -- the bot watcher can index them without JSON ops on every read.
+  jupiter_ok        BOOLEAN,
+  dexscreener_ok    BOOLEAN,
+  cross_source_ok   BOOLEAN,
+  program_ok        BOOLEAN,
+  template_loan_id  BIGINT,
+  notes             TEXT
+);
+
+-- Hot read pattern: latest run per service for the bot watcher.
+CREATE INDEX IF NOT EXISTS engine_canary_runs_service_run_at_idx
+  ON engine_canary_runs(service, run_at DESC);
+
+COMMENT ON TABLE engine_canary_runs IS
+  'Periodic end-to-end engine validation results. Engine writes
+   one row per canary tick (default every hour). Bot reads to alert
+   on consecutive failures. Distinct from engine_heartbeats
+   (liveness) and engine_metrics_hourly (activity).';

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,7 @@ import { startInfraHealth } from "./services/infra-health.js";
 import { startLimitCloseStalenessWatcher } from "./services/limit-close-staleness-watcher.js";
 import { registerLcStalenessCallbacks } from "./handlers/lc-staleness-callbacks.js";
 import { startImpersonatorWatchdog } from "./services/impersonator-watchdog.js";
+import { startCanaryWatcher } from "./services/canary-watcher.js";
 import { startNeonSync } from "./services/neon-sync.js";
 import { registerTxErrorCallbacks } from "./services/tx-error-callbacks.js";
 import { startAiAgentHealth } from "./services/ai-agent-health.js";
@@ -810,6 +811,11 @@ bot.start({
     // after the live incident). Defense-in-depth on top of the
     // real-time on-join filter.
     setTimeout(() => startImpersonatorWatchdog(bot), 95_000);
+    // Canary watcher — reads engine_canary_runs (written by the
+    // engine every hour) and DMs operator on consecutive failures.
+    // The actual canary RUNS in the magpie-limitclose engine; this
+    // is the bot-side observation surface.
+    setTimeout(() => startCanaryWatcher(bot), 105_000);
     // Auto-Protect — opt-in anti-liquidation. Watches every 90s.
     setTimeout(() => startAutoProtect(bot), 50_000);
     // Conditional-borrow watcher — fires agent intents when their

--- a/src/services/canary-watcher.js
+++ b/src/services/canary-watcher.js
@@ -1,0 +1,162 @@
+/**
+ * Canary watcher — reads engine_canary_runs and alerts the operator
+ * on consecutive failures.
+ *
+ * Pairs with magpie-limitclose/src/canary.js which writes one row
+ * per canary tick (default every hour). The watcher polls every
+ * POLL_INTERVAL_MS and surfaces the operator-relevant signals:
+ *
+ *   - 2 consecutive failures → WARN ("canary degraded")
+ *   - 3+ consecutive failures → CRITICAL ("canary blocked — fires
+ *     would likely fail right now")
+ *   - Recovery from any failure tier → one-shot "recovered" DM
+ *   - Canary row stale > 3h → engine not running canaries
+ *     (different from engine_heartbeats staleness but related; this
+ *     watcher only alerts on canary-specific staleness so we don't
+ *     duplicate the heartbeat watcher's alerts)
+ *
+ * Distinct from engine-heartbeat-watcher (liveness) and the existing
+ * status-aware alerts (Jupiter degraded) — canary is the highest-
+ * confidence "would a real fire succeed RIGHT NOW" signal because it
+ * runs the actual fire-path reads, not just dependency pings.
+ */
+import { query } from "../db/pool.js";
+import { getAdminId } from "./admin-notify.js";
+
+const POLL_INTERVAL_MS = Number(process.env.CANARY_WATCH_INTERVAL_MS) || 5 * 60_000; // 5min
+const STALE_THRESHOLD_MS = Number(process.env.CANARY_STALE_THRESHOLD_MS) || 3 * 60 * 60_000; // 3h
+const WARN_CONSEC_FAILS = 2;
+const CRIT_CONSEC_FAILS = 3;
+const ALERT_RE_NOTIFY_MS = 6 * 60 * 60_000; // re-alert every 6h if still degraded
+
+let lastAlertedTier = null;
+let lastAlertedAt = 0;
+let lastStalenessAlertedAt = 0;
+
+function fmtAgeMs(ms) {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${Math.round(ms / 3_600_000)}h`;
+}
+
+async function tick(bot) {
+  const adminId = getAdminId();
+  if (!adminId || !bot) return;
+
+  // Pull the most recent N canary runs to compute consecutive-fails
+  // window. CRIT requires 3 consecutive failures so we read 5 to be
+  // safe.
+  let rows;
+  try {
+    const r = await query(
+      `SELECT id, run_at, overall_ok, duration_ms, checks
+         FROM engine_canary_runs
+        WHERE service = 'limit_close_watcher'
+        ORDER BY run_at DESC
+        LIMIT 5`,
+    );
+    rows = r.rows;
+  } catch (err) {
+    console.warn("[canary-watch] read failed:", err.message?.slice(0, 80));
+    return;
+  }
+
+  // Staleness check first — if the engine hasn't written a canary
+  // row in over STALE_THRESHOLD_MS, that's an "engine not running
+  // canaries" signal. Distinct from heartbeat staleness.
+  const newestAt = rows[0]?.run_at ? new Date(rows[0].run_at).getTime() : 0;
+  const staleness = newestAt ? Date.now() - newestAt : null;
+  if (staleness != null && staleness > STALE_THRESHOLD_MS) {
+    const now = Date.now();
+    if (now - lastStalenessAlertedAt > ALERT_RE_NOTIFY_MS) {
+      try {
+        await bot.api.sendMessage(
+          adminId,
+          [
+            `*Canary stale*`,
+            "",
+            `Last engine canary run: ${fmtAgeMs(staleness)} ago.`,
+            `Threshold: ${fmtAgeMs(STALE_THRESHOLD_MS)}.`,
+            "",
+            `The engine should be writing a canary row hourly. If this is stale, the canary scheduler stopped (separately from the heartbeat). Check engine logs for [canary] entries.`,
+          ].join("\n"),
+          { parse_mode: "Markdown" },
+        );
+        lastStalenessAlertedAt = now;
+      } catch (err) {
+        console.warn("[canary-watch] staleness DM failed:", err.message?.slice(0, 80));
+      }
+    }
+    return;
+  }
+
+  if (rows.length === 0) {
+    // No rows yet — engine hasn't written its first canary. Could
+    // be a brand-new deploy. Skip silently.
+    return;
+  }
+
+  // Count consecutive failures at the head of the result list.
+  let consecFails = 0;
+  for (const r of rows) {
+    if (r.overall_ok) break;
+    consecFails++;
+  }
+
+  // Recovery — were we in a degraded state and now the latest run is OK?
+  if (rows[0].overall_ok && lastAlertedTier) {
+    try {
+      await bot.api.sendMessage(
+        adminId,
+        `Canary recovered — latest run OK. (was alerted at ${lastAlertedTier}.)`,
+        { parse_mode: "Markdown" },
+      );
+      lastAlertedTier = null;
+    } catch { /* silent */ }
+    return;
+  }
+
+  if (consecFails < WARN_CONSEC_FAILS) return;
+
+  const tier = consecFails >= CRIT_CONSEC_FAILS ? "CRITICAL" : "WARN";
+  const tierEscalated = lastAlertedTier === "WARN" && tier === "CRITICAL";
+  const now = Date.now();
+  const elapsedSinceAlert = now - lastAlertedAt;
+  if (!tierEscalated && lastAlertedTier === tier && elapsedSinceAlert < ALERT_RE_NOTIFY_MS) return;
+
+  // Build a single-line summary of the failing checks from the latest run.
+  const latestChecks = rows[0].checks || {};
+  const failingChecks = Object.entries(latestChecks)
+    .filter(([, v]) => v && !v.ok)
+    .map(([k, v]) => `${k} (${v.detail?.slice(0, 60) || "no detail"})`)
+    .join("; ");
+
+  try {
+    await bot.api.sendMessage(
+      adminId,
+      [
+        `*Canary ${tier} — ${consecFails} consecutive failures*`,
+        "",
+        `The engine's fire-path canary has failed ${consecFails} runs in a row. A real fire would likely fail right now.`,
+        "",
+        `Failing checks on the latest run:`,
+        failingChecks || "(no per-check details)",
+        "",
+        tier === "CRITICAL"
+          ? `Action: investigate immediately. Likely root causes — Jupiter outage, RPC degraded, supported_mints config rotated, or borrower wallet decryption broken.`
+          : `Action: keep an eye on the next canary. If it fails again the tier escalates to CRITICAL.`,
+      ].join("\n"),
+      { parse_mode: "Markdown" },
+    );
+    lastAlertedTier = tier;
+    lastAlertedAt = now;
+  } catch (err) {
+    console.warn("[canary-watch] alert DM failed:", err.message?.slice(0, 80));
+  }
+}
+
+export function startCanaryWatcher(bot) {
+  console.log(`[canary-watch] armed — polling every ${POLL_INTERVAL_MS / 60_000} min`);
+  setTimeout(() => tick(bot).catch((e) => console.warn("[canary-watch] tick:", e.message?.slice(0, 80))), 60_000);
+  setInterval(() => tick(bot).catch((e) => console.warn("[canary-watch] tick:", e.message?.slice(0, 80))), POLL_INTERVAL_MS);
+}


### PR DESCRIPTION
Bot-side half of the synthetic-canary system. Pairs with magpie-limitclose engine PR. Adds migration 046 + watcher that DMs operator on 2/3 consecutive failures and on canary staleness. Distinct from engine_heartbeats (liveness) and engine_metrics_hourly (activity). Generated with Claude Code