### PR TITLE
v3 safety nets: engine_program_id NULL sentinel + first-V3-fire watcher

### DIFF
--- a/migrations/063_first_v3_fire_milestone.sql
+++ b/migrations/063_first_v3_fire_milestone.sql
@@ -1,0 +1,27 @@
+-- migration 063: seed first_v3_fire milestone flag
+--
+-- Pairs with src/services/limit-close-first-v3-fire-watcher.js.
+-- The watcher polls every 5 min for the OLDEST successful V3 fire and
+-- DMs the operator a one-shot celebration. It also alerts on V3 fire
+-- failures so the operator hears about a broken executeRepayLoanV3
+-- path BEFORE a real user does.
+--
+-- V3 went live for RWA + memecoin dual-tier on 2026-06-13. Arm flow
+-- correctly stamps engine_program_id=V3 on V3-loan orders. The fill
+-- path lives in the external magpie-limitclose engine — this
+-- watcher is the bot-side proof the engine's V3 path is working
+-- end-to-end on real chain state.
+
+INSERT INTO engine_milestone_flags (milestone_key, notes)
+VALUES (
+  'first_v3_fire',
+  'First successful limit-close fire on the V3 lending program (RWA or memecoin) — celebrated once.'
+)
+ON CONFLICT (milestone_key) DO NOTHING;
+
+INSERT INTO engine_milestone_flags (milestone_key, notes)
+VALUES (
+  'first_v3_fire_failure',
+  'First observed V3 limit-close fire failure — operator alerted with full row details so the engine path can be debugged before more orders pile up.'
+)
+ON CONFLICT (milestone_key) DO NOTHING;

--- a/src/index.js
+++ b/src/index.js
@@ -175,8 +175,10 @@ import { registerLcStalenessCallbacks } from "./handlers/lc-staleness-callbacks.
 import { startImpersonatorWatchdog } from "./services/impersonator-watchdog.js";
 import { startCanaryWatcher } from "./services/canary-watcher.js";
 import { startLoanProgramIdHealer } from "./services/loan-program-id-healer.js";
+import { startLimitCloseEngineProgramIdSentinel } from "./services/limit-close-engine-program-id-sentinel.js";
 import { startLoanReceivedWatchdog } from "./services/loan-received-watchdog.js";
 import { startFirstV2FireWatcher } from "./services/first-v2-fire-watcher.js";
+import { startLimitCloseFirstV3FireWatcher } from "./services/limit-close-first-v3-fire-watcher.js";
 import { startNeonSync } from "./services/neon-sync.js";
 import { registerTxErrorCallbacks } from "./services/tx-error-callbacks.js";
 import { startAiAgentHealth } from "./services/ai-agent-health.js";
@@ -894,6 +896,10 @@ bot.start({
     // wallet-scoped filtering on the dashboard never silently drops
     // a loan due to stale/wrong program_id.
     setTimeout(() => startLoanProgramIdHealer(bot), 115_000);
+    // engine_program_id NULL sentinel — DMs admin if any post-2026-06-13
+    // limit_close_orders row is missing engine_program_id. Closes the
+    // silent-wrong-pool-fire failure mode flagged in the V3 audit.
+    setTimeout(() => startLimitCloseEngineProgramIdSentinel(bot), 120_000);
     // Loan actual-received watchdog — backfills + verifies the
     // on-chain SOL delta per borrow row. Catches the class of bug
     // where the dashboard shows ~$1 more "received" than the
@@ -906,6 +912,11 @@ bot.start({
     // limit-close shipped 2026-06-13; this watcher closes the loop
     // by announcing when production validates it.
     setTimeout(() => startFirstV2FireWatcher(bot), 145_000);
+    // First V3 limit-close fire watcher — two prongs: celebrate the first
+    // successful V3 fire AND alert on the first V3 fire FAILURE so the
+    // operator hears about a broken executeRepayLoanV3 path BEFORE more
+    // orders pile up. Closes the V3-engine-readiness gap from the audit.
+    setTimeout(() => startLimitCloseFirstV3FireWatcher(bot), 150_000);
     // Auto-Protect — opt-in anti-liquidation. Watches every 90s.
     setTimeout(() => startAutoProtect(bot), 50_000);
     // Conditional-borrow watcher — fires agent intents when their

--- a/src/services/limit-close-engine-program-id-sentinel.js
+++ b/src/services/limit-close-engine-program-id-sentinel.js
@@ -1,0 +1,125 @@
+/**
+ * Limit-close engine_program_id NULL sentinel.
+ *
+ * Migration 050 added `engine_program_id` to `limit_close_orders` as
+ * the discriminator the limit-close engine uses to pick which lending
+ * program to call when filling a TP/SL/trailing/bracket order. The
+ * column is nullable for backwards-compatibility with rows armed
+ * BEFORE the migration landed. The engine treats NULL as V1
+ * (memecoin) — fine for legacy rows, but a brand-new V2 or V3 row
+ * with NULL would silently fire against the wrong pool and either
+ * fail or fill against an unintended program.
+ *
+ * Three-layer defense already in place (arm-core stamps program_id,
+ * recordLoan reads on-chain owner, healer corrects drift) — this
+ * sentinel is the canary that surfaces any silent escape.
+ *
+ * Cadence: every 5 minutes. Cheap query (indexed by engine_program_id
+ * IS NULL via partial index 050).
+ *
+ * Alert policy:
+ *   - First non-zero count → DM operator with affected row IDs.
+ *   - While count stays non-zero, re-DM at most every 6h (anti-spam).
+ *   - When count returns to zero, send a recovery DM so the alert
+ *     state is visibly cleared.
+ *
+ * No emojis per Magpie copy rules.
+ */
+
+import { query } from "../db/pool.js";
+import { getAdminId, notifyAdmin } from "./admin-notify.js";
+
+// The boundary date: rows armed BEFORE this are legacy and may legitimately
+// have NULL engine_program_id (engine treats NULL as V1 — correct for the
+// memecoin-only pre-RWA-routing era). Rows armed AFTER must have a non-NULL
+// value because arm-core always stamps loan.program_id (which is itself
+// authoritatively sourced from the on-chain Loan account owner).
+//
+// 2026-06-13 = day migration 050 landed AND day V3 routing went live.
+// Any NULL row created after this date indicates either:
+//   - loan.program_id was somehow NULL when arm-core read it, OR
+//   - the arm-core INSERT silently dropped the column.
+// Either is a bug worth waking the operator over.
+const BOUNDARY_DATE = "2026-06-13";
+
+const POLL_INTERVAL_MS = Number(process.env.ENGINE_PROGRAM_ID_NULL_WATCH_MS) || 5 * 60_000;
+const ALERT_REPEAT_MS = 6 * 60 * 60 * 1000;
+
+let lastAlertedAt = 0;
+let lastAlertedCount = -1;
+
+function fmtRows(rows) {
+  if (rows.length === 0) return "";
+  const sample = rows.slice(0, 8).map((r) =>
+    `  • order_id=${r.id} loan_id=${r.loan_id} direction=${r.direction} status=${r.status} armed=${new Date(r.created_at).toISOString().slice(0, 16)}Z`,
+  ).join("\n");
+  const more = rows.length > 8 ? `\n  ... and ${rows.length - 8} more` : "";
+  return sample + more;
+}
+
+async function runOneCycle(bot) {
+  const { rows } = await query(
+    `SELECT id, loan_id, direction, status, created_at
+       FROM limit_close_orders
+      WHERE engine_program_id IS NULL
+        AND created_at > $1::date
+        AND status IN ('armed', 'fired')
+      ORDER BY created_at DESC`,
+    [BOUNDARY_DATE],
+  );
+  const count = rows.length;
+  const now = Date.now();
+
+  if (count === 0) {
+    // Recovery path: if we previously alerted and we're now back to zero,
+    // send a single recovery message so the operator's alert state is clear.
+    if (lastAlertedCount > 0) {
+      await notifyAdmin(
+        bot,
+        `[engine-program-id-null] CLEAR — no post-${BOUNDARY_DATE} rows with NULL engine_program_id remain.`,
+        { parse_mode: undefined },
+      );
+      lastAlertedCount = 0;
+      lastAlertedAt = 0;
+    }
+    return { count: 0 };
+  }
+
+  // Non-zero path. DM if first occurrence OR enough time has passed.
+  const shouldAlert =
+    lastAlertedCount <= 0 ||
+    now - lastAlertedAt > ALERT_REPEAT_MS ||
+    count > lastAlertedCount * 1.5; // re-alert if the count grows materially
+
+  if (shouldAlert) {
+    const msg = [
+      `[engine-program-id-null] ALERT — ${count} active limit-close order(s) armed after ${BOUNDARY_DATE} have NULL engine_program_id.`,
+      `These orders will fire against V1 by default. If the loan is V2 or V3, the fill will fail.`,
+      `Rows:`,
+      fmtRows(rows),
+      ``,
+      `Likely fix: re-run the loan-program-id healer + back-fill engine_program_id from loans.program_id for these order rows.`,
+    ].join("\n");
+    await notifyAdmin(bot, msg, { parse_mode: undefined });
+    lastAlertedAt = now;
+    lastAlertedCount = count;
+  }
+  return { count };
+}
+
+export function startLimitCloseEngineProgramIdSentinel(bot) {
+  if (!getAdminId()) {
+    console.warn("[engine-program-id-null] no ADMIN_TG_ID — sentinel will run but alerts will be silent");
+  }
+  // First tick on a short delay so boot completes; then every POLL_INTERVAL_MS.
+  setTimeout(async function tick() {
+    try {
+      await runOneCycle(bot);
+    } catch (err) {
+      console.error("[engine-program-id-null] tick failed:", err?.message?.slice(0, 200));
+    } finally {
+      setTimeout(tick, POLL_INTERVAL_MS);
+    }
+  }, 60_000);
+  console.log(`[engine-program-id-null] sentinel armed (interval ${Math.round(POLL_INTERVAL_MS / 1000)}s, boundary ${BOUNDARY_DATE})`);
+}

--- a/src/services/limit-close-first-v3-fire-watcher.js
+++ b/src/services/limit-close-first-v3-fire-watcher.js
@@ -1,0 +1,227 @@
+/**
+ * First-V3-fire watcher — two-prong observability for the V3 engine path.
+ *
+ * V3 went live for RWA + memecoin dual-tier on 2026-06-13. The bot
+ * arm-flow stamps engine_program_id=V3_PROGRAM_ID on V3-loan orders.
+ * The fill path runs in the external magpie-limitclose engine. This
+ * watcher is the bot-side proof the engine's executeRepayLoanV3
+ * path works end-to-end on real on-chain state.
+ *
+ * Prong A: celebrate the FIRST successful V3 fire.
+ *   Polls every 5 min for the oldest fired V3 order; one-shot DM
+ *   on milestone_key='first_v3_fire' so the operator hears the
+ *   path is alive.
+ *
+ * Prong B: alert the FIRST V3 fire FAILURE.
+ *   Polls for any status='failed' OR engine_error_reason populated
+ *   on a V3 order. One-shot DM on milestone_key='first_v3_fire_failure'
+ *   so the operator hears a broken V3 engine BEFORE more orders fire
+ *   against it. This is the actual risk the audit flagged: a deployed
+ *   V3 engine path that silently doesn't work and only manifests when
+ *   real user orders pile up against it.
+ *
+ * Both prongs are independent — both can fire on the same process.
+ *
+ * Race-safe: the UPDATE clause is conditional on notified_at IS NULL,
+ * so two bot replicas detecting the same milestone both attempt the
+ * UPDATE but only one's WHERE clause matches. Idempotent across
+ * restarts: once notified_at is set, prong short-circuits.
+ *
+ * No emojis per Magpie copy rules.
+ */
+import { query } from "../db/pool.js";
+
+const WATCHER_INTERVAL_MS = Number(process.env.FIRST_V3_FIRE_INTERVAL_MS) || 5 * 60_000;
+const FIRST_RUN_DELAY_MS = Number(process.env.FIRST_V3_FIRE_FIRST_DELAY_MS) || 2 * 60_000;
+const V3_PROGRAM_ID = process.env.PROGRAM_ID_V3 || null;
+
+let _timer = null;
+let _successDisabled = false;
+let _failureDisabled = false;
+
+async function findFirstV3Success() {
+  if (!V3_PROGRAM_ID) return null;
+  const { rows: [row] } = await query(
+    `SELECT lc.id, lc.fired_at, lc.tx_signature_repay, lc.tx_signature_swap,
+            lc.proceeds_lamports::text  AS proceeds,
+            lc.protocol_fee_lamports::text AS fee,
+            lc.net_to_user_lamports::text  AS net_user,
+            lc.trigger_direction,
+            l.loan_id::text AS loan_id,
+            l.borrower_wallet,
+            sm.symbol, sm.category
+       FROM limit_close_orders lc
+       JOIN loans l ON l.id = lc.loan_id
+       LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+      WHERE lc.status = 'fired'
+        AND lc.engine_program_id = $1
+      ORDER BY lc.fired_at ASC
+      LIMIT 1`,
+    [V3_PROGRAM_ID],
+  );
+  return row || null;
+}
+
+async function findFirstV3Failure() {
+  if (!V3_PROGRAM_ID) return null;
+  // 'failed' status OR a populated error_reason on a V3 order.
+  // First fail-shaped row by order_id (deterministic ordering across replicas).
+  const { rows: [row] } = await query(
+    `SELECT lc.id, lc.status, lc.armed_at, lc.firing_started_at,
+            lc.trigger_direction,
+            lc.notes,
+            l.loan_id::text AS loan_id,
+            l.borrower_wallet,
+            sm.symbol, sm.category
+       FROM limit_close_orders lc
+       JOIN loans l ON l.id = lc.loan_id
+       LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+      WHERE lc.engine_program_id = $1
+        AND lc.status = 'failed'
+      ORDER BY lc.id ASC
+      LIMIT 1`,
+    [V3_PROGRAM_ID],
+  );
+  return row || null;
+}
+
+function formatSuccessDm(fire) {
+  const direction = fire.trigger_direction === "below" ? "STOP-LOSS" : "TAKE-PROFIT";
+  const proceedsSol = (Number(fire.proceeds || 0) / 1e9).toFixed(4);
+  const feeSol = (Number(fire.fee || 0) / 1e9).toFixed(4);
+  const netSol = (Number(fire.net_user || 0) / 1e9).toFixed(4);
+  const sig = fire.tx_signature_swap || fire.tx_signature_repay || "";
+  const sigDisplay = sig ? `${sig.slice(0, 16)}...` : "n/a";
+  const sigLink = sig ? `\nhttps://solscan.io/tx/${sig}` : "";
+  return [
+    "*Milestone: first V3 limit-close fired*",
+    "",
+    `Order #${fire.id} (${direction}) on ${fire.symbol || "?"} (${fire.category || "?"}) just executed on the V3 lending pool.`,
+    "",
+    `*Proceeds:*  ${proceedsSol} SOL`,
+    `*Protocol fee:*  ${feeSol} SOL`,
+    `*Net to user:*  ${netSol} SOL`,
+    `*Tx signature:*  \`${sigDisplay}\`${sigLink}`,
+    "",
+    "V3 engine path is now PRODUCTION-VALIDATED. RWA + memecoin V3 fires confirmed end-to-end.",
+  ].join("\n");
+}
+
+function formatFailureDm(fail) {
+  const direction = fail.trigger_direction === "below" ? "STOP-LOSS" : "TAKE-PROFIT";
+  return [
+    "*ALERT: first V3 limit-close fire FAILED*",
+    "",
+    `Order #${fail.id} (${direction}) on ${fail.symbol || "?"} (${fail.category || "?"}) transitioned to status='failed' on the V3 lending pool.`,
+    "",
+    `*Loan ID:*  ${fail.loan_id}`,
+    `*Borrower:*  \`${(fail.borrower_wallet || "").slice(0, 10)}...\``,
+    `*Notes:*  ${(fail.notes || "(no notes recorded)").slice(0, 220)}`,
+    "",
+    "The V3 engine fill path may be broken. Inspect magpie-limitclose logs for this order before more V3 orders fire and pile up failures.",
+    "",
+    "Mitigation while debugging: set ROUTE_RWA_TO_V3=false to fall back to V2 for new RWA borrows.",
+  ].join("\n");
+}
+
+async function tickSuccess(bot) {
+  if (_successDisabled) return;
+  try {
+    const { rows: [flag] } = await query(
+      `SELECT notified_at FROM engine_milestone_flags WHERE milestone_key = 'first_v3_fire'`,
+    );
+    if (!flag) return;
+    if (flag.notified_at) {
+      _successDisabled = true;
+      return;
+    }
+    const fire = await findFirstV3Success();
+    if (!fire) return;
+
+    const { rowCount } = await query(
+      `UPDATE engine_milestone_flags
+          SET notified_at = NOW(),
+              reference_id = $1,
+              reference_sig = $2
+        WHERE milestone_key = 'first_v3_fire'
+          AND notified_at IS NULL`,
+      [String(fire.id), fire.tx_signature_swap || fire.tx_signature_repay || null],
+    );
+    if (rowCount === 0) {
+      _successDisabled = true;
+      return;
+    }
+
+    const adminId = process.env.ADMIN_TG_ID;
+    if (adminId && bot) {
+      try {
+        await bot.api.sendMessage(Number(adminId), formatSuccessDm(fire), { parse_mode: "Markdown" });
+        console.log(`[first-v3-fire-watcher] celebrated order ${fire.id}`);
+      } catch (err) {
+        console.warn("[first-v3-fire-watcher] success DM send failed:", err.message?.slice(0, 80));
+      }
+    }
+    _successDisabled = true;
+  } catch (err) {
+    console.warn("[first-v3-fire-watcher] success tick threw:", err.message?.slice(0, 80));
+  }
+}
+
+async function tickFailure(bot) {
+  if (_failureDisabled) return;
+  try {
+    const { rows: [flag] } = await query(
+      `SELECT notified_at FROM engine_milestone_flags WHERE milestone_key = 'first_v3_fire_failure'`,
+    );
+    if (!flag) return;
+    if (flag.notified_at) {
+      _failureDisabled = true;
+      return;
+    }
+    const fail = await findFirstV3Failure();
+    if (!fail) return;
+
+    const { rowCount } = await query(
+      `UPDATE engine_milestone_flags
+          SET notified_at = NOW(),
+              reference_id = $1
+        WHERE milestone_key = 'first_v3_fire_failure'
+          AND notified_at IS NULL`,
+      [String(fail.id)],
+    );
+    if (rowCount === 0) {
+      _failureDisabled = true;
+      return;
+    }
+
+    const adminId = process.env.ADMIN_TG_ID;
+    if (adminId && bot) {
+      try {
+        await bot.api.sendMessage(Number(adminId), formatFailureDm(fail), { parse_mode: "Markdown" });
+        console.warn(`[first-v3-fire-watcher] alerted on FAILED order ${fail.id}`);
+      } catch (err) {
+        console.warn("[first-v3-fire-watcher] failure DM send failed:", err.message?.slice(0, 80));
+      }
+    }
+    _failureDisabled = true;
+  } catch (err) {
+    console.warn("[first-v3-fire-watcher] failure tick threw:", err.message?.slice(0, 80));
+  }
+}
+
+export function startLimitCloseFirstV3FireWatcher(bot) {
+  if (_timer) return;
+  if (!V3_PROGRAM_ID) {
+    console.log("[first-v3-fire-watcher] PROGRAM_ID_V3 not set — disabled");
+    return;
+  }
+  console.log(`[first-v3-fire-watcher] armed — every ${WATCHER_INTERVAL_MS / 60_000} min for success + failure observability`);
+  setTimeout(() => {
+    tickSuccess(bot).catch((e) => console.warn("[first-v3-fire-watcher] first success tick threw:", e.message?.slice(0, 80)));
+    tickFailure(bot).catch((e) => console.warn("[first-v3-fire-watcher] first failure tick threw:", e.message?.slice(0, 80)));
+    _timer = setInterval(() => {
+      tickSuccess(bot).catch((e) => console.warn("[first-v3-fire-watcher] success tick threw:", e.message?.slice(0, 80)));
+      tickFailure(bot).catch((e) => console.warn("[first-v3-fire-watcher] failure tick threw:", e.message?.slice(0, 80)));
+    }, WATCHER_INTERVAL_MS);
+  }, FIRST_RUN_DELAY_MS);
+}


### PR DESCRIPTION
## Summary

Closes V3 observability gaps from today's limit-close audit.

### NEW: engine_program_id NULL sentinel
- Polls `limit_close_orders` every 5 min for rows armed after 2026-06-13 with NULL `engine_program_id`
- DMs operator with affected row IDs if any found; re-alerts every 6h while non-zero
- Sends CLEAR message on recovery
- Closes the silent-wrong-pool-fire failure mode

### NEW: first-V3-fire watcher (two prongs)
- **Prong A:** celebrate the FIRST successful V3 fire (proof the engine's executeRepayLoanV3 path works end-to-end)
- **Prong B:** ALERT on the FIRST V3 fire FAILURE — suggests `ROUTE_RWA_TO_V3=false` mitigation in the DM
- Race-safe via conditional UPDATE on `notified_at`
- Migration 063 seeds the milestone flags

### Boot wiring (src/index.js)
- Sentinel at T+120s
- V3 watcher at T+150s
- Confirmed via grep: loan-program-id-healer already boots at T+115s (no change needed)

## Test plan

- [ ] CI passes
- [ ] Migration 063 applies cleanly
- [ ] Sentinel logs `[engine-program-id-null] sentinel armed` on boot
- [ ] V3 watcher logs `[first-v3-fire-watcher] armed` on boot
- [ ] When first V3 fire succeeds: operator DM celebrates
- [ ] When first V3 fire fails: operator DM alerts with mitigation

## Risk

Very low: additive only, no changes to fill or arm paths. Sentinel reads — no writes that touch live orders.