### PR TITLE
RWA limit-close PR C: gate flip + weekend-aware slippage bump

### DIFF
--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -1051,9 +1051,11 @@ export async function handleAgentLimitCloseEligibleLoans(req, params) {
       if (l.status !== "active") reasons.push("loan_not_active");
       if (owedBI < MIN_LOAN_LAMPORTS) reasons.push("loan_below_minimum_size");
       if (!l.collateral_enabled) reasons.push("collateral_not_enabled");
-      if (["stock", "etf", "metal"].includes(l.collateral_category)) {
-        reasons.push("rwa_collateral_not_supported_in_v1");
-      }
+      // 2026-06-13 (PR C): RWA collateral now arm-eligible end-to-end.
+      // engine_program_id discriminator + V2 fill path (PR B) + weekend
+      // slippage bump (arm-core) make this safe. Kept the error code in
+      // the status map below for back-compat with old agent SDKs that
+      // pattern-match on the string.
       if (loanIdsWithActiveOrder.has(Number(l.id))) {
         reasons.push("loan_already_has_active_order");
       }

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -311,9 +311,9 @@ export async function handleSiteLimitCloseList(req, url) {
     const reasons = [];
     if (BigInt(l.owed_lamports) < MIN_LOAN_LAMPORTS) reasons.push("loan_below_minimum_size");
     if (!l.collateral_enabled) reasons.push("collateral_not_enabled");
-    if (["stock", "etf", "metal"].includes(l.collateral_category)) {
-      reasons.push("rwa_collateral_not_supported_in_v1");
-    }
+    // 2026-06-13 (PR C): RWA categories (stock/etf/metal) are NOW eligible
+    // for limit-close. The engine's V2 fill path landed in PR B; arm-core
+    // applies a weekend-aware initial-slippage bump for thin RWA routes.
     if (armedByLoan.has(Number(l.id))) reasons.push("loan_already_has_active_order");
     return {
       ...l,

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -205,9 +205,23 @@ export async function armOrder({
     [loan.collateral_mint],
   );
   if (!mintRow || !mintRow.enabled) return { ok: false, error: "collateral_not_enabled" };
-  if (["stock", "etf", "metal"].includes(mintRow.category)) {
-    return { ok: false, error: "rwa_collateral_not_supported_in_v1" };
-  }
+  // ── RWA collateral support (2026-06-13, PR C) ───────────────
+  // Pre-2026-06-13 we hard-refused RWA limit-close arms because the
+  // engine couldn't fire V2 program orders. PR B (engine repo) added
+  // the V2 fill path; this gate is now the limiting factor we remove.
+  //
+  // For RWA tokens (stock/etf/metal) the V2 lending program handles
+  // the actual repay — engine_program_id discriminator on the order
+  // row (PR A) routes the fire to V2.
+  //
+  // The remaining concern: stock-token Jupiter routes thin out hard
+  // during weekend hours when underlying equities are closed. Backed
+  // arb desks step away, AMM depth collapses 5-10x. The existing
+  // liquidity-floor tiers below already widen initial slippage based
+  // on a screener-vetted liquidity_usd reading — but that reading is
+  // a weekday-average, not a live snapshot. So for RWA we layer a
+  // weekend-aware bump ON TOP of the tier floor.
+  const isRwa = ["stock", "etf", "metal"].includes(mintRow.category);
 
   // ── Liquidity-aware initial slippage adjustment ─────────────
   // Operator mandate: "the order MUST execute." The arm-time INITIAL
@@ -231,6 +245,18 @@ export async function armOrder({
   //   mid       ($25k-$100k)             : 300 bps floor (3%)
   //   thin      ($5k-$25k)               : 500 bps floor (5%)
   //   very_thin (< $5k)                  : 1000 bps floor (10%)
+  //
+  // RWA weekend adjustment (PR C): when arming during weekend cutoff
+  // window, layer an additional bump because Jupiter route quality for
+  // stock tokens collapses outside US RTH. Same window the premium
+  // tier uses to refuse new borrows — we don't refuse here (limit
+  // arms are reversible and the engine can wait for Monday to fire),
+  // but we widen the initial so when the order DOES fire it clears.
+  //   weekend deep      : +200 bps  (300 if base was 0)
+  //   weekend mid       : +400 bps
+  //   weekend thin      : +800 bps
+  //   weekend very_thin : +1500 bps
+  // Clamped to effectiveCap regardless — never wider than user accepted.
   const liqUsd = Number(mintRow.liquidity_usd ?? 0);
   let liquidityFloorBps = 0;
   // Treat liquidity_usd <= 0 as UNKNOWN (screener data missing or stale)
@@ -245,6 +271,31 @@ export async function armOrder({
   else if (liqUsd >= 25_000) liquidityFloorBps = 300;
   else if (liqUsd >= 5_000) liquidityFloorBps = 500;
   else liquidityFloorBps = 1000;
+
+  // RWA weekend bump — only applied when collateral is RWA AND the
+  // weekend cutoff window is active. Lazy-imported to avoid module
+  // cycles between arm-core and the premium tier (which itself depends
+  // on supported_mints which is far from limit-close concerns).
+  if (isRwa) {
+    try {
+      const { isInWeekendCutoff } = await import("./premium-tier-screener.js");
+      if (isInWeekendCutoff()) {
+        let weekendBump;
+        if (liqUsd <= 0) weekendBump = 300;            // unknown liquidity → safe default
+        else if (liqUsd >= 100_000) weekendBump = 200;
+        else if (liqUsd >= 25_000) weekendBump = 400;
+        else if (liqUsd >= 5_000) weekendBump = 800;
+        else weekendBump = 1500;
+        liquidityFloorBps = liquidityFloorBps + weekendBump;
+      }
+    } catch (err) {
+      // Non-fatal — if the weekend check throws (e.g. premium-tier
+      // module rename), fall through with just the standard liquidity
+      // floor. The engine's runtime escalation is the actual fill
+      // guarantee; this is a soft optimization.
+      console.warn(`[limit-close-arm-core] weekend-bump check failed: ${err.message?.slice(0, 80)}`);
+    }
+  }
   const originalInitialBps = slippageBps;
   let appliedInitialBps = slippageBps;
   if (liquidityFloorBps > 0 && slippageBps < liquidityFloorBps) {


### PR DESCRIPTION
Final of the 3-PR RWA limit-close series. PR A landed engine_program_id data layer. PR B (engine repo PR #16, merged) landed V2 fill path + program-id allowlist. This PR removes the user-facing arm gate.

## Changes
- **arm-core.js** — drop \`rwa_collateral_not_supported_in_v1\` refusal. Detect RWA category. When RWA AND in premium-tier weekend cutoff (lazy import of \`isInWeekendCutoff\`), layer additional bump on top of existing liquidity-tier floor:
  - deep weekend: +200 bps
  - mid weekend: +400 bps  
  - thin weekend: +800 bps
  - very_thin weekend: +1500 bps
  - unknown weekend: +300 bps
  - All clamped to user effectiveCap
- **site-limit-close.js + internal-agent-limitclose.js** — drop RWA from eligibility-reasons exclusion. Keep error-code maps + user-facing error strings for back-compat with stale clients pattern-matching the string.

## Why the weekend bump
Stock-token Jupiter routes thin out hard during weekend hours when underlying equity markets are closed. Backed arb desks step away, AMM depth collapses 5-10x. The existing liquidity_usd reading is a weekday-average, not a live snapshot, so it understates how thin the route gets weekend-side. The weekend bump bridges that gap.

## Test plan
- [ ] RWA loan (e.g. SPCXxc.../GLDx/NVDAx) arm-able via TG + site + agent
- [ ] Same RWA arm during weekend cutoff window shows widened initial slippage
- [ ] Memecoin arm flow unchanged (no weekend bump, no surprise)
- [ ] First RWA TP/SL fires end-to-end (V2 fill via engine, sig confirms on-chain)