### PR TITLE
limit-close: trailing badge + /modifyorder trailing= + Pip propose_trailing_stop

### DIFF
--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -795,6 +795,8 @@ export async function handleLimitOrders(ctx) {
  *   slip=<2%|200bps|200>       — sets slippage_bps
  *   dest=<sol|usdc>            — sets sell_destination
  *   expires=<YYYY-MM-DD|ISO>   — sets expires_at, or "none" to clear
+ *   trailing=<10%|1000bps>     — converts SL to trailing (SL only),
+ *                                or "none" to clear back to regular SL
  *
  * To change trigger_kind, trigger_direction, or loan_id: use /cancel + /takeprofit.
  */
@@ -813,6 +815,8 @@ export async function handleModifyLimitOrder(ctx) {
         "• `/modifyorder 412 slip=3% dest=usdc`",
         "• `/modifyorder 412 expires=2026-06-30`",
         "• `/modifyorder 412 expires=none` (clear expiration)",
+        "• `/modifyorder 412 trailing=10%` (convert SL → trailing 10%)",
+        "• `/modifyorder 412 trailing=none` (back to regular SL)",
         "",
         "_Order stays armed — no cancel/re-arm gap._",
       ].join("\n"),
@@ -860,8 +864,25 @@ export async function handleModifyLimitOrder(ctx) {
       if (val.toLowerCase() === "none") updates.expiresAt = null;
       else if (Number.isNaN(Date.parse(val))) return ctx.reply(`\`expires=${val}\` couldn't be parsed.`, { parse_mode: "Markdown" });
       else updates.expiresAt = new Date(val).toISOString();
+    } else if (key === "trailing" || key === "trail") {
+      // trailing=10%   set/update trailing distance (SL only)
+      // trailing=1000bps   same in bps
+      // trailing=none   clear trailing (back to regular SL)
+      const lower = val.toLowerCase();
+      if (lower === "none" || lower === "off" || lower === "0") {
+        updates.trailingDistanceBps = null;
+      } else {
+        let bps;
+        if (lower.endsWith("%")) bps = Math.round(parseFloat(lower) * 100);
+        else if (lower.endsWith("bps")) bps = Math.round(parseFloat(lower));
+        else bps = Math.round(parseFloat(lower) * 100); // bare number → percent
+        if (!Number.isFinite(bps) || bps < 50 || bps > 5000) {
+          return ctx.reply(`\`trailing=${val}\` must be 0.5%–50% (50–5000 bps).`, { parse_mode: "Markdown" });
+        }
+        updates.trailingDistanceBps = bps;
+      }
     } else {
-      return ctx.reply(`Unknown field \`${key}\`. Supported: price, mc, slip, dest, expires.`, { parse_mode: "Markdown" });
+      return ctx.reply(`Unknown field \`${key}\`. Supported: price, mc, slip, dest, expires, trailing.`, { parse_mode: "Markdown" });
     }
   }
 
@@ -887,11 +908,30 @@ export async function handleModifyLimitOrder(ctx) {
       invalid_expires_at: "Expires couldn't be parsed.",
       trigger_would_fire_immediately: "That new trigger would fire RIGHT NOW. Pick a target on the unfired side.",
       no_changes_supplied: "No changes supplied.",
+      invalid_trailing_distance_bps: "Trailing must be 0.5%–50% (50–5000 bps).",
+      trailing_only_valid_on_stop_loss: "Trailing only makes sense on a stop-loss (direction=below). This order is a take-profit.",
     };
     return ctx.reply(friendly[result.error] || `Modify failed: \`${result.error}\``, { parse_mode: "Markdown" });
   }
 
   const o = result.order;
+  // Trailing line — surfaces the new floating-floor distance + the
+  // seeded peak so the user can sanity-check the conversion.
+  let trailingLine = null;
+  if (o.trailing_distance_bps != null) {
+    const pct = (o.trailing_distance_bps / 100).toFixed(1);
+    if (o.peak_price_micros) {
+      const peakUsd = Number(o.peak_price_micros) / 1e6;
+      const fmt = (n) => n < 0.01 ? n.toFixed(8) : n < 1 ? n.toFixed(6) : n.toFixed(4);
+      trailingLine = `Trailing: ${pct}% (peak $${fmt(peakUsd)} — floor floats with each new high)`;
+    } else {
+      trailingLine = `Trailing: ${pct}%`;
+    }
+  } else if (result.changedFields.includes("trailing_distance_bps")) {
+    // Trailing was just CLEARED — show that explicitly so the user
+    // doesn't wonder if their /modifyorder did nothing.
+    trailingLine = "Trailing: cleared (regular stop-loss)";
+  }
   return ctx.reply(
     [
       `*Order #${o.id} updated.*`,
@@ -900,6 +940,7 @@ export async function handleModifyLimitOrder(ctx) {
       o.trigger_value_micro ? `New trigger: \`${o.trigger_value_micro}\` micros` : null,
       `Slippage: ${(o.slippage_bps / 100).toFixed(2)}%`,
       `Destination: ${(o.sell_destination || "").toUpperCase()}`,
+      trailingLine,
       o.expires_at ? `Expires: ${new Date(o.expires_at).toISOString().slice(0, 10)}` : "Expires: never",
       "",
       "_Order stays armed — engine picks up new values on its next tick._",

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -687,6 +687,8 @@ export async function handleLimitOrders(ctx) {
             COALESCE(lc.trigger_direction, 'above') AS trigger_direction,
             lc.slippage_bps, lc.sell_destination, lc.status,
             lc.armed_at, lc.expires_at,
+            lc.trailing_distance_bps,
+            lc.peak_price_micros::text AS peak_price_micros,
             l.loan_id AS chain_loan_id,
             l.collateral_mint,
             m.symbol AS collateral_symbol,
@@ -720,7 +722,13 @@ export async function handleLimitOrders(ctx) {
     const r = rows[i];
     const trig = fmtTrigger(r.trigger_kind, BigInt(r.trigger_value_micro));
     const slip = (r.slippage_bps / 100).toFixed(r.slippage_bps < 200 ? 2 : 1);
-    const directionPill = r.trigger_direction === "below" ? "*SL*" : "*TP*";
+    // Trailing stops get their own pill so users can spot them at a glance.
+    // Direction is always 'below' for trailing — checked in the schema —
+    // so the trailing pill replaces the bare SL one rather than stacking.
+    const isTrailing = r.trailing_distance_bps != null;
+    const directionPill = isTrailing
+      ? `*TRAIL ${(r.trailing_distance_bps / 100).toFixed(1)}%*`
+      : (r.trigger_direction === "below" ? "*SL*" : "*TP*");
     // RWA badge — visible cue that this order routes through the V2
     // pool. Helps users mentally model why their stock-token TP might
     // pause Sat/Sun (engine weekend-fire skip for RWA TPs, PR #18 in
@@ -740,9 +748,17 @@ export async function handleLimitOrders(ctx) {
       else if (abs < 10) distLine = `\n   ~ ${abs.toFixed(1)}% from trigger`;
       else distLine = `\n   ~ ${Math.round(abs)}% from trigger`;
     }
+    // Trailing peak line — surfaces the moving high so users see what
+    // their effective floor is tracking. Watcher refreshes peak each tick.
+    let peakLine = "";
+    if (isTrailing && r.peak_price_micros) {
+      const peakUsd = Number(r.peak_price_micros) / 1e6;
+      const fmt = (n) => n < 0.01 ? n.toFixed(8) : n < 1 ? n.toFixed(6) : n.toFixed(4);
+      peakLine = `\n   ~ peak $${fmt(peakUsd)} (floor floats with each new high)`;
+    }
     lines.push(
       `${directionPill}${rwaBadge}  #${r.id} · loan ${r.chain_loan_id}${sym}`,
-      `   → ${trig}  ·  slip ${slip}%  ·  ${r.sell_destination.toUpperCase()}  ·  armed ${ageLabel(r.armed_at)}${expiry}${distLine}`,
+      `   → ${trig}  ·  slip ${slip}%  ·  ${r.sell_destination.toUpperCase()}  ·  armed ${ageLabel(r.armed_at)}${expiry}${peakLine}${distLine}`,
       "",
     );
   }

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -1828,6 +1828,7 @@ Mandatory tool triggers — pattern → tool:
 - User says "extend my loan", "push the due date", "need more time", "rollover" → \`propose_extend\`.
 - User says "partial repay", "pay down some", "reduce what I owe by X" → \`propose_partial_repay\`.
 - User says "take profit", "set a limit order", "sell when X 2x's", "auto-sell at $Y", "lock in if it moons" → \`propose_take_profit\`. CRITICAL: never guess the target. The user must specify a multiplier (2x), an explicit USD price ($0.005), OR a market cap ($150M). If they don't specify, ASK first with a concrete suggestion ("Want me to set it at 2× current? Or pick a specific price?"). After arming, the engine autonomously closes + sells the moment the target hits — explain this is "hands-off, you don't have to babysit." 1% protocol fee on proceeds. RWA / xStock collateral isn't supported in v1 (return the error message; don't propose).
+- User says "trailing stop", "trail my stop", "trailing 10%", "follow the price up but stop if it drops", "lock in gains with a moving stop" → \`propose_trailing_stop\`. Trailing stops are a stop-loss variant where the floor floats UP with each new high (never down). User specifies a distance (10% means "fire if price drops 10% from the most recent peak"). Default suggestion: 10–15%. Distance must be between 0.5% and 50%. Trailing only works on loans they want to PROTECT (downside) — it's not a take-profit. Explain plainly: "as long as price keeps making new highs, the floor moves with it; the first time price drops your distance, it fires." 1% protocol fee on proceeds, same as TP.
 - User says "show my take profits", "what limits do I have armed", "any take-profits set" → \`list_my_take_profits\`. After the call, summarize concisely: count + each one's collateral, target, slippage. If empty, suggest setting one with \`propose_take_profit\`.
 - User says "why did my take profit fire at X%", "what happened with my limit order", "why was the slippage so high", "explain my last take-profit", "did my TP partial fill" → \`explain_my_take_profit\`. Pass order_id when the user names one (e.g. "order #1842"); omit otherwise to default to the most recent. After the call, narrate the lifecycle in 2-3 sentences using the timeline_notes verbatim — never add or guess details. If outcome is non-null, report proceeds_sol and net_to_user_sol from the result. If it's still in flight (status armed / firing / twap_in_progress / awaiting_user), describe current state and what the engine is currently doing. NEVER speculate about token-specific reasons; the tool result is the truth.
 - User says "what would I net at 2x", "how much SOL if I set a 3x take-profit", "if I locked in at 1.5x what do I get", "is it worth arming a TP at X" → \`simulate_take_profit\` with their loan_id + multiplier. After the call, report net_to_user_sol as the headline ("you'd net ~X SOL after fees and slippage"). Always include the caveat from result.note about prices changing. Surface result.arm_hint as a one-tap command if the projection looks good. If error is present, narrate the error.note verbatim.
@@ -2083,6 +2084,24 @@ const TOOLS = [
         expire: { type: "string", description: "Order expiration as Nd or Nh (e.g. '30d', '12h'). Optional — no expiry by default." },
       },
       required: ["loan_id"],
+    },
+  },
+  {
+    name: "propose_trailing_stop",
+    description:
+      "Prepare a TRAILING-STOP proposal. Trailing stops are stop-losses with a floating floor — the floor moves UP with each new high, never down. Use when the user wants to ride momentum upside but auto-exit on a pullback: 'set a trailing 10%', 'trail my stop', 'sell if it drops 15% from peak', 'follow the price up'. " +
+      "REQUIRED: distance_pct between 0.5 and 50. If the user says 'trailing stop' without a number, ask: 'How wide a trail — 10% is the common default? (Tighter = quicker exit, looser = more room to ride.)' " +
+      "Site renders an inline confirmation card; borrower wallet signs the magpie: limit-close-arm/v1 envelope with the Trailing field. Pip does NOT execute the arm. 1% protocol fee on proceeds (same as TP).",
+    input_schema: {
+      type: "object",
+      properties: {
+        loan_id: { type: "string", description: "The numeric loan ID to arm a trailing stop on. Required." },
+        distance_pct: { type: "number", description: "Trailing distance as a percent (e.g. 10 = 10%, so floor = peak × 0.90). Range 0.5..50. Required." },
+        slippage_pct: { type: "number", description: "Slippage cap as a percent (e.g. 2 for 2%). Default 2%. Range 0.5..10." },
+        sell_to: { type: "string", enum: ["sol", "usdc"], description: "Sell proceeds destination. Default 'sol'." },
+        expire: { type: "string", description: "Order expiration as Nd or Nh (e.g. '30d', '12h'). Optional — no expiry by default." },
+      },
+      required: ["loan_id", "distance_pct"],
     },
   },
   {
@@ -2833,6 +2852,91 @@ const TOOL_HANDLERS = {
         String(loan.loan_id).slice(-6) +
         "`. Mention the target in human terms (e.g. 'at 2× current' or 'at $0.005') and the slippage cap. " +
         "DO NOT lecture them about how take-profit works — the card explains it. If the user picked a multiplier, mention the resolved USD price so they have a concrete number.",
+    };
+  },
+
+  // Trailing-stop proposal — sibling to propose_take_profit, but the
+  // proposed action's "target" is a floating floor (peak × (1 - distance))
+  // rather than a fixed price. The borrower's wallet still signs the same
+  // magpie: limit-close-arm/v1 envelope; the site SDK encodes the Trailing
+  // field instead of Target. Pip surfaces the resolved current price + the
+  // initial floor so the user has concrete numbers before signing.
+  propose_trailing_stop: async ({ loan_id, distance_pct, slippage_pct, sell_to, expire }, { userId, signerPubkey }) => {
+    const distPct = Number(distance_pct);
+    if (!Number.isFinite(distPct) || distPct < 0.5 || distPct > 50) {
+      return toolError(
+        "bad_distance",
+        null,
+        "Trailing distance must be between 0.5% and 50%. Common default is 10%. Ask the user to pick a number.",
+      );
+    }
+    const distanceBps = Math.round(distPct * 100);
+
+    const slipPct = slippage_pct != null ? Number(slippage_pct) : 2;
+    if (!Number.isFinite(slipPct) || slipPct < 0.1 || slipPct > 10) {
+      return toolError("bad_slippage", null, "Slippage must be between 0.5% and 10%.");
+    }
+    const slippageBps = Math.round(slipPct * 100);
+    const dest = sell_to === "usdc" ? "usdc" : "sol";
+
+    // Validate the loan belongs to the user + is active.
+    const { rows } = await query(
+      `SELECT l.*, sm.symbol, sm.decimals, sm.category, sm.enabled
+         FROM loans l
+         LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+        WHERE l.loan_id = $1 AND l.user_id = $2
+        LIMIT 1`,
+      [loan_id, userId],
+    );
+    if (!rows[0]) return toolError("loan_not_found", null, "That loan ID wasn't found for this user.");
+    const loan = rows[0];
+    if (loan.status !== "active") {
+      return toolError("loan_not_active", null, `This loan is ${loan.status}, not active. Trailing stop only works on active loans.`);
+    }
+    if (!loan.enabled) {
+      return toolError("collateral_not_enabled", null, "This collateral isn't currently enabled in the protocol.");
+    }
+    if (signerPubkey && loan.borrower_wallet && signerPubkey !== loan.borrower_wallet) {
+      return toolError(
+        "wrong_signer_wallet",
+        `loan.borrower=${loan.borrower_wallet} signer=${signerPubkey}`,
+        `That loan was opened by ${loan.borrower_wallet.slice(0,4)}…${loan.borrower_wallet.slice(-4)}. Tell the user to switch wallets in Phantom before arming the trailing stop.`,
+      );
+    }
+
+    // Resolve the current price so we can surface the initial floor.
+    // Fails-open (best-effort) — if the price read hiccups, the arm path
+    // still seeds peak at sign time. Pip just can't quote a number here.
+    let currentUsd = null;
+    let initialFloorUsd = null;
+    try {
+      const { getPriceInUsdCrossSourced } = await import("./price.js");
+      currentUsd = await getPriceInUsdCrossSourced(loan.collateral_mint);
+      if (currentUsd && currentUsd > 0) {
+        initialFloorUsd = currentUsd * (1 - distanceBps / 10_000);
+      }
+    } catch { /* fail-open */ }
+
+    return {
+      action_proposed: {
+        type: "trailing_stop",
+        loan_id: loan.loan_id,
+        collateral_symbol: loan.symbol,
+        distance_bps: distanceBps,
+        distance_pct: distPct,
+        current_usd: currentUsd,
+        initial_floor_usd: initialFloorUsd,
+        slippage_bps: slippageBps,
+        sell_destination: dest,
+        order_expire: expire || null,
+        expires_at: Date.now() + 5 * 60 * 1000,
+      },
+      _agent_instruction:
+        "Respond with ONE short line introducing the trailing-stop card. Refer to the loan as `#" +
+        String(loan.loan_id).slice(-6) +
+        "`. Mention the distance (e.g. 'trailing 10%') and, if current_usd is set, the resolved initial floor in plain prose " +
+        "(e.g. 'starts at ~$0.0042 — that's 10% below today's $0.0047 — and the floor floats UP with each new high'). " +
+        "Do NOT lecture; the card handles the rest. If current_usd came back null, just say the floor will seed at sign time.",
     };
   },
 

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -617,6 +617,13 @@ export async function modifyOrder({
   slippageBps,
   sellDestination,
   expiresAt,
+  // Trailing-stop adjustment. Three shapes:
+  //   undefined  — leave unchanged
+  //   null OR 0  — clear trailing on this order (regular SL again)
+  //   50..5000   — set/update trailing distance (only valid on SL)
+  // Transitioning a regular SL → trailing reseeds peak_price_micros
+  // from the live price so the floating floor starts at "today".
+  trailingDistanceBps,
 }) {
   // ── Load current order state for re-validation ─────────────
   const conditions = ["status = 'armed'"];
@@ -636,7 +643,9 @@ export async function modifyOrder({
             trigger_kind, trigger_value_micro::text AS trigger_value_micro,
             COALESCE(trigger_direction, 'above') AS trigger_direction,
             slippage_bps, sell_destination, expires_at,
-            max_slippage_bps_cap, source, source_agent_pubkey
+            max_slippage_bps_cap, source, source_agent_pubkey,
+            trailing_distance_bps,
+            peak_price_micros::text AS peak_price_micros
        FROM limit_close_orders
       WHERE id = $1 AND ${conditions.join(" AND ")}`,
     params,
@@ -682,19 +691,49 @@ export async function modifyOrder({
     }
     updates.expires_at = expiresAt;
   }
+  // Trailing-stop adjustment. Mirrors the shape validation in armOrder
+  // so a caller can't squeeze invalid values past modify that arm would
+  // have rejected. Peak seeding happens further down once we know the
+  // current price.
+  let seedPeakFromCurrent = false;
+  if (trailingDistanceBps !== undefined) {
+    if (trailingDistanceBps === null || trailingDistanceBps === 0) {
+      // Clearing trailing. Only meaningful if it was actually set.
+      if (current.trailing_distance_bps != null) {
+        updates.trailing_distance_bps = null;
+        updates.peak_price_micros = null;
+      }
+    } else {
+      if (!Number.isInteger(trailingDistanceBps) || trailingDistanceBps < 50 || trailingDistanceBps > 5000) {
+        return { ok: false, error: "invalid_trailing_distance_bps", detail: { allowed_range_bps: [50, 5000] } };
+      }
+      if (current.trigger_direction !== "below") {
+        return { ok: false, error: "trailing_only_valid_on_stop_loss", detail: { direction: current.trigger_direction } };
+      }
+      updates.trailing_distance_bps = trailingDistanceBps;
+      // First-time enable: seed peak from current price so the floating
+      // floor starts at "today" rather than the original trigger.
+      if (current.trailing_distance_bps == null) {
+        seedPeakFromCurrent = true;
+      }
+    }
+  }
 
-  if (Object.keys(updates).length === 0) {
+  if (Object.keys(updates).length === 0 && !seedPeakFromCurrent) {
     return { ok: false, error: "no_changes_supplied" };
   }
 
-  // ── Immediate-fire re-check (best-effort) for new trigger ───
+  // ── Immediate-fire re-check + peak seed (best-effort) ─────────
   // Mirrors armOrder's guard. Skips for price_sol (denominator moves)
   // and fails-open on oracle hiccup — engine re-checks at fire time.
-  if (updates.trigger_value_micro && (current.trigger_kind === "mc_usd" || current.trigger_kind === "price_usd")) {
+  // Same fetch double-duties as the peak-price seed when this modify
+  // is transitioning a regular SL → trailing.
+  const needPriceFetch =
+    (updates.trigger_value_micro && (current.trigger_kind === "mc_usd" || current.trigger_kind === "price_usd")) ||
+    seedPeakFromCurrent;
+  if (needPriceFetch) {
     try {
       const { getPriceInUsdCrossSourced } = await import("./price.js");
-      // We need the collateral mint for the price read. Pull from the
-      // loan row tied to this order.
       const { rows: [loan] } = await query(
         `SELECT collateral_mint FROM loans WHERE id = $1`,
         [current.loan_id],
@@ -702,13 +741,10 @@ export async function modifyOrder({
       if (loan) {
         const currentUsd = await getPriceInUsdCrossSourced(loan.collateral_mint);
         if (currentUsd && currentUsd > 0) {
-          let currentMicros = null;
-          if (current.trigger_kind === "price_usd") {
-            currentMicros = BigInt(Math.round(currentUsd * 1e6));
-          }
-          // mc_usd would need supply; skip if not trivially derivable —
-          // engine still catches at fire time.
-          if (currentMicros != null) {
+          const currentMicros = BigInt(Math.round(currentUsd * 1e6));
+          // Immediate-fire re-check, only for price_usd (mc_usd needs supply
+          // and we skip — engine catches at fire time).
+          if (updates.trigger_value_micro && current.trigger_kind === "price_usd") {
             const newBi = BigInt(updates.trigger_value_micro);
             if (current.trigger_direction === "above" && newBi <= currentMicros) {
               return { ok: false, error: "trigger_would_fire_immediately", detail: { direction: "above" } };
@@ -717,9 +753,14 @@ export async function modifyOrder({
               return { ok: false, error: "trigger_would_fire_immediately", detail: { direction: "below" } };
             }
           }
+          // Peak seed: start the trailing floor at today's price so the
+          // first watcher tick has a meaningful baseline to bump from.
+          if (seedPeakFromCurrent) {
+            updates.peak_price_micros = currentMicros.toString();
+          }
         }
       }
-    } catch { /* fail-open: engine re-checks at fire time */ }
+    } catch { /* fail-open: engine re-checks at fire time, peak self-heals on first tick */ }
   }
 
   // ── UPDATE ───────────────────────────────────────────────────
@@ -767,7 +808,9 @@ export async function modifyOrder({
       WHERE id = $${orderIdPos}
         AND ${updateConditions.join(" AND ")}
       RETURNING id, trigger_value_micro::text AS trigger_value_micro,
-                slippage_bps, sell_destination, expires_at, updated_at`,
+                slippage_bps, sell_destination, expires_at, updated_at,
+                trailing_distance_bps,
+                peak_price_micros::text AS peak_price_micros`,
     updateParams,
   );
   if (r.rows.length === 0) {


### PR DESCRIPTION
## Summary
Three pieces of trailing-stop polish on top of the trailing pipeline (#183/#184/#185, engine #22).

### `/limitorders` display
- `*TRAIL N%*` pill replaces `*SL*` for trailing orders
- Adds `peak \$X (floor floats with each new high)` line so users can see the moving high

### `/modifyorder trailing=...`
- `/modifyorder 412 trailing=10%` converts a regular SL into trailing (no cancel/re-arm gap)
- `/modifyorder 412 trailing=none` clears trailing back to a regular SL
- Arm-core gains `trailingDistanceBps` with full shape validation + auto-seeds peak from live price on first enable
- Surfaces trailing line in confirmation reply

### Pip `propose_trailing_stop` tool
- Pip can now resolve a trailing-stop proposal end-to-end
- Tool def + handler alongside `propose_take_profit`: validates loan, signer wallet, looks up live price, returns `action_proposed.type='trailing_stop'`
- System prompt gains trigger phrases ("trailing stop", "trail my stop", "follow price up", "lock in gains") with the floor-floats-up semantic

Site card for `trailing_stop` lives in magpiecapital/magpie-site#TBD.

## Test plan
- [ ] Arm a trailing stop via `/trailingstop 10%`; `/limitorders` renders the new pill + peak line
- [ ] Regular SL renders as `*SL*` with no peak line
- [ ] `/modifyorder <id> trailing=15%` converts a regular SL: confirmation surfaces trailing line; DB has trailing_distance_bps=1500 and peak_price_micros = current price
- [ ] `/modifyorder <id> trailing=none` clears trailing
- [ ] `/modifyorder <tp_id> trailing=20%` returns the "stop-loss only" error
- [ ] Pip: "set a trailing 10% on my BONK loan" → renders the trailing-stop card with resolved floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)