### PR TITLE
fix(gov-autopilot): also skip file-hash anomaly check when DB fallback

### DIFF
--- a/src/governance/anomaly.js
+++ b/src/governance/anomaly.js
@@ -21,6 +21,14 @@ import { getProposal } from "./registry.js";
  * Returns { ok: true } | { ok: false, reason }.
  */
 export function checkSnapshotIntegrity(snapshotPath, expectedHash) {
+  // DB-snapshot fallback path (#203, 2026-06-14) — when the
+  // pipeline ran tally against governance_snapshot_weights instead
+  // of an on-disk file, snapshotPath is null and there's no file
+  // hash to compare. The DB rows are the trusted source on Railway;
+  // skip file integrity check rather than fail the proposal.
+  if (!snapshotPath) {
+    return { ok: true, detail: { skipped: "db_snapshot_no_file_to_hash" } };
+  }
   let bytes;
   try {
     bytes = readFileSync(snapshotPath);

--- a/src/governance/pipeline.js
+++ b/src/governance/pipeline.js
@@ -259,7 +259,15 @@ export async function processProposal(proposal) {
     // which is persisted to governance_snapshots.hash_sha256 for
     // audit. Non-hash anomaly checks (vote spikes, vote-shape sanity)
     // still run for close-time mode below.
-    if (!closeSnapshotId) {
+    // File-hash tamper-detection only runs when we're using the
+    // on-disk file path. The DB-fallback path added in #203 uses
+    // governance_snapshot_weights as the trusted source; integrity is
+    // already enforced by the unique-per-(snapshot_id, voter) row
+    // semantics + the DB connection's auth surface. Without the
+    // `&& snapshotPath` guard, readFileSync(null) throws ENOENT and
+    // the pipeline fails at the anomaly step even after the DB tally
+    // succeeded — exactly the MGP-001 close-day pattern.
+    if (!closeSnapshotId && snapshotPath) {
       // Canonical hash comes from the registry (set at activation time, never
       // edited). The pipeline rejects the run if the on-disk snapshot's hash
       // doesn't match — an attacker who tampered with the snapshot file


### PR DESCRIPTION
Follow-up to #203. The DB-snapshot fallback path made the tally step work without a local snapshot file, but the anomaly step still called readFileSync(snapshotPath) which throws ENOENT when snapshotPath is null. Result: pipeline makes it past tally + verify but then fails at the anomaly step.

- pipeline.js: condition the file-hash block on snapshotPath being non-null
- anomaly.js: checkSnapshotIntegrity returns ok early with skip-detail when snapshotPath is null

After this lands, MGP-001 should run cleanly through tally → verify → anomaly → implementation_plan on the next autopilot tick.