### PR TITLE
fix(governance): audit bot_constant_pr via GitHub REST instead of git/gh

### DIFF
--- a/src/governance/audit.js
+++ b/src/governance/audit.js
@@ -29,26 +29,51 @@ async function auditDbConfigUpdate(action) {
   return { verified: true, reason: "config_value_matches_plan" };
 }
 
+const GITHUB_REPO_SLUG = process.env.GITHUB_REPO_SLUG || "magpiecapital/magpie-bot";
+const GITHUB_API_BASE = "https://api.github.com";
+
+/**
+ * Audit branch+PR existence via the GitHub REST API. The previous
+ * implementation shelled out to git + gh, but the Railway container
+ * doesn't include either binary — every audit failed with
+ * "git: not found", stalling MGP-001's pipeline at verification_failed.
+ * The bot repo is public, so unauthenticated REST calls suffice
+ * (60 req/hr/IP — autopilot ticks every 5 min so well under budget).
+ */
 async function auditBotConstantPr(action) {
   const { branch_name } = action;
-  // Verify branch exists on remote
+  const headers = { "Accept": "application/vnd.github+json", "User-Agent": "magpie-autopilot-audit" };
+  // Branch existence
   try {
-    execSync(`git ls-remote --exit-code --heads origin ${branch_name}`, { stdio: "pipe" });
-  } catch {
-    return { verified: false, reason: `branch_not_on_remote: ${branch_name}` };
+    const r = await fetch(
+      `${GITHUB_API_BASE}/repos/${GITHUB_REPO_SLUG}/branches/${encodeURIComponent(branch_name)}`,
+      { headers },
+    );
+    if (r.status === 404) {
+      return { verified: false, reason: `branch_not_on_remote: ${branch_name}` };
+    }
+    if (!r.ok) {
+      return { verified: false, reason: `branch_lookup_http_${r.status}` };
+    }
+  } catch (err) {
+    return { verified: false, reason: `branch_lookup_failed: ${err.message?.slice(0, 80)}` };
   }
-  // Verify a PR exists with the branch as head
+  // Open PR for the branch
   try {
-    const out = execSync(
-      `gh pr list --head ${branch_name} --state open --json number,headRefName --jq 'length'`,
-      { stdio: ["ignore", "pipe", "pipe"] },
-    ).toString().trim();
-    const count = Number(out);
-    if (count === 0) {
+    const [owner] = GITHUB_REPO_SLUG.split("/");
+    const r = await fetch(
+      `${GITHUB_API_BASE}/repos/${GITHUB_REPO_SLUG}/pulls?head=${owner}:${encodeURIComponent(branch_name)}&state=open`,
+      { headers },
+    );
+    if (!r.ok) {
+      return { verified: false, reason: `pr_lookup_http_${r.status}` };
+    }
+    const list = await r.json();
+    if (!Array.isArray(list) || list.length === 0) {
       return { verified: false, reason: "no_open_pr_for_branch" };
     }
   } catch (err) {
-    return { verified: false, reason: `gh_pr_list_failed: ${err.message}` };
+    return { verified: false, reason: `pr_lookup_failed: ${err.message?.slice(0, 80)}` };
   }
   return { verified: true, reason: "branch_pushed_and_pr_open" };
 }


### PR DESCRIPTION
## Summary

Railway runtime container has neither `git` nor `gh` installed. Every autopilot tick for MGP-001 since 2026-06-14 was shelling out to `git ls-remote`, hitting `/bin/sh: 1: git: not found`, and pinning `implementation_status` at `verification_failed` — even though PR #210's branch was actually present.

Replace the git+gh calls with two unauthenticated GitHub REST API fetches (repo is public, well under the 60 req/hr/IP quota at the 5-min autopilot cadence):

- `GET /repos/{owner}/{repo}/branches/{branch}`
- `GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open`

Verified locally — branch endpoint returns 200, PR endpoint returns the open PR #210.

## Why this unblocks MGP-001

`overall_verified = blocking_unverified === 0`. Action 4 (manual_required) is non-blocking. Action 5 (bot_constant_pr) is the only blocker. After this lands, the next 5-min autopilot tick re-audits action 5 via REST, sees the branch + PR exist, `blocking_unverified` drops to 0, `overall_verified` flips to true, the pipeline proceeds to announce, and `pipeline_completed_at` gets set.

## Out of scope

`executeBotConstantPr` (implementation step) still uses git and will keep failing in the container. Operator ships those PRs manually for now; the audit can now verify them. A separate change can teach the implementation step to gracefully detect missing git and emit a `manual_required`-style alert.

## Test plan

- [ ] CI green
- [ ] After deploy: next 5-min governance-autopilot tick re-audits MGP-001 → `implementation_status = 'verified'`, `pipeline_completed_at IS NOT NULL`
- [ ] No announcement spam — pipeline announces ONCE (announcement_status flips from null to 'sent')

🤖 Generated with [Claude Code](https://claude.com/claude-code)