### PR TITLE
RWA limit-close PR A: data layer (engine_program_id discriminator)

### DIFF
--- a/migrations/050_limit_close_engine_program_id.sql
+++ b/migrations/050_limit_close_engine_program_id.sql
@@ -1,0 +1,38 @@
+-- migration 050: add engine_program_id discriminator to limit_close_orders.
+--
+-- Motivation
+-- ──────────
+-- Limit-close orders are armed in arm-core and fired by a separate engine
+-- process (~/magpie-limitclose). Today every armed order assumes V1
+-- program semantics — V1's repay_loan ix signature, V1 PDAs, V1 collateral
+-- vault layout. That assumption breaks the moment we widen support to
+-- RWA collateral, which lives on V2 (PROGRAM_ID_V2).
+--
+-- This column records which program ID the engine MUST target when it
+-- fires. arm-core computes it from the loan's recorded program_id (which
+-- is itself the on-chain owner of the loan PDA — see services/loans.js
+-- recordLoan hardening from 2026-06-13).
+--
+-- Nullable for two reasons:
+--   1. Existing rows (memecoin V1 only) stay NULL — the engine treats
+--      NULL as "use PROGRAM_ID" (V1). Back-compat by design.
+--   2. New rows will get populated by arm-core, but if arm-core ever
+--      hits a path where program_id lookup fails (race condition during
+--      a re-org or RPC blip), we'd rather record the order without the
+--      discriminator and let the engine refuse-to-fire than fail the arm.
+--
+-- The engine in PR B reads this column. PR C flips the user-facing
+-- RWA gate once the engine is verified.
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS engine_program_id text;
+
+CREATE INDEX IF NOT EXISTS limit_close_orders_engine_program_id_idx
+  ON limit_close_orders(engine_program_id)
+  WHERE engine_program_id IS NOT NULL;
+
+COMMENT ON COLUMN limit_close_orders.engine_program_id IS
+  'Solana program ID the fill engine targets when this order fires.
+   NULL = default to PROGRAM_ID (V1 memecoin lending — back-compat for
+   pre-2026-06-13 orders). Set explicitly by arm-core from the loan''s
+   on-chain-verified program_id so engine routing is unambiguous.';

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -186,7 +186,7 @@ export async function armOrder({
             original_loan_amount_lamports::text AS owed,
             collateral_mint, collateral_amount::text AS coll_amount,
             collateral_amount::text AS collateral_amount_raw,
-            borrower_wallet, user_id
+            borrower_wallet, user_id, program_id
        FROM loans
       WHERE user_id = $1 AND loan_id = $2`,
     [userId, loanIdChain],
@@ -414,6 +414,7 @@ export async function armOrder({
           source, source_agent_pubkey, status, armed_at,
           auto_escalate_slippage, max_slippage_bps_cap, initial_slippage_bps,
           preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at,
+          engine_program_id,
           notes)
        VALUES ($1, $2, $3, $4,
                $5,
@@ -421,7 +422,8 @@ export async function armOrder({
                $9, $10, 'armed', NOW(),
                $11, $12, $13,
                $14, $15, $16,
-               $17)
+               $17,
+               $18)
        RETURNING id, armed_at`,
       [userId, loan.id, triggerKind, triggerBI.toString(),
        triggerDirection,
@@ -431,6 +433,13 @@ export async function armOrder({
        advisory ? null : effectiveCap,
        advisory ? null : (preflight.proceedsLamports || null),
        advisory ? null : (preflight.quotedAtIso || new Date().toISOString()),
+       // engine_program_id: source-of-truth for which Solana program the
+       // fill engine targets when this order fires. Pulled from the
+       // loan row (loans.program_id) which is itself derived from the
+       // on-chain owner of the loan PDA at recordLoan time. Engine
+       // treats NULL as legacy-V1 for back-compat with pre-2026-06-13
+       // rows; new arms always populate this.
+       loan.program_id || null,
        armNote
          || (appliedInitialBps !== originalInitialBps
            ? `armed via ${source}; ${triggerDirection === "below" ? "STOP-LOSS" : "TP"}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`


### PR DESCRIPTION
First of three PRs adding RWA support to the limit-close pipeline.

## What this PR does
- Migration 050: limit_close_orders.engine_program_id (nullable text)
- arm-core: reads loan.program_id and writes it onto each new order

## What this PR does NOT do
- Does NOT remove the RWA gate at arm-core (rwa_collateral_not_supported_in_v1)
- Does NOT enable RWA limit-close end-to-end
- Engine treats NULL engine_program_id as V1 (back-compat)

## Why split it
PR B = V2 fill path in engine repo. PR C = flip gate + Jupiter route quality guards.
Data layer ships first so we can watch a few days of memecoin orders populate the column.

## Test plan
- [ ] CI green
- [ ] Railway on-boot migration runner applies 050
- [ ] Next memecoin TP/SL arm writes non-null engine_program_id
- [ ] Existing armed orders (NULL) still fire correctly