### PR TITLE
Rewards distributor wallet — separate snapshot payout signer from lender

### DIFF
--- a/scripts/backfill-magpie-burns.mjs
+++ b/scripts/backfill-magpie-burns.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Backfill the magpie_burns ledger with EVERY historical $MAGPIE burn
+ * conducted from the lender wallet.
+ *
+ * Operator burns seized $MAGPIE collateral (and conducts other manual
+ * burns) directly from the lender wallet
+ * 4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx. This script walks the
+ * wallet's history and records every $MAGPIE burn into magpie_burns.
+ *
+ * TWO-STAGE DETECTION (the important bit)
+ * ───────────────────────────────────────
+ * The first version of this script used only Helius's top-level
+ * `tx.type === "BURN"` signal. It missed every real lender-wallet burn
+ * (verified 2026-06-14 against 4 known burns) because the operator's
+ * burns go through a custom burn program that CPIs into Token-2022 —
+ * Helius classifies the top-level type as "UNKNOWN" and surfaces no
+ * burn event. tokenTransfers stays empty for burns too.
+ *
+ * Fix: a two-stage scan.
+ *
+ *   STAGE 1 — FAST PREFILTER (Helius enhanced API, 100 txs/req):
+ *     Walk the wallet's history via /v0/addresses/{addr}/transactions
+ *     (paginated). For each tx, mark it a CANDIDATE if ANY outer or
+ *     inner instruction's programId is the Token-2022 program. Most
+ *     lender-wallet activity (SOL transfers, loan accounting, lamport
+ *     drains) never touches Token-2022 at all — this filter typically
+ *     eliminates >99% of txs.
+ *
+ *   STAGE 2 — EXACT DECODE (JSON-RPC getParsedTransaction, candidate-only):
+ *     For each candidate, fetch the fully-parsed transaction and walk
+ *     every parsed instruction looking for spl-token type=burn or
+ *     burnChecked targeting MAGPIE_MINT with authority=LENDER. Pull
+ *     amount + blockTime. Insert into magpie_burns idempotently.
+ *
+ * Because Stage 2 only fires on candidates, the slow per-tx RPC path
+ * is bounded by the wallet's actual Token-2022 activity, not the full
+ * sig firehose. Months of history → minutes instead of hours.
+ *
+ * IDEMPOTENT
+ * ──────────
+ * recordBurn() uses INSERT … ON CONFLICT (burn_tx_sig) DO NOTHING,
+ * so any tx already in the ledger is skipped. Safe to re-run.
+ *
+ * USAGE
+ * ─────
+ *   railway run --service magpie-bot -- node scripts/backfill-magpie-burns.mjs [--dry-run] [--max-pages=N] [--since=YYYY-MM-DD]
+ */
+import "dotenv/config";
+import { Connection } from "@solana/web3.js";
+import { recordBurn, getBurnSummary, rawToHumanString } from "../src/services/magpie-burns.js";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const MAX_PAGES_ARG = process.argv.find((a) => a.startsWith("--max-pages="));
+const MAX_PAGES = MAX_PAGES_ARG ? Number(MAX_PAGES_ARG.split("=")[1]) : 1000;
+const SINCE_ARG = process.argv.find((a) => a.startsWith("--since="));
+const SINCE_MS = SINCE_ARG
+  ? new Date(SINCE_ARG.split("=")[1]).getTime()
+  : new Date("2026-03-01").getTime();
+
+const LENDER = process.env.LENDER_PUBKEY || "4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx";
+const MAGPIE_MINT = "9UuLsJ3jf8ViBNeRcwXD53re5G3ypgfKK3s2EiMMpump";
+const TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+
+const RPC = process.env.SOLANA_RPC_URL || "";
+const apiKeyMatch = RPC.match(/api-key=([a-f0-9-]+)/i);
+const API_KEY = apiKeyMatch ? apiKeyMatch[1] : process.env.HELIUS_API_KEY;
+if (!API_KEY) {
+  console.error("Helius API key not found in SOLANA_RPC_URL or HELIUS_API_KEY");
+  process.exit(1);
+}
+
+const HELIUS_TX_URL = `https://api.helius.xyz/v0/addresses/${LENDER}/transactions`;
+const RPC_URL = RPC || `https://mainnet.helius-rpc.com/?api-key=${API_KEY}`;
+const conn = new Connection(RPC_URL, "confirmed");
+
+async function fetchPage(before = null) {
+  const url = new URL(HELIUS_TX_URL);
+  url.searchParams.set("api-key", API_KEY);
+  url.searchParams.set("limit", "100");
+  if (before) url.searchParams.set("before", before);
+  const res = await fetch(url.toString());
+  if (res.status === 429) {
+    await new Promise((r) => setTimeout(r, 2000));
+    return fetchPage(before);
+  }
+  if (!res.ok) {
+    throw new Error(`Helius ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+/**
+ * Stage 1 prefilter: does this Helius-enhanced tx touch the Token-2022
+ * program anywhere in its outer or inner instructions? We use this as
+ * a cheap "worth decoding" signal because Token-2022 invocation is rare
+ * in this wallet's traffic but mandatory for any $MAGPIE burn.
+ */
+function touchesToken2022(tx) {
+  const outer = tx.instructions || [];
+  for (const ix of outer) {
+    if (ix.programId === TOKEN_2022_PROGRAM_ID) return true;
+    for (const inner of (ix.innerInstructions || [])) {
+      if (inner.programId === TOKEN_2022_PROGRAM_ID) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Stage 2: decode a candidate tx via JSON-RPC parsed format and pull
+ * every Token-2022 burn / burnChecked targeting MAGPIE_MINT where the
+ * authority is the lender wallet. Returns array of { amountRaw, type }.
+ */
+async function decodeMagpieBurnsForTx(signature) {
+  let tx;
+  try {
+    tx = await conn.getParsedTransaction(signature, {
+      commitment: "confirmed",
+      maxSupportedTransactionVersion: 0,
+    });
+  } catch {
+    return [];
+  }
+  if (!tx?.transaction?.message?.instructions) return [];
+  const all = [
+    ...tx.transaction.message.instructions,
+    ...((tx.meta?.innerInstructions || []).flatMap((ii) => ii.instructions)),
+  ];
+  const found = [];
+  for (const ix of all) {
+    if (ix.program !== "spl-token") continue;
+    const info = ix.parsed?.info;
+    const type = ix.parsed?.type;
+    if (!info || !type) continue;
+    if (type !== "burn" && type !== "burnChecked") continue;
+    if (info.mint !== MAGPIE_MINT) continue;
+    const auth = info.authority || info.multisigAuthority;
+    if (auth !== LENDER) continue;
+    let amountRaw;
+    if (type === "burn") amountRaw = info.amount;
+    else amountRaw = info.tokenAmount?.amount;
+    if (!amountRaw) continue;
+    const amt = BigInt(amountRaw);
+    if (amt <= 0n) continue;
+    found.push({ amountRaw: amt, type });
+  }
+  return found;
+}
+
+async function main() {
+  console.log(`[backfill-burns] start  dryRun=${DRY_RUN}  lender=${LENDER}`);
+  console.log(`[backfill-burns] cutoff: ${new Date(SINCE_MS).toISOString()}  maxPages=${MAX_PAGES}`);
+  console.log(`[backfill-burns] detection: two-stage (Helius prefilter + JSON-RPC decode of candidates)`);
+
+  const t0 = Date.now();
+  let before = null;
+  let pages = 0;
+  let totalTxScanned = 0;
+  let candidates = 0;
+  let burnsFound = 0;
+  let burnsInserted = 0;
+  let burnsSkippedDuplicate = 0;
+  let totalAmountRaw = 0n;
+
+  while (pages < MAX_PAGES) {
+    let page;
+    try {
+      page = await fetchPage(before);
+    } catch (err) {
+      console.error(`[backfill-burns] fetch failed page ${pages + 1}:`, err.message);
+      break;
+    }
+    if (!page?.length) {
+      console.log(`[backfill-burns] no more pages — exhausted history at page ${pages}`);
+      break;
+    }
+    pages++;
+    totalTxScanned += page.length;
+    const oldest = page[page.length - 1];
+    before = oldest.signature;
+    const oldestMs = (oldest.timestamp ?? 0) * 1000;
+
+    // Stage 1: collect candidates from this page
+    const pageCandidates = page.filter(touchesToken2022);
+    candidates += pageCandidates.length;
+
+    if (pages % 10 === 0 || page.length < 100 || pageCandidates.length > 0) {
+      console.log(`[backfill-burns] page ${pages}: ${page.length} txs (oldest ${new Date(oldestMs).toISOString()})  candidates=${pageCandidates.length}  burns_so_far=${burnsFound}`);
+    }
+
+    // Stage 2: decode each candidate
+    for (const tx of pageCandidates) {
+      const burns = await decodeMagpieBurnsForTx(tx.signature);
+      for (const b of burns) {
+        burnsFound++;
+        totalAmountRaw += b.amountRaw;
+        const burnedAt = tx.timestamp ? new Date(tx.timestamp * 1000) : null;
+        console.log(
+          `  BURN  ${rawToHumanString(b.amountRaw)} \$MAGPIE  ` +
+          `tx=${tx.signature.slice(0, 24)}…  ` +
+          `at=${burnedAt?.toISOString() ?? "(unknown)"}  type=${b.type}`,
+        );
+
+        if (DRY_RUN) continue;
+
+        try {
+          const id = await recordBurn({
+            amountRaw: b.amountRaw.toString(),
+            source: "manual",
+            relatedLoanId: null,
+            burnTxSig: tx.signature,
+            notes: `Backfilled lender-wallet \$MAGPIE burn — operator-conducted`,
+            burnedAt,
+          });
+          if (id) burnsInserted++;
+          else burnsSkippedDuplicate++;
+        } catch (err) {
+          console.warn(`  insert failed for ${tx.signature}: ${err.message?.slice(0, 100)}`);
+        }
+      }
+    }
+
+    if (oldestMs && oldestMs < SINCE_MS) {
+      console.log(`[backfill-burns] crossed since cutoff at page ${pages} — stopping`);
+      break;
+    }
+  }
+
+  const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+  console.log("");
+  console.log(`[backfill-burns] done in ${elapsed}s  pages=${pages}  txs_scanned=${totalTxScanned}  candidates=${candidates}  burns_found=${burnsFound}  inserted=${burnsInserted}  duplicates=${burnsSkippedDuplicate}`);
+  console.log(`[backfill-burns] total amount across found burns: ${rawToHumanString(totalAmountRaw)} \$MAGPIE`);
+
+  if (!DRY_RUN) {
+    const summary = await getBurnSummary();
+    console.log(`[backfill-burns] LEDGER total post-backfill: ${summary.total_tokens} \$MAGPIE  (${summary.burn_count} events)`);
+  }
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("[backfill-burns] fatal:", err);
+  process.exit(1);
+});

--- a/src/services/distributor-keypair.js
+++ b/src/services/distributor-keypair.js
@@ -1,0 +1,108 @@
+/**
+ * Rewards distributor wallet keypair loader.
+ *
+ * As of 2026-06-14, the operator wants snapshot payouts to flow OUT of
+ * a dedicated rewards distributor wallet — not the lender wallet that
+ * holds loan principal. The defaulted-loan profits get pre-moved to
+ * the distributor wallet at default-time, so by snapshot time the SOL
+ * that's been earmarked for holders / LPs / referrers is already
+ * physically segregated from the protocol's working capital.
+ *
+ * This module is the single source of truth for "which keypair signs
+ * snapshot payouts" — every distributor (magpie-holder-rewards,
+ * lp-loyalty, referral-rewards) imports getRewardsDistributorKeypair()
+ * so a future credential rotation is one change.
+ *
+ * BACKWARD COMPAT
+ * ───────────────
+ * If REWARDS_DISTRIBUTOR_PRIVATE_KEY isn't set, we fall back to the
+ * existing LENDER_PRIVATE_KEY. This keeps live deploys functional
+ * during rollout — the operator can flip the env var when ready and
+ * the next snapshot will use the new wallet. A startup log makes the
+ * mode explicit so it's never ambiguous from observation alone.
+ *
+ * INTENDED LIFECYCLE
+ * ──────────────────
+ * 1. (Today) — REWARDS_DISTRIBUTOR_PRIVATE_KEY unset → fall back to
+ *    LENDER_PRIVATE_KEY, log a warning. Behaviour identical to pre-
+ *    2026-06-14 — no user-visible change.
+ * 2. (Operator action) — set REWARDS_DISTRIBUTOR_PRIVATE_KEY on Railway
+ *    (the CHCAM... wallet's secret). The next snapshot will sign + pay
+ *    out from CHCAM, which now holds the accrued profits.
+ * 3. (Future) — accrueing services that route fees on-chain at fee
+ *    time could send directly to the distributor wallet instead of the
+ *    lender wallet, removing the manual SOL-move step entirely. Out
+ *    of scope for this change.
+ */
+import { Keypair } from "@solana/web3.js";
+import bs58 from "bs58";
+import fs from "fs";
+
+/**
+ * Returns the keypair that should sign reward-payout transactions.
+ *
+ * Lookup order:
+ *   1. REWARDS_DISTRIBUTOR_PRIVATE_KEY (base58 secret) — preferred
+ *   2. LENDER_PRIVATE_KEY (base58 secret) — backward-compat
+ *   3. LENDER_KEYPAIR_PATH (json file) — backward-compat for local dev
+ *
+ * Throws if none of those is set — distributors are not allowed to
+ * silently fall back to CWD-relative defaults (same posture as the
+ * cosign-borrow path that signs loan disbursements).
+ */
+let _cachedKeypair = null;
+let _cachedMode = null;
+export function getRewardsDistributorKeypair() {
+  if (_cachedKeypair) return _cachedKeypair;
+  const distSecret = process.env.REWARDS_DISTRIBUTOR_PRIVATE_KEY;
+  if (distSecret) {
+    _cachedKeypair = Keypair.fromSecretKey(bs58.decode(distSecret));
+    _cachedMode = "distributor";
+    console.log(
+      `[distributor-keypair] using REWARDS_DISTRIBUTOR_PRIVATE_KEY ` +
+      `(${_cachedKeypair.publicKey.toBase58().slice(0, 8)}…)`,
+    );
+    return _cachedKeypair;
+  }
+  const lenderSecret = process.env.LENDER_PRIVATE_KEY;
+  if (lenderSecret) {
+    _cachedKeypair = Keypair.fromSecretKey(bs58.decode(lenderSecret));
+    _cachedMode = "lender-fallback";
+    console.warn(
+      `[distributor-keypair] REWARDS_DISTRIBUTOR_PRIVATE_KEY not set — ` +
+      `falling back to LENDER_PRIVATE_KEY (${_cachedKeypair.publicKey.toBase58().slice(0, 8)}…). ` +
+      `Set REWARDS_DISTRIBUTOR_PRIVATE_KEY to switch payouts to the dedicated wallet.`,
+    );
+    return _cachedKeypair;
+  }
+  const kpPath = process.env.LENDER_KEYPAIR_PATH;
+  if (kpPath) {
+    const raw = JSON.parse(fs.readFileSync(kpPath, "utf8"));
+    _cachedKeypair = Keypair.fromSecretKey(new Uint8Array(raw));
+    _cachedMode = "lender-file-fallback";
+    return _cachedKeypair;
+  }
+  throw new Error(
+    "[distributor-keypair] No keypair available. Set REWARDS_DISTRIBUTOR_PRIVATE_KEY (preferred) " +
+    "or LENDER_PRIVATE_KEY. Refusing to fall back to CWD-relative defaults.",
+  );
+}
+
+/**
+ * "distributor" | "lender-fallback" | "lender-file-fallback".
+ * Used by /stats and other introspection paths to surface which mode
+ * the snapshot system is currently running in.
+ */
+export function getRewardsDistributorMode() {
+  if (!_cachedKeypair) getRewardsDistributorKeypair();
+  return _cachedMode;
+}
+
+/**
+ * The pubkey users should see for the rewards distributor. Read by
+ * /stats, the about page, and Pip's knowledge base so the public
+ * always knows which on-chain wallet to verify payouts from.
+ */
+export function getRewardsDistributorPubkey() {
+  return getRewardsDistributorKeypair().publicKey;
+}

--- a/src/services/liquidation-distribution-watcher.js
+++ b/src/services/liquidation-distribution-watcher.js
@@ -60,12 +60,40 @@
  *   LIQUIDATION_DISTRIBUTION_TICK_MS    — default 90_000 (1.5 min)
  */
 import { query } from "../db/pool.js";
+import { PublicKey, Keypair, SystemProgram, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import bs58 from "bs58";
+import { connection } from "../solana/connection.js";
 
 const TICK_MS = Number(process.env.LIQUIDATION_DISTRIBUTION_TICK_MS) || 90_000;
 const FIRST_TICK_DELAY_MS = 180_000; // wait 3 min after boot so other services init
 const DISABLED = /^(1|true|yes|on)$/i.test(process.env.LIQUIDATION_DISTRIBUTION_DISABLED || "");
 
 const DEFAULT_PROFIT_EVENT_TYPE = "default_profit";
+
+// Optional: pubkey of the rewards distributor wallet. When set, the
+// watcher moves the net profit lamports from the lender wallet to this
+// wallet immediately after crediting the DB ledgers, so the snapshot
+// distributors (which now sign with REWARDS_DISTRIBUTOR_PRIVATE_KEY)
+// have the SOL on hand at payout time. When unset, the watcher stays
+// DB-ledger-only and the SOL stays in the lender wallet (legacy
+// behaviour).
+const REWARDS_DISTRIBUTOR_PUBKEY = process.env.REWARDS_DISTRIBUTOR_PUBKEY
+  ? new PublicKey(process.env.REWARDS_DISTRIBUTOR_PUBKEY)
+  : null;
+
+let _lenderKeypair = null;
+function getLenderKeypairForTransfer() {
+  if (_lenderKeypair) return _lenderKeypair;
+  const b58 = process.env.LENDER_PRIVATE_KEY;
+  if (!b58) return null;
+  try {
+    _lenderKeypair = Keypair.fromSecretKey(bs58.decode(b58));
+    return _lenderKeypair;
+  } catch (err) {
+    console.error("[liq-distribute] LENDER_PRIVATE_KEY decode failed:", err.message);
+    return null;
+  }
+}
 
 let _running = false;
 let _ticking = false;
@@ -183,6 +211,47 @@ async function distributeOne(row) {
       );
     } catch (err) {
       errors.push(`referral: ${err.message?.slice(0, 80)}`);
+    }
+  }
+
+  // On-chain SOL move: lender → rewards distributor wallet, for the
+  // amount this row's profit credited into the distributable pools
+  // (holder + LP + referrer slices). The protocol reserve stays in
+  // the lender wallet as a buffer.
+  //
+  // Gated on REWARDS_DISTRIBUTOR_PUBKEY being set. Without it, the
+  // watcher stays DB-ledger-only and behaves identically to the
+  // pre-2026-06-14 version. On-chain failures are non-fatal — they
+  // log and degrade to 'distribute_error' so an operator can review,
+  // but they don't corrupt the credited ledgers (those already landed).
+  if (errors.length === 0 && REWARDS_DISTRIBUTOR_PUBKEY) {
+    const transferAmount = holderShare + lpShare + refShare;
+    if (transferAmount > 0n) {
+      const lender = getLenderKeypairForTransfer();
+      if (!lender) {
+        errors.push("on_chain_transfer: LENDER_PRIVATE_KEY missing");
+      } else {
+        try {
+          const tx = new Transaction().add(
+            SystemProgram.transfer({
+              fromPubkey: lender.publicKey,
+              toPubkey: REWARDS_DISTRIBUTOR_PUBKEY,
+              lamports: Number(transferAmount),
+            }),
+          );
+          const sig = await sendAndConfirmTransaction(connection, tx, [lender], {
+            commitment: "confirmed",
+            maxRetries: 3,
+          });
+          console.log(
+            `[liq-distribute] loan ${row.loan_id} on-chain move: ` +
+            `${(Number(transferAmount) / 1e9).toFixed(4)} SOL → ` +
+            `${REWARDS_DISTRIBUTOR_PUBKEY.toBase58().slice(0, 8)}…  sig=${sig.slice(0, 24)}…`,
+          );
+        } catch (err) {
+          errors.push(`on_chain_transfer: ${err.message?.slice(0, 80)}`);
+        }
+      }
     }
   }
 

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -30,6 +30,7 @@ import { connection } from "../solana/connection.js";
 import { getReadOnlyProgram, PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3 } from "../solana/program.js";
 import { lendingPoolPda } from "../solana/pdas.js";
 import { query } from "../db/pool.js";
+import { getRewardsDistributorKeypair } from "./distributor-keypair.js";
 import { getRuntimeConfigBps } from "./runtime-config.js";
 
 // Fallback used when governance_config.lp_loyalty_reward_bps can't be
@@ -375,11 +376,12 @@ export async function snapshotAndDistributeLpLoyalty() {
   // Sync from chain so positions are current
   await syncOnChainPositions();
 
-  // Pre-flight lender balance
-  const lender = loadLenderKeypair();
-  const lenderBalance = BigInt(await connection.getBalance(lender.publicKey));
-  if (lenderBalance < pool + MIN_LENDER_RESERVE_LAMPORTS) {
-    console.warn(`[lp-loyalty] Skipped: lender balance too low for pool ${pool}`);
+  // Pre-flight distributor balance (REWARDS_DISTRIBUTOR_PRIVATE_KEY,
+  // with backward-compat fallback to LENDER_PRIVATE_KEY).
+  const distributor = getRewardsDistributorKeypair();
+  const distributorBalance = BigInt(await connection.getBalance(distributor.publicKey));
+  if (distributorBalance < pool + MIN_LENDER_RESERVE_LAMPORTS) {
+    console.warn(`[lp-loyalty] Skipped: distributor balance too low for pool ${pool}`);
     return null;
   }
 
@@ -476,14 +478,14 @@ export async function snapshotAndDistributeLpLoyalty() {
     for (const r of batch) {
       tx.add(
         SystemProgram.transfer({
-          fromPubkey: lender.publicKey,
+          fromPubkey: distributor.publicKey,
           toPubkey: new PublicKey(r.wallet_address),
           lamports: BigInt(r.reward_lamports),
         }),
       );
     }
     try {
-      const sig = await sendAndConfirmTransaction(connection, tx, [lender], { commitment: "confirmed" });
+      const sig = await sendAndConfirmTransaction(connection, tx, [distributor], { commitment: "confirmed" });
       await query(
         `UPDATE lp_loyalty_rewards
             SET status = 'paid', paid_at = NOW(), paid_tx_signature = $2
@@ -521,9 +523,9 @@ export async function retryAccruedLpLoyaltyPayouts() {
   );
   if (rows.length === 0) return { retried: 0, paid: 0 };
 
-  const lender = loadLenderKeypair();
+  const distributor = getRewardsDistributorKeypair();
   const total = rows.reduce((s, r) => s + BigInt(r.reward_lamports), 0n);
-  const bal = BigInt(await connection.getBalance(lender.publicKey));
+  const bal = BigInt(await connection.getBalance(distributor.publicKey));
   if (bal < total + MIN_LENDER_RESERVE_LAMPORTS) return { retried: 0, paid: 0, skipped: rows.length };
 
   let paid = 0;
@@ -532,13 +534,13 @@ export async function retryAccruedLpLoyaltyPayouts() {
     const tx = new Transaction();
     for (const r of batch) {
       tx.add(SystemProgram.transfer({
-        fromPubkey: lender.publicKey,
+        fromPubkey: distributor.publicKey,
         toPubkey: new PublicKey(r.wallet_address),
         lamports: BigInt(r.reward_lamports),
       }));
     }
     try {
-      const sig = await sendAndConfirmTransaction(connection, tx, [lender], { commitment: "confirmed" });
+      const sig = await sendAndConfirmTransaction(connection, tx, [distributor], { commitment: "confirmed" });
       await query(
         `UPDATE lp_loyalty_rewards SET status = 'paid', paid_at = NOW(), paid_tx_signature = $2 WHERE id = ANY($1::bigint[])`,
         [batch.map((r) => r.id), sig],

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -32,6 +32,7 @@ import path from "node:path";
 import "dotenv/config";
 import { connection } from "../solana/connection.js";
 import { query } from "../db/pool.js";
+import { getRewardsDistributorKeypair } from "./distributor-keypair.js";
 
 export const MAGPIE_MINT = new PublicKey(
   "9UuLsJ3jf8ViBNeRcwXD53re5G3ypgfKK3s2EiMMpump",
@@ -626,14 +627,18 @@ export async function snapshotAndDistribute() {
     return null;
   }
 
-  // Pre-flight: lender must cover the entire pool + safety reserve.
-  // Skipped in snapshot-only mode since no SOL moves during the snapshot.
-  const lender = loadLenderKeypair();
+  // Pre-flight: the distributor wallet must cover the entire pool +
+  // safety reserve. Skipped in snapshot-only mode since no SOL moves
+  // during the snapshot. As of 2026-06-14 this reads from the dedicated
+  // rewards distributor wallet (set via REWARDS_DISTRIBUTOR_PRIVATE_KEY);
+  // until the operator flips that env var on Railway it transparently
+  // falls back to the lender wallet, preserving prior behaviour.
+  const distributor = getRewardsDistributorKeypair();
   if (!snapshotOnly) {
-    const lenderBalance = BigInt(await connection.getBalance(lender.publicKey));
-    if (lenderBalance < pool + MIN_LENDER_RESERVE_LAMPORTS) {
+    const distributorBalance = BigInt(await connection.getBalance(distributor.publicKey));
+    if (distributorBalance < pool + MIN_LENDER_RESERVE_LAMPORTS) {
       console.warn(
-        `[holder-rewards] Distribution skipped: lender ${lenderBalance} < pool ${pool} + reserve ${MIN_LENDER_RESERVE_LAMPORTS}`,
+        `[holder-rewards] Distribution skipped: distributor ${distributorBalance} < pool ${pool} + reserve ${MIN_LENDER_RESERVE_LAMPORTS}`,
       );
       return null;
     }
@@ -811,11 +816,11 @@ export async function retryAccruedPayouts() {
   );
   if (rows.length === 0) return { retried: 0, paid: 0 };
 
-  const lender = loadLenderKeypair();
+  const distributor = getRewardsDistributorKeypair();
   const totalNeeded = rows.reduce((acc, r) => acc + BigInt(r.reward_lamports), 0n);
-  const lenderBalance = BigInt(await connection.getBalance(lender.publicKey));
-  if (lenderBalance < totalNeeded + MIN_LENDER_RESERVE_LAMPORTS) {
-    console.warn("[holder-rewards] Retry skipped: lender too low");
+  const distributorBalance = BigInt(await connection.getBalance(distributor.publicKey));
+  if (distributorBalance < totalNeeded + MIN_LENDER_RESERVE_LAMPORTS) {
+    console.warn("[holder-rewards] Retry skipped: distributor balance too low");
     return { retried: 0, paid: 0, skipped: rows.length };
   }
 
@@ -826,14 +831,14 @@ export async function retryAccruedPayouts() {
     for (const r of batch) {
       tx.add(
         SystemProgram.transfer({
-          fromPubkey: lender.publicKey,
+          fromPubkey: distributor.publicKey,
           toPubkey: new PublicKey(r.wallet_address),
           lamports: BigInt(r.reward_lamports),
         }),
       );
     }
     try {
-      const sig = await sendAndConfirmTransaction(connection, tx, [lender], {
+      const sig = await sendAndConfirmTransaction(connection, tx, [distributor], {
         commitment: "confirmed",
       });
       await query(
@@ -886,26 +891,26 @@ export async function claimHolderRewards({ walletAddress }) {
       };
     }
 
-    const lender = loadLenderKeypair();
-    const lenderBalance = BigInt(await connection.getBalance(lender.publicKey));
-    if (lenderBalance < total + MIN_LENDER_RESERVE_LAMPORTS) {
+    const distributor = getRewardsDistributorKeypair();
+    const distributorBalance = BigInt(await connection.getBalance(distributor.publicKey));
+    if (distributorBalance < total + MIN_LENDER_RESERVE_LAMPORTS) {
       await client.query("ROLLBACK");
       return {
         ok: false,
         reason: "treasury_low",
-        treasury_lamports: lenderBalance,
+        treasury_lamports: distributorBalance,
         required_lamports: total,
       };
     }
 
     const tx = new Transaction().add(
       SystemProgram.transfer({
-        fromPubkey: lender.publicKey,
+        fromPubkey: distributor.publicKey,
         toPubkey: recipient,
         lamports: total,
       }),
     );
-    const signature = await sendAndConfirmTransaction(connection, tx, [lender], {
+    const signature = await sendAndConfirmTransaction(connection, tx, [distributor], {
       commitment: "confirmed",
     });
 

--- a/src/services/referral-rewards.js
+++ b/src/services/referral-rewards.js
@@ -26,6 +26,7 @@ import path from "node:path";
 import "dotenv/config";
 import { connection } from "../solana/connection.js";
 import { query } from "../db/pool.js";
+import { getRewardsDistributorKeypair } from "./distributor-keypair.js";
 import { getRuntimeConfigBps } from "./runtime-config.js";
 
 // Fallback used when governance_config.referral_reward_bps can't be
@@ -194,15 +195,18 @@ export async function claimReferralEarnings({ userId, recipientPublicKey }) {
       };
     }
 
-    // Verify lender wallet can cover payout + small safety reserve.
-    const lender = loadLenderKeypair();
-    const lenderBalance = BigInt(await connection.getBalance(lender.publicKey));
-    if (lenderBalance < total + MIN_LENDER_RESERVE_LAMPORTS) {
+    // Verify the rewards distributor wallet can cover payout + small
+    // safety reserve. Reads REWARDS_DISTRIBUTOR_PRIVATE_KEY if set,
+    // falls back to LENDER_PRIVATE_KEY for backward-compat during
+    // rollout.
+    const distributor = getRewardsDistributorKeypair();
+    const distributorBalance = BigInt(await connection.getBalance(distributor.publicKey));
+    if (distributorBalance < total + MIN_LENDER_RESERVE_LAMPORTS) {
       await client.query("ROLLBACK");
       return {
         ok: false,
         reason: "treasury_low",
-        treasury_lamports: lenderBalance,
+        treasury_lamports: distributorBalance,
         required_lamports: total,
       };
     }
@@ -211,12 +215,12 @@ export async function claimReferralEarnings({ userId, recipientPublicKey }) {
     // native SOL straight to their wallet.
     const tx = new Transaction().add(
       SystemProgram.transfer({
-        fromPubkey: lender.publicKey,
+        fromPubkey: distributor.publicKey,
         toPubkey: new PublicKey(recipientPublicKey),
         lamports: total,
       }),
     );
-    const signature = await sendAndConfirmTransaction(connection, tx, [lender], {
+    const signature = await sendAndConfirmTransaction(connection, tx, [distributor], {
       commitment: "confirmed",
     });
 


### PR DESCRIPTION
## Summary

Per the 2026-06-14 architecture: snapshot payouts (holder, LP loyalty, referral) should sign from a dedicated rewards distributor wallet rather than the lender wallet that holds loan principal. Defaulted-loan profits get pre-moved to the distributor wallet at default-time, so by snapshot time the SOL is physically segregated from working capital.

This PR builds the plumbing — env-var-gated, fully backward compatible — so operator can flip the switch when ready.

## What's in this PR

**New helper** \`src/services/distributor-keypair.js\` — single source of truth for the signing keypair. Order: \`REWARDS_DISTRIBUTOR_PRIVATE_KEY\` → \`LENDER_PRIVATE_KEY\` → fail-closed. Cached. Logs the active mode at startup.

**Refactored payout call sites** in:
- \`magpie-holder-rewards.js\` (3 sites: distribution main, retry loop, single-wallet claim)
- \`lp-loyalty.js\` (2 sites: distribution + retry)
- \`referral-rewards.js\` (1 site: claim)

All now read balance + sign with the distributor keypair. \`loadLenderKeypair()\` is left in place as dead-code in each file in case non-distribution paths get added later.

**Phase 2 watcher upgrade** in \`liquidation-distribution-watcher.js\`: after crediting the four pool ledgers, if \`REWARDS_DISTRIBUTOR_PUBKEY\` is set, it moves (holder + LP + referrer) lamports on-chain from lender → distributor. Protocol-reserve stays in the lender wallet as a buffer. On-chain failures are non-fatal — credited ledgers stay intact; row degrades to \`'distribute_error'\` for operator review.

**Burn backfill script** \`scripts/backfill-magpie-burns.mjs\` — rewritten with a two-stage detector (Helius prefilter + per-candidate \`getParsedTransaction\` decode) after discovering the previous \`tx.type === \"BURN\"\` filter missed every real lender-wallet burn (they're CPI'd from a custom burn program).

## Rollout plan

1. **This deploy** — nothing changes. Without \`REWARDS_DISTRIBUTOR_PUBKEY\` and \`REWARDS_DISTRIBUTOR_PRIVATE_KEY\` set, the system runs exactly as before, with a one-line warn on startup making the mode unambiguous.
2. **Operator sets \`REWARDS_DISTRIBUTOR_PUBKEY=CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac\` on Railway** — Phase 2 auto-moves SOL for every new default profit.
3. **Operator sets \`REWARDS_DISTRIBUTOR_PRIVATE_KEY=<CHCAM secret>\` on Railway** — next snapshot pays out from CHCAM. Pre-flight will skip if underfunded (same safety posture lender had).

## Test plan

- [ ] CI green
- [ ] After deploy without env vars: startup log says \"falling back to LENDER_PRIVATE_KEY\". Bot boots. Watchers tick. Snapshot system unaffected.
- [ ] After operator sets \`REWARDS_DISTRIBUTOR_PUBKEY\`: next Phase 2 distribution (when a new default comes in) shows the \`[liq-distribute] loan X on-chain move: Y SOL → CHCAM…\` log line.
- [ ] After operator sets \`REWARDS_DISTRIBUTOR_PRIVATE_KEY\`: startup log switches to \"using REWARDS_DISTRIBUTOR_PRIVATE_KEY (CHCAM…)\".
- [ ] Next snapshot distribution \`paid_tx_signature\` shows fromPubkey=CHCAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)