### PR TITLE
feat(trailing-stop): schema + arm-core + site envelope

### DIFF
--- a/migrations/057_limit_close_trailing_stop.sql
+++ b/migrations/057_limit_close_trailing_stop.sql
@@ -1,0 +1,94 @@
+-- migration 057: trailing stop support on limit_close_orders.
+--
+-- "Trailing stop" is the standard trading primitive — the stop-loss
+-- trigger isn't a fixed price, it's a percentage distance below a
+-- moving "peak" price. As price climbs, the peak rises and the
+-- effective trigger rises with it; if price retraces by more than
+-- the trailing distance from the peak, the order fires. Classic
+-- "let profits run, cap drawdowns" tool.
+--
+-- Trailing applies ONLY to stop-loss orders (trigger_direction =
+-- 'below'). Take-profit is always a fixed target — its whole point
+-- is "fire when price hits this level," which is incompatible with
+-- a trailing semantic. arm-core enforces this; the column-level
+-- constraint here is a hard backstop.
+--
+-- Two columns:
+--   trailing_distance_bps  : non-null when this is a trailing SL.
+--                            Distance from peak below which the
+--                            order fires. 1000 = 10%, 500 = 5%, etc.
+--                            Bounded 50..5000 bps (0.5%..50%) — at
+--                            the tighter end, normal price noise
+--                            would fire the order immediately; at
+--                            the looser end you might as well use
+--                            a fixed SL. arm-core enforces.
+--   peak_price_micros      : highest price observed since the
+--                            order was armed. Initialized at arm
+--                            time to the current cross-sourced
+--                            price (so the first tick doesn't reset
+--                            to whatever volatility put us at).
+--                            Updated each watcher tick where the
+--                            current price exceeds the stored peak.
+--
+-- Effective trigger formula at each watcher tick:
+--   effective_trigger_micros = peak_price_micros × (10000 - trailing_distance_bps) / 10000
+-- Fire when current_price_micros <= effective_trigger_micros.
+--
+-- Migration is non-destructive: existing orders stay non-trailing
+-- (both columns NULL). The watcher path checks
+-- trailing_distance_bps IS NOT NULL before applying trailing logic,
+-- so every existing armed SL keeps its fixed-trigger behavior.
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS trailing_distance_bps SMALLINT,
+  ADD COLUMN IF NOT EXISTS peak_price_micros NUMERIC(40, 0);
+
+-- Sanity ranges. NULL is allowed (means "not trailing"); when set,
+-- bps must be in the operator-tuned range.
+ALTER TABLE limit_close_orders
+  DROP CONSTRAINT IF EXISTS limit_close_orders_trailing_distance_range_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_trailing_distance_range_check
+  CHECK (
+    trailing_distance_bps IS NULL
+    OR (trailing_distance_bps >= 50 AND trailing_distance_bps <= 5000)
+  );
+
+-- Trailing only makes sense for stop-loss. Take-profit's whole
+-- point is firing at a fixed target, which is incompatible with
+-- the trailing semantic.
+ALTER TABLE limit_close_orders
+  DROP CONSTRAINT IF EXISTS limit_close_orders_trailing_direction_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_trailing_direction_check
+  CHECK (
+    trailing_distance_bps IS NULL
+    OR COALESCE(trigger_direction, 'above') = 'below'
+  );
+
+-- Peak must be NULL exactly when trailing is NULL; if trailing
+-- is set, the watcher seeds peak at arm time, so post-arm rows
+-- always have it.
+ALTER TABLE limit_close_orders
+  DROP CONSTRAINT IF EXISTS limit_close_orders_trailing_peak_paired_check;
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_trailing_peak_paired_check
+  CHECK (
+    (trailing_distance_bps IS NULL AND peak_price_micros IS NULL)
+    OR (trailing_distance_bps IS NOT NULL AND peak_price_micros IS NOT NULL)
+  );
+
+COMMENT ON COLUMN limit_close_orders.trailing_distance_bps IS
+  'Trailing stop distance in basis points (50-5000). NULL = fixed-trigger SL.
+   Effective trigger = peak_price_micros * (10000 - trailing_distance_bps) / 10000.
+   Trailing applies only to trigger_direction=below (stop-loss).';
+
+COMMENT ON COLUMN limit_close_orders.peak_price_micros IS
+  'Highest price observed since arm, in trigger_kind units (price_usd or mc_usd).
+   Updated by the watcher when current > peak. NULL when not trailing.';
+
+-- Hot-path filter for the watcher: armed trailing orders only,
+-- ordered by armed_at so older trailing orders evaluate first.
+CREATE INDEX IF NOT EXISTS limit_close_orders_armed_trailing_idx
+  ON limit_close_orders(armed_at DESC)
+  WHERE status = 'armed' AND trailing_distance_bps IS NOT NULL;

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -366,7 +366,15 @@ export async function handleSiteLimitCloseList(req, url) {
  *   Target: 2x                  (multiplier; OR Price: 0.005 OR MC: 150m.
  *                                For Direction: below, multiplier MUST be
  *                                < 1 (e.g. 0.7x = "sell if price drops
- *                                to 70% of current").)
+ *                                to 70% of current"). Omit when using
+ *                                Trailing: below.)
+ *   Trailing: 1000              (optional; trailing-stop distance in bps,
+ *                                50-5000. ONLY valid with Direction:
+ *                                below. When set, the effective stop
+ *                                floats with the highest observed price
+ *                                — see migration 057. Trailing arms
+ *                                seed peak = current price; explicit
+ *                                Target/Price/MC is ignored.)
  *   Slippage: 200               (optional, default 200, bps)
  *   Dest: sol                   (optional, default sol)
  *   Expire: 30d                 (optional, days or hours)
@@ -386,6 +394,19 @@ export async function handleSiteLimitCloseArm(req) {
     return { status: 400, body: { error: "invalid_direction", detail: "Direction must be 'above' (take-profit) or 'below' (stop-loss)." } };
   }
   const isSl = triggerDirection === "below";
+
+  // ── Parse trailing-distance (optional, SL only) ──
+  let trailingDistanceBps = null;
+  if (fields.Trailing !== undefined) {
+    if (!isSl) {
+      return { status: 400, body: { error: "trailing_only_valid_on_stop_loss", detail: "Trailing: requires Direction: below. Take-profit always fires at a fixed target." } };
+    }
+    const t = Number(String(fields.Trailing).trim());
+    if (!Number.isInteger(t) || t < 50 || t > 5000) {
+      return { status: 400, body: { error: "invalid_trailing_distance_bps", detail: "Trailing must be an integer in [50, 5000] bps (0.5%-50%)." } };
+    }
+    trailingDistanceBps = t;
+  }
 
   // ── Parse target ──
   let triggerKind = null;
@@ -429,8 +450,21 @@ export async function handleSiteLimitCloseArm(req) {
     const usd = n * mul;
     triggerKind = "mc_usd";
     triggerValueMicro = BigInt(Math.round(usd * 1e6));
+  } else if (trailingDistanceBps != null) {
+    // Trailing arms don't need an explicit target — the watcher seeds
+    // peak = current price and computes effective trigger as
+    // peak × (1 - trailing/10000). We still need a triggerKind for
+    // arm-core's downstream logic. Default to price_usd as the most
+    // common; the multiplier-to-price helper below picks up live
+    // price and seeds triggerValueMicro at that × (1-trailing).
+    triggerKind = "price_usd";
+    // Defer triggerValueMicro resolution to the multiplier path —
+    // multiplierUsed = (1 - trailing/10000) accomplishes "set initial
+    // trigger to current-price × that ratio", which is the right seed
+    // for the watcher's first-tick peak.
+    multiplierUsed = 1 - (trailingDistanceBps / 10_000);
   } else {
-    return { status: 400, body: { error: "missing_target", detail: "Provide Target (e.g. 2x), Price ($0.005), or MC ($150m)." } };
+    return { status: 400, body: { error: "missing_target", detail: "Provide Target (e.g. 2x), Price ($0.005), or MC ($150m). For a trailing stop, send Trailing: <bps>." } };
   }
 
   const slippageBps = fields.Slippage ? Number(fields.Slippage) : 200;
@@ -481,10 +515,11 @@ export async function handleSiteLimitCloseArm(req) {
     triggerKind,
     triggerValueMicro,
     triggerDirection,
+    trailingDistanceBps,
     slippageBps,
     sellDestination: dest,
     expiresAt,
-    armNote: `armed via site (${isSl ? "SL" : "TP"}) by ${auth.signerPubkey.slice(0, 8)}…`,
+    armNote: `armed via site (${trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : (isSl ? "SL" : "TP")}) by ${auth.signerPubkey.slice(0, 8)}…`,
   });
   if (!armed.ok) {
     return {

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -118,6 +118,13 @@ export async function armOrder({
   triggerKind,
   triggerValueMicro,       // BigInt or string
   triggerDirection = "above", // 'above' = take-profit, 'below' = stop-loss
+  // 2026-06-13: trailing-stop support. When trailingDistanceBps is
+  // non-null, the order is a trailing SL — the effective trigger
+  // floats with the highest observed price since arm. Watcher seeds
+  // peak_price_micros at arm time and updates each tick. Trailing
+  // is incompatible with triggerDirection='above' (TP fires at a
+  // fixed target by definition); validated below.
+  trailingDistanceBps = null,
   slippageBps,
   sellDestination = "sol",
   expiresAt = null,
@@ -156,6 +163,15 @@ export async function armOrder({
   }
   if (!VALID_DESTINATIONS.has(sellDestination)) {
     return { ok: false, error: "invalid_sell_destination" };
+  }
+  // Trailing validation. Bounded same as the migration's CHECK constraint.
+  if (trailingDistanceBps != null) {
+    if (!Number.isInteger(trailingDistanceBps) || trailingDistanceBps < 50 || trailingDistanceBps > 5000) {
+      return { ok: false, error: "invalid_trailing_distance_bps", detail: { allowed_range_bps: [50, 5000] } };
+    }
+    if (triggerDirection !== "below") {
+      return { ok: false, error: "trailing_only_valid_on_stop_loss", detail: { direction: triggerDirection } };
+    }
   }
   if (!/^\d+$/.test(String(loanIdChain))) {
     return { ok: false, error: "invalid_loan_id" };
@@ -455,6 +471,16 @@ export async function armOrder({
     };
   }
 
+  // Trailing stops seed peak_price_micros at arm time so the watcher's
+  // first tick has a baseline. Using `currentMicrosForLater` (computed
+  // above as part of the immediate-fire guard) avoids a second oracle
+  // round-trip. Falls back to triggerBI when the immediate-fire guard
+  // didn't get a price quote — the watcher will correct on its first
+  // tick if the real price is higher.
+  const peakAtArm = trailingDistanceBps != null
+    ? (currentMicrosForLater != null ? currentMicrosForLater : triggerBI)
+    : null;
+
   let inserted;
   try {
     inserted = await query(
@@ -466,6 +492,7 @@ export async function armOrder({
           auto_escalate_slippage, max_slippage_bps_cap, initial_slippage_bps,
           preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at,
           engine_program_id,
+          trailing_distance_bps, peak_price_micros,
           notes)
        VALUES ($1, $2, $3, $4,
                $5,
@@ -474,7 +501,8 @@ export async function armOrder({
                $11, $12, $13,
                $14, $15, $16,
                $17,
-               $18)
+               $18, $19,
+               $20)
        RETURNING id, armed_at`,
       [userId, loan.id, triggerKind, triggerBI.toString(),
        triggerDirection,
@@ -491,10 +519,12 @@ export async function armOrder({
        // treats NULL as legacy-V1 for back-compat with pre-2026-06-13
        // rows; new arms always populate this.
        loan.program_id || null,
+       trailingDistanceBps,
+       peakAtArm != null ? peakAtArm.toString() : null,
        armNote
          || (appliedInitialBps !== originalInitialBps
-           ? `armed via ${source}; ${triggerDirection === "below" ? "STOP-LOSS" : "TP"}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
-           : `armed via ${source}; ${triggerDirection === "below" ? "STOP-LOSS" : "TP"}`)],
+           ? `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
+           : `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}`)],
     );
   } catch (err) {
     if (/duplicate key value violates unique constraint/i.test(err.message || "")) {


### PR DESCRIPTION
Wave 1 of trailing-stop. Adds trailing_distance_bps + peak_price_micros to limit_close_orders (mig 057), wires arm-core to accept the new field with full validation, extends site limit-close-arm/v1 envelope with a Trailing: bps field that SL-only. Paired engine PR will land the per-tick peak update + effective-trigger recomputation. Site UI for arming trailing stops is Wave 2.