### PR TITLE
TP/SL multi-target arming + slice_pct scaffolding (#200 phase A)

### DIFF
--- a/migrations/064_limit_close_orders_slice_pct_ladder.sql
+++ b/migrations/064_limit_close_orders_slice_pct_ladder.sql
@@ -1,0 +1,99 @@
+-- migration 064: TP/SL ladder — slice_pct + sum-cap trigger
+--
+-- Today: migration 047 enforces UNIQUE (loan_id, trigger_direction)
+-- on armed orders. That caps each loan at ONE armed TP + ONE armed
+-- SL — fine for the basic "set it and forget it" user, but it
+-- forecloses the strategy of selling portions at multiple price
+-- targets (e.g. "take 25% off at 1.5x, another 25% at 1.8x, the
+-- rest at 2.2x").
+--
+-- This migration:
+--   1) Adds slice_pct (basis-points fraction of collateral closed
+--      when the leg fires). DEFAULT 10000 (= 100%) so every legacy
+--      armed order remains a single full-close leg.
+--   2) Drops the per-direction UNIQUE index from migration 047.
+--   3) Replaces it with a BEFORE INSERT/UPDATE trigger that enforces
+--      SUM(slice_pct) <= 10000 across the (loan_id, trigger_direction)
+--      armed-order set. Users can now arm 1-N legs per direction so
+--      long as the cumulative slice never exceeds 100%.
+--
+-- Engine-side semantics (paired magpie-limitclose change, separate
+-- PR):
+--   - When a leg with slice_pct < 10000 fires, the engine calls
+--     partial_repay sized to its slice. The remaining armed legs on
+--     the same loan stay armed (they're still wanted).
+--   - When the cumulative fired slice for the loan reaches 10000
+--     (across however many legs), the loan is fully closed and any
+--     remaining armed legs are auto-cancelled with
+--     reason='ladder_complete'.
+--   - Opposite-direction armed orders (e.g. a SL when a TP just
+--     fired its full 100% slice) are still auto-cancelled with
+--     reason='sibling_order_fired', same as today.
+--
+-- This bot-side migration ships the storage + validation. Until the
+-- engine PR lands, slice_pct < 10000 is rejected at the arm path so
+-- users don't arm a ladder that can't be honored end-to-end. See
+-- src/services/limit-close-arm-core.js for the env-gated rollout.
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS slice_pct INT NOT NULL DEFAULT 10000;
+
+ALTER TABLE limit_close_orders
+  DROP CONSTRAINT IF EXISTS limit_close_orders_slice_pct_range;
+
+ALTER TABLE limit_close_orders
+  ADD CONSTRAINT limit_close_orders_slice_pct_range
+  CHECK (slice_pct > 0 AND slice_pct <= 10000);
+
+DROP INDEX IF EXISTS limit_close_orders_one_armed_per_direction_idx;
+
+CREATE OR REPLACE FUNCTION limit_close_orders_validate_slice_sum()
+RETURNS TRIGGER AS $$
+DECLARE
+  total_pct INT;
+  effective_direction TEXT;
+BEGIN
+  -- Only enforce on rows transitioning into 'armed'. Cancellations
+  -- and fires aren't subject to the sum cap (a fired leg has already
+  -- consumed its slice; a cancelled leg releases its slice back to
+  -- the available budget).
+  IF NEW.status IS DISTINCT FROM 'armed' THEN
+    RETURN NEW;
+  END IF;
+
+  effective_direction := COALESCE(NEW.trigger_direction, 'above');
+
+  SELECT COALESCE(SUM(slice_pct), 0)
+    INTO total_pct
+    FROM limit_close_orders
+   WHERE loan_id = NEW.loan_id
+     AND COALESCE(trigger_direction, 'above') = effective_direction
+     AND status = 'armed'
+     AND id IS DISTINCT FROM NEW.id;   -- exclude self on UPDATE
+
+  IF total_pct + NEW.slice_pct > 10000 THEN
+    RAISE EXCEPTION
+      'TP/SL ladder exceeds 100%%: existing armed legs sum to % bps (loan_id=%, direction=%); incoming leg of % bps would push to %.',
+      total_pct, NEW.loan_id, effective_direction, NEW.slice_pct, total_pct + NEW.slice_pct
+    USING ERRCODE = '23514';   -- check_violation
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS limit_close_orders_slice_sum_check
+  ON limit_close_orders;
+
+CREATE TRIGGER limit_close_orders_slice_sum_check
+  BEFORE INSERT OR UPDATE OF status, slice_pct, trigger_direction, loan_id
+  ON limit_close_orders
+  FOR EACH ROW
+  EXECUTE FUNCTION limit_close_orders_validate_slice_sum();
+
+COMMENT ON COLUMN limit_close_orders.slice_pct IS
+  'Fraction of loan collateral closed when this leg fires, in basis
+   points (10000 = 100% = full close). SUM(slice_pct) across armed
+   legs per (loan_id, trigger_direction) is capped at 10000 by the
+   slice_sum_check trigger. Legacy rows default to 10000 = single
+   full-close leg, matching pre-ladder behavior.';

--- a/migrations/064_limit_close_orders_slice_pct_ladder.sql
+++ b/migrations/064_limit_close_orders_slice_pct_ladder.sql
@@ -1,39 +1,36 @@
--- migration 064: TP/SL ladder — slice_pct + sum-cap trigger
+-- migration 064: TP/SL multi-target arming + slice_pct scaffolding
 --
--- Today: migration 047 enforces UNIQUE (loan_id, trigger_direction)
--- on armed orders. That caps each loan at ONE armed TP + ONE armed
--- SL — fine for the basic "set it and forget it" user, but it
--- forecloses the strategy of selling portions at multiple price
--- targets (e.g. "take 25% off at 1.5x, another 25% at 1.8x, the
--- rest at 2.2x").
+-- Today (migration 047) enforces a UNIQUE per (loan_id, trigger_direction)
+-- WHERE status='armed' — at most one armed TP + one armed SL per loan.
+-- This forecloses the common strategy of arming MULTIPLE TPs at
+-- different price targets (e.g. "TP at 1.5x AND a backup TP at 2x;
+-- whichever hits first fires").
 --
--- This migration:
---   1) Adds slice_pct (basis-points fraction of collateral closed
---      when the leg fires). DEFAULT 10000 (= 100%) so every legacy
---      armed order remains a single full-close leg.
---   2) Drops the per-direction UNIQUE index from migration 047.
---   3) Replaces it with a BEFORE INSERT/UPDATE trigger that enforces
---      SUM(slice_pct) <= 10000 across the (loan_id, trigger_direction)
---      armed-order set. Users can now arm 1-N legs per direction so
---      long as the cumulative slice never exceeds 100%.
+-- What this migration does:
+--   1) Adds slice_pct INT NOT NULL DEFAULT 10000 (= 100% = full close).
+--      Scaffolding for a future on-chain "partial close with swap"
+--      instruction. Today's repay_loan + partial_repay don't release
+--      fractional collateral, so slice_pct < 10000 cannot be honored
+--      end-to-end on chain. The arm path (limit-close-arm-core.js)
+--      keeps an env-gated refuse for slice < 10000 until the on-chain
+--      capability lands. Schema is in place so we can flip it on
+--      without a migration when the V4 program ships.
 --
--- Engine-side semantics (paired magpie-limitclose change, separate
--- PR):
---   - When a leg with slice_pct < 10000 fires, the engine calls
---     partial_repay sized to its slice. The remaining armed legs on
---     the same loan stay armed (they're still wanted).
---   - When the cumulative fired slice for the loan reaches 10000
---     (across however many legs), the loan is fully closed and any
---     remaining armed legs are auto-cancelled with
---     reason='ladder_complete'.
---   - Opposite-direction armed orders (e.g. a SL when a TP just
---     fired its full 100% slice) are still auto-cancelled with
---     reason='sibling_order_fired', same as today.
+--   2) Drops migration 047's per-direction UNIQUE index — so users can
+--      arm N TPs at different prices (and N SLs). The engine's
+--      existing markFired() sibling-cancel logic handles the
+--      first-trigger-wins semantic: when one leg fires (full close),
+--      the loan is closed, and any remaining armed legs on the loan
+--      auto-cancel with reason='sibling_order_fired'.
 --
--- This bot-side migration ships the storage + validation. Until the
--- engine PR lands, slice_pct < 10000 is rejected at the arm path so
--- users don't arm a ladder that can't be honored end-to-end. See
--- src/services/limit-close-arm-core.js for the env-gated rollout.
+-- Why no sum trigger here:
+--   A SUM(slice_pct) cap only makes sense when the engine actually
+--   honors fractional fills. Until then, every leg is implicitly
+--   slice=100% (full close on trigger), and a "sum cap" would just
+--   re-impose the migration-047 UNIQUE in different syntax. When V4
+--   lands and the operator enables ladder mode, a follow-up migration
+--   will add the sum trigger so SUM(slice_pct) <= 10000 enforces a
+--   coherent fractional plan.
 
 ALTER TABLE limit_close_orders
   ADD COLUMN IF NOT EXISTS slice_pct INT NOT NULL DEFAULT 10000;
@@ -45,55 +42,16 @@ ALTER TABLE limit_close_orders
   ADD CONSTRAINT limit_close_orders_slice_pct_range
   CHECK (slice_pct > 0 AND slice_pct <= 10000);
 
+-- Drop the per-direction UNIQUE so multi-target arming becomes possible.
+-- Engine-side: first leg to fire closes the loan; sibling armed legs
+-- cancel automatically via the existing markFired() flow. No engine
+-- code change needed for this migration.
 DROP INDEX IF EXISTS limit_close_orders_one_armed_per_direction_idx;
-
-CREATE OR REPLACE FUNCTION limit_close_orders_validate_slice_sum()
-RETURNS TRIGGER AS $$
-DECLARE
-  total_pct INT;
-  effective_direction TEXT;
-BEGIN
-  -- Only enforce on rows transitioning into 'armed'. Cancellations
-  -- and fires aren't subject to the sum cap (a fired leg has already
-  -- consumed its slice; a cancelled leg releases its slice back to
-  -- the available budget).
-  IF NEW.status IS DISTINCT FROM 'armed' THEN
-    RETURN NEW;
-  END IF;
-
-  effective_direction := COALESCE(NEW.trigger_direction, 'above');
-
-  SELECT COALESCE(SUM(slice_pct), 0)
-    INTO total_pct
-    FROM limit_close_orders
-   WHERE loan_id = NEW.loan_id
-     AND COALESCE(trigger_direction, 'above') = effective_direction
-     AND status = 'armed'
-     AND id IS DISTINCT FROM NEW.id;   -- exclude self on UPDATE
-
-  IF total_pct + NEW.slice_pct > 10000 THEN
-    RAISE EXCEPTION
-      'TP/SL ladder exceeds 100%%: existing armed legs sum to % bps (loan_id=%, direction=%); incoming leg of % bps would push to %.',
-      total_pct, NEW.loan_id, effective_direction, NEW.slice_pct, total_pct + NEW.slice_pct
-    USING ERRCODE = '23514';   -- check_violation
-  END IF;
-
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS limit_close_orders_slice_sum_check
-  ON limit_close_orders;
-
-CREATE TRIGGER limit_close_orders_slice_sum_check
-  BEFORE INSERT OR UPDATE OF status, slice_pct, trigger_direction, loan_id
-  ON limit_close_orders
-  FOR EACH ROW
-  EXECUTE FUNCTION limit_close_orders_validate_slice_sum();
 
 COMMENT ON COLUMN limit_close_orders.slice_pct IS
   'Fraction of loan collateral closed when this leg fires, in basis
-   points (10000 = 100% = full close). SUM(slice_pct) across armed
-   legs per (loan_id, trigger_direction) is capped at 10000 by the
-   slice_sum_check trigger. Legacy rows default to 10000 = single
-   full-close leg, matching pre-ladder behavior.';
+   points (10000 = 100% = full close). Today the on-chain protocol
+   only supports full close, so every armed leg implicitly uses 10000
+   and a "ladder of fractional sells" is gated off in the arm path.
+   Schema in place for when a future on-chain partial-close
+   instruction lands.';

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -92,6 +92,11 @@ function parseLimitCloseArgs(text, direction = "above") {
   let slippage_bps = 200;
   let dest = "sol";
   let expire_iso = null;
+  // TP/SL ladder slice (migration 064). Default 100% (10000 bps) =
+  // single-leg full close, matching pre-ladder behavior. User opts in
+  // with `slice=25%` to arm a 25% leg, leaving 75% available for
+  // additional legs at other price targets.
+  let slice_pct = 10000;
 
   // Natural-language path: "at <value>" where <value> is either:
   //   - "<N>x"     → multiplier semantic
@@ -198,8 +203,21 @@ function parseLimitCloseArgs(text, direction = "above") {
       const parsed = parseExpiry(v);
       if (!parsed.ok) return parsed;
       expire_iso = parsed.iso;
+    } else if (k === "slice") {
+      // Accepted forms: "25%", "25", "2500bps". Bps stored as integer
+      // 1..10000. Sum across armed legs per (loan_id, direction) is
+      // enforced at INSERT time by migration 064's trigger.
+      const raw = String(v).replace(/%$/, "").replace(/bps$/i, "").trim();
+      const n = Number(raw);
+      if (!Number.isFinite(n) || n <= 0) {
+        return { ok: false, error: `Invalid slice: \`${v}\`. Use a percent like \`slice=25%\`.` };
+      }
+      slice_pct = /bps$/i.test(v) ? Math.round(n) : Math.round(n * 100);
+      if (slice_pct < 1 || slice_pct > 10000) {
+        return { ok: false, error: "Slice must be between 0.01% and 100%." };
+      }
     } else {
-      return { ok: false, error: `Unknown option \`${k}=\`. Allowed: mc=, price=, slip=, dest=, expire=` };
+      return { ok: false, error: `Unknown option \`${k}=\`. Allowed: mc=, price=, slip=, dest=, expire=, slice=` };
     }
   }
 
@@ -208,7 +226,7 @@ function parseLimitCloseArgs(text, direction = "above") {
   }
   return {
     ok: true,
-    parsed: { loan_id, trigger_kind, trigger_value_micro, slippage_bps, dest, expire_iso, multiplier },
+    parsed: { loan_id, trigger_kind, trigger_value_micro, slippage_bps, dest, expire_iso, multiplier, slice_pct },
   };
 }
 
@@ -350,6 +368,7 @@ export async function handleLimitClose(ctx, direction = "above") {
     slippageBps: slippage_bps,
     sellDestination: dest,
     expiresAt: expire_iso,
+    slicePct: parseResult.parsed.slice_pct,
   });
 
   if (!armed.ok) {
@@ -366,6 +385,12 @@ export async function handleLimitClose(ctx, direction = "above") {
           return `Loan is below the 1 SOL minimum for limit-close orders.`;
         case "collateral_not_enabled":
           return `Collateral token is not currently enabled in the protocol.`;
+        case "invalid_slice_pct":
+          return `Slice must be between 0.01% and 100%. Try \`slice=25%\` for a 25% leg.`;
+        case "ladder_not_yet_enabled":
+          return `Partial-slice TP/SL is rolling out — for now, slice must be 100%. Engine support ships next.`;
+        case "ladder_sum_exceeds_100":
+          return `You already have armed legs in this direction totaling close to 100%. Cancel one or shrink your slice.`;
         case "rwa_collateral_not_supported_in_v1":
           // Unreachable since 2026-06-13 (PR C flipped the arm-core
           // gate; RWA collateral is now arm-eligible end-to-end via the
@@ -936,6 +961,7 @@ export async function handleLimitOrders(ctx) {
             lc.armed_at, lc.expires_at,
             lc.trailing_distance_bps,
             lc.peak_price_micros::text AS peak_price_micros,
+            COALESCE(lc.slice_pct, 10000) AS slice_pct,
             l.loan_id AS chain_loan_id,
             l.collateral_mint,
             m.symbol AS collateral_symbol,
@@ -1003,9 +1029,14 @@ export async function handleLimitOrders(ctx) {
       const fmt = (n) => n < 0.01 ? n.toFixed(8) : n < 1 ? n.toFixed(6) : n.toFixed(4);
       peakLine = `\n   ~ peak $${fmt(peakUsd)} (floor floats with each new high)`;
     }
+    // Slice badge — surfaces ladder legs. Hidden for the default 100%
+    // case to keep single-leg display unchanged. Showing "slice 25%"
+    // tells the user this is one rung of a multi-target plan.
+    const slicePct = Number(r.slice_pct) || 10000;
+    const sliceBadge = slicePct < 10000 ? ` · slice ${(slicePct / 100).toFixed(slicePct % 100 === 0 ? 0 : 1)}%` : "";
     lines.push(
       `${directionPill}${rwaBadge}  #${r.id} · loan ${r.chain_loan_id}${sym}`,
-      `   → ${trig}  ·  slip ${slip}%  ·  ${r.sell_destination.toUpperCase()}  ·  armed ${ageLabel(r.armed_at)}${expiry}${peakLine}${distLine}`,
+      `   → ${trig}  ·  slip ${slip}%  ·  ${r.sell_destination.toUpperCase()}${sliceBadge}  ·  armed ${ageLabel(r.armed_at)}${expiry}${peakLine}${distLine}`,
       "",
     );
   }

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -387,10 +387,8 @@ export async function handleLimitClose(ctx, direction = "above") {
           return `Collateral token is not currently enabled in the protocol.`;
         case "invalid_slice_pct":
           return `Slice must be between 0.01% and 100%. Try \`slice=25%\` for a 25% leg.`;
-        case "ladder_not_yet_enabled":
-          return `Partial-slice TP/SL is rolling out — for now, slice must be 100%. Engine support ships next.`;
-        case "ladder_sum_exceeds_100":
-          return `You already have armed legs in this direction totaling close to 100%. Cancel one or shrink your slice.`;
+        case "fractional_slice_not_supported_today":
+          return `Today's on-chain protocol only supports full close per leg. Multi-target arming at different prices IS supported — e.g. \`/takeprofit ${loan_id} at 1.5x\` AND \`/takeprofit ${loan_id} at 2x\`. First to trigger fires; the other auto-cancels.`;
         case "rwa_collateral_not_supported_in_v1":
           // Unreachable since 2026-06-13 (PR C flipped the arm-core
           // gate; RWA collateral is now arm-eligible end-to-end via the

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -178,20 +178,25 @@ export async function armOrder({
   if (!VALID_DESTINATIONS.has(sellDestination)) {
     return { ok: false, error: "invalid_sell_destination" };
   }
-  // ── Slice (ladder) validation ────────────────────────────────
+  // ── Slice (ladder scaffolding) validation ────────────────────
   if (!Number.isInteger(slicePct) || slicePct <= 0 || slicePct > 10000) {
     return { ok: false, error: "invalid_slice_pct", detail: { allowed_range_bps: [1, 10000] } };
   }
-  // Engine-side partial-fill ships separately. Until then, refuse any
-  // slice < 100% so the bot never accepts a ladder it can't honor.
-  // Operator unblocks by setting LIMIT_CLOSE_LADDER_ENABLED=true once
-  // the magpie-limitclose partial_repay PR has rolled out.
+  // Migration 064 keeps slice_pct as scaffolding: the column exists but
+  // every armed leg is implicitly full-close (slice = 10000) until a
+  // future on-chain instruction supports fractional collateral release.
+  // Today's on-chain partial_repay only reduces debt — it doesn't
+  // release fractional collateral — so a slice<100% arm can't be
+  // honored end-to-end. Refuse it explicitly so users never see a
+  // misleading "armed" status on something the engine can't fire as
+  // promised. The env flag is here for the day the partial-close
+  // instruction lands; flipping it to true is part of that rollout.
   const LADDER_ENABLED = process.env.LIMIT_CLOSE_LADDER_ENABLED === "true";
   if (slicePct < 10000 && !LADDER_ENABLED) {
     return {
       ok: false,
-      error: "ladder_not_yet_enabled",
-      detail: "Partial-slice TP/SL is rolling out — for now, slice_pct must be 100% (10000 bps). Engine support ships next.",
+      error: "fractional_slice_not_supported_today",
+      detail: "Today's on-chain protocol only supports full close per leg. For now, every TP/SL leg is implicitly 100%. Multi-target arming at different prices IS supported — arm a TP at 1.5x AND another at 2x; first to trigger fires, the other auto-cancels.",
     };
   }
   // Trailing validation. Bounded same as the migration's CHECK constraint.
@@ -560,17 +565,11 @@ export async function armOrder({
            : `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}${slicePct < 10000 ? ` slice=${slicePct/100}%` : ""}`)],
     );
   } catch (err) {
-    // Slice-sum trigger (migration 064): TP/SL ladder exceeds 100%.
-    // Surface as a structured error so UI can show the over-allocation.
-    if (/TP\/SL ladder exceeds 100/i.test(err.message || "")) {
-      return {
-        ok: false,
-        error: "ladder_sum_exceeds_100",
-        detail: err.message?.slice(0, 240),
-      };
-    }
-    // (Legacy migration 047 UNIQUE is dropped by 064, but tolerate
-    // any other DB-level duplicate signal in case rollouts overlap.)
+    // Migration 047's per-direction UNIQUE is dropped by 064 so multi-
+    // target arming is allowed. Tolerate the duplicate-key signal in
+    // case a stale replica is still using the pre-064 schema during
+    // rollout. The 064 deploy is single-step (no overlap window
+    // expected) so this branch should never fire in practice.
     if (/duplicate key value violates unique constraint/i.test(err.message || "")) {
       return {
         ok: false,

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -125,6 +125,20 @@ export async function armOrder({
   // is incompatible with triggerDirection='above' (TP fires at a
   // fixed target by definition); validated below.
   trailingDistanceBps = null,
+  // TP/SL ladder support. Fraction of loan collateral closed when
+  // this leg fires, in basis points (10000 = 100% = full close).
+  // The DB trigger (migration 064) enforces SUM(slice_pct) <= 10000
+  // across all armed legs per (loan_id, trigger_direction), so this
+  // function just needs to forward a valid integer 1..10000. Default
+  // 10000 preserves pre-ladder single-leg behavior for callers that
+  // don't pass it (TG /tp without slice, site arm without slice picker).
+  //
+  // Engine note: until the magpie-limitclose partial-fill PR ships,
+  // env LIMIT_CLOSE_LADDER_ENABLED gates whether < 10000 is accepted
+  // at all — the bot won't let users arm a ladder the engine can't
+  // honor end-to-end. See limit-close-arm-core.js LADDER_ENABLED
+  // check below.
+  slicePct = 10000,
   slippageBps,
   sellDestination = "sol",
   expiresAt = null,
@@ -163,6 +177,22 @@ export async function armOrder({
   }
   if (!VALID_DESTINATIONS.has(sellDestination)) {
     return { ok: false, error: "invalid_sell_destination" };
+  }
+  // ── Slice (ladder) validation ────────────────────────────────
+  if (!Number.isInteger(slicePct) || slicePct <= 0 || slicePct > 10000) {
+    return { ok: false, error: "invalid_slice_pct", detail: { allowed_range_bps: [1, 10000] } };
+  }
+  // Engine-side partial-fill ships separately. Until then, refuse any
+  // slice < 100% so the bot never accepts a ladder it can't honor.
+  // Operator unblocks by setting LIMIT_CLOSE_LADDER_ENABLED=true once
+  // the magpie-limitclose partial_repay PR has rolled out.
+  const LADDER_ENABLED = process.env.LIMIT_CLOSE_LADDER_ENABLED === "true";
+  if (slicePct < 10000 && !LADDER_ENABLED) {
+    return {
+      ok: false,
+      error: "ladder_not_yet_enabled",
+      detail: "Partial-slice TP/SL is rolling out — for now, slice_pct must be 100% (10000 bps). Engine support ships next.",
+    };
   }
   // Trailing validation. Bounded same as the migration's CHECK constraint.
   if (trailingDistanceBps != null) {
@@ -493,6 +523,7 @@ export async function armOrder({
           preflight_slippage_quoted_bps, preflight_proceeds_lamports, preflight_quoted_at,
           engine_program_id,
           trailing_distance_bps, peak_price_micros,
+          slice_pct,
           notes)
        VALUES ($1, $2, $3, $4,
                $5,
@@ -502,7 +533,8 @@ export async function armOrder({
                $14, $15, $16,
                $17,
                $18, $19,
-               $20)
+               $20,
+               $21)
        RETURNING id, armed_at`,
       [userId, loan.id, triggerKind, triggerBI.toString(),
        triggerDirection,
@@ -521,20 +553,25 @@ export async function armOrder({
        loan.program_id || null,
        trailingDistanceBps,
        peakAtArm != null ? peakAtArm.toString() : null,
+       slicePct,
        armNote
          || (appliedInitialBps !== originalInitialBps
-           ? `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
-           : `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}`)],
+           ? `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}${slicePct < 10000 ? ` slice=${slicePct/100}%` : ""}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
+           : `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}${slicePct < 10000 ? ` slice=${slicePct/100}%` : ""}`)],
     );
   } catch (err) {
+    // Slice-sum trigger (migration 064): TP/SL ladder exceeds 100%.
+    // Surface as a structured error so UI can show the over-allocation.
+    if (/TP\/SL ladder exceeds 100/i.test(err.message || "")) {
+      return {
+        ok: false,
+        error: "ladder_sum_exceeds_100",
+        detail: err.message?.slice(0, 240),
+      };
+    }
+    // (Legacy migration 047 UNIQUE is dropped by 064, but tolerate
+    // any other DB-level duplicate signal in case rollouts overlap.)
     if (/duplicate key value violates unique constraint/i.test(err.message || "")) {
-      // Post migration 047, the UNIQUE is (loan_id, trigger_direction).
-      // The error means an armed TP already exists when caller asked
-      // for a TP, OR an armed SL already exists when caller asked for
-      // SL. The OTHER direction is still open for arming. Detail tells
-      // the caller which side they collided on so the UI can suggest
-      // "you already have a TP on this loan — modify or cancel it,
-      // OR arm a stop-loss instead".
       return {
         ok: false,
         error: "loan_already_has_active_order_in_direction",


### PR DESCRIPTION
## Summary

#200 originally scoped \"partial sells across multiple price targets\". On a deeper check of the on-chain layer, \`partial_repay\` in V1/V3 only reduces debt — it does NOT release fractional collateral. A true \"ladder of fractional sells\" cannot be honored end-to-end today without a new on-chain instruction.

**This PR delivers the shippable slice:** multi-target arming. Schema scaffolding for the day fractional close lands.

### What ships today

- Migration 064: drops migration 047's per-direction UNIQUE so users can arm N TPs at different prices (and N SLs).
- \`slice_pct INT NOT NULL DEFAULT 10000\` column + range CHECK — scaffolding for the future fractional-close instruction.
- arm-core refuses \`slice<100%\` with a clear error pointing users at multi-target arming as the supported alternative today (gated by \`LIMIT_CLOSE_LADDER_ENABLED\` for the day on-chain support exists).
- TG \`/tp\` \`/sl\` accept \`slice=\` (forward-compatible). Until on-chain partial-close ships, the bot only accepts \`slice=100%\`.
- /limitorders surfaces a \`· slice X%\` badge when slice<100% (forward-compat display).

### What multi-target arming actually delivers

A user arms \`/takeprofit <loan> at 1.5x\` AND \`/takeprofit <loan> at 2x\` simultaneously. First to trigger fires (full close); the other auto-cancels via the engine's existing \`markFired()\` sibling-cancel logic. No engine PR needed.

### What's NOT in this PR

- Fractional collateral release. Requires a new on-chain instruction (V4 program work). Tracking separately.
- SUM(slice_pct) cap trigger. Without fractional close, a sum cap would just re-impose the 047 single-leg rule under different syntax. When fractional close ships, a follow-up migration adds the sum trigger.

## Test plan

- [ ] CI passes
- [ ] Migration 064 applies cleanly
- [ ] Two \`/tp\` calls on the same loan at different prices both arm (no duplicate-key error)
- [ ] \`/tp\` with \`slice=25%\` returns the multi-target alternative hint
- [ ] Engine fires the first-trigger leg as a full close; sibling armed legs auto-cancel