### PR TITLE
feat(near-trigger): one-time DM when order is ~10% from firing

### DIFF
--- a/migrations/055_limit_close_near_trigger_dm.sql
+++ b/migrations/055_limit_close_near_trigger_dm.sql
@@ -1,0 +1,39 @@
+-- migration 055: near-trigger DM tracking on limit_close_orders.
+--
+-- Pairs with src/services/limit-close-near-trigger-watcher.js. The
+-- watcher sweeps armed orders every 5 min, computes distance to
+-- trigger, and DMs the user a one-time heads-up when current price
+-- is within NEAR_TRIGGER_PCT (default 10%) of the trigger.
+--
+-- One-time gate: `near_trigger_dm_sent_at IS NULL`. Set BEFORE
+-- enqueueing the DM so a duplicate watcher tick on a slow cycle
+-- can't double-send. Reset to NULL whenever the user modifies the
+-- trigger via /modify (TG), site modify, or x402 agent — a fresh
+-- trigger deserves a fresh nudge if the new value lands in the near
+-- band.
+--
+-- Why this is separate from staleness_nudged_at: staleness is "you
+-- forgot you set this, want to clean up?" — once per 30 days, gentle.
+-- Near-trigger is "this is about to fire, glance and adjust if
+-- needed" — once per arm, time-sensitive. Different cadences, different
+-- audiences (staleness targets long-armed forgotten orders; near-
+-- trigger targets active orders with imminent action).
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS near_trigger_dm_sent_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN limit_close_orders.near_trigger_dm_sent_at IS
+  'When the bot sent the one-time near-trigger DM for this order
+   (within ~10% of firing). NULL = never sent for this arm. Reset to
+   NULL on modify so a re-tuned trigger gets a fresh nudge.
+   See src/services/limit-close-near-trigger-watcher.js.';
+
+-- Hot-path read pattern for the watcher:
+--   WHERE status = 'armed'
+--     AND near_trigger_dm_sent_at IS NULL
+--     AND trigger_kind IN ('price_usd', 'mc_usd')
+-- Partial index covers the unsent set tightly without overhead on
+-- the much-larger fired/cancelled subset.
+CREATE INDEX IF NOT EXISTS limit_close_orders_unsent_near_trigger_idx
+  ON limit_close_orders(armed_at DESC)
+  WHERE status = 'armed' AND near_trigger_dm_sent_at IS NULL;

--- a/src/index.js
+++ b/src/index.js
@@ -159,6 +159,7 @@ import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
 import { registerSupportVigilCallbacks } from "./services/support-vigil.js";
 import { startInfraHealth } from "./services/infra-health.js";
 import { startLimitCloseStalenessWatcher } from "./services/limit-close-staleness-watcher.js";
+import { startLimitCloseNearTriggerWatcher } from "./services/limit-close-near-trigger-watcher.js";
 import { registerLcStalenessCallbacks } from "./handlers/lc-staleness-callbacks.js";
 import { startImpersonatorWatchdog } from "./services/impersonator-watchdog.js";
 import { startCanaryWatcher } from "./services/canary-watcher.js";
@@ -810,6 +811,13 @@ bot.start({
     // orders are old AND trigger far from current price. One-time
     // nudge per order. See feedback_tg_changes_careful.
     setTimeout(() => startLimitCloseStalenessWatcher(), 90_000);
+    // Near-trigger nudge — every 5 min DMs users whose armed orders
+    // are within ~10% of firing. One-time per arm; reset on modify so
+    // a re-tuned trigger gets a fresh nudge if it lands in the band.
+    // Different cadence + audience than the staleness watcher:
+    // staleness = "forgotten old order", near-trigger = "imminent
+    // action heads-up". See feedback_tg_changes_careful.
+    setTimeout(() => startLimitCloseNearTriggerWatcher(), 95_000);
     // Impersonator watchdog — every 30 min retroactively scans the
     // last 24h of community joins against the CURRENT
     // IMPERSONATION_PATTERNS list. Catches impersonators who slipped

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -703,6 +703,13 @@ export async function modifyOrder({
     updateParams.push(val);
   }
   setParts.push("updated_at = NOW()");
+  // 2026-06-13: any modify resets the near-trigger DM gate so a
+  // re-tuned trigger gets a fresh nudge if the new value lands in the
+  // ~10% band. Otherwise users who modified an order would never hear
+  // about the new trigger getting close.
+  if (updates.trigger_value_micro !== undefined) {
+    setParts.push("near_trigger_dm_sent_at = NULL");
+  }
   // Audit note appended so /lc-status armed shows that the order was modified.
   const noteSuffix = ` modified ${new Date().toISOString().slice(0, 19)}Z (${Object.keys(updates).join(",")})`;
   setParts.push(`notes = COALESCE(notes, '') || $${up++}`);

--- a/src/services/limit-close-near-trigger-watcher.js
+++ b/src/services/limit-close-near-trigger-watcher.js
@@ -1,0 +1,169 @@
+/**
+ * Near-trigger watcher — proactive DM when an armed limit order is
+ * within striking distance of its trigger.
+ *
+ * Users arm a TP / SL and then either monitor the chart obsessively
+ * OR forget the order exists. Both are bad UX. This watcher splits
+ * the difference: a single, one-time DM when current price gets
+ * within NEAR_TRIGGER_PCT (default 10%) of the trigger so the user
+ * knows the engine is about to act AND has a chance to adjust or
+ * cancel if the market context has changed.
+ *
+ * Cadence: every NEAR_CHECK_INTERVAL_MS (default 5 min). More frequent
+ * than the staleness watcher because the actionable window is short —
+ * a 10% gap on a moving token can close fast.
+ *
+ * Once-only via `near_trigger_dm_sent_at` column (migration 056).
+ * Reset to NULL on modify so a user editing the trigger gets a fresh
+ * nudge if they re-enter the near band.
+ *
+ * Operator-stated rule [[feedback_tg_changes_careful]]: never spam
+ * existing users. Respects proactive_dms_disabled, bails silently on
+ * any error, marks the timestamp BEFORE enqueueing so a duplicate
+ * tick can't double-send.
+ *
+ * 2026-06-13.
+ */
+import { query } from "../db/pool.js";
+
+const NEAR_CHECK_INTERVAL_MS = Number(process.env.LIMIT_CLOSE_NEAR_INTERVAL_MS) || 5 * 60 * 1000; // 5 min
+// Width of the "near-trigger" band. 10% means "within 10% of firing".
+// Tunable via env so the operator can dial sensitivity without a deploy.
+const NEAR_TRIGGER_PCT = Number(process.env.LIMIT_CLOSE_NEAR_PCT) || 10;
+const NEAR_BATCH_LIMIT = 50; // soft cap per cycle so a backlog can't slam Jupiter
+
+/**
+ * Distance to trigger as a SIGNED percent, normalized so positive =
+ * "still need to move toward trigger".
+ *
+ * Above (TP): pct = (trigger - current) / current × 100. Positive
+ * when trigger is above current (still need to move up).
+ *
+ * Below (SL): pct = (current - trigger) / current × 100. Positive
+ * when current is above trigger (still need to move down).
+ *
+ * Negative or zero means the trigger has already been crossed —
+ * the engine should have fired this tick or last. We do NOT nudge
+ * in that case (it'd be redundant noise).
+ */
+function distanceToTriggerPct(triggerMicros, currentMicros, direction) {
+  if (currentMicros == null || currentMicros === 0n) return null;
+  const diff = direction === "above"
+    ? triggerMicros - currentMicros   // need price to rise
+    : currentMicros - triggerMicros;  // need price to fall
+  return Number(diff) / Number(currentMicros) * 100;
+}
+
+async function fetchCandidates() {
+  // Same shape as the staleness watcher's fetcher, but without the
+  // armed-for-X-days clause — near-trigger is independent of age.
+  // `near_trigger_dm_sent_at IS NULL` is the one-time gate.
+  const { rows } = await query(
+    `SELECT o.id, o.user_id, o.loan_id, o.trigger_kind,
+            o.trigger_value_micro::text AS trigger_value_micro,
+            COALESCE(o.trigger_direction, 'above') AS trigger_direction,
+            o.armed_at, o.slippage_bps,
+            o.sell_destination,
+            l.collateral_mint, l.loan_id AS loan_id_chain,
+            m.symbol AS collateral_symbol,
+            u.telegram_id, u.proactive_dms_disabled
+       FROM limit_close_orders o
+       JOIN loans l ON l.id = o.loan_id
+       LEFT JOIN supported_mints m ON m.mint = l.collateral_mint
+       JOIN users u ON u.id = o.user_id
+      WHERE o.status = 'armed'
+        AND o.near_trigger_dm_sent_at IS NULL
+        AND o.trigger_kind IN ('price_usd', 'mc_usd')
+      ORDER BY o.armed_at DESC
+      LIMIT $1`,
+    [NEAR_BATCH_LIMIT],
+  );
+  return rows;
+}
+
+async function currentMicrosFor(row) {
+  try {
+    const { getPriceInUsdCrossSourced } = await import("./price.js");
+    const usd = await getPriceInUsdCrossSourced(row.collateral_mint);
+    if (!usd || usd <= 0) return null;
+    if (row.trigger_kind === "price_usd") {
+      return BigInt(Math.round(usd * 1e6));
+    }
+    // mc_usd: multiply by circulating supply when available; otherwise
+    // skip (we can't compare a USD-price-only oracle to a MC trigger).
+    const { rows: [mintRow] } = await query(
+      `SELECT supply FROM supported_mints WHERE mint = $1`,
+      [row.collateral_mint],
+    );
+    if (!mintRow?.supply) return null;
+    return BigInt(Math.round(usd * 1e6)) * BigInt(mintRow.supply);
+  } catch {
+    return null;
+  }
+}
+
+async function enqueueNudge(order, distancePct) {
+  // Mark BEFORE enqueueing — duplicate ticks on a slow cycle never
+  // re-nudge. If the notification enqueue fails the timestamp is
+  // already set; user just doesn't get THIS nudge but won't be
+  // spammed.
+  await query(
+    `UPDATE limit_close_orders SET near_trigger_dm_sent_at = NOW() WHERE id = $1`,
+    [order.id],
+  );
+  await query(
+    `INSERT INTO pending_notifications (user_id, channel, kind, payload, status)
+       VALUES ($1, 'tg', 'limit_close_near_trigger', $2::jsonb, 'pending')`,
+    [order.user_id, JSON.stringify({
+      order_id: order.id,
+      loan_id_chain: order.loan_id_chain,
+      trigger_kind: order.trigger_kind,
+      trigger_direction: order.trigger_direction,
+      trigger_value_micro: order.trigger_value_micro,
+      collateral_symbol: order.collateral_symbol || "your token",
+      slippage_bps: order.slippage_bps,
+      distance_pct: Math.round(distancePct * 10) / 10, // 1 decimal
+    })],
+  );
+}
+
+async function tick() {
+  let candidates;
+  try {
+    candidates = await fetchCandidates();
+  } catch (err) {
+    console.warn("[lc-near-trigger] fetch failed:", err.message?.slice(0, 80));
+    return;
+  }
+  if (candidates.length === 0) return;
+  let nudged = 0;
+  for (const order of candidates) {
+    if (order.proactive_dms_disabled) continue;
+    const currentMicros = await currentMicrosFor(order);
+    if (currentMicros == null) continue;
+    const triggerMicros = BigInt(order.trigger_value_micro);
+    const distancePct = distanceToTriggerPct(triggerMicros, currentMicros, order.trigger_direction);
+    if (distancePct == null) continue;
+    // distancePct <= 0 means the trigger has already been hit (engine
+    // should fire on its next tick). Don't nudge — it'd land milliseconds
+    // before the fired-confirmation DM.
+    if (distancePct <= 0) continue;
+    if (distancePct > NEAR_TRIGGER_PCT) continue;
+    try {
+      await enqueueNudge(order, distancePct);
+      nudged++;
+    } catch (err) {
+      console.warn(`[lc-near-trigger] nudge ${order.id} failed:`, err.message?.slice(0, 80));
+    }
+  }
+  if (nudged > 0) {
+    console.log(`[lc-near-trigger] nudged ${nudged} near-trigger order(s) of ${candidates.length} candidates`);
+  }
+}
+
+export function startLimitCloseNearTriggerWatcher() {
+  console.log(`[lc-near-trigger] armed — sweeping every ${NEAR_CHECK_INTERVAL_MS / 60_000} min for orders within ${NEAR_TRIGGER_PCT}% of trigger`);
+  // First sweep waits 2 min so it doesn't run during boot-storm.
+  setTimeout(() => tick().catch((e) => console.warn("[lc-near-trigger] first tick threw:", e.message?.slice(0, 80))), 2 * 60 * 1000);
+  setInterval(() => tick().catch((e) => console.warn("[lc-near-trigger] tick threw:", e.message?.slice(0, 80))), NEAR_CHECK_INTERVAL_MS);
+}

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -186,6 +186,20 @@ function renderLimitCloseStalenessNudge(p) {
   ].join("\n");
 }
 
+function renderLimitCloseNearTrigger(p) {
+  const dirLabel = p.trigger_direction === "below" ? "stop-loss" : "take-profit";
+  const moveDir  = p.trigger_direction === "below" ? "drops" : "moves up";
+  return [
+    `*Your ${dirLabel} is close to firing*`,
+    "",
+    `${p.collateral_symbol} is within ~${p.distance_pct}% of your trigger on order #${p.order_id}. If price ${moveDir} a touch more, the engine will repay the loan and sell automatically.`,
+    "",
+    `If your plan changed, you can /modify ${p.order_id} (tighten or widen the trigger) or /cancel ${p.order_id} now. Otherwise sit tight — we've got it.`,
+    "",
+    `_One-time nudge per arm — you won't see this again until you re-arm or modify._`,
+  ].join("\n");
+}
+
 function renderEnginePreflightFailed(p) {
   const failures = Array.isArray(p?.failures) ? p.failures : [];
   const lines = [
@@ -212,6 +226,7 @@ const RENDERERS = {
   limit_close_action_required: renderLimitCloseActionRequired,
   limit_close_intervention: renderLimitCloseIntervention,
   limit_close_staleness_nudge: renderLimitCloseStalenessNudge,
+  limit_close_near_trigger:    renderLimitCloseNearTrigger,
   engine_preflight_failed:  renderEnginePreflightFailed,
   pip_upside_alert:         renderPipUpsideAlert,
   // Downside alert reuses the same renderer — the watcher pre-renders


### PR DESCRIPTION
## Summary
- New limit-close-near-trigger watcher sweeps every 5 min for armed orders within ~10% of triggering.
- Migration 055 adds near_trigger_dm_sent_at column (partial index for the unsent set). modifyOrder resets it to NULL whenever the trigger value changes so a re-tuned trigger lands a fresh nudge.
- New 'limit_close_near_trigger' pending_notifications kind + renderer in notification-sender.
- Respects feedback_tg_changes_careful: proactive_dms_disabled honored, marks before enqueueing, bails silently on error.

## Test plan
- [ ] Migration 055 applies cleanly: ledger entry written + column visible in psql
- [ ] Arm a TP at $X, set current price ~9% below trigger → within 5 min the user gets a near-trigger DM
- [ ] DM contains /modify and /cancel hints with the order ID
- [ ] Same order won't re-nudge within the same arm even after re-fire condition resets
- [ ] Modify the trigger via TG → near_trigger_dm_sent_at clears, next watcher tick re-evaluates
- [ ] User with proactive_dms_disabled=true does not get DM'd