### PR TITLE
fix(tg): show tier breakdown in body, shorten button labels

### DIFF
--- a/migrations/054_engine_canary_program_id.sql
+++ b/migrations/054_engine_canary_program_id.sql
@@ -1,0 +1,29 @@
+-- migration 054: tag engine_canary_runs rows with the program the
+-- template loan belonged to.
+--
+-- Engine canary picks a recent loan as the canary template and exercises
+-- the fire-path read surface (Jupiter quote, cross-source agreement,
+-- borrower wallet load, Solana program reachable). Before this change it
+-- picked the SINGLE most-recent loan regardless of program — so a quiet
+-- V2 (RWA) pool stretch meant the canary never exercised V2's fire path,
+-- and a V2 outage would go undetected.
+--
+-- Engine PR (paired with this migration) picks ONE template per pool per
+-- tick: one V1, one V2. Two rows per cycle when both pools have eligible
+-- templates. Operator can drill into per-pool health via /lc-perf.
+--
+-- Nullable: pre-PR rows have NULL — engine treats NULL as legacy V1 for
+-- back-compat with the historical canary.
+
+ALTER TABLE engine_canary_runs
+  ADD COLUMN IF NOT EXISTS program_id text;
+
+CREATE INDEX IF NOT EXISTS engine_canary_runs_program_id_run_at_idx
+  ON engine_canary_runs(program_id, run_at DESC)
+  WHERE program_id IS NOT NULL;
+
+COMMENT ON COLUMN engine_canary_runs.program_id IS
+  'Solana program the canary template loan belonged to. V1 (memecoin)
+   or V2 (RWA). NULL = pre-2026-06-13 canary (treated as legacy V1).
+   Operator-facing /lc-perf will eventually split health by program
+   so a V2-pool degradation surfaces independently of V1.';

--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -231,16 +231,25 @@ export function registerBorrowCallbacks(bot) {
     // RWA collateral (stock/etf/metal) lands the higher-LTV ladder
     // out of rwa_loan_tiers; memecoin (and uncategorized) get MEMECOIN_TIERS.
     const tiers = await getEligibleTiers({ category: state.selected.category });
+    // Telegram inline-button labels visually truncate around 30-40 chars
+    // on mobile — RWA tiers' full label "50% LTV · 7d · 2.5% fee
+    // (RWA Express) → ~1.2345 SOL" cut off the receive amount to
+    // "→ ~..." in the UI (operator screenshot 2026-06-13). Render the
+    // full breakdown in the message body (Markdown, no length limit)
+    // and keep buttons short.
     const kb = new InlineKeyboard();
-    for (const t of tiers) {
+    const tierLines = tiers.map((t) => {
       const loanSol = ((valueLamports * t.ltv) / 100) / 1e9;
       const fee = loanSol * (t.feeBps / 10_000);
       const receive = loanSol - fee;
+      const shortMatch = t.label.match(/\(([^)]+)\)\s*$/);
+      const shortName = shortMatch ? shortMatch[1] : t.label;
       kb.text(
-        `${t.label} → ~${receive.toFixed(4)} SOL`,
+        `${shortName} — ${receive.toFixed(4)} SOL`,
         `borrow:tier:${t.option}`,
       ).row();
-    }
+      return `• *${shortName}* — ${t.ltv}% LTV · ${t.days}d · ${(t.feeBps / 100).toFixed(1)}% fee → *${receive.toFixed(4)} SOL*`;
+    });
     kb.text("✕ Cancel", "borrow:cancel");
 
     const riskBlock = await renderRiskBlock(state.selected.symbol).catch(() => "");
@@ -252,8 +261,9 @@ export function registerBorrowCallbacks(bot) {
         riskBlock || null,
         "",
         "*Choose a loan tier:*",
-        "_(amount shown is what you receive after tier fee)_",
+        ...tierLines,
         "",
+        "_Amount shown is what you receive after the tier fee._",
         "⏱ _This quote expires in 60 seconds._",
       ].filter((l) => l != null).join("\n"),
       { parse_mode: "Markdown", reply_markup: kb },
@@ -291,17 +301,22 @@ export function registerBorrowCallbacks(bot) {
     pending.set(ctx.chat.id, state);
 
     // Same category-aware tier resolution as the prior flow.
+    // See note above on tier-label truncation on mobile — render the
+    // breakdown in the message body and keep button labels short.
     const tiers = await getEligibleTiers({ category: state.selected.category });
     const kb = new InlineKeyboard();
-    for (const t of tiers) {
+    const tierLines = tiers.map((t) => {
       const loanSol = ((valueLamports * t.ltv) / 100) / 1e9;
       const fee = loanSol * (t.feeBps / 10_000);
       const receive = loanSol - fee;
+      const shortMatch = t.label.match(/\(([^)]+)\)\s*$/);
+      const shortName = shortMatch ? shortMatch[1] : t.label;
       kb.text(
-        `${t.label} → ~${receive.toFixed(4)} SOL`,
+        `${shortName} — ${receive.toFixed(4)} SOL`,
         `borrow:tier:${t.option}`,
       ).row();
-    }
+      return `• *${shortName}* — ${t.ltv}% LTV · ${t.days}d · ${(t.feeBps / 100).toFixed(1)}% fee → *${receive.toFixed(4)} SOL*`;
+    });
     kb.text("✕ Cancel", "borrow:cancel");
 
     const riskBlock = await renderRiskBlock(state.selected.symbol).catch(() => "");
@@ -314,8 +329,9 @@ export function registerBorrowCallbacks(bot) {
         riskBlock || null,
         "",
         "*Choose a loan tier:*",
-        "_(amount shown is what you receive after tier fee)_",
+        ...tierLines,
         "",
+        "_Amount shown is what you receive after the tier fee._",
         "⏱ _This quote expires in 60 seconds._",
       ].filter((l) => l != null).join("\n"),
       { parse_mode: "Markdown", reply_markup: kb },


### PR DESCRIPTION
## Summary
- Telegram inline-button labels visually truncate around 30-40 chars on mobile; the full tier label for RWA tiers was being cut off as "→ ~..." leaving users without the receive amount.
- Move the LTV/duration/fee/receive breakdown into the message body (Markdown, no length limit) and shorten button labels to "<short-name> — <receive> SOL".
- Applies to both the /borrow entry flow and the borrow:pct callback flow.

## Test plan
- [ ] /borrow → SPCX → 100% — verify tier breakdown lines appear in body, buttons show "RWA Express — 1.2345 SOL" style labels
- [ ] /borrow → memecoin → 100% — verify "Express — ... SOL" buttons
- [ ] /borrow → 50% callback path — same checks for the borrow:pct flow