### PR TITLE
fix(loans): track ACTUAL on-chain received SOL per borrow + permanent watchdog

### DIFF
--- a/migrations/048_loan_actual_received_lamports.sql
+++ b/migrations/048_loan_actual_received_lamports.sql
@@ -1,0 +1,42 @@
+-- migration 048: capture the borrower's ACTUAL on-chain delta per borrow.
+--
+-- Background
+-- Today the `loans` row has:
+--   original_loan_amount_lamports  — total principal owed (what user repays)
+--   loan_amount_lamports           — principal minus protocol origination fee
+--                                    (what the DB *thinks* the user received)
+--
+-- 2026-06-13 audit found the SECOND value is overstated. The on-chain
+-- borrow flow lets account-creation rent come out of the loan
+-- proceeds (collateral vault ATA + borrower wSOL ATA, ~0.004414 SOL).
+-- That rent never appears as a DB deduction so the dashboard shows
+-- a number ~$1 higher than the borrower's wallet actually moved.
+--
+-- This migration adds a third value: actual_received_lamports — the
+-- borrower wallet's NET SOL delta on the borrow tx, fetched on-chain
+-- after the tx confirms. This is the canonical "what did you really
+-- get" number. The dashboard renders this; the existing fields stay
+-- intact for back-compat and repay math.
+--
+-- NULLable for two reasons:
+--   1. Backfill is async — a script populates historical rows after
+--      migration runs.
+--   2. RPC outage at write time leaves it NULL. The watchdog catches
+--      these later and writes the missing value.
+
+ALTER TABLE loans
+  ADD COLUMN IF NOT EXISTS actual_received_lamports NUMERIC(20, 0);
+
+CREATE INDEX IF NOT EXISTS loans_actual_received_null_idx
+  ON loans(id)
+  WHERE actual_received_lamports IS NULL;
+
+COMMENT ON COLUMN loans.actual_received_lamports IS
+  'Borrower wallet ACTUAL net SOL delta on the borrow tx (in lamports).
+   Distinct from loan_amount_lamports because it subtracts not only
+   the protocol origination fee but ALSO Solana account-creation rent
+   (collateral vault ATA + borrower wSOL ATA) that the protocol
+   silently takes from loan proceeds. The canonical "what did the
+   borrower really receive" value — render this in user-facing UI.
+   Populated by recordLoan() on insert and by the on-chain-delta
+   watchdog if the insert-time read failed.';

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -630,6 +630,7 @@ async function handleLoans(req, url) {
   const { rows: allUserRows } = await query(
     `SELECT l.id, l.loan_id, l.loan_pda, l.collateral_mint, l.collateral_amount,
             l.loan_amount_lamports, l.original_loan_amount_lamports,
+            l.actual_received_lamports,
             l.ltv_percentage, l.duration_days,
             l.start_timestamp, l.due_timestamp,
             l.status, l.tx_signature, l.updated_at, l.program_id,
@@ -672,7 +673,16 @@ async function handleLoans(req, url) {
       amount: l.collateral_amount?.toString?.() ?? null,
     },
     loan: {
+      // Legacy field (kept for back-compat with existing site code):
+      // post-protocol-fee value. Does NOT subtract Solana account-
+      // creation rent.
       amount_lamports: l.loan_amount_lamports?.toString?.() ?? null,
+      // The borrower's TRUE on-chain SOL credit on the borrow tx.
+      // Subtracts protocol fee AND Solana account-creation rent
+      // (collateral vault ATA + borrower wSOL ATA). Render THIS in
+      // user-facing "you received" UI — it matches what the user
+      // sees in their wallet.
+      actual_received_lamports: l.actual_received_lamports?.toString?.() ?? null,
       original_amount_lamports: l.original_loan_amount_lamports?.toString?.() ?? null,
       ltv_percentage: l.ltv_percentage,
       duration_days: l.duration_days,

--- a/src/index.js
+++ b/src/index.js
@@ -163,6 +163,7 @@ import { registerLcStalenessCallbacks } from "./handlers/lc-staleness-callbacks.
 import { startImpersonatorWatchdog } from "./services/impersonator-watchdog.js";
 import { startCanaryWatcher } from "./services/canary-watcher.js";
 import { startLoanProgramIdHealer } from "./services/loan-program-id-healer.js";
+import { startLoanReceivedWatchdog } from "./services/loan-received-watchdog.js";
 import { startNeonSync } from "./services/neon-sync.js";
 import { registerTxErrorCallbacks } from "./services/tx-error-callbacks.js";
 import { startAiAgentHealth } from "./services/ai-agent-health.js";
@@ -829,6 +830,13 @@ bot.start({
     // wallet-scoped filtering on the dashboard never silently drops
     // a loan due to stale/wrong program_id.
     setTimeout(() => startLoanProgramIdHealer(bot), 115_000);
+    // Loan actual-received watchdog — backfills + verifies the
+    // on-chain SOL delta per borrow row. Catches the class of bug
+    // where the dashboard shows ~$1 more "received" than the
+    // borrower's wallet actually went up by (2026-06-13 audit
+    // finding — protocol takes account-creation rent out of loan
+    // proceeds without reflecting it in loan_amount_lamports).
+    setTimeout(() => startLoanReceivedWatchdog(bot), 130_000);
     // Auto-Protect — opt-in anti-liquidation. Watches every 90s.
     setTimeout(() => startAutoProtect(bot), 50_000);
     // Conditional-borrow watcher — fires agent intents when their

--- a/src/services/loan-received-watchdog.js
+++ b/src/services/loan-received-watchdog.js
@@ -1,0 +1,184 @@
+/**
+ * Loan actual-received watchdog — fills + verifies the
+ * `actual_received_lamports` column on every borrow row.
+ *
+ * Two responsibilities
+ * ──────────────────────
+ *
+ * 1. **Backfill**: for any loan with `actual_received_lamports IS NULL`
+ *    AND `tx_signature IS NOT NULL`, read the tx, compute the
+ *    borrower's true SOL credit (post-balance delta + signer tx fee),
+ *    and UPDATE the column. Catches:
+ *      - Historical rows (pre migration 048)
+ *      - Rows where the write-time read in recordLoan() failed
+ *        (RPC blip, tx still propagating at insert time)
+ *
+ * 2. **Drift verification**: for a sample of recent loans, re-read
+ *    the on-chain delta and compare to the stored value. If they
+ *    disagree beyond NETWORK_RENT_TOLERANCE, alert the operator —
+ *    means the program changed account-creation costs, OR the row
+ *    was written wrong, OR an on-chain compaction happened. This
+ *    catches the EXACT class of bug the 2026-06-13 audit found.
+ *
+ * Why these are in one watchdog
+ * ──────────────────────────────
+ * Both jobs need to look up the same transactions and apply the same
+ * delta math. Splitting them would duplicate the on-chain reads.
+ *
+ * Cadence
+ * ───────
+ * Default 5 min between cycles. Backfill batch size is small (10 per
+ * cycle) so a large backlog drains gradually without slamming Helius.
+ * Drift sample is 5 most-recent loans per cycle.
+ */
+import { Connection, PublicKey } from "@solana/web3.js";
+import { query } from "../db/pool.js";
+
+const RUN_INTERVAL_MS = Number(process.env.LOAN_RECEIVED_WATCHDOG_INTERVAL_MS) || 5 * 60_000;
+const BACKFILL_BATCH = Number(process.env.LOAN_RECEIVED_BACKFILL_BATCH) || 10;
+const DRIFT_SAMPLE = Number(process.env.LOAN_RECEIVED_DRIFT_SAMPLE) || 5;
+const NETWORK_RENT_TOLERANCE_LAMPORTS = Number(process.env.LOAN_RECEIVED_TOLERANCE) || 50_000; // 0.00005 SOL
+const RPC_GAP_MS = 500;
+const FIRST_DELAY_MS = 3 * 60_000;
+
+let _timer = null;
+let _connection = null;
+function getConnection() {
+  if (!_connection) {
+    _connection = new Connection(process.env.SOLANA_RPC_URL || "https://api.mainnet-beta.solana.com", "confirmed");
+  }
+  return _connection;
+}
+
+/** Read borrower's true SOL credit (post-balance delta + signer tx fee). */
+async function computeActualReceived(conn, txSignature, borrowerWallet) {
+  const tx = await conn.getTransaction(txSignature, {
+    commitment: "confirmed",
+    maxSupportedTransactionVersion: 0,
+  });
+  if (!tx || tx.meta?.err) return null;
+  const keys = tx.transaction.message.staticAccountKeys
+    || tx.transaction.message.accountKeys
+    || [];
+  const borrowerPk = new PublicKey(borrowerWallet).toBase58();
+  const bi = keys.findIndex((k) => (k.toBase58 ? k.toBase58() : String(k)) === borrowerPk);
+  if (bi < 0) return null;
+  const delta = BigInt(tx.meta.postBalances[bi]) - BigInt(tx.meta.preBalances[bi]);
+  const txFee = BigInt(tx.meta.fee || 0);
+  const credit = delta + txFee;
+  return credit > 0n ? credit : null;
+}
+
+async function backfillCycle(bot) {
+  const { rows } = await query(
+    `SELECT id, tx_signature, borrower_wallet
+       FROM loans
+      WHERE actual_received_lamports IS NULL
+        AND tx_signature IS NOT NULL
+        AND borrower_wallet IS NOT NULL
+      ORDER BY id DESC
+      LIMIT $1`,
+    [BACKFILL_BATCH],
+  );
+  if (rows.length === 0) return { backfilled: 0 };
+
+  const conn = getConnection();
+  let backfilled = 0;
+  for (const l of rows) {
+    try {
+      const credit = await computeActualReceived(conn, l.tx_signature, l.borrower_wallet);
+      if (credit != null) {
+        await query(
+          `UPDATE loans SET actual_received_lamports = $1 WHERE id = $2 AND actual_received_lamports IS NULL`,
+          [credit.toString(), l.id],
+        );
+        backfilled++;
+      }
+    } catch (err) {
+      // Skip — next cycle re-tries
+      if (!/not found|missing|undefined/i.test(err.message || "")) {
+        console.warn(`[loan-received-watchdog] backfill failed for loan ${l.id}: ${err.message?.slice(0, 80)}`);
+      }
+    }
+    await new Promise((r) => setTimeout(r, RPC_GAP_MS));
+  }
+  return { backfilled };
+}
+
+async function driftCycle(bot) {
+  // Sample the N most-recent loans whose actual_received was already
+  // recorded. Re-read on-chain to confirm the stored value matches.
+  // Mismatch beyond tolerance fires an operator alert.
+  const { rows } = await query(
+    `SELECT id, tx_signature, borrower_wallet, actual_received_lamports::text AS stored
+       FROM loans
+      WHERE actual_received_lamports IS NOT NULL
+        AND tx_signature IS NOT NULL
+        AND borrower_wallet IS NOT NULL
+      ORDER BY id DESC
+      LIMIT $1`,
+    [DRIFT_SAMPLE],
+  );
+  if (rows.length === 0) return { drifted: 0 };
+
+  const conn = getConnection();
+  const drifted = [];
+  for (const l of rows) {
+    try {
+      const onChainCredit = await computeActualReceived(conn, l.tx_signature, l.borrower_wallet);
+      if (onChainCredit == null) continue;
+      const stored = BigInt(l.stored);
+      const diff = stored > onChainCredit ? stored - onChainCredit : onChainCredit - stored;
+      if (diff > BigInt(NETWORK_RENT_TOLERANCE_LAMPORTS)) {
+        drifted.push({ id: l.id, stored: stored.toString(), chain: onChainCredit.toString(), diff: diff.toString() });
+      }
+    } catch { /* skip transient */ }
+    await new Promise((r) => setTimeout(r, RPC_GAP_MS));
+  }
+
+  if (drifted.length > 0 && bot) {
+    const adminId = process.env.ADMIN_TG_ID;
+    if (adminId) {
+      const detail = drifted.slice(0, 3)
+        .map((d) => `loan #${d.id}: stored=${(Number(d.stored) / 1e9).toFixed(6)} SOL chain=${(Number(d.chain) / 1e9).toFixed(6)} SOL`)
+        .join("\n");
+      try {
+        await bot.api.sendMessage(
+          Number(adminId),
+          `*Loan actual-received drift detected*\n\n` +
+          `${drifted.length} loan(s) have stored actual_received_lamports that disagree with on-chain by > ${(NETWORK_RENT_TOLERANCE_LAMPORTS / 1e9).toFixed(6)} SOL.\n\n` +
+          `${detail}\n\n` +
+          `This is the class of bug that hit borrowers seeing "you got X SOL" on the dashboard when they actually got X − ~0.004 SOL.`,
+          { parse_mode: "Markdown" },
+        );
+      } catch { /* non-fatal */ }
+    }
+  }
+
+  return { drifted: drifted.length };
+}
+
+async function tick(bot) {
+  try {
+    const [bf, df] = await Promise.all([
+      backfillCycle(bot),
+      driftCycle(bot),
+    ]);
+    if (bf.backfilled > 0 || df.drifted > 0) {
+      console.log(`[loan-received-watchdog] backfilled=${bf.backfilled} drifted=${df.drifted}`);
+    }
+  } catch (err) {
+    console.warn("[loan-received-watchdog] tick threw:", err.message?.slice(0, 80));
+  }
+}
+
+export function startLoanReceivedWatchdog(bot) {
+  if (_timer) return;
+  console.log(`[loan-received-watchdog] armed — every ${RUN_INTERVAL_MS / 60_000} min (backfill ${BACKFILL_BATCH}/cycle, drift sample ${DRIFT_SAMPLE})`);
+  setTimeout(() => {
+    tick(bot).catch((e) => console.warn("[loan-received-watchdog] first tick threw:", e.message?.slice(0, 80)));
+    _timer = setInterval(() => {
+      tick(bot).catch((e) => console.warn("[loan-received-watchdog] tick threw:", e.message?.slice(0, 80)));
+    }, RUN_INTERVAL_MS);
+  }, FIRST_DELAY_MS);
+}

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -554,6 +554,54 @@ export async function recordLoan({
 
   const loanDbId = rows[0].id;
 
+  // Capture the borrower's ACTUAL on-chain SOL delta on the borrow tx.
+  // The DB's loan_amount_lamports = principal - protocol_fee but ignores
+  // Solana account-creation rent (collateral vault ATA + borrower wSOL
+  // ATA, ~0.004414 SOL total) that the program silently subtracts from
+  // loan proceeds. The borrower's wallet went up by less than
+  // loan_amount_lamports suggests, so the dashboard was overstating
+  // received-amount by ~$1 per borrow.
+  //
+  // We read the tx after the insert and store the real delta into
+  // actual_received_lamports (migration 048). Dashboard renders this;
+  // loan_amount_lamports stays as the legacy fee-net value for back-
+  // compat. If the read fails (RPC blip, tx still propagating), leave
+  // NULL — the on-chain-delta watchdog backfills.
+  if (txSignature && borrowerWallet) {
+    try {
+      const { Connection, PublicKey } = await import("@solana/web3.js");
+      const conn = new Connection(process.env.SOLANA_RPC_URL || "https://api.mainnet-beta.solana.com", "confirmed");
+      const tx = await conn.getTransaction(txSignature, {
+        commitment: "confirmed",
+        maxSupportedTransactionVersion: 0,
+      });
+      if (tx && !tx.meta?.err) {
+        const keys = tx.transaction.message.staticAccountKeys
+          || tx.transaction.message.accountKeys
+          || [];
+        const borrowerPk = new PublicKey(borrowerWallet).toBase58();
+        const bi = keys.findIndex((k) => (k.toBase58 ? k.toBase58() : String(k)) === borrowerPk);
+        if (bi >= 0) {
+          const delta = BigInt(tx.meta.postBalances[bi]) - BigInt(tx.meta.preBalances[bi]);
+          // Add back the tx fee that the borrower paid as signer — that's
+          // a Solana-runtime cost separate from the protocol-side
+          // accounting. The borrower's true credit from the borrow is
+          // (delta + tx_fee).
+          const txFee = BigInt(tx.meta.fee || 0);
+          const credit = delta + txFee;
+          if (credit > 0n) {
+            await query(
+              `UPDATE loans SET actual_received_lamports = $1 WHERE id = $2`,
+              [credit.toString(), loanDbId],
+            );
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(`[loans.recordLoan] on-chain delta capture failed for ${txSignature?.slice(0, 16)}…: ${err.message?.slice(0, 80)}`);
+    }
+  }
+
   // Canonical credit-event emission. This is the SINGLE source of truth
   // for the "user borrowed" event so BOTH the TG path and the site path
   // get +N points for a borrow. Previously this ran inside


### PR DESCRIPTION
Closes the ~$1-per-borrow discrepancy where dashboard claimed users received more than their wallet actually moved. Migration 048 adds actual_received_lamports; recordLoan populates it; watchdog backfills history + DMs operator on drift. Generated with Claude Code