### PR TITLE
feat(site-limit-close): expose trailing fields in GET response

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -292,7 +292,9 @@ export async function handleSiteLimitCloseList(req, url) {
               slippage_bps, sell_destination, status,
               armed_at, expires_at,
               max_slippage_bps_cap, auto_escalate_slippage,
-              source, source_agent_pubkey
+              source, source_agent_pubkey,
+              trailing_distance_bps,
+              peak_price_micros::text AS peak_price_micros
          FROM limit_close_orders
         WHERE loan_id = ANY($1::bigint[])
           AND status IN ('armed','firing','twap_in_progress','awaiting_user')


### PR DESCRIPTION
Follow-up to PR #183 trailing-stop work. Adds trailing_distance_bps + peak_price_micros to the /api/v1/site/limit-close GET response. Backwards-compatible field additions.