### PR TITLE
URGENT: fix V3 price-feed PDA seed ("price_v3") — unblocks all V3 borrows

### DIFF
--- a/src/solana/pdas.js
+++ b/src/solana/pdas.js
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
-import { PROGRAM_ID } from "./program.js";
+import { PROGRAM_ID, PROGRAM_ID_V3 } from "./program.js";
 
 // All PDA derivations accept an optional `programId` so v1 and v2 callers
 // can share these functions. Defaulting to v1's PROGRAM_ID keeps every
@@ -37,8 +37,17 @@ export function collateralVaultPda(loanPubkey, programId = PROGRAM_ID) {
 }
 
 export function priceFeedPda(mintPubkey, poolPubkey, programId = PROGRAM_ID) {
+  // V3 uses a different seed prefix ("price_v3") to keep its price
+  // feed PDAs distinct from v1/v2. The mainnet program (B8AwYzFm…)
+  // enforces this via Anchor seeds constraint — passing the v1/v2
+  // "price" seed against v3 triggers ConstraintSeeds (2006) and the
+  // borrow simulation in Phantom shows StalePriceAttestation.
+  // Detected 2026-06-14 when V3 RWA borrows started failing for every
+  // Xs-prefixed xStocks mint immediately after V3 routing went live.
+  const isV3 = PROGRAM_ID_V3 && programId.equals(PROGRAM_ID_V3);
+  const seedPrefix = isV3 ? "price_v3" : "price";
   return PublicKey.findProgramAddressSync(
-    [Buffer.from("price"), mintPubkey.toBuffer(), poolPubkey.toBuffer()],
+    [Buffer.from(seedPrefix), mintPubkey.toBuffer(), poolPubkey.toBuffer()],
     programId,
   );
 }


### PR DESCRIPTION
**Live V3 borrow blocker.** Operator hit `Transaction rejected: StalePriceAttestation` trying to borrow against $SPCX on V3. Root cause: V3 program expects `price_v3 + mint + pool` seeds for the price_feed PDA; `priceFeedPda` was hardcoded to `price + mint + pool` (V1/V2 style) for all programs.

Symptom chain:
1. site /borrow → `POST /api/v1/price/refresh` returned 502 (`attest_failed: ConstraintSeeds 2006`)
2. wallet simulation rejected the tx → `StalePriceAttestation`
3. every Xs-prefixed xStocks mint (SPCX, AMZNX, TSLAX, etc.) on V3 was hitting the same failure on every refresh tick

Fix: when `programId.equals(PROGRAM_ID_V3)`, use `Buffer.from("price_v3")` as the seed prefix. V1/V2 callers unchanged.

Verified the PDA derivation: with V1 "price" seed, mint+pool derives `Az7SeVvq…` — which is exactly what the failure log showed as `Left:`. With the new `price_v3` seed it derives `9virYAPJ…` which is what V3 expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)