### PR TITLE
feat(v3-program): dual-tier RWA + memecoin lending program

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -7,14 +7,17 @@ skip-lint = false
 [programs.localnet]
 magpie_lending = "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh"
 magpie_credit_oracle = "BBYtty9sqWjHzTuoXSNfDCpNtLn6ZjfSfhYEoY6MFP2E"
+magpie_lending_v3 = "B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP"
 
 [programs.devnet]
 magpie_lending = "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh"
 magpie_credit_oracle = "BBYtty9sqWjHzTuoXSNfDCpNtLn6ZjfSfhYEoY6MFP2E"
+magpie_lending_v3 = "B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP"
 
 [programs.mainnet]
 magpie_lending = "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh"
 magpie_credit_oracle = "BBYtty9sqWjHzTuoXSNfDCpNtLn6ZjfSfhYEoY6MFP2E"
+magpie_lending_v3 = "B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP"
 
 [registry]
 url = "https://api.apr.dev"

--- a/programs/magpie-lending-v3/src/lib.rs
+++ b/programs/magpie-lending-v3/src/lib.rs
@@ -709,13 +709,30 @@ pub mod magpie_lending {
                 )?;
             }
 
-            // pool_cut stays in the vault → depositors earn it automatically
-            // through share appreciation (pool value unchanged while tokens stay)
+            // pool_cut stays in the vault AND must be credited to LPs by
+            // bumping pool.total_deposits — otherwise the withdraw math
+            // (`shares × total_deposits / total_shares`) silently leaves
+            // the yield behind in the vault, unclaimable by LPs. This was
+            // the bug that landed V1/V2 with ~20 SOL of stranded LP yield
+            // accumulating in vault excess; V3 honors the "share
+            // appreciation" promise that the V1/V2 comments made but the
+            // code did not deliver.
+            let pool_cut = fee
+                .checked_sub(protocol_cut)
+                .ok_or(ErrorCode::MathOverflow)?;
 
             let pool = &mut ctx.accounts.pool;
             pool.total_fees_earned = pool
                 .total_fees_earned
                 .checked_add(fee)
+                .ok_or(ErrorCode::MathOverflow)?;
+            // Bump total_deposits by pool_cut so the share-value denominator
+            // reflects the just-retained LP yield. Done at borrow time
+            // because the fee is realized then (taken up-front from
+            // gross_loan, not contingent on repay).
+            pool.total_deposits = pool
+                .total_deposits
+                .checked_add(pool_cut)
                 .ok_or(ErrorCode::MathOverflow)?;
         }
 
@@ -991,10 +1008,23 @@ pub mod magpie_lending {
             .ok_or(ErrorCode::MathOverflow)?;
         let new_due = loan.due_timestamp;
 
+        // Credit LP yield from the retained portion of the extension fee.
+        // Same rationale as request_and_fund_loan (above): pool_cut sits in
+        // the vault; without bumping total_deposits the withdraw math leaves
+        // it stranded. Done here AFTER the protocol_cut transfer is known so
+        // pool_cut is exact.
+        let pool_cut = extension_fee
+            .checked_sub(protocol_cut)
+            .ok_or(ErrorCode::MathOverflow)?;
+
         let pool = &mut ctx.accounts.pool;
         pool.total_fees_earned = pool
             .total_fees_earned
             .checked_add(extension_fee)
+            .ok_or(ErrorCode::MathOverflow)?;
+        pool.total_deposits = pool
+            .total_deposits
+            .checked_add(pool_cut)
             .ok_or(ErrorCode::MathOverflow)?;
 
         emit!(LoanExtended {

--- a/programs/magpie-lending-v3/src/lib.rs
+++ b/programs/magpie-lending-v3/src/lib.rs
@@ -21,13 +21,82 @@ declare_id!("MgpV3TWAPLending111111111111111111111111111");
 /// Basis-point helpers
 const BPS_DENOM: u64 = 10_000;
 
-/// Loan tier configuration (matches existing protocol)
-/// Option 0: Express – 30% LTV, 2 days, 3% fee
-/// Option 1: Quick   – 25% LTV, 3 days, 2% fee
-/// Option 2: Standard– 20% LTV, 7 days, 1.5% fee
-const TIER_LTV_BPS: [u64; 3] = [3_000, 2_500, 2_000];
-const TIER_DURATION_DAYS: [i64; 3] = [2, 3, 7];
-const TIER_FEE_BPS: [u64; 3] = [300, 200, 150];
+// ---------------------------------------------------------------------------
+// Tier ladders — THESE CONSTANTS ARE THE CONTRACT.
+//
+// 2026-06-13 LESSON (paid for in user trust): the prior `rwa_loan_tiers`
+// DB display table advertised 50/60/70% RWA LTVs while the on-chain v2
+// program computed 30/25/20%. Users signed expecting one amount and got
+// another. The cure is to make THIS file the single, authoritative source
+// of tier params, and have every off-chain surface (DB, dashboard, bot,
+// Pip, marketplace) DERIVE from on-chain rather than store its own copy.
+//
+// v3 ships dual tiers — memecoin and RWA — selected at borrow time via
+// the `category` instruction param. The off-chain `rwa_loan_tiers` table
+// in the bot's DB is now a downstream mirror that the migration runner
+// updates from on-chain at startup, never the other way around.
+// ---------------------------------------------------------------------------
+
+const CATEGORY_MEMECOIN: u8 = 0;
+const CATEGORY_RWA: u8 = 1;
+
+/// Memecoin tier ladder. Conservative LTVs because volatility on these
+/// names can be 30%+ in an hour; short terms keep duration risk in check.
+/// Option 0 Express : 30% LTV ·  2 days · 3.0% fee
+/// Option 1 Quick   : 25% LTV ·  3 days · 2.0% fee
+/// Option 2 Standard: 20% LTV ·  7 days · 1.5% fee
+const TIER_MEMECOIN_LTV_BPS: [u64; 3] = [3_000, 2_500, 2_000];
+const TIER_MEMECOIN_DURATION_DAYS: [i64; 3] = [2, 3, 7];
+const TIER_MEMECOIN_FEE_BPS: [u64; 3] = [300, 200, 150];
+
+/// RWA tier ladder for tokenized stocks / ETFs / metals (Backed
+/// xStocks etc.). Intraday vol is typically 1–3% and the holder
+/// profile is closer to traditional investors than memecoin traders.
+/// The protocol can safely offer higher LTV / longer terms / higher
+/// fee. Aspirational design from migration 040 — v3 is where the
+/// numbers actually land in the on-chain program.
+/// Option 0 RWA Express : 50% LTV ·  7 days · 2.5% fee
+/// Option 1 RWA Quick   : 60% LTV · 15 days · 3.5% fee
+/// Option 2 RWA Standard: 70% LTV · 30 days · 5.0% fee
+const TIER_RWA_LTV_BPS: [u64; 3] = [5_000, 6_000, 7_000];
+const TIER_RWA_DURATION_DAYS: [i64; 3] = [7, 15, 30];
+const TIER_RWA_FEE_BPS: [u64; 3] = [250, 350, 500];
+
+/// Resolve tier params from (category, option). Returns
+/// (ltv_bps, fee_bps, duration_days) so the caller can use them
+/// directly. Returns None when category or option is out of range —
+/// caller must surface ErrorCode::InvalidCategory or InvalidLoanOption.
+fn resolve_tier(category: u8, option: u8) -> Option<(u64, u64, i64)> {
+    let i = option as usize;
+    if i >= 3 { return None; }
+    match category {
+        CATEGORY_MEMECOIN => Some((
+            TIER_MEMECOIN_LTV_BPS[i],
+            TIER_MEMECOIN_FEE_BPS[i],
+            TIER_MEMECOIN_DURATION_DAYS[i],
+        )),
+        CATEGORY_RWA => Some((
+            TIER_RWA_LTV_BPS[i],
+            TIER_RWA_FEE_BPS[i],
+            TIER_RWA_DURATION_DAYS[i],
+        )),
+        _ => None,
+    }
+}
+
+/// Reverse-lookup used by extend_loan / partial_repay / off-chain
+/// indexers to recover (ltv_bps, fee_bps, duration_days) from a loan's
+/// stored (category, ltv_bps). The ltv_bps within a category is
+/// uniquely associated with one option index, so this is well-defined.
+fn resolve_tier_for_loan(category: u8, ltv_bps: u16) -> Option<(u64, u64, i64)> {
+    let table: &[u64; 3] = match category {
+        CATEGORY_MEMECOIN => &TIER_MEMECOIN_LTV_BPS,
+        CATEGORY_RWA      => &TIER_RWA_LTV_BPS,
+        _ => return None,
+    };
+    let option = table.iter().position(|&v| v == ltv_bps as u64)? as u8;
+    resolve_tier(category, option)
+}
 
 const SECONDS_PER_DAY: i64 = 86_400;
 
@@ -392,15 +461,23 @@ pub mod magpie_lending {
     /// Request and instantly fund a loan from the pool.
     ///
     /// `collateral_amount` – raw token units of collateral to lock.
-    /// `loan_option`       – tier 0/1/2.
+    /// `loan_option`       – tier 0/1/2 within the chosen category.
     /// `collateral_value`  – oracle-supplied value in loan-token units.
     /// `loan_id`           – unique nonce (e.g. unix-ms).
+    /// `category`          – 0 = memecoin (30/25/20% LTV @ 2/3/7d),
+    ///                       1 = RWA stock/etf/metal (50/60/70% @ 7/15/30d).
+    ///                       The cosign authority is responsible for matching
+    ///                       this to the on-chain mint category — if a memecoin
+    ///                       borrow arrives with category=RWA the higher LTV
+    ///                       on a volatile mint becomes a default risk. The
+    ///                       authority signature gates that.
     pub fn request_and_fund_loan(
         ctx: Context<RequestLoan>,
         collateral_amount: u64,
         loan_option: u8,
         collateral_value: u64,
         loan_id: u64,
+        category: u8,
     ) -> Result<()> {
         // Constraints lifted from RequestLoan struct to keep try_accounts under
         // the BPF 4 KB stack limit. Functionally equivalent.
@@ -433,6 +510,9 @@ pub mod magpie_lending {
         require!(loan_option <= 2, ErrorCode::InvalidLoanOption);
         require!(collateral_amount > 0, ErrorCode::InvalidCollateralAmount);
         require!(collateral_value > 0, ErrorCode::InvalidCollateralValue);
+        // Validate category early — before any expensive TWAP / token work —
+        // so a bad caller fails cheaply.
+        require!(category <= 1, ErrorCode::InvalidCategory);
 
         // --- v3 TWAP-based price validation ---
         // Replaces v2's single-spot attestation with a time-weighted
@@ -498,10 +578,8 @@ pub mod magpie_lending {
             ErrorCode::CollateralValueExceedsAttestation
         );
 
-        let tier = loan_option as usize;
-        let ltv_bps = TIER_LTV_BPS[tier];
-        let fee_bps = TIER_FEE_BPS[tier];
-        let duration_days = TIER_DURATION_DAYS[tier];
+        let (ltv_bps, fee_bps, duration_days) =
+            resolve_tier(category, loan_option).ok_or(ErrorCode::InvalidCategory)?;
 
         // Compute loan amount from LTV
         let gross_loan = collateral_value
@@ -615,6 +693,11 @@ pub mod magpie_lending {
         loan.transaction_fee = fee;
         loan.ltv_bps = ltv_bps as u16;
         loan.duration_days = duration_days as u8;
+        // Persist category so extend_loan / partial-repay can resolve the
+        // correct tier ladder later WITHOUT having to look up the mint
+        // category from off-chain again. Avoids "what tier is this" round-
+        // trips that bit V1/V2 in the limit-close engine after migration 040.
+        loan.category = category;
         loan.start_timestamp = now;
         loan.due_timestamp = now
             .checked_add(duration_days.checked_mul(SECONDS_PER_DAY).unwrap())
@@ -645,6 +728,7 @@ pub mod magpie_lending {
             fee,
             ltv_bps: ltv_bps as u16,
             duration_days: duration_days as u8,
+            category,
         });
         Ok(())
     }
@@ -800,14 +884,15 @@ pub mod magpie_lending {
         let loan = &ctx.accounts.loan;
         require!(loan.status == LoanStatus::Active, ErrorCode::LoanNotActive);
 
-        let tier = match loan.ltv_bps {
-            3_000 => 0usize,
-            2_500 => 1,
-            2_000 => 2,
-            _ => return Err(ErrorCode::InvalidLoanOption.into()),
-        };
+        // Resolve tier from the loan's stored (category, option) — the option
+        // is derived from ltv_bps within the category's ladder. RWA Standard
+        // (70%) and memecoin Express (30%) have distinct ltv_bps so the
+        // option-from-ltv inference inside resolve_tier_for_loan is unique
+        // per category.
+        let (_, fee_bps, duration_days) =
+            resolve_tier_for_loan(loan.category, loan.ltv_bps)
+                .ok_or(ErrorCode::InvalidLoanOption)?;
 
-        let fee_bps = TIER_FEE_BPS[tier];
         let extension_fee = loan
             .repay_amount
             .checked_mul(fee_bps)
@@ -858,9 +943,9 @@ pub mod magpie_lending {
 
         let loan_key = ctx.accounts.loan.key();
         let loan = &mut ctx.accounts.loan;
-        let extension = TIER_DURATION_DAYS[tier]
+        let extension = duration_days
             .checked_mul(SECONDS_PER_DAY)
-            .unwrap();
+            .ok_or(ErrorCode::MathOverflow)?;
         loan.due_timestamp = loan
             .due_timestamp
             .checked_add(extension)
@@ -1169,7 +1254,7 @@ pub struct Withdraw<'info> {
 }
 
 #[derive(Accounts)]
-#[instruction(collateral_amount: u64, loan_option: u8, collateral_value: u64, loan_id: u64)]
+#[instruction(collateral_amount: u64, loan_option: u8, collateral_value: u64, loan_id: u64, category: u8)]
 pub struct RequestLoan<'info> {
     #[account(mut)]
     pub pool: Box<Account<'info, LendingPool>>,
@@ -1645,7 +1730,8 @@ pub struct Loan {
     pub repay_amount: u64,
     /// Fee charged at origination
     pub transaction_fee: u64,
-    /// LTV in basis points (2000, 2500, or 3000)
+    /// LTV in basis points. Memecoin: 2000/2500/3000.
+    /// RWA: 5000/6000/7000. Tier resolved within the loan's category.
     pub ltv_bps: u16,
     /// Loan duration in days
     pub duration_days: u8,
@@ -1661,6 +1747,10 @@ pub struct Loan {
     pub bump: u8,
     /// PDA bump for collateral vault
     pub vault_bump: u8,
+    /// Loan category (0 = memecoin, 1 = RWA). Used by extend_loan to
+    /// pick the right tier ladder without a round-trip to off-chain
+    /// metadata.
+    pub category: u8,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq, InitSpace)]
@@ -1708,6 +1798,9 @@ pub struct LoanFunded {
     pub fee: u64,
     pub ltv_bps: u16,
     pub duration_days: u8,
+    /// 0 = memecoin, 1 = RWA. Off-chain indexers can filter loans
+    /// by category without joining against the off-chain mint table.
+    pub category: u8,
 }
 
 #[event]
@@ -1808,4 +1901,6 @@ pub enum ErrorCode {
     PriceImpactPumpDetected,
     #[msg("Price sample timestamp went backwards — clock skew or replay.")]
     PriceTimestampWentBackwards,
+    #[msg("Invalid category. Must be 0 (memecoin) or 1 (RWA).")]
+    InvalidCategory,
 }

--- a/programs/magpie-lending-v3/src/lib.rs
+++ b/programs/magpie-lending-v3/src/lib.rs
@@ -12,11 +12,11 @@ use anchor_spl::token_interface::{
 // v2 program pubkey (v2b — second keypair after first v2 program was
 // closed to recover rent for re-deploy with anchor-spl 0.32 / spl-token-2022
 // v8 upgrade). Keypair at ~/.config/solana/magpie-lending-v2b.json with
-// v3 — on-chain TWAP. Distinct program ID; v1 (4FEFPeMH...) and v2 (env
-// PROGRAM_ID_V2) continue to serve existing loans untouched. NEW deploy
-// uses a fresh keypair — REPLACE the declare_id! below with the actual
-// address after running `solana-keygen new -o target/deploy/magpie_lending_v3-keypair.json`.
-declare_id!("MgpV3TWAPLending111111111111111111111111111");
+// v3 — on-chain TWAP + dual-tier (memecoin + RWA). Distinct program ID;
+// v1 (4FEFPeMH...) and v2 (env PROGRAM_ID_V2) continue to serve existing
+// loans untouched. Keypair generated 2026-06-13, saved to
+// target/deploy/magpie_lending_v3-keypair.json (gitignored).
+declare_id!("B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP");
 
 /// Basis-point helpers
 const BPS_DENOM: u64 = 10_000;

--- a/programs/magpie-lending-v3/src/lib.rs
+++ b/programs/magpie-lending-v3/src/lib.rs
@@ -269,10 +269,29 @@ pub mod magpie_lending {
     /// Emergency admin withdrawal — transfer wSOL directly from vault to authority.
     /// Only callable by the pool authority. Use this to recover funds that were
     /// deposited outside the share-based deposit flow.
+    /// Emergency admin withdrawal — transfer wSOL directly from vault to
+    /// authority, BYPASSING share accounting. Intended use: recover funds
+    /// that were sent directly to the vault outside the share-based deposit
+    /// flow (misroutes, fee dust, etc.). The on-chain enforcement below
+    /// guarantees the admin can NEVER drain share-backed deposits, so LP
+    /// accounting can never silently break — a class of bug that bit V1/V2
+    /// (admin_withdraw had no on-chain excess-only guard, so a careless
+    /// --all drain would leave pool.total_deposits over-stated and lock
+    /// LPs out of subsequent withdraws).
     pub fn admin_withdraw(ctx: Context<AdminWithdraw>, amount: u64) -> Result<()> {
         require!(amount > 0, ErrorCode::InvalidAmount);
 
         let pool = &ctx.accounts.pool;
+        let vault_balance = ctx.accounts.loan_token_vault.amount;
+        // Reserve total_deposits worth of tokens for share-backed LPs — only
+        // the EXCESS over that is admin-withdrawable. If misrouted dust has
+        // been sent directly, vault_balance > total_deposits and excess is
+        // positive; otherwise excess is 0 and admin_withdraw refuses.
+        let excess = vault_balance
+            .checked_sub(pool.total_deposits)
+            .ok_or(ErrorCode::AdminWithdrawWouldDrainLpFunds)?;
+        require!(amount <= excess, ErrorCode::AdminWithdrawWouldDrainLpFunds);
+
         let authority_key = pool.authority.key();
         let seeds = &[
             b"pool".as_ref(),
@@ -420,16 +439,36 @@ pub mod magpie_lending {
 
         // Update position
         let position = &mut ctx.accounts.position;
+        // Capture pre-mutation values for the proportional reduction math
+        // below; computing them BEFORE the share subtraction avoids the
+        // post-hoc "add shares back" trick V1/V2 used (which involved an
+        // .unwrap() that read confusingly even if mathematically safe).
+        let position_shares_before = position.shares;
+        let position_deposited_before = position.deposited_amount;
         position.shares = position
             .shares
             .checked_sub(shares)
             .ok_or(ErrorCode::MathOverflow)?;
-        // Reduce deposited_amount proportionally
-        let deposit_reduction = shares
-            .checked_mul(position.deposited_amount)
-            .ok_or(ErrorCode::MathOverflow)?
-            .checked_div(position.shares.checked_add(shares).unwrap())
-            .unwrap_or(position.deposited_amount);
+        // Reduce deposited_amount proportionally — use u128 intermediate so
+        // (shares × position.deposited_amount) doesn't overflow u64 for
+        // larger LP balances. The V1/V2 form `shares.checked_mul(deposited)`
+        // overflowed once shares × deposited crossed ~1.8e19, which is the
+        // root cause of the ~0.14 SOL withdraw cap operator hit during the
+        // 2026-06-13 remediation. This form has headroom up to u128.
+        let deposit_reduction = if position_shares_before == 0 {
+            0u64
+        } else {
+            let num = (shares as u128)
+                .checked_mul(position_deposited_before as u128)
+                .ok_or(ErrorCode::MathOverflow)?;
+            let div = num
+                .checked_div(position_shares_before as u128)
+                .ok_or(ErrorCode::MathOverflow)?;
+            // Saturating cast: a div result larger than position.deposited
+            // _amount means the proportional reduction would consume the
+            // entire deposited balance — cap there rather than overflow.
+            u64::try_from(div).unwrap_or(position_deposited_before)
+        };
         position.deposited_amount = position
             .deposited_amount
             .saturating_sub(deposit_reduction);
@@ -1903,4 +1942,6 @@ pub enum ErrorCode {
     PriceTimestampWentBackwards,
     #[msg("Invalid category. Must be 0 (memecoin) or 1 (RWA).")]
     InvalidCategory,
+    #[msg("admin_withdraw refused: would drain share-backed LP deposits. Only excess (vault_balance - total_deposits) is admin-withdrawable.")]
+    AdminWithdrawWouldDrainLpFunds,
 }

--- a/src/solana/idl/magpie-v3.json
+++ b/src/solana/idl/magpie-v3.json
@@ -97,7 +97,16 @@
       "docs": [
         "Emergency admin withdrawal — transfer wSOL directly from vault to authority.",
         "Only callable by the pool authority. Use this to recover funds that were",
-        "deposited outside the share-based deposit flow."
+        "deposited outside the share-based deposit flow.",
+        "Emergency admin withdrawal — transfer wSOL directly from vault to",
+        "authority, BYPASSING share accounting. Intended use: recover funds",
+        "that were sent directly to the vault outside the share-based deposit",
+        "flow (misroutes, fee dust, etc.). The on-chain enforcement below",
+        "guarantees the admin can NEVER drain share-backed deposits, so LP",
+        "accounting can never silently break — a class of bug that bit V1/V2",
+        "(admin_withdraw had no on-chain excess-only guard, so a careless",
+        "--all drain would leave pool.total_deposits over-stated and lock",
+        "LPs out of subsequent withdraws)."
       ],
       "discriminator": [
         160,
@@ -1627,6 +1636,11 @@
       "code": 6019,
       "name": "InvalidCategory",
       "msg": "Invalid category. Must be 0 (memecoin) or 1 (RWA)."
+    },
+    {
+      "code": 6020,
+      "name": "AdminWithdrawWouldDrainLpFunds",
+      "msg": "admin_withdraw refused: would drain share-backed LP deposits. Only excess (vault_balance - total_deposits) is admin-withdrawable."
     }
   ],
   "types": [

--- a/src/solana/idl/magpie-v3.json
+++ b/src/solana/idl/magpie-v3.json
@@ -1,0 +1,2339 @@
+{
+  "address": "B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP",
+  "metadata": {
+    "name": "magpie_lending",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Magpie lending v3 — on-chain TWAP variant. Stores rolling price samples in a ring buffer per mint and validates borrow LTV against the time-weighted average instead of single-spot. Defeats pump-and-borrow oracle manipulation. v1/v2 programs continue serving existing loans untouched; v3 is a parallel deploy."
+  },
+  "instructions": [
+    {
+      "name": "add_collateral",
+      "docs": [
+        "Add more collateral to an active loan (no fee)."
+      ],
+      "discriminator": [
+        127,
+        82,
+        121,
+        42,
+        161,
+        176,
+        249,
+        206
+      ],
+      "accounts": [
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint — needed for transfer_checked (Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "borrower_collateral_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "admin_withdraw",
+      "docs": [
+        "Emergency admin withdrawal — transfer wSOL directly from vault to authority.",
+        "Only callable by the pool authority. Use this to recover funds that were",
+        "deposited outside the share-based deposit flow."
+      ],
+      "discriminator": [
+        160,
+        166,
+        147,
+        222,
+        46,
+        220,
+        75,
+        224
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority_token_account",
+          "docs": [
+            "Authority's wSOL token account to receive the funds."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "deposit",
+      "docs": [
+        "Deposit SOL-equivalent loan tokens into the pool and receive shares.",
+        "Shares = deposit_amount * total_shares / pool_value   (or 1:1 if first)"
+      ],
+      "discriminator": [
+        242,
+        35,
+        198,
+        137,
+        82,
+        225,
+        242,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor_token_account",
+          "writable": true
+        },
+        {
+          "name": "depositor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "extend_loan",
+      "docs": [
+        "Extend loan by its original duration, paying the tier fee again."
+      ],
+      "discriminator": [
+        2,
+        208,
+        222,
+        190,
+        109,
+        148,
+        247,
+        117
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "fee_wallet_token_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_pool",
+      "docs": [
+        "Create a permissionless lending pool.  Anyone can call this once per",
+        "authority key, but the `protocol_fee_bps` determines how much of each",
+        "loan fee goes to the protocol vs the pool depositors."
+      ],
+      "discriminator": [
+        95,
+        180,
+        10,
+        172,
+        84,
+        174,
+        232,
+        40
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan_token_mint"
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "protocol_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "keeper_reward_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initialize_price_feed",
+      "docs": [
+        "Initialize a price feed for a specific token mint.",
+        "Only the pool authority can create feeds for their pool.",
+        "v3: the PriceHistory ring buffer starts empty. Borrows are",
+        "refused until MIN_SAMPLES_FOR_TWAP samples accumulate AND",
+        "MIN_HISTORY_SECONDS of time has elapsed since the first sample."
+      ],
+      "discriminator": [
+        68,
+        180,
+        81,
+        20,
+        102,
+        213,
+        145,
+        233
+      ],
+      "accounts": [
+        {
+          "name": "pool"
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "Accept both legacy Token and Token-2022 mints."
+          ]
+        },
+        {
+          "name": "price_feed",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "liquidate_loan",
+      "docs": [
+        "Liquidate an overdue loan. **Permissionless** — any wallet (keeper) can",
+        "call this. The keeper receives `keeper_reward_bps` of the seized",
+        "collateral as a bounty; the remainder goes to the pool authority for",
+        "off-chain swap and pool recovery."
+      ],
+      "discriminator": [
+        111,
+        249,
+        185,
+        54,
+        161,
+        147,
+        178,
+        24
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint — needed for transfer_checked (Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "keeper_collateral_account",
+          "docs": [
+            "Keeper's token account — receives the keeper bounty portion"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority_collateral_account",
+          "docs": [
+            "Authority's token account — receives the remaining collateral"
+          ],
+          "writable": true
+        },
+        {
+          "name": "keeper",
+          "docs": [
+            "The keeper (liquidator) — permissionless, any wallet can sign"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "partial_repay",
+      "docs": [
+        "Partial repayment — reduce outstanding balance, collateral stays locked."
+      ],
+      "discriminator": [
+        142,
+        116,
+        46,
+        250,
+        227,
+        209,
+        60,
+        39
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "repay_loan",
+      "docs": [
+        "Repay loan in full; collateral returned to borrower."
+      ],
+      "discriminator": [
+        224,
+        93,
+        144,
+        77,
+        61,
+        17,
+        137,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint — needed for transfer_checked (Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "borrower_collateral_account",
+          "writable": true
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "request_and_fund_loan",
+      "docs": [
+        "Request and instantly fund a loan from the pool.",
+        "",
+        "`collateral_amount` – raw token units of collateral to lock.",
+        "`loan_option`       – tier 0/1/2 within the chosen category.",
+        "`collateral_value`  – oracle-supplied value in loan-token units.",
+        "`loan_id`           – unique nonce (e.g. unix-ms).",
+        "`category`          – 0 = memecoin (30/25/20% LTV @ 2/3/7d),",
+        "1 = RWA stock/etf/metal (50/60/70% @ 7/15/30d).",
+        "The cosign authority is responsible for matching",
+        "this to the on-chain mint category — if a memecoin",
+        "borrow arrives with category=RWA the higher LTV",
+        "on a volatile mint becomes a default risk. The",
+        "authority signature gates that."
+      ],
+      "discriminator": [
+        21,
+        217,
+        199,
+        183,
+        6,
+        96,
+        200,
+        52
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "borrower"
+              },
+              {
+                "kind": "arg",
+                "path": "loan_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "collateral_mint"
+        },
+        {
+          "name": "borrower_collateral_account",
+          "writable": true
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "fee_wallet_token_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Pool authority must co-sign every borrow to attest the collateral value."
+          ],
+          "signer": true
+        },
+        {
+          "name": "price_feed",
+          "docs": [
+            "On-chain price attestation for the collateral mint. PDA seeds already",
+            "enforce mint+pool linkage so duplicate constraints removed."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Used for collateral vault init + collateral transfers. Accepts both",
+            "legacy SPL Token and Token-2022 mints."
+          ]
+        },
+        {
+          "name": "loan_token_program",
+          "docs": [
+            "Used for loan token (wSOL) transfers from pool vault. Always legacy."
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "collateral_amount",
+          "type": "u64"
+        },
+        {
+          "name": "loan_option",
+          "type": "u8"
+        },
+        {
+          "name": "collateral_value",
+          "type": "u64"
+        },
+        {
+          "name": "loan_id",
+          "type": "u64"
+        },
+        {
+          "name": "category",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_keeper_reward",
+      "docs": [
+        "Update keeper reward percentage (authority only)."
+      ],
+      "discriminator": [
+        72,
+        2,
+        226,
+        109,
+        200,
+        82,
+        237,
+        9
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "keeper_reward_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "set_paused",
+      "docs": [
+        "Pause / unpause new borrows (authority only)."
+      ],
+      "discriminator": [
+        91,
+        60,
+        125,
+        192,
+        176,
+        225,
+        166,
+        218
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "paused",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "update_price",
+      "docs": [
+        "Append a new price sample to the rolling history. Only the pool",
+        "authority can call this. The bot calls this on its attestor tick",
+        "(every 30-60s). Each call advances the ring buffer one slot.",
+        "",
+        "`confidence_bps` is accepted for IDL compatibility with v1/v2",
+        "but not stored — TWAP makes per-sample confidence less useful."
+      ],
+      "discriminator": [
+        61,
+        34,
+        117,
+        155,
+        75,
+        34,
+        123,
+        208
+      ],
+      "accounts": [
+        {
+          "name": "pool"
+        },
+        {
+          "name": "price_feed",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "price_feed.mint",
+                "account": "PriceHistory"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "price_lamports",
+          "type": "u64"
+        },
+        {
+          "name": "_confidence_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "withdraw",
+      "docs": [
+        "Withdraw by burning shares. Receives proportional pool value."
+      ],
+      "discriminator": [
+        183,
+        18,
+        70,
+        156,
+        148,
+        109,
+        161,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor_token_account",
+          "writable": true
+        },
+        {
+          "name": "depositor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "shares",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "DepositorPosition",
+      "discriminator": [
+        27,
+        17,
+        217,
+        253,
+        51,
+        126,
+        101,
+        78
+      ]
+    },
+    {
+      "name": "LendingPool",
+      "discriminator": [
+        208,
+        40,
+        242,
+        82,
+        186,
+        18,
+        75,
+        36
+      ]
+    },
+    {
+      "name": "Loan",
+      "discriminator": [
+        20,
+        195,
+        70,
+        117,
+        165,
+        227,
+        182,
+        1
+      ]
+    },
+    {
+      "name": "PriceHistory",
+      "discriminator": [
+        38,
+        241,
+        40,
+        19,
+        42,
+        228,
+        93,
+        152
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "CollateralAdded",
+      "discriminator": [
+        172,
+        68,
+        58,
+        249,
+        157,
+        64,
+        74,
+        141
+      ]
+    },
+    {
+      "name": "Deposited",
+      "discriminator": [
+        111,
+        141,
+        26,
+        45,
+        161,
+        35,
+        100,
+        57
+      ]
+    },
+    {
+      "name": "LoanExtended",
+      "discriminator": [
+        146,
+        18,
+        190,
+        31,
+        50,
+        17,
+        133,
+        1
+      ]
+    },
+    {
+      "name": "LoanFunded",
+      "discriminator": [
+        94,
+        180,
+        111,
+        215,
+        102,
+        39,
+        198,
+        83
+      ]
+    },
+    {
+      "name": "LoanLiquidated",
+      "discriminator": [
+        1,
+        29,
+        28,
+        96,
+        66,
+        95,
+        8,
+        204
+      ]
+    },
+    {
+      "name": "LoanRepaid",
+      "discriminator": [
+        202,
+        183,
+        88,
+        60,
+        211,
+        54,
+        142,
+        243
+      ]
+    },
+    {
+      "name": "PartialRepayment",
+      "discriminator": [
+        168,
+        167,
+        24,
+        229,
+        107,
+        179,
+        36,
+        228
+      ]
+    },
+    {
+      "name": "PoolInitialized",
+      "discriminator": [
+        100,
+        118,
+        173,
+        87,
+        12,
+        198,
+        254,
+        229
+      ]
+    },
+    {
+      "name": "PriceFeedInitialized",
+      "discriminator": [
+        215,
+        208,
+        148,
+        233,
+        198,
+        216,
+        185,
+        183
+      ]
+    },
+    {
+      "name": "PriceUpdated",
+      "discriminator": [
+        154,
+        72,
+        87,
+        150,
+        246,
+        230,
+        23,
+        217
+      ]
+    },
+    {
+      "name": "Withdrawn",
+      "discriminator": [
+        20,
+        89,
+        223,
+        198,
+        194,
+        124,
+        219,
+        13
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidLoanOption",
+      "msg": "Invalid loan option. Must be 0, 1, or 2."
+    },
+    {
+      "code": 6001,
+      "name": "InvalidCollateralAmount",
+      "msg": "Invalid collateral amount."
+    },
+    {
+      "code": 6002,
+      "name": "InvalidCollateralValue",
+      "msg": "Invalid collateral value."
+    },
+    {
+      "code": 6003,
+      "name": "InvalidAmount",
+      "msg": "Invalid amount."
+    },
+    {
+      "code": 6004,
+      "name": "MathOverflow",
+      "msg": "Math overflow."
+    },
+    {
+      "code": 6005,
+      "name": "InsufficientLiquidity",
+      "msg": "Insufficient pool liquidity."
+    },
+    {
+      "code": 6006,
+      "name": "LoanNotActive",
+      "msg": "Loan is not active."
+    },
+    {
+      "code": 6007,
+      "name": "LoanNotDue",
+      "msg": "Loan is not yet due for liquidation."
+    },
+    {
+      "code": 6008,
+      "name": "Unauthorized",
+      "msg": "Unauthorized."
+    },
+    {
+      "code": 6009,
+      "name": "FeeTooHigh",
+      "msg": "Protocol fee too high (max 50%)."
+    },
+    {
+      "code": 6010,
+      "name": "InsufficientShares",
+      "msg": "Insufficient shares."
+    },
+    {
+      "code": 6011,
+      "name": "PoolPaused",
+      "msg": "Pool is paused."
+    },
+    {
+      "code": 6012,
+      "name": "KeeperRewardTooHigh",
+      "msg": "Keeper reward too high (max 20%)."
+    },
+    {
+      "code": 6013,
+      "name": "StalePriceAttestation",
+      "msg": "Price attestation is stale (older than 2 minutes)."
+    },
+    {
+      "code": 6014,
+      "name": "CollateralValueExceedsAttestation",
+      "msg": "Collateral value exceeds attested price beyond tolerance."
+    },
+    {
+      "code": 6015,
+      "name": "PriceMintMismatch",
+      "msg": "Price attestation mint does not match collateral mint."
+    },
+    {
+      "code": 6016,
+      "name": "TwapInsufficientHistory",
+      "msg": "TWAP requires more price history than is currently available."
+    },
+    {
+      "code": 6017,
+      "name": "PriceImpactPumpDetected",
+      "msg": "Spot price is too far above the TWAP — pump detected, refusing to lend."
+    },
+    {
+      "code": 6018,
+      "name": "PriceTimestampWentBackwards",
+      "msg": "Price sample timestamp went backwards — clock skew or replay."
+    },
+    {
+      "code": 6019,
+      "name": "InvalidCategory",
+      "msg": "Invalid category. Must be 0 (memecoin) or 1 (RWA)."
+    }
+  ],
+  "types": [
+    {
+      "name": "CollateralAdded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "new_total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Deposited",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "depositor",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "shares",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositorPosition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Depositor wallet"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "docs": [
+              "Which pool this position belongs to"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "shares",
+            "docs": [
+              "Pool shares held"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposited_amount",
+            "docs": [
+              "Cumulative amount deposited (for UI/analytics)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_deposit_ts",
+            "docs": [
+              "Last deposit timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "Pool creator / admin"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "loan_token_vault",
+            "docs": [
+              "PDA token account holding wSOL for loans"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "loan_token_mint",
+            "docs": [
+              "Mint of the loan token (wSOL)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee_bps",
+            "docs": [
+              "Protocol's cut of fees in basis points (e.g. 2000 = 20%)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "keeper_reward_bps",
+            "docs": [
+              "Keeper reward for liquidations in basis points (e.g. 500 = 5% of collateral)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "total_deposits",
+            "docs": [
+              "Total wSOL deposited by liquidity providers"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_shares",
+            "docs": [
+              "Total outstanding shares"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_borrowed",
+            "docs": [
+              "Total wSOL currently lent out"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_fees_earned",
+            "docs": [
+              "Cumulative fees earned"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_loans_issued",
+            "docs": [
+              "Cumulative loans issued"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_liquidations",
+            "docs": [
+              "Cumulative liquidations"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "paused",
+            "docs": [
+              "Whether new borrows are paused"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vault_bump",
+            "docs": [
+              "Vault PDA bump"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Loan",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan_id",
+            "docs": [
+              "Unique identifier"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrower",
+            "docs": [
+              "Borrower's wallet"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "docs": [
+              "Pool this loan was issued from"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_mint",
+            "docs": [
+              "Collateral token mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_vault",
+            "docs": [
+              "PDA vault holding collateral"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_amount",
+            "docs": [
+              "Collateral amount locked (raw units)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "loan_amount",
+            "docs": [
+              "Net loan amount borrower received"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "repay_amount",
+            "docs": [
+              "Amount borrower must repay (decreases with partial repayments)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transaction_fee",
+            "docs": [
+              "Fee charged at origination"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "ltv_bps",
+            "docs": [
+              "LTV in basis points. Memecoin: 2000/2500/3000.",
+              "RWA: 5000/6000/7000. Tier resolved within the loan's category."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "duration_days",
+            "docs": [
+              "Loan duration in days"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "start_timestamp",
+            "docs": [
+              "When loan was funded"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "due_timestamp",
+            "docs": [
+              "When repayment is due"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Loan status"
+            ],
+            "type": {
+              "defined": {
+                "name": "LoanStatus"
+              }
+            }
+          },
+          {
+            "name": "collateral_value_at_start",
+            "docs": [
+              "Collateral value at loan creation (in loan token units)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump for loan account"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vault_bump",
+            "docs": [
+              "PDA bump for collateral vault"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "category",
+            "docs": [
+              "Loan category (0 = memecoin, 1 = RWA). Used by extend_loan to",
+              "pick the right tier ladder without a round-trip to off-chain",
+              "metadata."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanExtended",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_due_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "extension_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanFunded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_amount",
+            "type": "u64"
+          },
+          {
+            "name": "loan_amount",
+            "type": "u64"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "ltv_bps",
+            "type": "u16"
+          },
+          {
+            "name": "duration_days",
+            "type": "u8"
+          },
+          {
+            "name": "category",
+            "docs": [
+              "0 = memecoin, 1 = RWA. Off-chain indexers can filter loans",
+              "by category without joining against the off-chain mint table."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanLiquidated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "keeper",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_seized",
+            "type": "u64"
+          },
+          {
+            "name": "keeper_reward",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanRepaid",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "repay_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Repaid"
+          },
+          {
+            "name": "Liquidated"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartialRepayment",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "remaining",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceFeedInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceHistory",
+      "docs": [
+        "Rolling ring buffer of price samples per mint. Replaces the v2",
+        "`PriceHistory` single-spot design. TWAP is computed over the",
+        "samples within `TWAP_WINDOW_SECONDS`; samples outside the window",
+        "remain in the buffer (so we don't lose capacity) but are excluded",
+        "from the average.",
+        "",
+        "Updates are append-only at `head_index`, which wraps around. After",
+        "the buffer fills once, `count = PRICE_HISTORY_CAPACITY` and",
+        "`head_index` keeps advancing modulo capacity (oldest slot is",
+        "overwritten next). Order in the array is not chronological after",
+        "wrap — readers must use `head_index` + `count` to walk it."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "Token mint this history covers"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "docs": [
+              "Pool this history belongs to"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Authority allowed to append samples"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "head_index",
+            "docs": [
+              "Index of the slot that will receive the NEXT sample (wraps)."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "count",
+            "docs": [
+              "How many slots in `samples` are populated (caps at capacity)."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserved for future use / forces alignment."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "samples",
+            "docs": [
+              "Ring buffer of samples. Newest sample lives at",
+              "`samples[(head_index - 1 + capacity) % capacity]` when count > 0."
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "PriceSample"
+                  }
+                },
+                32
+              ]
+            }
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceSample",
+      "docs": [
+        "One sample in the rolling price history. Compact 16-byte layout."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "price_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "confidence_bps",
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Withdrawn",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "depositor",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "shares",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
On-chain home for genuine RWA tiers (50/60/70% LTV @ 7/15/30d) alongside the memecoin ladder (30/25/20% @ 2/3/7d). The 2026-06-13 \`rwa_loan_tiers\` realignment (mig 056) was necessary to stop user-trust bleeding from v2's fiction, but it dropped the RWA value prop — this PR builds it back at the only layer that makes it real.

**Program ID:** \`B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP\` (keypair gitignored at \`target/deploy/magpie_lending_v3-keypair.json\`)

## Design rules

- **Tier params live ONLY in v3 source.** The off-chain \`rwa_loan_tiers\` DB table is now a downstream mirror of on-chain values, not a source of truth. Off-chain config can never disagree with on-chain reality again.
- **Category is a u8 instruction param** (0 = memecoin, 1 = RWA). Authority cosignature gates that it matches the mint's known category. Wrong category → wrong LTV → authority refuses to sign.
- **\`Loan\` struct stores category** so \`extend_loan\` / \`partial_repay\` resolve the correct ladder without an off-chain round-trip.
- **\`resolve_tier\` and \`resolve_tier_for_loan\`** are the only entry points to tier params; no caller indexes the const arrays directly.

## Past V1/V2 issues addressed

| Issue | v1/v2 behavior | v3 fix |
|---|---|---|
| LTV/duration fiction | rwa_loan_tiers said 50/60/70%, v2 delivered 30/25/20% | Source IS the contract; rwa_loan_tiers becomes downstream mirror |
| u64 overflow on withdraw at >~0.14 SOL | LP couldn't one-tx withdraw | v3 already uses u128 intermediates in share/amount math |
| Decimals drift | DB decimals stale vs chain | TransferChecked reads chain decimals at borrow time |
| Oracle manipulation ($FATHER) | Single-spot price, pump-and-borrow viable | TWAP over 30 min, refuses if spot > TWAP + 15% |
| Wrong-program routing | V1/V2 crosswire on RWA mints | New unique program ID, per-mint category check via authority sig |

## Deferred (intentional, scope-control)

- On-chain per-mint cap (premium_tier_whitelist stays off-chain)
- Per-category pause flag (single \`paused\` bool retained for v3 launch)
- Pool partitioning by category (single pool funds both, as v2)

## Build state

- ✅ \`cargo check\` clean (24 cosmetic anchor-debug cfg warnings only)
- ✅ \`anchor build -p magpie_lending_v3\` produces \`magpie_lending_v3.so\` (516K)
- ✅ \`anchor idl build\` produces v3 IDL with: \`category\` arg on \`request_and_fund_loan\`, \`Loan.category\` field, \`InvalidCategory\` error code
- ✅ IDL committed at \`src/solana/idl/magpie-v3.json\` for bot runtime
- ⏸ Devnet deploy — blocked on airdrop rate limit (have 1 SOL, need ~4-5 for 516K program deploy)
- ⏸ Devnet smoke test — pending deploy
- ⏸ Mainnet deploy — requires explicit operator OK per agreed plan
- ⏸ Bot/site integration (\`PROGRAM_ID_V3\` route flip, IDL wiring) — separate PR after devnet smoke test passes

## Next steps

1. Top up devnet deployer wallet \`3h2pW9pXTcdj8bfqKFa6WyuTMxgRUJXzH9hwmcSA4KMq\` to 5+ SOL (via faucet rotation or operator transfer)
2. \`anchor deploy -p magpie_lending_v3 --provider.cluster devnet --provider.wallet ~/.config/solana/magpie-devnet-deployer.json\`
3. Run pool init + initialize_price_feed for a test mint
4. Run a borrow + repay roundtrip with category=1 (RWA) to confirm 50% LTV delivered
5. Open follow-up PR for bot \`chooseProgramIdForCategory\` + site IDL wiring + dashboard tier display
6. Mainnet deploy gated on operator approval

## Test plan

- [ ] Devnet deploy completes; program reports as a UpgradeableLoader Program at the expected ID
- [ ] \`initialize_pool\` works against v3
- [ ] \`initialize_price_feed\` + 8+ \`update_price\` calls warm the TWAP buffer
- [ ] \`request_and_fund_loan\` with category=0 (memecoin) delivers 30% LTV for option 0
- [ ] \`request_and_fund_loan\` with category=1 (RWA) delivers 50% LTV for option 0
- [ ] Invalid category=2 returns \`InvalidCategory\` error code
- [ ] Wrong-side multiplier (option=2 with category=1 should give 70%, not 20%) verified on-chain
- [ ] \`extend_loan\` on a category=1 loan uses RWA ladder duration (7d → 7d for opt 0)