### PR TITLE
site limit-close modify: accept Trailing field

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -602,10 +602,16 @@ export async function handleSiteLimitCloseArm(req) {
  *   Slippage?: <bps integer>    — change slippage_bps
  *   Dest?: sol | usdc           — change sell_destination
  *   Expires?: <ISO|none>        — change expires_at (or "none" to clear)
+ *   Trailing?: <bps|"none">     — change trailing_distance_bps (50-5000 bps)
+ *                                  or "none" to clear trailing (back to fixed SL).
+ *                                  First-time enable seeds peak_price_micros from
+ *                                  live price; later changes recompute trigger
+ *                                  from the existing peak so the new distance is
+ *                                  live on the next watcher tick.
  *   Wallet: <pubkey>
  *   IssuedAt: <ISO>
  *
- * At least one of Price / MC / Slippage / Dest / Expires required.
+ * At least one of Price / MC / Slippage / Dest / Expires / Trailing required.
  *
  * Pairs with magpie-bot#148 (modifyOrder core) + magpie-x402#29
  * (x402 forwarder). Brings site users to parity with TG and agent
@@ -655,6 +661,18 @@ export async function handleSiteLimitCloseModify(req) {
       updates.expiresAt = new Date(fields.Expires).toISOString();
     }
   }
+  if (fields.Trailing !== undefined) {
+    const t = String(fields.Trailing).toLowerCase();
+    if (t === "none" || t === "off" || t === "0") {
+      updates.trailingDistanceBps = null;
+    } else {
+      const bps = Number(t);
+      if (!Number.isInteger(bps) || bps < 50 || bps > 5000) {
+        return { status: 400, body: { error: "invalid_trailing_distance_bps", detail: "Trailing must be an integer in [50, 5000] bps, or 'none' to clear." } };
+      }
+      updates.trailingDistanceBps = bps;
+    }
+  }
   if (Object.keys(updates).length === 0) {
     return { status: 400, body: { error: "no_changes_supplied" } };
   }
@@ -676,6 +694,8 @@ export async function handleSiteLimitCloseModify(req) {
       invalid_expires_at: 400,
       trigger_would_fire_immediately: 409,
       no_changes_supplied: 400,
+      invalid_trailing_distance_bps: 400,
+      trailing_only_valid_on_stop_loss: 409,
     };
     return {
       status: statusMap[r.error] || 409,
@@ -693,6 +713,10 @@ export async function handleSiteLimitCloseModify(req) {
       sell_destination: r.order.sell_destination,
       expires_at: r.order.expires_at,
       updated_at: r.order.updated_at,
+      // Echo trailing state so the dashboard can update its in-memory
+      // armed-order view without a separate refetch round-trip.
+      trailing_distance_bps: r.order.trailing_distance_bps ?? null,
+      peak_price_micros: r.order.peak_price_micros ?? null,
     },
   };
 }


### PR DESCRIPTION
## Summary
\`/modifyorder trailing=\` works via TG (#187) but the site's signed modify envelope was missing \`Trailing\` — site users couldn't tighten/loosen a live trailing distance without canceling and re-arming.

- New \`Trailing: <bps|"none">\` envelope field
- Validation: integer in [50, 5000] or "none"/"off"/"0" to clear
- Status map entries for \`invalid_trailing_distance_bps\` (400) and \`trailing_only_valid_on_stop_loss\` (409)
- Response body echoes \`trailing_distance_bps\` + \`peak_price_micros\` so the dashboard updates its in-memory armed view without a refetch round-trip

Site SDK + dashboard Edit-panel UI in the companion magpie-site PR.

## Test plan
- [ ] POST /api/v1/site/limit-close/modify with \`Trailing: 1500\` flips a regular SL into a 15% trailing stop
- [ ] \`Trailing: none\` clears trailing on an existing trailing stop
- [ ] \`Trailing: 999999\` returns 400 invalid_trailing_distance_bps
- [ ] Trailing change on a TP order returns 409 trailing_only_valid_on_stop_loss
- [ ] Response body now carries trailing_distance_bps + peak_price_micros

🤖 Generated with [Claude Code](https://claude.com/claude-code)