### PR TITLE
feat(limit-close): allow simultaneous TP + SL on same loan

### DIFF
--- a/migrations/047_limit_close_orders_per_direction_unique.sql
+++ b/migrations/047_limit_close_orders_per_direction_unique.sql
@@ -1,0 +1,35 @@
+-- migration 047: allow ONE armed TP + ONE armed SL on the same loan.
+--
+-- Background
+-- Previously a UNIQUE partial index on (loan_id WHERE status='armed')
+-- physically capped a loan to ONE armed limit-close order at a time.
+-- That meant a borrower had to choose between take-profit OR
+-- stop-loss; they couldn't protect both sides simultaneously.
+--
+-- This migration replaces that index with a per-direction one. Now:
+--   ONE armed TP (trigger_direction='above')   +   ONE armed SL
+--   (trigger_direction='below')   on the same loan is allowed.
+--   TWO armed TPs OR TWO armed SLs on the same loan still throws —
+--   that's the intended dedupe: you can't have two TPs racing.
+--
+-- COALESCE handles legacy rows that pre-date the trigger_direction
+-- column (migration 039); they're treated as TP ('above'), matching
+-- the column DEFAULT.
+--
+-- Engine-side effect (paired magpie-limitclose change): when one
+-- order fires successfully, the loan is closed (collateral sold,
+-- repay done), so any sibling armed order on that loan must be
+-- auto-cancelled with reason='sibling_order_fired'. Without that,
+-- an SL on a TP'd-out loan would sit armed against a non-existent
+-- position. Engine handles this in markFired().
+
+DROP INDEX IF EXISTS limit_close_orders_one_armed_per_loan_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS limit_close_orders_one_armed_per_direction_idx
+  ON limit_close_orders(loan_id, COALESCE(trigger_direction, 'above'))
+  WHERE status = 'armed';
+
+COMMENT ON INDEX limit_close_orders_one_armed_per_direction_idx IS
+  'One armed limit-close order per (loan_id, trigger_direction).
+   Allows simultaneous TP + SL on the same loan. Replaces the prior
+   single-direction index from migration 025.';

--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -57,6 +57,7 @@ const ARM_ERROR_STATUS = {
   trigger_would_fire_immediately: 409,
   sl_below_solvency: 409,
   loan_already_has_active_order: 409,
+  loan_already_has_active_order_in_direction: 409,
   // concurrency → 429
   user_concurrency_cap_reached: 429,
   // server-side failures → 500

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -438,7 +438,18 @@ export async function armOrder({
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message || "")) {
-      return { ok: false, error: "loan_already_has_active_order" };
+      // Post migration 047, the UNIQUE is (loan_id, trigger_direction).
+      // The error means an armed TP already exists when caller asked
+      // for a TP, OR an armed SL already exists when caller asked for
+      // SL. The OTHER direction is still open for arming. Detail tells
+      // the caller which side they collided on so the UI can suggest
+      // "you already have a TP on this loan — modify or cancel it,
+      // OR arm a stop-loss instead".
+      return {
+        ok: false,
+        error: "loan_already_has_active_order_in_direction",
+        detail: { direction: triggerDirection },
+      };
     }
     console.error(`[arm-core] insert failed (source=${source}):`, err.message);
     return { ok: false, error: "insert_failed", detail: err.message?.slice(0, 200) };


### PR DESCRIPTION
Replaces single-direction UNIQUE with per-direction. Borrower can now hold TP+SL on same loan. Engine auto-cancels sibling on first fire. Generated with Claude Code