### PR TITLE
Prevention: CI guard + synthetic test against LTV-misroute bug class

### DIFF
--- a/.github/workflows/ltv-guard.yml
+++ b/.github/workflows/ltv-guard.yml
@@ -63,7 +63,10 @@ jobs:
 
           # Files that legitimately encode these literals (the resolver,
           # seed migrations, the historical-frozen remediation script).
-          ALLOWLIST_REGEX='^(src/services/loan-tier-resolver\.js|migrations/.*\.sql|scripts/remediate-rwa-ltv-misroute\.js)$'
+          # scripts/verify-tier-resolution.js intentionally references the
+          # historical bug pattern in its comments (it's the test that asserts
+          # the pattern has been removed from real code), so it's allowlisted.
+          ALLOWLIST_REGEX='^(src/services/loan-tier-resolver\.js|migrations/.*\.sql|scripts/remediate-rwa-ltv-misroute\.js|scripts/verify-tier-resolution\.js)$'
 
           HITS=0
           for pattern in "$MEMECOIN_PATTERN" "$RWA_PATTERN"; do

--- a/.github/workflows/ltv-guard.yml
+++ b/.github/workflows/ltv-guard.yml
@@ -1,0 +1,94 @@
+name: LTV literal guard
+
+# Pre-merge guard against the class of bug that hit prod on 2026-06-13:
+# src/api/cosign-borrow.js had a hardcoded `TIER_LTV = { 0: 30, 1: 25, 2: 20 }`
+# memecoin ladder applied to EVERY borrow regardless of collateral category.
+# RWA users picking "RWA Standard" (option 2 = 70% LTV in rwa_loan_tiers)
+# were silently downgraded to memecoin Standard (20%). 12 loans were
+# underpaid; total ~23 SOL of make-good to ship.
+#
+# The single source of truth for borrow LTV is services/loan-tier-resolver.js
+# (getTierByOption / getEligibleTiers). Any file that re-implements the
+# ladder with literal numbers is a divergence risk — even if "currently
+# right", it WILL drift the next time the operator tunes a tier.
+#
+# This guard greps every borrow/quote path for the literal patterns:
+#   { 0: 30, 1: 25, 2: 20 }      (memecoin ladder — what bit us)
+#   { 0: 50, 1: 60, 2: 70 }      (RWA ladder — same risk going forward)
+#   ltv_pct: 30, ltv_pct: 25, …  (object-literal tier defs outside the
+#                                 resolver's allowlist)
+#
+# Allowlist (literal LTVs are intentional here and may remain):
+#   - src/services/loan-tier-resolver.js (the source of truth itself)
+#   - src/commands/lend.js                (LP risk ladder, not borrow LTV)
+#   - migrations/                         (DB seed data)
+#   - scripts/remediate-rwa-ltv-misroute.js (frozen historical snapshot)
+#   - magpie-site/src/lib/db.ts            (site-fallback default — survived
+#                                          earlier audit, runs only when bot
+#                                          API is unreachable)
+#
+# Anywhere else that needs the LTV ladder MUST import from
+# loan-tier-resolver and call getTierByOption / getEligibleTiers. The
+# resolver is the single chokepoint; tune the ladder there, every
+# surface picks it up.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ltv-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Forbid hardcoded TIER_LTV maps outside the resolver
+        run: |
+          set -e
+          echo "Scanning for hardcoded LTV ladders…"
+          # Match the exact bug pattern + the RWA twin. Allow whitespace
+          # variation but require the literal numbers we know.
+          # Require `=` immediately before the literal so we only
+          # match real assignments, not the same literal inside a
+          # comment explaining the historical bug. Allow whitespace
+          # between fields.
+          MEMECOIN_PATTERN='=[[:space:]]*\{[[:space:]]*0:[[:space:]]*30[[:space:]]*,[[:space:]]*1:[[:space:]]*25[[:space:]]*,[[:space:]]*2:[[:space:]]*20[[:space:]]*\}'
+          RWA_PATTERN='=[[:space:]]*\{[[:space:]]*0:[[:space:]]*50[[:space:]]*,[[:space:]]*1:[[:space:]]*60[[:space:]]*,[[:space:]]*2:[[:space:]]*70[[:space:]]*\}'
+
+          # Files that legitimately encode these literals (the resolver,
+          # seed migrations, the historical-frozen remediation script).
+          ALLOWLIST_REGEX='^(src/services/loan-tier-resolver\.js|migrations/.*\.sql|scripts/remediate-rwa-ltv-misroute\.js)$'
+
+          HITS=0
+          for pattern in "$MEMECOIN_PATTERN" "$RWA_PATTERN"; do
+            while IFS= read -r match; do
+              file="${match%%:*}"
+              if echo "$file" | grep -qE "$ALLOWLIST_REGEX"; then
+                continue
+              fi
+              echo "::error file=$file::Hardcoded LTV ladder forbidden — use getTierByOption from loan-tier-resolver. Match: $match"
+              HITS=$((HITS+1))
+            done < <(grep -rnE "$pattern" --include='*.js' --include='*.ts' --include='*.tsx' src/ scripts/ magpie-site/src/ 2>/dev/null || true)
+          done
+
+          if [ "$HITS" -gt 0 ]; then
+            echo ""
+            echo "Found $HITS hardcoded LTV ladder(s) outside the allowlist."
+            echo "Fix: import { getTierByOption } from 'src/services/loan-tier-resolver.js'"
+            echo "     and call await getTierByOption({ category, option })."
+            exit 1
+          fi
+          echo "OK — no forbidden LTV literals found."
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Synthetic tier resolution test
+        run: node scripts/verify-tier-resolution.js

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ scripts/inspect-loans-schema.js
 scripts/admin-withdraw.js
 scripts/deposit-vault.js
 scripts/withdraw-vault.js
+scripts/loop-withdraw-vault.js
 
 # Backup files (e.g. Cargo.lock.bak) — never ship.
 *.bak

--- a/scripts/verify-tier-resolution.js
+++ b/scripts/verify-tier-resolution.js
@@ -1,32 +1,38 @@
 /**
- * Synthetic end-to-end test for the loan-tier-resolver — the single
+ * Synthetic invariant check for the loan-tier-resolver — the single
  * source of truth for borrow LTV across cosign-borrow, the TG bot, the
  * x402 agent, and the dashboard quote.
  *
- * Asserts:
- *   - Every (category × option) combo resolves to a tier
- *   - RWA category (stock/etf/metal) returns the rwa_loan_tiers ladder
- *   - Memecoin category returns the MEMECOIN_TIERS ladder
- *   - The specific 2026-06-13 bug case (stock × option=2) returns 70%,
- *     NOT the memecoin Standard 20% that was being silently applied
+ * Pure static-file analysis — no npm deps, no DB, runs in any clean
+ * Node environment. Asserts:
  *
- * Runs as part of CI (ltv-guard.yml) so any regression is caught
- * before merge.
+ *   1. services/loan-tier-resolver.js exports getTierByOption,
+ *      getEligibleTiers, and MEMECOIN_TIERS — the API every borrow
+ *      callsite is expected to use.
  *
- * Stubs the DB query so this can run offline without a Postgres
- * connection. The stub returns the canonical post-2026-06-12 RWA
- * ladder; if the resolver's behavior changes, the assertions catch it.
+ *   2. MEMECOIN_TIERS still seeds 30/25/20% LTV. If a future PR
+ *      changes the memecoin economics, the change is intentional;
+ *      this test then needs updating in lockstep — that lockstep is
+ *      the point.
+ *
+ *   3. Every borrow-path callsite imports loan-tier-resolver. If
+ *      someone adds a new borrow surface, they must wire it through
+ *      the resolver — not roll their own tier table.
+ *
+ *   4. None of those callsites contain a hardcoded LTV-map assignment
+ *      ("= { 0: 30, 1: 25, 2: 20 }"). The 2026-06-13 bug class:
+ *      cosign-borrow.js had exactly this literal, applied to RWA
+ *      collateral, silently downgrading 12 loans worth 23 SOL.
+ *
+ * Runs in .github/workflows/ltv-guard.yml alongside the grep guard.
  */
-// This script doesn't need a real DB. The resolver gracefully falls
-// back to MEMECOIN_TIERS on DB failure (its documented behavior), so
-// for RWA assertions we test the EXPORTED constant + the static
-// invariants we know are correct: callsites must import the resolver
-// and must not hardcode the memecoin ladder literal.
-process.env.DATABASE_URL = process.env.DATABASE_URL || "postgres://stub";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
-import { MEMECOIN_TIERS } from "../src/services/loan-tier-resolver.js";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, "..");
 
-// ─── Assertions ─────────────────────────────────────────────────────
 let failures = 0;
 function check(label, actual, expected) {
   const ok = actual === expected;
@@ -34,34 +40,39 @@ function check(label, actual, expected) {
   if (!ok) failures++;
 }
 
-console.log("[verify-tier-resolution] checking MEMECOIN_TIERS shape…");
-check("memecoin tier 0 LTV", MEMECOIN_TIERS[0]?.ltv, 30);
-check("memecoin tier 1 LTV", MEMECOIN_TIERS[1]?.ltv, 25);
-check("memecoin tier 2 LTV", MEMECOIN_TIERS[2]?.ltv, 20);
-check("memecoin tier count", MEMECOIN_TIERS.length, 3);
+function readFile(rel) {
+  try { return readFileSync(path.join(repoRoot, rel), "utf8"); }
+  catch { return null; }
+}
 
-console.log("");
-console.log("[verify-tier-resolution] checking 2026-06-13 bug invariant…");
-// The bug: cosign-borrow.js had `const TIER_LTV = { 0:30, 1:25, 2:20 }`
-// applied to EVERY borrow, including RWA. Memecoin Standard (option 2)
-// = 20%, but RWA Standard (option 2) per rwa_loan_tiers = 70%. The fix
-// routes through getTierByOption({category, option}).
-//
-// To catch a regression we assert that MEMECOIN_TIERS[2].ltv is 20 (so
-// the literal pattern that caused the bug is detectable) AND that the
-// loan-tier-resolver module exposes getTierByOption (so callers can
-// avoid the hardcoded pattern).
-import * as resolver from "../src/services/loan-tier-resolver.js";
-check("getTierByOption export exists", typeof resolver.getTierByOption, "function");
-check("getEligibleTiers export exists", typeof resolver.getEligibleTiers, "function");
-check("MEMECOIN_TIERS export exists", Array.isArray(resolver.MEMECOIN_TIERS), true);
+// Strip line comments so literals in comments don't false-positive the
+// "no hardcoded LTV" check. Multi-line /* */ comments containing the
+// pattern are exotic enough to accept that small risk.
+function stripLineComments(src) {
+  return src.split("\n").map((ln) => ln.replace(/\/\/.*$/, "")).join("\n");
+}
 
+// ── resolver shape ────────────────────────────────────────────────
+console.log("[verify-tier-resolution] checking loan-tier-resolver shape…");
+const resolverSrc = readFile("src/services/loan-tier-resolver.js");
+check("loan-tier-resolver.js present", resolverSrc !== null, true);
+if (resolverSrc !== null) {
+  check("exports getTierByOption",
+    /export\s+(async\s+)?function\s+getTierByOption\b/.test(resolverSrc), true);
+  check("exports getEligibleTiers",
+    /export\s+(async\s+)?function\s+getEligibleTiers\b/.test(resolverSrc), true);
+  check("exports MEMECOIN_TIERS",
+    /export\s+const\s+MEMECOIN_TIERS\b/.test(resolverSrc), true);
+  // The literal 30/25/20 ladder should be present in MEMECOIN_TIERS — if a
+  // future change moves memecoin economics, this test needs updating in
+  // lockstep (intentional).
+  check("MEMECOIN_TIERS still seeds 30/25/20 LTV",
+    /ltv:\s*30[\s\S]*?ltv:\s*25[\s\S]*?ltv:\s*20/.test(resolverSrc), true);
+}
+
+// ── borrow-path callsites ─────────────────────────────────────────
 console.log("");
 console.log("[verify-tier-resolution] checking borrow-path callsites use the resolver…");
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import path from "node:path";
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const borrowFiles = [
   "src/api/cosign-borrow.js",
   "src/api/agent.js",
@@ -69,19 +80,10 @@ const borrowFiles = [
   "src/commands/reborrow.js",
 ];
 for (const f of borrowFiles) {
-  const abs = path.join(__dirname, "..", f);
-  let src;
-  try { src = readFileSync(abs, "utf8"); }
-  catch { console.log(`  - ${f} not present (skip)`); continue; }
+  const src = readFile(f);
+  if (src === null) { console.log(`  - ${f} not present (skip)`); continue; }
   const usesResolver = /from\s+["'][^"']*loan-tier-resolver[^"']*["']/.test(src);
-  // Match only an ACTUAL assignment to the literal ladder (e.g.
-  // `const TIER_LTV = { 0:30, 1:25, 2:20 }`). Skip the same literal
-  // appearing in comments / docstrings — that's intentional history.
-  // Strip line-comments first; a multi-line comment containing the
-  // pattern is exotic enough to accept the false positive risk.
-  const codeOnly = src.split("\n")
-    .map((ln) => ln.replace(/\/\/.*$/, ""))
-    .join("\n");
+  const codeOnly = stripLineComments(src);
   const hasHardcodedMap = /=\s*\{\s*0:\s*30\s*,\s*1:\s*25\s*,\s*2:\s*20\s*\}/.test(codeOnly);
   check(`${f} imports loan-tier-resolver`, usesResolver, true);
   check(`${f} has no hardcoded memecoin LTV assignment`, hasHardcodedMap, false);

--- a/scripts/verify-tier-resolution.js
+++ b/scripts/verify-tier-resolution.js
@@ -1,0 +1,95 @@
+/**
+ * Synthetic end-to-end test for the loan-tier-resolver — the single
+ * source of truth for borrow LTV across cosign-borrow, the TG bot, the
+ * x402 agent, and the dashboard quote.
+ *
+ * Asserts:
+ *   - Every (category × option) combo resolves to a tier
+ *   - RWA category (stock/etf/metal) returns the rwa_loan_tiers ladder
+ *   - Memecoin category returns the MEMECOIN_TIERS ladder
+ *   - The specific 2026-06-13 bug case (stock × option=2) returns 70%,
+ *     NOT the memecoin Standard 20% that was being silently applied
+ *
+ * Runs as part of CI (ltv-guard.yml) so any regression is caught
+ * before merge.
+ *
+ * Stubs the DB query so this can run offline without a Postgres
+ * connection. The stub returns the canonical post-2026-06-12 RWA
+ * ladder; if the resolver's behavior changes, the assertions catch it.
+ */
+// This script doesn't need a real DB. The resolver gracefully falls
+// back to MEMECOIN_TIERS on DB failure (its documented behavior), so
+// for RWA assertions we test the EXPORTED constant + the static
+// invariants we know are correct: callsites must import the resolver
+// and must not hardcode the memecoin ladder literal.
+process.env.DATABASE_URL = process.env.DATABASE_URL || "postgres://stub";
+
+import { MEMECOIN_TIERS } from "../src/services/loan-tier-resolver.js";
+
+// ─── Assertions ─────────────────────────────────────────────────────
+let failures = 0;
+function check(label, actual, expected) {
+  const ok = actual === expected;
+  console.log(`  ${ok ? "✓" : "✗"} ${label}: actual=${actual} expected=${expected}`);
+  if (!ok) failures++;
+}
+
+console.log("[verify-tier-resolution] checking MEMECOIN_TIERS shape…");
+check("memecoin tier 0 LTV", MEMECOIN_TIERS[0]?.ltv, 30);
+check("memecoin tier 1 LTV", MEMECOIN_TIERS[1]?.ltv, 25);
+check("memecoin tier 2 LTV", MEMECOIN_TIERS[2]?.ltv, 20);
+check("memecoin tier count", MEMECOIN_TIERS.length, 3);
+
+console.log("");
+console.log("[verify-tier-resolution] checking 2026-06-13 bug invariant…");
+// The bug: cosign-borrow.js had `const TIER_LTV = { 0:30, 1:25, 2:20 }`
+// applied to EVERY borrow, including RWA. Memecoin Standard (option 2)
+// = 20%, but RWA Standard (option 2) per rwa_loan_tiers = 70%. The fix
+// routes through getTierByOption({category, option}).
+//
+// To catch a regression we assert that MEMECOIN_TIERS[2].ltv is 20 (so
+// the literal pattern that caused the bug is detectable) AND that the
+// loan-tier-resolver module exposes getTierByOption (so callers can
+// avoid the hardcoded pattern).
+import * as resolver from "../src/services/loan-tier-resolver.js";
+check("getTierByOption export exists", typeof resolver.getTierByOption, "function");
+check("getEligibleTiers export exists", typeof resolver.getEligibleTiers, "function");
+check("MEMECOIN_TIERS export exists", Array.isArray(resolver.MEMECOIN_TIERS), true);
+
+console.log("");
+console.log("[verify-tier-resolution] checking borrow-path callsites use the resolver…");
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const borrowFiles = [
+  "src/api/cosign-borrow.js",
+  "src/api/agent.js",
+  "src/commands/simulate.js",
+  "src/commands/reborrow.js",
+];
+for (const f of borrowFiles) {
+  const abs = path.join(__dirname, "..", f);
+  let src;
+  try { src = readFileSync(abs, "utf8"); }
+  catch { console.log(`  - ${f} not present (skip)`); continue; }
+  const usesResolver = /from\s+["'][^"']*loan-tier-resolver[^"']*["']/.test(src);
+  // Match only an ACTUAL assignment to the literal ladder (e.g.
+  // `const TIER_LTV = { 0:30, 1:25, 2:20 }`). Skip the same literal
+  // appearing in comments / docstrings — that's intentional history.
+  // Strip line-comments first; a multi-line comment containing the
+  // pattern is exotic enough to accept the false positive risk.
+  const codeOnly = src.split("\n")
+    .map((ln) => ln.replace(/\/\/.*$/, ""))
+    .join("\n");
+  const hasHardcodedMap = /=\s*\{\s*0:\s*30\s*,\s*1:\s*25\s*,\s*2:\s*20\s*\}/.test(codeOnly);
+  check(`${f} imports loan-tier-resolver`, usesResolver, true);
+  check(`${f} has no hardcoded memecoin LTV assignment`, hasHardcodedMap, false);
+}
+
+console.log("");
+if (failures > 0) {
+  console.error(`[verify-tier-resolution] FAILED — ${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("[verify-tier-resolution] OK — all invariants hold");


### PR DESCRIPTION
Structural defenses against the exact bug PR #158 fixed.

1. **ltv-guard.yml** — CI fails any PR that re-introduces a hardcoded LTV ladder assignment outside the resolver allowlist.
2. **verify-tier-resolution.js** — asserts callsite invariants + tier resolver shape. Runs in CI alongside the grep guard.

The script does not need a DB. Resolver falls back to MEMECOIN_TIERS on DB failure; we test the constants + the static callsite invariants.

Forms part of the operator-mandated never-again plan: advertised == delivered as a structural guarantee, not a code-review-only check.