### PR TITLE
feat(lc-perf): persist + surface rwa_tp_weekend_skipped metric

### DIFF
--- a/migrations/053_engine_metrics_rwa_weekend_skip.sql
+++ b/migrations/053_engine_metrics_rwa_weekend_skip.sql
@@ -1,0 +1,29 @@
+-- migration 053: track RWA take-profit weekend-fire skips per hour.
+--
+-- Engine PR #18 (magpie-limitclose feat/rwa-tp-weekend-fire-skip)
+-- added a fire-time gate: when a stock/etf/metal collateral order
+-- with trigger_direction='above' (TP) hits its trigger DURING the
+-- premium-tier weekend cutoff window, the engine skips firing this
+-- tick and leaves the order armed for next-tick re-eval. The order
+-- effectively waits for Monday RTH when Jupiter routes for the
+-- underlying stock token thicken up again.
+--
+-- The skip count was only logged + accumulated in a per-tick metrics
+-- accumulator. Without persisting it, /lc-perf can't show "how
+-- many RWA TPs paused this weekend" across history — which is the
+-- operator-facing answer to "is the weekend gate doing anything?".
+--
+-- This migration adds a column that the engine's writeMetricsRollup
+-- now UPSERTs. Default 0 so older rows are sane; the rollup += new
+-- column on conflict keeps the additive math correct.
+
+ALTER TABLE engine_metrics_hourly
+  ADD COLUMN IF NOT EXISTS rwa_tp_weekend_skipped integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN engine_metrics_hourly.rwa_tp_weekend_skipped IS
+  'Count of RWA take-profit orders whose trigger hit during the
+   premium-tier weekend cutoff window and were intentionally not
+   fired this tick. Populated by the engine watcher when category
+   is stock/etf/metal AND trigger_direction is above AND
+   isInWeekendCutoff() is true. Order stays armed; next tick after
+   the window closes re-evaluates and fires normally.';

--- a/src/commands/lc-perf.js
+++ b/src/commands/lc-perf.js
@@ -206,6 +206,12 @@ async function showPerf(ctx, windowKey) {
               COALESCE(SUM(fires_failed), 0)::bigint::text          AS fires_failed,
               COALESCE(SUM(fires_reverted), 0)::bigint::text        AS fires_reverted,
               COALESCE(SUM(errors), 0)::bigint::text                AS errors,
+              -- 2026-06-13: count of RWA TPs the engine intentionally
+              -- skipped during the weekend cutoff window (engine PR #18).
+              -- Column added by bot migration 053; COALESCE makes the
+              -- SELECT survive on a fresh deploy where 053 isn't applied
+              -- yet (NULL would otherwise poison Number(...) below).
+              COALESCE(SUM(rwa_tp_weekend_skipped), 0)::bigint::text AS rwa_tp_weekend_skipped,
               MIN(hour)                                              AS earliest_hour,
               MAX(hour)                                              AS latest_hour
          FROM engine_metrics_hourly
@@ -316,6 +322,12 @@ async function showPerf(ctx, windowKey) {
     lines.push(`• Fires attempted:    ${Number(eng.fires_attempted)} → ${Number(eng.fires_succeeded)} ok · ${Number(eng.fires_failed)} fail · ${Number(eng.fires_reverted)} revert`);
     if (Number(eng.errors) > 0) {
       lines.push(`• Tick errors:        ${Number(eng.errors)}`);
+    }
+    // RWA TP weekend-skip count — only render when nonzero so the
+    // line doesn't clutter weekday output. Engine PR #18 + bot
+    // migration 053.
+    if (Number(eng.rwa_tp_weekend_skipped) > 0) {
+      lines.push(`• RWA TP weekend skips: ${Number(eng.rwa_tp_weekend_skipped)} (held for Mon RTH)`);
     }
   }
 


### PR DESCRIPTION
Migration 053 + /lc-perf SELECT/render for the rwa_tp_weekend_skipped counter. Engine companion PR ships the watcher write side. Renders only when nonzero so weekday output stays clean.