### PR TITLE
fix(preflight): align slippage ceiling with MAX_PROTOCOL_SLIPPAGE_BPS

### DIFF
--- a/src/services/limit-close-preflight.js
+++ b/src/services/limit-close-preflight.js
@@ -29,6 +29,7 @@
  *     arm goes through this gate. (Operator kill switch is separate.)
  */
 import axios from "axios";
+import { MAX_PROTOCOL_SLIPPAGE_BPS } from "../lib/slippage-constants.js";
 
 const JUP_QUOTE_API = process.env.JUPITER_QUOTE_API || "https://lite-api.jup.ag/swap/v1/quote";
 const SOL_MINT = "So11111111111111111111111111111111111111112";
@@ -122,7 +123,14 @@ export async function runArmPreflight({
   const amountBI = BigInt(collateralAmountRaw);
   if (amountBI <= 0n) return { ok: false, reason: "zero_collateral_amount" };
   const dst = sellDestination === "usdc" ? USDC_MINT : SOL_MINT;
-  if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > 1000) {
+  // 2026-06-13: preflight previously refused slippage > 1000 bps but
+  // arm-core's effectiveCap defaults to DEFAULT_CAP_FLOOR_BPS = 2500
+  // (the MAX_PROTOCOL_SLIPPAGE_BPS) so EVERY default-cap arm hit this
+  // refusal — caught by the RWA dry-run on 2026-06-13. Aligning the
+  // ceiling with the protocol-wide constant so the two layers agree.
+  // The actual fill-quality protection is the no_route / slippage_too_low
+  // checks below — those still flag a route that won't clear.
+  if (!Number.isInteger(slippageBps) || slippageBps < 10 || slippageBps > MAX_PROTOCOL_SLIPPAGE_BPS) {
     return { ok: false, reason: "invalid_slippage" };
   }
   let owedBI;


### PR DESCRIPTION
## Why
RWA dry-run after PR #161 surfaced a pre-existing inconsistency: preflight refused slippage > 1000 bps but arm-core defaults effectiveCap to 2500 (MAX_PROTOCOL_SLIPPAGE_BPS). Every arm with a default cap (capBps:null) tripped preflight refusal with `invalid_slippage`.

## Fix
Import MAX_PROTOCOL_SLIPPAGE_BPS in preflight and use it as the upper bound. Lockstep with arm-core.

Safety unchanged — no_route + slippage_too_low checks still catch routes that wont clear at the requested slippage.

## Test plan
- [x] RWA arm with default cap now succeeds (verified via dry-run on SPCX loan #690 — initial 100→300 bps with weekend bump)
- [ ] Memecoin arm flow unchanged