### PR TITLE
copy(pip): mark unshipped agent endpoints (deposit/withdraw/liquidate) as planned

### DIFF
--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -730,9 +730,9 @@ The endpoint surface (live on x402.magpie.capital + magpie.capital/x402):
   • POST /api/v1/agent/build-borrow     — immediate borrow tx builder
   • POST /api/v1/agent/build-repay      — repay tx builder
   • POST /api/v1/agent/build-extend|topup|partial-repay
-  • POST /api/v1/agent/build-deposit    — LP deposit (agent as lender)
-  • POST /api/v1/agent/build-withdraw   — LP withdraw (agent as lender)
-  • POST /api/v1/agent/build-liquidate  — liquidate past-due loan + keeper bounty
+  • (planned) /api/v1/agent/build-deposit     — LP deposit, not yet shipped
+  • (planned) /api/v1/agent/build-withdraw    — LP withdraw, not yet shipped
+  • (planned) /api/v1/agent/build-liquidate   — permissionless liquidation, not yet shipped (the in-house keeper covers liquidations today)
   • GET  /api/v1/agent/credit-attest    — ed25519-signed credit score
   • GET  /api/v1/agent/token-risk       — per-token risk profile for collateral selection
   • GET  /api/v1/agent/lp-state         — depositor position + pool context (free)
@@ -768,11 +768,10 @@ WHY THIS IS GAME-CHANGING (your standard articulation when asked):
       reference yield-bot in /agents/yield-bot demonstrates the full
       loop.
 
-   3. Permissionless liquidation (shipped June 10). build-liquidate
-      constructs an unsigned liquidate_loan tx for any past-due loan;
-      the keeper receives the bounty share of seized collateral.
-      Closes the loop for liquidation-bot agents that used to have
-      to roll their own Anchor client.
+   3. Permissionless liquidation (PLANNED — not yet shipped). The in-house
+      keeper handles all liquidations today (V1 + V2 pools as of 2026-06-13).
+      A future build-liquidate endpoint would let third-party agents
+      participate; current state: roadmap, not production.
 
    4. Conditional borrows with optional webhooks. Agents post an intent
       — 'when \$TOKEN trades above \$0.50, fire a borrow against 10000
@@ -812,9 +811,7 @@ PRICING (public):
   • /agent/intent (conditional borrow)  — 0.01 SOL per intent
   • /agent/build-borrow                 — 0.005 SOL
   • /agent/build-repay/extend/topup/pr  — 0.002 SOL each
-  • /agent/build-deposit (LP)           — 0.002 SOL
-  • /agent/build-withdraw (LP)          — 0.002 SOL
-  • /agent/build-liquidate              — 0.003 SOL
+  • (planned — not yet live: build-deposit / build-withdraw / build-liquidate)
   • /agent/credit-attest                — 0.0005 SOL
   • /agent/token-risk                   — 0.001 SOL
   • /credit-score                       — 0.001 SOL

--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -101,9 +101,9 @@ The first lending protocol on Solana designed for autonomous AI agents. Built on
 
  1. *Permissionless borrow.* Agents borrow SOL the same way a human does — sign-with-your-wallet, no oauth, no account. Same anti-exploit gauntlet applies (no shortcuts). build-borrow + build-repay + build-extend + build-topup + build-partial-repay endpoints cover the full loan lifecycle (each 0.002–0.005 SOL per build).
 
- 2. *Permissionless LP (shipped 2026-06-10).* Agents can also LEND — build-deposit + build-withdraw + lp-state endpoints let agents deposit SOL into the LendingPool and earn yield programmatically. The yield-bot reference agent at agents/yield-bot/ in the github repo demonstrates the full loop (0.002 SOL per build, free reads).
+ 2. *Permissionless LP (planned, not yet shipped).* build-deposit / build-withdraw endpoints are on the roadmap so agents can lend SOL into the pool programmatically. Today the lending pool is operator-funded; the yield-bot reference will become useful when these endpoints ship.
 
- 3. *Permissionless liquidation (shipped 2026-06-10).* build-liquidate endpoint constructs an unsigned liquidate_loan tx for any past-due loan; the keeper receives the bounty share of seized collateral. Closes the loop for liquidation-bot agents — they used to have to roll their own Anchor client (0.003 SOL per attempt).
+ 3. *Permissionless liquidation (planned, not yet shipped).* The in-house keeper handles all liquidations today across V1 and V2 pools. A future build-liquidate endpoint will let third-party agents participate. Until then, don't tell users they can liquidate via x402 — point them at the in-house keeper if asked.
 
  4. *Conditional borrows — "limit orders for borrows."* An agent posts an intent specifying a trigger (price_above, price_below, time_after, pool_liq_above). Our watcher polls live cross-sourced DEX prices every 30s. The moment the condition fires, the server builds the unsigned borrow tx; the agent signs + submits whenever it next checks in. First permissionless lending protocol with this primitive. One payment (0.01 SOL) covers the entire intent lifecycle, up to 30 days. **NEW**: optional webhook_url for push delivery — server POSTs HMAC-signed payload on match, eliminating polling cost.
 


### PR DESCRIPTION
Audit follow-up. Three x402 endpoints were documented as shipped but no handler exists. Pip + AI-support now mark them as planned to avoid promising features that 404. In-house keeper covers liquidations today (PR #172 added V2 support).