### PR TITLE
fix(liq-econ): enroll older liquidations with NULL borrower_wallet / actual_received

### DIFF
--- a/src/services/liquidation-economics-watcher.js
+++ b/src/services/liquidation-economics-watcher.js
@@ -141,12 +141,23 @@ function deriveSeizureSplits(collateralAmountRaw, keeperBps) {
  */
 async function enrollUntrackedLiquidations(keeperBps) {
   const { rows } = await query(
-    `SELECT l.id, l.loan_id, l.borrower_wallet, l.collateral_mint, l.collateral_amount,
+    `SELECT l.id, l.loan_id,
+            -- borrower_wallet was added in a later migration. For older
+            -- TG-bot-only loans it's NULL; fall back to the user's
+            -- custodial wallet public_key via the wallets join. Site
+            -- borrows always have l.borrower_wallet populated directly.
+            COALESCE(l.borrower_wallet, w.public_key) AS borrower_wallet,
+            l.collateral_mint, l.collateral_amount,
             l.original_loan_amount_lamports::bigint AS principal_with_fee,
-            l.actual_received_lamports::bigint AS principal_lent,
+            -- actual_received_lamports was added recently; for historical
+            -- loans it's NULL. Fall back to the headline loan_amount which
+            -- is what actually hit the borrower's wallet (origination fee
+            -- is already netted out of this field on the program side).
+            COALESCE(l.actual_received_lamports, l.loan_amount_lamports)::bigint AS principal_lent,
             sm.symbol AS collateral_symbol
        FROM loans l
        LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+       LEFT JOIN wallets w ON w.user_id = l.user_id
       WHERE l.status = 'liquidated'
         AND NOT EXISTS (
           SELECT 1 FROM liquidation_economics le WHERE le.loan_id = l.id
@@ -155,12 +166,17 @@ async function enrollUntrackedLiquidations(keeperBps) {
       LIMIT 100`,
   );
   let enrolled = 0;
+  let skipped = 0;
   for (const loan of rows) {
+    // After the COALESCE fallbacks: if borrower_wallet is still NULL we
+    // can't enroll (would violate liquidation_economics NOT NULL). Skip
+    // silently — operator can backfill the loans row if needed.
+    if (!loan.borrower_wallet) {
+      skipped++;
+      continue;
+    }
     const splits = deriveSeizureSplits(loan.collateral_amount, keeperBps);
     const isMagpie = loan.collateral_mint === MAGPIE_MINT;
-    // For $MAGPIE collateral, principal_lent may be null if it predates
-    // the actual_received_lamports column; fall back to the headline
-    // loan amount minus the standard origination-fee assumption.
     const principalLent = loan.principal_lent != null
       ? loan.principal_lent
       : null;
@@ -190,6 +206,9 @@ async function enrollUntrackedLiquidations(keeperBps) {
     } catch (err) {
       console.warn(`[liq-econ] enroll failed for loan ${loan.loan_id}: ${err.message?.slice(0, 100)}`);
     }
+  }
+  if (skipped > 0) {
+    console.log(`[liq-econ] enroll: ${enrolled} enrolled, ${skipped} skipped (NULL borrower_wallet — no wallets join match)`);
   }
   return enrolled;
 }


### PR DESCRIPTION
## Summary

Phase 1A's enrollment SELECT pulled `l.borrower_wallet` and `l.actual_received_lamports` directly, but both columns were added in later migrations and are NULL on older loans. The INSERT then failed NOT NULL constraints, so **none** of the 11 historical liquidations enrolled — including the +11.96 SOL PUMP default we just told users would distribute autonomously.

Verified live on prod: 11 liquidated loans, 8 with NULL `borrower_wallet`, all 11 with NULL `actual_received_lamports`. Watcher was logging `[liq-econ] enroll failed` on every tick.

## Fix

- `borrower_wallet` → `COALESCE(l.borrower_wallet, w.public_key)` via a `LEFT JOIN wallets w ON w.user_id = l.user_id`. Site borrows already populate `l.borrower_wallet` directly; TG-bot borrows resolve to the user's custodial wallet via the join.
- `actual_received_lamports` → `COALESCE(l.actual_received_lamports, l.loan_amount_lamports)`. The headline `loan_amount_lamports` is the post-origination-fee amount the borrower actually received.
- If both the borrower_wallet and the wallets-join lookup return NULL, the loan is silently skipped with a counter log line. Operator can backfill `loans.borrower_wallet` manually if needed.

## Test plan

- [ ] CI green (syntax-check, lint, leak-check, ltv-guard)
- [ ] After deploy: next Phase 1A tick should enroll all 11 historical liquidations (4 $MAGPIE → `magpie_burn_pending`, 7 others → `pending_sale`)
- [ ] Run `railway run --service magpie-bot -- node scripts/backfill-liquidation-economics.mjs` to match sale txs; PUMP loan 533 (D5n6…YjX2, +11.96 SOL) should land in `awaiting_distribution`
- [ ] Phase 2 watcher's next 90-s tick should credit `magpie_holder_pool` ≈ 9.57 SOL (80%), `lp_loyalty_pool` ≈ 1.196 SOL (10%), `protocol_reserve_pool` ≈ 1.196 SOL (10%) — borrower has no referrer so the referrer slice rolls to holders

🤖 Generated with [Claude Code](https://claude.com/claude-code)