### PR TITLE
fix(gov-autopilot): verify step uses snapshotIdForTally, not closeSnapshotId

### DIFF
--- a/src/governance/pipeline.js
+++ b/src/governance/pipeline.js
@@ -219,7 +219,17 @@ export async function processProposal(proposal) {
         proposalId,
         questionId: "Vote",
         snapshotPath,
-        snapshotId: closeSnapshotId,
+        // 2026-06-14: was `closeSnapshotId` here, which is null on
+        // activation-mode proposals when the DB-snapshot fallback is
+        // in use (#203 + #204). tallyProposal then threw "requires
+        // snapshotId or snapshotPath" because BOTH inputs were null,
+        // and the pipeline kept stalling at verify_recompute_failed.
+        // The verify step should re-use whatever snapshot identifier
+        // the tally step landed on. snapshotIdForTally is set in step
+        // 1 above and is either the DB-fallback registry ID, the
+        // close-time snapshot ID, or null when we're using the file
+        // path (snapshotPath is non-null in that case).
+        snapshotId: snapshotIdForTally,
         expectedSnapshotId: proposal.snapshot_id ?? proposalId,
         capFraction: 0.02,
       });


### PR DESCRIPTION
Third autopilot fix in the MGP-001 chain (#203 + #204 + this).

#203 fixed tally step to use DB-snapshot fallback. #204 fixed anomaly step. This fixes the verify step which still passed `closeSnapshotId` (null on activation-mode + DB-fallback) — tallyProposal then threw 'requires snapshotId or snapshotPath' and the pipeline kept stalling at verify_recompute_failed.

After this lands, MGP-001 runs end-to-end on the next 5-min tick.

**Side-note**: governance_config already has the correct 70/10/10/10 values applied at 2026-06-13 22:01:46 UTC. The protocol IS paying the new split. This PR just unsticks the pipeline state machine so the proposal moves to 'ratified' cleanly.