### PR TITLE
MGP-001: make LP/referral/reserve bps live-read from governance_config

### DIFF
--- a/migrations/049_protocol_reserve_pool.sql
+++ b/migrations/049_protocol_reserve_pool.sql
@@ -1,0 +1,46 @@
+-- migration 049: protocol_reserve_pool
+--
+-- MGP-001 ratified a 10% protocol reserve share of every loan fee
+-- (protocol_reserve_bps = 1000 in governance_config). Before this
+-- migration, there was no consumer for that key — fees passed through
+-- to the operator wallet without being earmarked as "reserve".
+--
+-- The reserve pool is the protocol-owned counter-cyclical buffer: covers
+-- bad-debt events, funds emergency oracle/program fixes, backstops the
+-- lender wallet during volatility windows. It is NOT auto-distributed;
+-- spend happens via operator action and is governance-visible.
+--
+-- Schema mirrors lp_loyalty_pool (single row, accrued_lamports counter).
+-- Spend events get their own log table later if needed.
+
+CREATE TABLE IF NOT EXISTS protocol_reserve_pool (
+  id                INT PRIMARY KEY DEFAULT 1,
+  accrued_lamports  NUMERIC(30, 0) NOT NULL DEFAULT 0,
+  spent_lamports    NUMERIC(30, 0) NOT NULL DEFAULT 0,
+  last_accrual_at   TIMESTAMPTZ,
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT singleton CHECK (id = 1)
+);
+
+INSERT INTO protocol_reserve_pool (id, accrued_lamports, spent_lamports)
+VALUES (1, 0, 0)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS protocol_reserve_events (
+  id              BIGSERIAL PRIMARY KEY,
+  loan_db_id      BIGINT,
+  event_type      TEXT NOT NULL, -- 'borrow', 'extend', 'limit_close'
+  fee_lamports    NUMERIC(30, 0) NOT NULL,
+  reward_lamports NUMERIC(30, 0) NOT NULL,
+  reward_bps      INT NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (loan_db_id, event_type)
+);
+
+CREATE INDEX IF NOT EXISTS protocol_reserve_events_loan_idx
+  ON protocol_reserve_events(loan_db_id);
+
+COMMENT ON TABLE protocol_reserve_pool IS
+  'Protocol-owned counter-cyclical reserve. Receives 10% of every loan
+   fee per MGP-001 (governance_config.protocol_reserve_bps). Spend is
+   manual + governance-visible — not auto-distributed.';

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -206,11 +206,12 @@ async function authenticateRequest(req) {
 async function handleLpLoyalty(req, url) {
   const wallet = url.searchParams.get("wallet");
   if (!wallet) return { status: 400, body: { error: "Provide ?wallet=<address>" } };
-  const { getLpLoyaltyByWallet, LP_LOYALTY_REWARD_BPS } = await import(
+  const { getLpLoyaltyByWallet, getLpLoyaltyRewardBps } = await import(
     "../services/lp-loyalty.js"
   );
   const info = await getLpLoyaltyByWallet(wallet);
   if (!info) return { status: 400, body: { error: "Invalid wallet" } };
+  const liveBps = await getLpLoyaltyRewardBps();
   return {
     status: 200,
     body: {
@@ -222,8 +223,8 @@ async function handleLpLoyalty(req, url) {
       lifetime_lamports: info.lifetime_lamports.toString(),
       paid_lamports: info.paid_lamports.toString(),
       distributions_received: info.distributions_received,
-      reward_bps: LP_LOYALTY_REWARD_BPS,
-      reward_pct: LP_LOYALTY_REWARD_BPS / 100,
+      reward_bps: liveBps,
+      reward_pct: liveBps / 100,
       // INTENTIONALLY OMITTED: weighted_deposit_at, next snapshot timing.
       // Same operator-private pattern as $MAGPIE holders.
       auto_distribute: true,
@@ -306,9 +307,12 @@ async function handleReferrals(req, url) {
   if (!wallet) {
     return { status: 400, body: { error: "Provide ?wallet=<address>" } };
   }
-  const { getReferralSummaryByWallet, REFERRAL_REWARD_BPS, MIN_CLAIM_LAMPORTS } =
+  const { getReferralSummaryByWallet, getReferralRewardBps, MIN_CLAIM_LAMPORTS } =
     await import("../services/referral-rewards.js");
-  const summary = await getReferralSummaryByWallet(wallet);
+  const [summary, liveReferralBps] = await Promise.all([
+    getReferralSummaryByWallet(wallet),
+    getReferralRewardBps(),
+  ]);
   if (!summary) {
     return {
       status: 404,
@@ -337,8 +341,8 @@ async function handleReferrals(req, url) {
       share_link: tgShareLink,           // backward-compat (TG audience)
       site_share_link: siteShareLink,    // for the magpie.capital audience
       tg_share_link: tgShareLink,        // explicit alias
-      reward_bps: REFERRAL_REWARD_BPS,
-      reward_pct: REFERRAL_REWARD_BPS / 100,
+      reward_bps: liveReferralBps,
+      reward_pct: liveReferralBps / 100,
       min_claim_lamports: MIN_CLAIM_LAMPORTS.toString(),
       referred_count: summary.referred_count,
       borrowed_count: summary.borrowed_count,

--- a/src/commands/refer.js
+++ b/src/commands/refer.js
@@ -10,7 +10,7 @@ import { upsertUser } from "../services/users.js";
 import { getOrCreateCode } from "../services/referrals.js";
 import {
   getReferralSummary,
-  REFERRAL_REWARD_BPS,
+  getReferralRewardBps,
   MIN_CLAIM_LAMPORTS,
 } from "../services/referral-rewards.js";
 
@@ -26,10 +26,13 @@ export async function handleRefer(ctx) {
 
   const user = await upsertUser(tgUser.id, tgUser.username);
   const code = await getOrCreateCode(user.id);
-  const summary = await getReferralSummary(user.id);
+  const [summary, liveBps] = await Promise.all([
+    getReferralSummary(user.id),
+    getReferralRewardBps(),
+  ]);
 
   const shareLink = `https://t.me/${BOT_USERNAME}?start=${code}`;
-  const pct = (REFERRAL_REWARD_BPS / 100).toFixed(0);
+  const pct = (liveBps / 100).toFixed(0);
 
   const lines = [
     "🎁 *Magpie Referral Program*",

--- a/src/services/limit-close-fee-accrual-watcher.js
+++ b/src/services/limit-close-fee-accrual-watcher.js
@@ -62,10 +62,16 @@ async function tick() {
   }
   if (rows.length === 0) return;
 
-  const [{ accrueFromLoan }, { accrueToHolderPool }, { accrueToLpLoyaltyPool }] = await Promise.all([
+  const [
+    { accrueFromLoan },
+    { accrueToHolderPool },
+    { accrueToLpLoyaltyPool },
+    { accrueToProtocolReserve },
+  ] = await Promise.all([
     import("./referral-rewards.js"),
     import("./magpie-holder-rewards.js"),
     import("./lp-loyalty.js"),
+    import("./protocol-reserve.js"),
   ]);
 
   let accruedCount = 0;
@@ -87,16 +93,10 @@ async function tick() {
         continue;
       }
 
-      // Three accrual paths — all on the same fee number.
-      // accrueFromLoan: looks up the referrer of refereeUserId and
-      //                 credits referral_earnings.
-      // accrueToHolderPool: bumps the global holder pool by the BPS
-      //                    configured (default 1000 = 10%, will become
-      //                    7000 after MGP-001).
-      // accrueToLpLoyaltyPool: bumps the LP loyalty pool by its BPS.
-      // Each is independent; they read the current bps from
-      // governance_config (or hardcoded defaults) at call time. So
-      // MGP-001's split takes effect automatically without changes.
+      // Four accrual paths — all on the same fee number, all reading
+      // their share from governance_config at call time (MGP-001 split
+      // takes effect automatically: 70% holders / 10% LPs / 10% referrers
+      // / 10% protocol reserve).
       try {
         await accrueFromLoan({
           refereeUserId: row.user_id,
@@ -116,6 +116,15 @@ async function tick() {
         await accrueToLpLoyaltyPool(feeLamports);
       } catch (err) {
         console.warn(`[limit-close-accrual] LP accrual failed for order ${row.id}:`, err.message);
+      }
+      try {
+        await accrueToProtocolReserve({
+          loanDbId: row.loan_id,
+          feeLamports,
+          eventType: "limit_close",
+        });
+      } catch (err) {
+        console.warn(`[limit-close-accrual] protocol reserve accrual failed for order ${row.id}:`, err.message);
       }
 
       await c.query(

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -657,7 +657,7 @@ export async function recordLoan({
     console.error("[loans] holder pool accrual on borrow failed (continuing):", err.message);
   }
 
-  // LP Loyalty Bonus Pool accrual (2% of fee, sourced from protocol slice)
+  // LP Loyalty Bonus Pool accrual (bps live-read from governance_config)
   try {
     const { accrueToLpLoyaltyPool } = await import("./lp-loyalty.js");
     if (feeLamports > 0n) {
@@ -665,6 +665,20 @@ export async function recordLoan({
     }
   } catch (err) {
     console.error("[loans] LP loyalty accrual on borrow failed (continuing):", err.message);
+  }
+
+  // Protocol Reserve accrual (MGP-001, 10% of fee, live-read from governance_config)
+  try {
+    const { accrueToProtocolReserve } = await import("./protocol-reserve.js");
+    if (feeLamports > 0n) {
+      await accrueToProtocolReserve({
+        loanDbId: rows[0].id,
+        feeLamports,
+        eventType: "borrow",
+      });
+    }
+  } catch (err) {
+    console.error("[loans] protocol reserve accrual on borrow failed (continuing):", err.message);
   }
 }
 
@@ -958,6 +972,20 @@ export async function executeExtendLoan({ userId, loanDbRow }) {
     }
   } catch (err) {
     console.error("[loans] LP loyalty accrual on extend failed (continuing):", err.message);
+  }
+
+  // Protocol Reserve accrual on the extend fee (MGP-001).
+  try {
+    const { accrueToProtocolReserve } = await import("./protocol-reserve.js");
+    if (feeLamports > 0n) {
+      await accrueToProtocolReserve({
+        loanDbId: loanDbRow.id,
+        feeLamports,
+        eventType: "extend",
+      });
+    }
+  } catch (err) {
+    console.error("[loans] protocol reserve accrual on extend failed (continuing):", err.message);
   }
 
   return { signature: sig, feeLamports: feeLamports.toString() };

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -30,8 +30,24 @@ import { connection } from "../solana/connection.js";
 import { getReadOnlyProgram, PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3 } from "../solana/program.js";
 import { lendingPoolPda } from "../solana/pdas.js";
 import { query } from "../db/pool.js";
+import { getRuntimeConfigBps } from "./runtime-config.js";
 
-export const LP_LOYALTY_REWARD_BPS = 200; // 2% of every loan fee
+// Fallback used when governance_config.lp_loyalty_reward_bps can't be
+// read (DB outage or unset key). MGP-001 ratified the live value to
+// 1000 (10%); the runtime reader takes precedence over this constant.
+// Kept exported (= fallback) so legacy importers still resolve.
+export const LP_LOYALTY_REWARD_BPS_FALLBACK = 1_000; // 10%
+export const LP_LOYALTY_REWARD_BPS = LP_LOYALTY_REWARD_BPS_FALLBACK;
+
+/**
+ * Read the LIVE lp-loyalty reward bps from governance_config. Mirrors
+ * getHolderRewardBps in magpie-holder-rewards.js. Any governance vote
+ * that changes lp_loyalty_reward_bps takes effect everywhere within
+ * runtime-config's TTL with no code change.
+ */
+export async function getLpLoyaltyRewardBps() {
+  return getRuntimeConfigBps("lp_loyalty_reward_bps", LP_LOYALTY_REWARD_BPS_FALLBACK);
+}
 export const MIN_LP_LOYALTY_CLAIM_LAMPORTS = 5_000_000n; // 0.005 SOL
 export const MIN_LP_DISTRIBUTION_LAMPORTS = 10_000_000n; // 0.01 SOL (don't run dust distributions)
 export const MIN_LENDER_RESERVE_LAMPORTS = 100_000_000n; // 0.1 SOL ops floor
@@ -65,7 +81,8 @@ function loadLenderKeypair() {
 export async function accrueToLpLoyaltyPool(feeLamports) {
   const fee = BigInt(feeLamports);
   if (fee <= 0n) return null;
-  const reward = (fee * BigInt(LP_LOYALTY_REWARD_BPS)) / 10_000n;
+  const liveBps = await getLpLoyaltyRewardBps();
+  const reward = (fee * BigInt(liveBps)) / 10_000n;
   if (reward <= 0n) return null;
   try {
     await query(

--- a/src/services/protocol-reserve.js
+++ b/src/services/protocol-reserve.js
@@ -1,0 +1,95 @@
+/**
+ * Protocol Reserve Pool — the 10% share of every loan fee earmarked for
+ * the protocol's counter-cyclical buffer (bad-debt cover, emergency
+ * fixes, lender wallet backstop). Created by MGP-001 governance vote.
+ *
+ * Bps is read live from governance_config.protocol_reserve_bps so any
+ * future vote that adjusts the share takes effect without a code push.
+ *
+ * Accrual is idempotent per (loan_db_id, event_type) via the unique
+ * constraint on protocol_reserve_events — safe to retry on transient
+ * DB errors during recordLoan's accrual block.
+ *
+ * Spend is intentionally manual + governance-visible. No auto-payout
+ * path. Operator runs a separate spend script when authorized.
+ */
+import { query } from "../db/pool.js";
+import { getRuntimeConfigBps } from "./runtime-config.js";
+
+export const PROTOCOL_RESERVE_BPS_FALLBACK = 1_000; // 10% (matches MGP-001 ratified value)
+
+/**
+ * Read the LIVE protocol reserve bps from governance_config.
+ */
+export async function getProtocolReserveBps() {
+  return getRuntimeConfigBps("protocol_reserve_bps", PROTOCOL_RESERVE_BPS_FALLBACK);
+}
+
+/**
+ * Accrue the reserve share of a single loan-fee event. Idempotent per
+ * (loan_db_id, event_type). Mirrors the holder/LP/referral hooks so
+ * the caller pattern is uniform.
+ *
+ * Returns the lamports added on this call, or null if no-op
+ * (zero fee, duplicate event, or DB error — never throws).
+ */
+export async function accrueToProtocolReserve({ loanDbId, feeLamports, eventType }) {
+  const fee = BigInt(feeLamports);
+  if (fee <= 0n) return null;
+  const liveBps = await getProtocolReserveBps();
+  const reward = (fee * BigInt(liveBps)) / 10_000n;
+  if (reward <= 0n) return null;
+
+  try {
+    // Insert the event idempotently first. If the unique constraint
+    // catches a duplicate, the pool counter must NOT bump again.
+    const ins = await query(
+      `INSERT INTO protocol_reserve_events
+         (loan_db_id, event_type, fee_lamports, reward_lamports, reward_bps)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (loan_db_id, event_type) DO NOTHING
+       RETURNING id`,
+      [loanDbId, eventType, fee.toString(), reward.toString(), liveBps],
+    );
+    if (ins.rows.length === 0) return null; // duplicate — already accrued
+
+    await query(
+      `UPDATE protocol_reserve_pool
+          SET accrued_lamports = accrued_lamports + $1::numeric,
+              last_accrual_at = NOW(),
+              updated_at = NOW()
+        WHERE id = 1`,
+      [reward.toString()],
+    );
+    return reward;
+  } catch (err) {
+    console.error("[protocol-reserve] accrual failed:", err.message);
+    return null;
+  }
+}
+
+/**
+ * Current reserve pool state — read-only.
+ */
+export async function getProtocolReserveState() {
+  const { rows } = await query(
+    `SELECT accrued_lamports::text AS accrued,
+            spent_lamports::text AS spent,
+            last_accrual_at,
+            updated_at
+       FROM protocol_reserve_pool
+      WHERE id = 1`,
+  );
+  if (rows.length === 0) {
+    return { accrued_lamports: 0n, spent_lamports: 0n, balance_lamports: 0n };
+  }
+  const accrued = BigInt(rows[0].accrued);
+  const spent = BigInt(rows[0].spent);
+  return {
+    accrued_lamports: accrued,
+    spent_lamports: spent,
+    balance_lamports: accrued - spent,
+    last_accrual_at: rows[0].last_accrual_at,
+    updated_at: rows[0].updated_at,
+  };
+}

--- a/src/services/referral-rewards.js
+++ b/src/services/referral-rewards.js
@@ -26,8 +26,22 @@ import path from "node:path";
 import "dotenv/config";
 import { connection } from "../solana/connection.js";
 import { query } from "../db/pool.js";
+import { getRuntimeConfigBps } from "./runtime-config.js";
 
-export const REFERRAL_REWARD_BPS = 500; // 5% of fee
+// Fallback used when governance_config.referral_reward_bps can't be
+// read (DB outage or unset key). MGP-001 ratified the live value to
+// 1000 (10%); the runtime reader takes precedence.
+export const REFERRAL_REWARD_BPS_FALLBACK = 1_000; // 10%
+export const REFERRAL_REWARD_BPS = REFERRAL_REWARD_BPS_FALLBACK;
+
+/**
+ * Read the LIVE referral reward bps from governance_config. Mirrors
+ * getHolderRewardBps / getLpLoyaltyRewardBps. Any governance vote that
+ * changes referral_reward_bps takes effect within runtime-config TTL.
+ */
+export async function getReferralRewardBps() {
+  return getRuntimeConfigBps("referral_reward_bps", REFERRAL_REWARD_BPS_FALLBACK);
+}
 export const MIN_LOAN_LAMPORTS = 10_000_000n; // 0.01 SOL minimum to accrue
 export const MIN_CLAIM_LAMPORTS = 5_000_000n; // 0.005 SOL minimum to claim
 export const MIN_LENDER_RESERVE_LAMPORTS = 100_000_000n; // 0.1 SOL safety floor on lender
@@ -66,7 +80,8 @@ export async function accrueFromLoan({ refereeUserId, loanDbId, feeLamports, eve
   const referrerId = rows[0]?.referred_by;
   if (!referrerId) return null;
 
-  const reward = (fee * BigInt(REFERRAL_REWARD_BPS)) / 10_000n;
+  const liveBps = await getReferralRewardBps();
+  const reward = (fee * BigInt(liveBps)) / 10_000n;
   if (reward <= 0n) return null;
 
   try {
@@ -77,7 +92,7 @@ export async function accrueFromLoan({ refereeUserId, loanDbId, feeLamports, eve
        VALUES ($1, $2, $3, $4, $5, $6, $7, 'accrued')
        ON CONFLICT (loan_db_id, event_type) DO NOTHING
        RETURNING id`,
-      [referrerId, refereeUserId, loanDbId, eventType, fee.toString(), reward.toString(), REFERRAL_REWARD_BPS],
+      [referrerId, refereeUserId, loanDbId, eventType, fee.toString(), reward.toString(), liveBps],
     );
     return r.rows[0]?.id ?? null;
   } catch (err) {


### PR DESCRIPTION
## Why
After MGP-001 ratified, three of four reward channels were still ignoring `governance_config`:
- holders (7000 bps): already runtime-config-driven, live
- LPs (1000 bps): hardcoded at 200 — silently wrong
- referrers (1000 bps): hardcoded at 500 — silently wrong
- protocol reserve (1000 bps): no sink existed at all

Public Pip post and pending tweet advertise 70/10/10/10. This PR makes that true everywhere.

## Changes
- `lp-loyalty.js`: new \`getLpLoyaltyRewardBps()\` reading runtime config; accrual uses it
- `referral-rewards.js`: new \`getReferralRewardBps()\`; accrual + DB row write use live bps
- `protocol-reserve.js`: NEW — \`accrueToProtocolReserve\` writes to new pool + idempotent event log
- `migrations/049_protocol_reserve_pool.sql`: NEW pool + event log tables
- `loans.js`: wired reserve accrual into recordLoan + executeExtendLoan
- `limit-close-fee-accrual-watcher.js`: wired reserve into TP/SL fill path
- `api/server.js` + `commands/refer.js`: surfaces live bps instead of hardcoded constants

## Deploy gate
- Migration 049 is additive (CREATE TABLE IF NOT EXISTS) — safe to apply via \`npm run db:migrate\` against prod
- Until migration runs, reserve accrual silently no-ops (logs error, swallows). Holders/LPs/referrers all switch to the new bps the moment Railway picks up this code

## Test plan
- [ ] Railway deploy completes green
- [ ] \`npm run db:migrate\` applies 049
- [ ] Next live borrow accrues to all four pools at 70/10/10/10
- [ ] /refer shows 10%
- [ ] /api/v1/lp/loyalty?wallet= shows reward_pct: 10
- [ ] /api/v1/referrals?wallet= shows reward_pct: 10