### PR TITLE
feat(limit-close): in-place order modification — no cancel/re-arm gap

### DIFF
--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -27,7 +27,7 @@
  */
 import { query } from "../db/pool.js";
 import { constantTimeEqual } from "./auth-utils.js";
-import { armOrder } from "../services/limit-close-arm-core.js";
+import { armOrder, modifyOrder } from "../services/limit-close-arm-core.js";
 
 const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN || "";
 
@@ -686,6 +686,89 @@ export async function handleAgentLimitCloseList(req, params) {
  * uses — the engine flips status to 'firing' before doing any
  * on-chain work, so once 'firing' the cancel is too late.
  */
+/**
+ * PATCH /api/v1/internal/agent/limit-close/modify
+ *
+ * Body: { id: <order_id>, trigger_value_micro?, slippage_bps?,
+ *         sell_destination?, expires_at? }
+ *
+ * Agent identity: X-Agent-Pubkey header (same scoping as /list /get).
+ * Internal-token gated. Calls into the shared modifyOrder() so the
+ * agent path applies the same gates as the TG/site /modifyorder.
+ *
+ * Why agents need modify: an agent that arms a TP at $0.0030 and the
+ * market moves wants to push to $0.0040 without re-paying the x402
+ * arm fee. Modify is free (no x402) — the agent already paid for
+ * the slot at arm time.
+ */
+export async function handleAgentLimitCloseModify(req) {
+  if (!INTERNAL_API_TOKEN) {
+    return { status: 503, body: { error: "service_not_configured" } };
+  }
+  if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
+    return { status: 401, body: { error: "Invalid or missing API key" } };
+  }
+  let body;
+  try { body = await readJsonBody(req); }
+  catch { return { status: 400, body: { error: "Invalid JSON body" } }; }
+
+  const agentPubkey = String(req.headers["x-agent-pubkey"] || body?.agent_pubkey || "");
+  const orderIdRaw  = String(body?.id ?? "");
+  if (!isValidPubkey(agentPubkey)) return bad("invalid_agent_pubkey");
+  if (!/^\d+$/.test(orderIdRaw))   return bad("invalid_order_id");
+
+  // Optional fields — passed through to modifyOrder when present.
+  const updates = {};
+  if (body?.trigger_value_micro !== undefined) {
+    const v = String(body.trigger_value_micro);
+    if (!/^\d+$/.test(v)) return bad("invalid_trigger_value");
+    updates.triggerValueMicro = v;
+  }
+  if (body?.slippage_bps !== undefined) {
+    if (!Number.isInteger(body.slippage_bps)) return bad("invalid_slippage_bps");
+    updates.slippageBps = body.slippage_bps;
+  }
+  if (body?.sell_destination !== undefined) {
+    updates.sellDestination = String(body.sell_destination).toLowerCase();
+  }
+  if (body?.expires_at !== undefined) {
+    if (body.expires_at !== null) updates.expiresAt = String(body.expires_at);
+    else updates.expiresAt = null;
+  }
+  if (Object.keys(updates).length === 0) {
+    return bad("no_changes_supplied");
+  }
+
+  const result = await modifyOrder({
+    orderId: Number(orderIdRaw),
+    sourceAgentPubkey: agentPubkey,
+    ...updates,
+  });
+  if (!result.ok) {
+    const status = ARM_ERROR_STATUS[result.error] || 409;
+    return {
+      status,
+      body: {
+        error: result.error,
+        ...(result.detail ? { detail: result.detail } : {}),
+      },
+    };
+  }
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      order_id: result.order.id,
+      changed_fields: result.changedFields,
+      trigger_value_micro: result.order.trigger_value_micro,
+      slippage_bps: result.order.slippage_bps,
+      sell_destination: result.order.sell_destination,
+      expires_at: result.order.expires_at,
+      updated_at: result.order.updated_at,
+    },
+  };
+}
+
 export async function handleAgentLimitCloseDelete(req, params) {
   if (!constantTimeEqual(req.headers["x-internal-token"], INTERNAL_API_TOKEN)) {
     return { status: 401, body: { error: "Invalid or missing API key" } };

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1471,6 +1471,7 @@ const PUBLIC_ROUTES = new Set([
   // proves it came from the x402 service.
   "/api/v1/internal/agent/limit-close/arm",
   "/api/v1/internal/agent/limit-close/preflight",
+  "/api/v1/internal/agent/limit-close/modify",
   "/api/v1/internal/agent/limit-close",
   "/api/v1/internal/agent/limit-close/list",
   "/api/v1/internal/agent/limit-close/delegations",
@@ -1743,6 +1744,11 @@ async function router(req, res) {
       case "/api/v1/internal/agent/limit-close/preflight": {
         const { handleAgentLimitClosePreflight } = await import("./internal-agent-limitclose.js");
         result = await handleAgentLimitClosePreflight(req);
+        break;
+      }
+      case "/api/v1/internal/agent/limit-close/modify": {
+        const { handleAgentLimitCloseModify } = await import("./internal-agent-limitclose.js");
+        result = await handleAgentLimitCloseModify(req);
         break;
       }
       case "/api/v1/internal/agent/limit-close/list": {

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -597,6 +597,134 @@ export async function handleLimitOrders(ctx) {
   });
 }
 
+/* ─── /modifyorder ─────────────────────────────────────────────── */
+
+/**
+ * /modifyorder <order_id> price=0.0030 slip=3% dest=usdc expires=2026-06-30
+ *
+ * All but order_id are optional — pass only what's changing. The
+ * order stays armed throughout (no cancel/re-arm gap where the
+ * market can move past the trigger).
+ *
+ * Accepted shortcuts (mirror /takeprofit):
+ *   price=<usd_per_token>     — sets trigger_value_micro for price_usd
+ *   mc=<$130M | 130_000_000>  — sets trigger_value_micro for mc_usd
+ *   slip=<2%|200bps|200>       — sets slippage_bps
+ *   dest=<sol|usdc>            — sets sell_destination
+ *   expires=<YYYY-MM-DD|ISO>   — sets expires_at, or "none" to clear
+ *
+ * To change trigger_kind, trigger_direction, or loan_id: use /cancel + /takeprofit.
+ */
+export async function handleModifyLimitOrder(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const text = ctx.message?.text ?? "";
+  const parts = text.trim().split(/\s+/).slice(1);
+  if (parts.length < 1 || !/^\d+$/.test(parts[0])) {
+    return ctx.reply(
+      [
+        "Usage: `/modifyorder <order_id> <changes…>`",
+        "",
+        "Examples:",
+        "• `/modifyorder 412 price=0.0030`",
+        "• `/modifyorder 412 slip=3% dest=usdc`",
+        "• `/modifyorder 412 expires=2026-06-30`",
+        "• `/modifyorder 412 expires=none` (clear expiration)",
+        "",
+        "_Order stays armed — no cancel/re-arm gap._",
+      ].join("\n"),
+      { parse_mode: "Markdown" },
+    );
+  }
+
+  const orderId = Number(parts[0]);
+  const args = parts.slice(1);
+  const user = await upsertUser(tgUser.id, tgUser.username);
+
+  // Parse kv args
+  const updates = {};
+  for (const a of args) {
+    const m = a.match(/^([a-z_]+)=(.+)$/i);
+    if (!m) return ctx.reply(`Couldn't parse \`${a}\` — use \`key=value\` form.`, { parse_mode: "Markdown" });
+    const key = m[1].toLowerCase();
+    const val = m[2];
+    if (key === "price") {
+      const usd = parseFloat(val);
+      if (!Number.isFinite(usd) || usd <= 0) return ctx.reply(`\`price=${val}\` is invalid.`, { parse_mode: "Markdown" });
+      updates.triggerValueMicro = BigInt(Math.round(usd * 1e6)).toString();
+    } else if (key === "mc") {
+      // Accept "130M", "130_000_000", "$130000000"
+      const raw = val.replace(/[$_,]/g, "").toLowerCase();
+      let usd;
+      if (raw.endsWith("b")) usd = parseFloat(raw) * 1e9;
+      else if (raw.endsWith("m")) usd = parseFloat(raw) * 1e6;
+      else if (raw.endsWith("k")) usd = parseFloat(raw) * 1e3;
+      else usd = parseFloat(raw);
+      if (!Number.isFinite(usd) || usd <= 0) return ctx.reply(`\`mc=${val}\` is invalid.`, { parse_mode: "Markdown" });
+      updates.triggerValueMicro = BigInt(Math.round(usd * 1e6)).toString();
+    } else if (key === "slip") {
+      let bps;
+      if (val.endsWith("%")) bps = Math.round(parseFloat(val) * 100);
+      else if (val.endsWith("bps")) bps = Math.round(parseFloat(val));
+      else bps = Math.round(parseFloat(val));
+      if (!Number.isFinite(bps) || bps < 10) return ctx.reply(`\`slip=${val}\` is invalid.`, { parse_mode: "Markdown" });
+      updates.slippageBps = bps;
+    } else if (key === "dest") {
+      const v = val.toLowerCase();
+      if (v !== "sol" && v !== "usdc") return ctx.reply(`\`dest=${val}\` must be sol or usdc.`, { parse_mode: "Markdown" });
+      updates.sellDestination = v;
+    } else if (key === "expires") {
+      if (val.toLowerCase() === "none") updates.expiresAt = null;
+      else if (Number.isNaN(Date.parse(val))) return ctx.reply(`\`expires=${val}\` couldn't be parsed.`, { parse_mode: "Markdown" });
+      else updates.expiresAt = new Date(val).toISOString();
+    } else {
+      return ctx.reply(`Unknown field \`${key}\`. Supported: price, mc, slip, dest, expires.`, { parse_mode: "Markdown" });
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return ctx.reply("No changes supplied. See /modifyorder for usage.", { parse_mode: "Markdown" });
+  }
+
+  const { modifyOrder } = await import("../services/limit-close-arm-core.js");
+  const result = await modifyOrder({
+    orderId,
+    userId: user.id,
+    ...updates,
+  });
+  if (!result.ok) {
+    const friendly = {
+      not_modifiable_or_not_found: "That order isn't yours, or it's already firing / closed.",
+      invalid_trigger_value: "Trigger value is out of range.",
+      invalid_slippage_bps: "Slippage must be 10–2500 bps (0.1%–25%).",
+      slippage_exceeds_order_cap: result.detail
+        ? `Slippage above this order's cap (${(result.detail.cap_bps / 100).toFixed(2)}%). Cancel + re-arm if you need more headroom.`
+        : "Slippage above this order's cap. Cancel + re-arm if you need more.",
+      invalid_sell_destination: "Destination must be sol or usdc.",
+      invalid_expires_at: "Expires couldn't be parsed.",
+      trigger_would_fire_immediately: "That new trigger would fire RIGHT NOW. Pick a target on the unfired side.",
+      no_changes_supplied: "No changes supplied.",
+    };
+    return ctx.reply(friendly[result.error] || `Modify failed: \`${result.error}\``, { parse_mode: "Markdown" });
+  }
+
+  const o = result.order;
+  return ctx.reply(
+    [
+      `*Order #${o.id} updated.*`,
+      "",
+      `Changed: ${result.changedFields.join(", ")}`,
+      o.trigger_value_micro ? `New trigger: \`${o.trigger_value_micro}\` micros` : null,
+      `Slippage: ${(o.slippage_bps / 100).toFixed(2)}%`,
+      `Destination: ${(o.sell_destination || "").toUpperCase()}`,
+      o.expires_at ? `Expires: ${new Date(o.expires_at).toISOString().slice(0, 10)}` : "Expires: never",
+      "",
+      "_Order stays armed — engine picks up new values on its next tick._",
+    ].filter(Boolean).join("\n"),
+    { parse_mode: "Markdown" },
+  );
+}
+
 /* ─── /cancellimitorder ────────────────────────────────────────── */
 
 export async function handleCancelLimitOrder(ctx) {

--- a/src/index.js
+++ b/src/index.js
@@ -384,6 +384,10 @@ bot.command("crosspost", handleCommunityCrosspost);
   bot.command("cancellimitorder", lc.handleCancelLimitOrder);
   bot.command("canceltp", lc.handleCancelLimitOrder);
   bot.command("cancelsl", lc.handleCancelLimitOrder);
+  // In-place order modification — change trigger / slippage / dest /
+  // expires without canceling. Order stays armed throughout so users
+  // can fine-tune without a market-move gap.
+  bot.command(["modifyorder", "modifylimitorder", "lcmodify", "lc_modify"], lc.handleModifyLimitOrder);
 
   // Layer 3 — intervention callback handler (inline keyboard taps).
   // Registers a bot.callbackQuery(/^lcint:/) handler that processes

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -463,6 +463,217 @@ export async function armOrder({
 }
 
 /**
+ * Modify an armed order in place — change trigger value, slippage,
+ * sell destination, or expires_at without canceling first.
+ *
+ * Why this exists
+ * ───────────────
+ * Before: a user who wanted to adjust their trigger had to /cancel
+ * then /takeprofit again. That left a small window where the market
+ * could move past their old trigger before the new arm landed. The
+ * UX nudged users away from fine-tuning — bad for "set it and forget
+ * it" + bad for the order-perfection mandate.
+ *
+ * After: a single UPDATE call. The order stays armed throughout; the
+ * engine sees the new values on its next tick. No window.
+ *
+ * What CAN be modified
+ *   trigger_value_micro  — change the price target
+ *   slippage_bps         — tighten or loosen
+ *   sell_destination     — swap between sol/usdc
+ *   expires_at           — extend or set a new auto-cancel
+ *
+ * What CAN'T
+ *   trigger_kind         — switching mc_usd ↔ price_usd ↔ price_sol
+ *                          changes the units. Force cancel + re-arm
+ *                          to avoid silent unit mismatches.
+ *   trigger_direction    — TP ↔ SL is a semantic change too risky to
+ *                          smuggle through a modify endpoint.
+ *   loan_id              — different loan = different order; cancel + arm
+ *
+ * Re-validates the new values against the same gates armOrder()
+ * applied at original arm time: immediate-fire guard, SL solvency
+ * floor (for SL direction), slippage bounds, expires_at parse,
+ * trigger value range. If any new value violates a gate, the modify
+ * fails and the existing order continues unchanged.
+ *
+ * Concurrency: WHERE status='armed' makes a race with the engine's
+ * atomic claim safe. If the engine flipped status='firing' between
+ * read and write, the UPDATE matches zero rows and returns
+ * not_modifiable_or_not_found — caller treats that as "too late, the
+ * order is firing already".
+ *
+ * Scoping: same model as cancelOrder — user_id for TG/site paths,
+ * source_agent_pubkey for the x402 agent path.
+ */
+export async function modifyOrder({
+  orderId,
+  userId = null,
+  sourceAgentPubkey = null,
+  // Each modifiable field is OPTIONAL. Caller passes only what's
+  // changing. Undefined fields are left untouched on the row.
+  triggerValueMicro,
+  slippageBps,
+  sellDestination,
+  expiresAt,
+}) {
+  // ── Load current order state for re-validation ─────────────
+  const conditions = ["status = 'armed'"];
+  const params = [orderId];
+  let p = 2;
+  if (userId != null) {
+    conditions.push(`user_id = $${p++}`);
+    params.push(userId);
+  }
+  if (sourceAgentPubkey != null) {
+    conditions.push(`source = 'agent_x402' AND source_agent_pubkey = $${p++}`);
+    params.push(sourceAgentPubkey);
+  }
+
+  const { rows: [current] } = await query(
+    `SELECT id, user_id, loan_id,
+            trigger_kind, trigger_value_micro::text AS trigger_value_micro,
+            COALESCE(trigger_direction, 'above') AS trigger_direction,
+            slippage_bps, sell_destination, expires_at,
+            max_slippage_bps_cap, source, source_agent_pubkey
+       FROM limit_close_orders
+      WHERE id = $1 AND ${conditions.join(" AND ")}`,
+    params,
+  );
+  if (!current) return { ok: false, error: "not_modifiable_or_not_found" };
+
+  // ── Shape validation per modifiable field ───────────────────
+  const updates = {};
+
+  if (triggerValueMicro !== undefined) {
+    let bi;
+    try { bi = BigInt(triggerValueMicro); } catch { return { ok: false, error: "invalid_trigger_value" }; }
+    if (bi < MIN_TRIGGER_VALUE_MICRO || bi > MAX_TRIGGER_VALUE_MICRO) {
+      return { ok: false, error: "trigger_value_out_of_range" };
+    }
+    updates.trigger_value_micro = bi.toString();
+  }
+  if (slippageBps !== undefined) {
+    if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > MAX_INITIAL_SLIPPAGE_BPS) {
+      return { ok: false, error: "invalid_slippage_bps" };
+    }
+    // Slippage cannot exceed the order's existing cap. The cap was set
+    // at arm time from delegation / derived headroom; loosening past
+    // it would silently widen user consent.
+    if (current.max_slippage_bps_cap != null && slippageBps > Number(current.max_slippage_bps_cap)) {
+      return {
+        ok: false,
+        error: "slippage_exceeds_order_cap",
+        detail: { requested: slippageBps, cap_bps: Number(current.max_slippage_bps_cap) },
+      };
+    }
+    updates.slippage_bps = slippageBps;
+  }
+  if (sellDestination !== undefined) {
+    if (!VALID_DESTINATIONS.has(sellDestination)) {
+      return { ok: false, error: "invalid_sell_destination" };
+    }
+    updates.sell_destination = sellDestination;
+  }
+  if (expiresAt !== undefined) {
+    if (expiresAt !== null && Number.isNaN(Date.parse(expiresAt))) {
+      return { ok: false, error: "invalid_expires_at" };
+    }
+    updates.expires_at = expiresAt;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { ok: false, error: "no_changes_supplied" };
+  }
+
+  // ── Immediate-fire re-check (best-effort) for new trigger ───
+  // Mirrors armOrder's guard. Skips for price_sol (denominator moves)
+  // and fails-open on oracle hiccup — engine re-checks at fire time.
+  if (updates.trigger_value_micro && (current.trigger_kind === "mc_usd" || current.trigger_kind === "price_usd")) {
+    try {
+      const { getPriceInUsdCrossSourced } = await import("./price.js");
+      // We need the collateral mint for the price read. Pull from the
+      // loan row tied to this order.
+      const { rows: [loan] } = await query(
+        `SELECT collateral_mint FROM loans WHERE id = $1`,
+        [current.loan_id],
+      );
+      if (loan) {
+        const currentUsd = await getPriceInUsdCrossSourced(loan.collateral_mint);
+        if (currentUsd && currentUsd > 0) {
+          let currentMicros = null;
+          if (current.trigger_kind === "price_usd") {
+            currentMicros = BigInt(Math.round(currentUsd * 1e6));
+          }
+          // mc_usd would need supply; skip if not trivially derivable —
+          // engine still catches at fire time.
+          if (currentMicros != null) {
+            const newBi = BigInt(updates.trigger_value_micro);
+            if (current.trigger_direction === "above" && newBi <= currentMicros) {
+              return { ok: false, error: "trigger_would_fire_immediately", detail: { direction: "above" } };
+            }
+            if (current.trigger_direction === "below" && newBi >= currentMicros) {
+              return { ok: false, error: "trigger_would_fire_immediately", detail: { direction: "below" } };
+            }
+          }
+        }
+      }
+    } catch { /* fail-open: engine re-checks at fire time */ }
+  }
+
+  // ── UPDATE ───────────────────────────────────────────────────
+  // Build a parameterized UPDATE. WHERE status='armed' is the race
+  // guard. RETURNING gives us the post-update row.
+  const setParts = [];
+  const updateParams = [];
+  let up = 1;
+  for (const [col, val] of Object.entries(updates)) {
+    setParts.push(`${col} = $${up++}`);
+    updateParams.push(val);
+  }
+  setParts.push("updated_at = NOW()");
+  // Audit note appended so /lc-status armed shows that the order was modified.
+  const noteSuffix = ` modified ${new Date().toISOString().slice(0, 19)}Z (${Object.keys(updates).join(",")})`;
+  setParts.push(`notes = COALESCE(notes, '') || $${up++}`);
+  updateParams.push(noteSuffix);
+  updateParams.push(orderId);
+  const orderIdPos = up;
+
+  // Re-apply ownership guard so a stale userId or source_agent_pubkey
+  // can't bypass scope between the SELECT and the UPDATE.
+  const updateConditions = ["status = 'armed'"];
+  if (userId != null) {
+    updateConditions.push(`user_id = $${++up - 1}`);
+    updateParams.push(userId);
+    up++;
+  }
+  if (sourceAgentPubkey != null) {
+    updateConditions.push(`source = 'agent_x402' AND source_agent_pubkey = $${up - 1}`);
+    updateParams.push(sourceAgentPubkey);
+    up++;
+  }
+
+  const r = await query(
+    `UPDATE limit_close_orders
+        SET ${setParts.join(", ")}
+      WHERE id = $${orderIdPos}
+        AND ${updateConditions.join(" AND ")}
+      RETURNING id, trigger_value_micro::text AS trigger_value_micro,
+                slippage_bps, sell_destination, expires_at, updated_at`,
+    updateParams,
+  );
+  if (r.rows.length === 0) {
+    // Raced with engine flipping status to 'firing' — too late.
+    return { ok: false, error: "not_modifiable_or_not_found" };
+  }
+  return {
+    ok: true,
+    order: r.rows[0],
+    changedFields: Object.keys(updates),
+  };
+}
+
+/**
  * Cancel an armed order by ID. Scoped to a specific user OR a specific
  * agent pubkey. The UPDATE's WHERE status='armed' makes a too-late
  * cancel a 409 no-op rather than corrupting an in-flight 'firing' row.


### PR DESCRIPTION
Adds /modifyorder TG command + PATCH /api/v1/internal/agent/limit-close/modify (x402 parity). Order stays armed throughout the change so users can fine-tune without a market-move gap. Race-safe via WHERE status='armed'. Cannot bypass arm-time consent (slippage capped at existing max_slippage_bps_cap). Generated with Claude Code