### PR TITLE
copy(limit-close): drop stale "memecoin only / v1.1" copy after RWA gate flip

### DIFF
--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -367,7 +367,11 @@ export async function handleLimitClose(ctx, direction = "above") {
         case "collateral_not_enabled":
           return `Collateral token is not currently enabled in the protocol.`;
         case "rwa_collateral_not_supported_in_v1":
-          return `Limit-close is not available on RWA collateral (xStocks/metals) in v1. Memecoin collateral only for now. Coming in v1.1.`;
+          // Unreachable since 2026-06-13 (PR C flipped the arm-core
+          // gate; RWA collateral is now arm-eligible end-to-end via the
+          // V2 fill path). Kept for back-compat with cached agent SDKs
+          // that pattern-match on this error string.
+          return `Limit-close on RWA collateral is now live — please try again.`;
         case "user_concurrency_cap_reached":
           return `You have ${armed.detail?.active} active limit orders (max ${armed.detail?.cap}). Cancel one with /cancellimitorder first.`;
         case "loan_already_has_active_order":

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -2747,9 +2747,9 @@ const TOOL_HANDLERS = {
     if (loan.status !== "active") {
       return toolError("loan_not_active", null, `This loan is ${loan.status}, not active. Take-profit only works on active loans.`);
     }
-    if (["stock", "etf", "metal"].includes(loan.category)) {
-      return toolError("rwa_not_supported", null, "Take-profit isn't available on xStock / RWA collateral in v1 — memecoin loans only. Tell the user to wait for v1.1.");
-    }
+    // 2026-06-13: take-profit/stop-loss on RWA collateral (xStocks/metals)
+    // is now live. Fall through to standard handling — the engine routes
+    // to the V2 fill path automatically via engine_program_id.
     if (!loan.enabled) {
       return toolError("collateral_not_enabled", null, "This collateral isn't currently enabled in the protocol.");
     }


### PR DESCRIPTION
Same-sprint marketing sync for PR #161 (RWA limit-close gate flip).

Two stale user-facing strings updated:
- TG bot error switch: "Coming in v1.1" → "now live — please try again"
- Pip propose_takeprofit: dropped the refusal, RWA proposals flow through standard handling now

Same-sprint marketing rule per operator standing instruction.