### PR TITLE
fix: /modifyorder trailing= must recompute trigger from peak

### DIFF
--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -715,6 +715,21 @@ export async function modifyOrder({
       // floor starts at "today" rather than the original trigger.
       if (current.trailing_distance_bps == null) {
         seedPeakFromCurrent = true;
+      } else if (current.trailing_distance_bps !== trailingDistanceBps) {
+        // Distance tightened/loosened on an existing trailing stop.
+        // The watcher only recomputes trigger when it sees a NEW high,
+        // so without this we'd carry the old distance until the next
+        // peak update — meaning "I tightened my trail to 5%" wouldn't
+        // actually take effect until price moved up. Recompute the
+        // effective trigger from the existing peak immediately so the
+        // change is live on the next watcher tick.
+        try {
+          const existingPeak = BigInt(current.peak_price_micros || "0");
+          if (existingPeak > 0n) {
+            const newTrigger = (existingPeak * BigInt(10000 - trailingDistanceBps)) / 10000n;
+            updates.trigger_value_micro = newTrigger.toString();
+          }
+        } catch { /* fall-through; watcher will heal on next high */ }
       }
     }
   }


### PR DESCRIPTION
## Summary
Found a latent bug while reviewing the /modifyorder trailing= path I shipped in #187: when a user tightens or loosens an existing trailing distance (e.g. 10% → 5%), the watcher only recomputes \`trigger_value_micro\` on a NEW high. That means the user-intended distance wasn't actually live until price moved up — "I tightened my trail to 5%" stayed at 10% effective trail until the next peak update.

## Fix
When \`trailing_distance_bps\` changes on an existing trailing stop in \`modifyOrder\`, immediately recompute:
\`\`\`
trigger_value_micro = existing_peak × (1 - new_distance/10000)
\`\`\`
so the change is live on the next watcher tick.

- First-time enable still seeds peak from current price (unchanged)
- Clearing trailing still nulls both columns (unchanged)
- Distance unchanged (no-op modify) leaves trigger alone (unchanged)

## Test plan
- [ ] Arm a trailing 10%, run /modifyorder <id> trailing=5%: confirm new trigger = peak × 0.95
- [ ] Arm a trailing 10%, run /modifyorder <id> trailing=15%: trigger drops to peak × 0.85 (loosened)
- [ ] First-time enable still seeds peak (regression check)
- [ ] trailing=none still nulls everything (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)