### PR TITLE
limit-orders: shared natural-language strike parser + Pip deep knowledge

### DIFF
--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -28,6 +28,7 @@ import { query } from "../db/pool.js";
 import { upsertUser } from "../services/users.js";
 import { runArmPreflight } from "../services/limit-close-preflight.js";
 import { armOrder, resolveMultiplierToPrice } from "../services/limit-close-arm-core.js";
+import { parseStrike } from "../lib/strike-price-parser.js";
 
 const MIN_LOAN_LAMPORTS = BigInt(1_000_000_000n); // 1 SOL eligibility floor
 const MAX_ACTIVE_ORDERS_PER_USER = 10;
@@ -98,72 +99,66 @@ function parseLimitCloseArgs(text, direction = "above") {
   // additional legs at other price targets.
   let slice_pct = 10000;
 
-  // Natural-language path: "at <value>" where <value> is either:
-  //   - "<N>x"     → multiplier semantic
-  //   - "$<num>m"  → market cap USD
-  //   - "$<num>"   → USD price target
+  // Natural-language path: "at <value>" — the value can be ANY shape
+  // the shared strike-price parser accepts. Examples:
+  //   at 17M                  →  $17M MC (bare big numbers default to MC)
+  //   at 17m mc               →  $17M MC (explicit kind word)
+  //   at 17,000,000 MC        →  $17M MC (commas tolerated)
+  //   at 17 million market cap →  $17M MC (number words tolerated)
+  //   at $0.005               →  $0.005 USD price
+  //   at 0.0025 sol           →  0.0025 SOL price
+  //   at 2x / 0.7x            →  multiplier (resolved to USD price downstream)
+  //   at -30% / down 30%      →  -30% multiplier (SL only)
+  //   at +50% / up 50%        →  +50% multiplier (TP only)
+  // Operator mandate (2026-06-14): all these forms MUST work the same
+  // across TG, Pip, and the site. See src/lib/strike-price-parser.js.
   for (let i = 1; i < filtered.length; i++) {
     const t = filtered[i];
 
-    // Handle "at <value>" — consume i+1 too.
+    // Handle "at <value [more words]>" — slurp everything until we hit
+    // a key=value token or end of input. That way "at 17 million market
+    // cap" works as one logical value even though it's 4 tokens.
     if (t.toLowerCase() === "at" && i + 1 < filtered.length) {
-      const v = filtered[i + 1];
-      // Stop-loss percent: "-30%" / "-5%"
-      const mPct = v.match(/^-([0-9]+(?:\.[0-9]+)?)%$/);
-      if (mPct) {
-        if (direction !== "below") {
-          return { ok: false, error: "Percent-drop targets (e.g. `at -30%`) are only valid for /stoploss." };
-        }
-        const p = Number(mPct[1]);
-        if (!Number.isFinite(p) || p <= 0 || p >= 100) {
-          return { ok: false, error: "Stop-loss percent must be between 0% and 100% (e.g. `at -30%`)." };
-        }
-        multiplier = 1 - (p / 100); // 30% drop → 0.7x of current
+      const slurpedParts = [];
+      let j = i + 1;
+      while (j < filtered.length) {
+        const next = filtered[j];
+        // key=value tokens end the slurp.
+        if (/^([a-z_]+)=/i.test(next)) break;
+        slurpedParts.push(next);
+        j++;
+      }
+      const rawValue = slurpedParts.join(" ");
+      // bareNumberDefaultKind hint: SL uses price_usd by default (most
+      // SL targets are USD price drops), TP uses mc_usd for big numbers.
+      // The parser only uses this when the input is bare ("17"); explicit
+      // kind words always win.
+      const parsed = parseStrike(rawValue, {
+        bareNumberDefaultKind: direction === "below" ? "price_usd" : undefined,
+      });
+      if (!parsed.ok) {
+        return { ok: false, error: parsed.error };
+      }
+      // Direction sanity: percent-move and multiplier targets carry
+      // their own implied direction. Reject mismatches loudly.
+      if (parsed.impliedDirection && parsed.impliedDirection !== direction) {
+        return {
+          ok: false,
+          error: parsed.impliedDirection === "below"
+            ? "That's a downside target — use /stoploss, not /takeprofit."
+            : "That's an upside target — use /takeprofit, not /stoploss.",
+        };
+      }
+      if (parsed.kind === "multiplier") {
+        // Caller resolves to USD price using cross-sourced oracle.
+        multiplier = parsed.multiplier;
         trigger_kind = "price_usd";
-        i++; continue;
+      } else {
+        trigger_kind = parsed.kind;
+        trigger_value_micro = parsed.valueMicro;
       }
-      // multiplier: "2x", "1.5x" (TP) or "0.7x", "0.5x" (SL)
-      const mMul = v.match(/^([0-9]+(?:\.[0-9]+)?)x$/i);
-      if (mMul) {
-        const n = Number(mMul[1]);
-        if (!Number.isFinite(n) || n <= 0) {
-          return { ok: false, error: "Multiplier must be a positive number (e.g. `at 2x`, `at 0.7x`)." };
-        }
-        if (direction === "below") {
-          if (n >= 1) {
-            return { ok: false, error: "Stop-loss multiplier must be < 1x (e.g. `at 0.7x` = sell at 70% of current). Use /takeprofit for upside targets." };
-          }
-        } else {
-          if (n <= 1) {
-            return { ok: false, error: "Take-profit multiplier must be > 1x (e.g. `at 2x`). Use /stoploss for downside targets." };
-          }
-        }
-        multiplier = n;
-        trigger_kind = "price_usd"; // resolved to actual USD value before INSERT
-        i++; // consume value
-        continue;
-      }
-      // market cap: "$130m", "150M"
-      const mMc = v.match(/^\$?([0-9]+(?:\.[0-9]+)?)([KMBkmb])$/);
-      if (mMc) {
-        trigger_kind = "mc_usd";
-        const parsed = parseMcOrPrice(mMc[1] + mMc[2], "mc");
-        if (!parsed.ok) return parsed;
-        trigger_value_micro = parsed.micro;
-        i++;
-        continue;
-      }
-      // USD price: "$0.005" or "0.005"
-      const mPrice = v.match(/^\$?([0-9]+(?:\.[0-9]+)?)$/);
-      if (mPrice) {
-        trigger_kind = "price_usd";
-        const parsed = parseMcOrPrice(mPrice[1], "price_usd");
-        if (!parsed.ok) return parsed;
-        trigger_value_micro = parsed.micro;
-        i++;
-        continue;
-      }
-      return { ok: false, error: `Couldn't parse target after "at": \`${v}\`. Try \`at 2x\` or \`at $150m\` or \`at $0.005\`.` };
+      i = j - 1; // outer loop increment will move us past the consumed slurp
+      continue;
     }
 
     // Power-user path: key=value
@@ -172,23 +167,23 @@ function parseLimitCloseArgs(text, direction = "above") {
     const k = m[1].toLowerCase();
     const v = m[2];
     if (k === "mc") {
-      trigger_kind = "mc_usd";
-      const parsed = parseMcOrPrice(v, "mc");
-      if (!parsed.ok) return parsed;
-      trigger_value_micro = parsed.micro;
-    } else if (k === "price") {
-      // Default unit is USD unless v ends in "sol"
-      if (/sol$/i.test(v)) {
-        trigger_kind = "price_sol";
-        const parsed = parseMcOrPrice(v.replace(/sol$/i, ""), "price_sol");
-        if (!parsed.ok) return parsed;
-        trigger_value_micro = parsed.micro;
-      } else {
-        trigger_kind = "price_usd";
-        const parsed = parseMcOrPrice(v, "price_usd");
-        if (!parsed.ok) return parsed;
-        trigger_value_micro = parsed.micro;
+      // Route through the shared parser so commas, kind words, and
+      // magnitude words all work in key=value form too.
+      const parsed = parseStrike(v, { bareNumberDefaultKind: "mc_usd" });
+      if (!parsed.ok) return { ok: false, error: parsed.error };
+      if (parsed.kind === "multiplier") {
+        return { ok: false, error: "Use `at 2x` syntax for multipliers (not `mc=`)." };
       }
+      trigger_kind = parsed.kind;
+      trigger_value_micro = parsed.valueMicro;
+    } else if (k === "price") {
+      const parsed = parseStrike(v, { bareNumberDefaultKind: "price_usd" });
+      if (!parsed.ok) return { ok: false, error: parsed.error };
+      if (parsed.kind === "multiplier") {
+        return { ok: false, error: "Use `at 2x` syntax for multipliers (not `price=`)." };
+      }
+      trigger_kind = parsed.kind;
+      trigger_value_micro = parsed.valueMicro;
     } else if (k === "slip") {
       const parsed = parseSlippage(v);
       if (!parsed.ok) return parsed;

--- a/src/lib/strike-price-parser.js
+++ b/src/lib/strike-price-parser.js
@@ -1,0 +1,330 @@
+/**
+ * Strike-price parser — the ONE source of truth for "what does this
+ * user-typed strike mean."
+ *
+ * Used by:
+ *   - TG /takeprofit /stoploss commands (src/commands/limit-close.js)
+ *   - Pip propose_takeprofit / propose_stoploss / propose_trailing_stop
+ *     tools (src/services/community-pip.js, src/services/ai-support.js)
+ *   - Site dashboard arm panel + modify panel (via the
+ *     /api/v1/internal/parse-strike helper endpoint)
+ *
+ * Keeping all three behind ONE parser prevents the surfaces from
+ * drifting. A user can type "17,000,000 MC" in TG and "17M mc" on
+ * the dashboard and "take profit at seventeen million market cap"
+ * to Pip — all three should resolve to the same trigger_value_micro
+ * and trigger_kind.
+ *
+ * Inputs the parser MUST accept (operator-stated 2026-06-14):
+ *
+ *   Market caps (resolves to trigger_kind="mc_usd"):
+ *     "17m mc", "17M MC", "17m market cap", "17M marketcap"
+ *     "17,000,000 mc", "17,000,000 MC", "$17m mc", "$17M MC"
+ *     "17 million mc", "17 million market cap"
+ *     "17m" / "17M" → ambiguous, default to MC for big numbers (>=100k)
+ *
+ *   USD prices (resolves to trigger_kind="price_usd"):
+ *     "$0.005", "0.005 usd", "0.005 dollars"
+ *     "5 cents", "$5", "$5.00", "5.0"
+ *     "0.0025 sol" → trigger_kind="price_sol", BigInt lamports
+ *
+ *   Multipliers (resolves to multiplier; caller resolves to price_usd):
+ *     "2x", "1.5x", "1.5X"
+ *     "0.7x" / "0.5x" for stop-loss
+ *     "-30%" / "30% down" / "down 30%"  (SL direction; multiplier = 0.7)
+ *     "+50%" / "50% up" / "up 50%"      (TP direction; multiplier = 1.5)
+ *
+ * Returns a structured result the caller can pass straight to armOrder():
+ *   {
+ *     ok: true,
+ *     kind: "mc_usd" | "price_usd" | "price_sol" | "multiplier",
+ *     valueMicro: BigInt | null,    // null when kind="multiplier"
+ *     multiplier: number | null,    // only set when kind="multiplier"
+ *     impliedDirection: "above" | "below" | null,
+ *     normalizedDisplay: string,    // human-readable for echo
+ *   }
+ *   OR
+ *   { ok: false, error: string, examples?: string[] }
+ *
+ * Numbers DON'T need to be integers. "0.5m mc" = $500k MC. "1.7M MC" works.
+ *
+ * Whitespace in numbers is tolerated. "1 7 m" → not a number; reject.
+ * Underscore separators tolerated. "17_000_000" → 17M.
+ *
+ * Implementation philosophy: prefer obvious matches with a fallback
+ * heuristic for ambiguous cases. NEVER guess silently when the input
+ * is ambiguous about direction (e.g. "17m" could be MC or price for a
+ * memecoin trading at $0.00005); use the caller-supplied
+ * `directionHint` ("above" for TP, "below" for SL) only as a tiebreak,
+ * not as authoritative kind detection.
+ *
+ * The parser is intentionally permissive but ALWAYS deterministic — same
+ * input string always parses to the same result.
+ */
+
+const MAGNITUDE_WORDS = new Map([
+  ["k", 1_000],
+  ["thousand", 1_000],
+  ["m", 1_000_000],
+  ["mil", 1_000_000],
+  ["mm", 1_000_000],
+  ["million", 1_000_000],
+  ["b", 1_000_000_000],
+  ["bn", 1_000_000_000],
+  ["bil", 1_000_000_000],
+  ["billion", 1_000_000_000],
+  ["t", 1_000_000_000_000],
+  ["tn", 1_000_000_000_000],
+  ["trillion", 1_000_000_000_000],
+]);
+
+// Synonyms — all collapse to the same canonical kind.
+const MC_WORDS = new Set([
+  "mc", "mcap", "marketcap", "mktcap",
+  "market", "marketcap",
+  "market_cap", "mkt_cap", "mc_usd",
+]);
+const PRICE_USD_WORDS = new Set([
+  "price", "usd", "dollars", "dollar", "usdc", "cents", "cent",
+  "price_usd",
+]);
+const PRICE_SOL_WORDS = new Set([
+  "sol", "lamports", "lamport", "price_sol",
+]);
+
+// "1 7 m" is two tokens; we want one. Normalize commas, underscores,
+// and condense whitespace inside a number.
+function normalizeInput(s) {
+  if (typeof s !== "string") return "";
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/ /g, " ")   // nbsp
+    .replace(/\s+/g, " ");
+}
+
+function stripFormattingChars(numStr) {
+  return numStr.replace(/[,_]/g, "");
+}
+
+// Detect "down N%", "up N%", "-N%", "+N%" → returns {ok, multiplier, direction}.
+function parsePercentMove(s) {
+  // "down 30%"
+  let m = s.match(/^down\s+([0-9]+(?:\.[0-9]+)?)\s*%$/);
+  if (m) return { ok: true, multiplier: 1 - Number(m[1]) / 100, direction: "below" };
+  // "up 50%"
+  m = s.match(/^up\s+([0-9]+(?:\.[0-9]+)?)\s*%$/);
+  if (m) return { ok: true, multiplier: 1 + Number(m[1]) / 100, direction: "above" };
+  // "-30%" or "30% down"
+  m = s.match(/^[-]\s*([0-9]+(?:\.[0-9]+)?)\s*%$/);
+  if (m) return { ok: true, multiplier: 1 - Number(m[1]) / 100, direction: "below" };
+  m = s.match(/^([0-9]+(?:\.[0-9]+)?)\s*%\s*down$/);
+  if (m) return { ok: true, multiplier: 1 - Number(m[1]) / 100, direction: "below" };
+  // "+50%" or "50% up"
+  m = s.match(/^[+]\s*([0-9]+(?:\.[0-9]+)?)\s*%$/);
+  if (m) return { ok: true, multiplier: 1 + Number(m[1]) / 100, direction: "above" };
+  m = s.match(/^([0-9]+(?:\.[0-9]+)?)\s*%\s*up$/);
+  if (m) return { ok: true, multiplier: 1 + Number(m[1]) / 100, direction: "above" };
+  return null;
+}
+
+// "2x", "1.5x", "0.7x" — multiplier.
+function parseMultiplier(s) {
+  const m = s.match(/^([0-9]+(?:\.[0-9]+)?)\s*x$/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+// Extracts the leading number from a token, returning {num, rest}.
+// Accepts $0.005, 17,000,000, 17_000_000, etc.
+function extractLeadingNumber(s) {
+  const m = s.match(/^\$?\s*([0-9][0-9_,]*(?:\.[0-9]+)?)\s*(.*)$/);
+  if (!m) return null;
+  const raw = stripFormattingChars(m[1]);
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return { num: n, rest: m[2].trim() };
+}
+
+// Resolves trailing magnitude word (m, mm, million, b, billion, k, etc.)
+// into a multiplier. Eats one word from `rest`. Returns {factor, rest}.
+function extractMagnitudeWord(rest) {
+  if (!rest) return { factor: 1, rest: "" };
+  const tokens = rest.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return { factor: 1, rest: "" };
+  const head = tokens[0].toLowerCase().replace(/[.,!?]$/, "");
+  if (MAGNITUDE_WORDS.has(head)) {
+    return { factor: MAGNITUDE_WORDS.get(head), rest: tokens.slice(1).join(" ") };
+  }
+  return { factor: 1, rest };
+}
+
+// Resolves a trailing kind word (mc, usd, sol) to a canonical kind.
+// Eats one or two words. Returns {kind, rest}.
+function extractKindWord(rest) {
+  if (!rest) return { kind: null, rest: "" };
+  const lower = rest.toLowerCase();
+  // Multi-word: "market cap", "marketcap"
+  const mcMatch = lower.match(/^(market\s*cap|market_cap)\b\s*(.*)/);
+  if (mcMatch) return { kind: "mc_usd", rest: mcMatch[2].trim() };
+  const tokens = lower.split(/\s+/).filter(Boolean);
+  const head = tokens[0]?.replace(/[.,!?]$/, "");
+  if (!head) return { kind: null, rest: "" };
+  if (MC_WORDS.has(head)) return { kind: "mc_usd", rest: tokens.slice(1).join(" ") };
+  if (PRICE_USD_WORDS.has(head)) return { kind: "price_usd", rest: tokens.slice(1).join(" ") };
+  if (PRICE_SOL_WORDS.has(head)) return { kind: "price_sol", rest: tokens.slice(1).join(" ") };
+  return { kind: null, rest };
+}
+
+function fmtDisplayMc(usd) {
+  if (usd >= 1e9) return `$${(usd / 1e9).toFixed(2)}B MC`;
+  if (usd >= 1e6) return `$${(usd / 1e6).toFixed(2)}M MC`;
+  if (usd >= 1e3) return `$${(usd / 1e3).toFixed(1)}K MC`;
+  return `$${usd.toFixed(2)} MC`;
+}
+function fmtDisplayUsd(usd) {
+  if (usd >= 1) return `$${usd.toFixed(usd >= 100 ? 0 : 2)}`;
+  if (usd >= 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(8).replace(/0+$/, "0")}`;
+}
+
+// MIN/MAX trigger value bounds — must match limit-close-arm-core.js.
+const MIN_MICRO = 1n;
+const MAX_MICRO = 1_000_000_000_000_000n;
+
+function toMicro(num) {
+  const micro = BigInt(Math.round(num * 1e6));
+  if (micro < MIN_MICRO) return null;
+  if (micro > MAX_MICRO) return null;
+  return micro;
+}
+
+/**
+ * Parse a strike-price input string into a structured arm-ready result.
+ *
+ * Optional opts.directionHint ("above" for TP, "below" for SL) is used
+ * ONLY as a tiebreak when the input is genuinely ambiguous. The parser
+ * never silently overrides an explicit direction word.
+ *
+ * Optional opts.bareNumberDefaultKind controls the kind assigned to a
+ * bare number (no magnitude word, no kind word). Default: "price_usd"
+ * for sub-100 numbers, "mc_usd" for 100k+ numbers — matches how users
+ * mentally bucket "$0.005" vs "17000000".
+ */
+export function parseStrike(raw, opts = {}) {
+  const norm = normalizeInput(raw);
+  if (!norm) {
+    return {
+      ok: false,
+      error: "Empty target. Try `17m mc` or `$0.005` or `2x`.",
+    };
+  }
+
+  // 1. Percent-move forms first (most explicit).
+  const pct = parsePercentMove(norm);
+  if (pct) {
+    return {
+      ok: true,
+      kind: "multiplier",
+      valueMicro: null,
+      multiplier: pct.multiplier,
+      impliedDirection: pct.direction,
+      normalizedDisplay: `${pct.multiplier > 1 ? "+" : ""}${((pct.multiplier - 1) * 100).toFixed(1)}% (${pct.direction === "above" ? "TP" : "SL"})`,
+    };
+  }
+
+  // 2. Multiplier ("2x", "0.7x")
+  const mult = parseMultiplier(norm);
+  if (mult != null) {
+    const dir = mult >= 1 ? "above" : "below";
+    return {
+      ok: true,
+      kind: "multiplier",
+      valueMicro: null,
+      multiplier: mult,
+      impliedDirection: dir,
+      normalizedDisplay: `${mult}x (${dir === "above" ? "TP" : "SL"})`,
+    };
+  }
+
+  // 3. Standard form: <number> [<magnitude word>] [<kind word>]
+  const numHead = extractLeadingNumber(norm);
+  if (!numHead) {
+    return {
+      ok: false,
+      error: `Couldn't parse target "${raw}". Try \`17m mc\` (market cap), \`$0.005\` (price), or \`2x\` (multiplier).`,
+      examples: ["17m mc", "$0.005", "2x", "down 30%"],
+    };
+  }
+  const { num, rest: afterNum } = numHead;
+
+  // 4. Magnitude word — multiplies the number.
+  const { factor, rest: afterFactor } = extractMagnitudeWord(afterNum);
+  const adjustedNum = num * factor;
+
+  // 5. Kind word — explicit "mc", "usd", "sol".
+  const { kind: explicitKind, rest: afterKind } = extractKindWord(afterFactor);
+  if (afterKind && afterKind.length > 0) {
+    return {
+      ok: false,
+      error: `Trailing text after target: "${afterKind}". Try \`17m mc\` (just the value).`,
+    };
+  }
+
+  let kind = explicitKind;
+  if (!kind) {
+    // Bare number: infer based on size + bareNumberDefaultKind.
+    // - Big numbers (>= 100k effective) → MC by default
+    // - Small numbers (< 100k) with no explicit kind → USD price
+    // Operator can override per-surface via opts.bareNumberDefaultKind.
+    const defaultKind = opts.bareNumberDefaultKind
+      || (adjustedNum >= 100_000 ? "mc_usd" : "price_usd");
+    kind = defaultKind;
+  }
+
+  if (adjustedNum <= 0) {
+    return { ok: false, error: `Target must be positive.` };
+  }
+
+  if (kind === "price_sol") {
+    // SOL price stored in lamports (1e9 precision).
+    const lamports = BigInt(Math.round(adjustedNum * 1e9));
+    if (lamports < MIN_MICRO || lamports > MAX_MICRO) {
+      return { ok: false, error: `Target out of range.` };
+    }
+    return {
+      ok: true,
+      kind: "price_sol",
+      valueMicro: lamports,
+      multiplier: null,
+      impliedDirection: null,
+      normalizedDisplay: `${adjustedNum.toFixed(6)} SOL`,
+    };
+  }
+
+  // mc_usd and price_usd both stored as micros at 1e6 precision.
+  const micro = toMicro(adjustedNum);
+  if (!micro) {
+    return { ok: false, error: `Target out of range.` };
+  }
+  return {
+    ok: true,
+    kind,
+    valueMicro: micro,
+    multiplier: null,
+    impliedDirection: null,
+    normalizedDisplay: kind === "mc_usd" ? fmtDisplayMc(adjustedNum) : fmtDisplayUsd(adjustedNum),
+  };
+}
+
+/**
+ * Convenience: parse a strike and emit a one-line user-facing echo
+ * confirming what we understood. Surfaces ambiguous parses with hints.
+ */
+export function describeStrike(raw, opts = {}) {
+  const r = parseStrike(raw, opts);
+  if (!r.ok) return r.error;
+  return `Got it: ${r.normalizedDisplay}`;
+}

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -1830,8 +1830,8 @@ Mandatory tool triggers — pattern → tool:
 - User says "topup", "add collateral", "lower my LTV", "protect from liquidation", "boost health" → \`propose_topup\` (ask for amount if not given).
 - User says "extend my loan", "push the due date", "need more time", "rollover" → \`propose_extend\`.
 - User says "partial repay", "pay down some", "reduce what I owe by X" → \`propose_partial_repay\`.
-- User says "take profit", "set a limit order", "sell when X 2x's", "auto-sell at $Y", "lock in if it moons" → \`propose_take_profit\`. CRITICAL: never guess the target. The user must specify a multiplier (2x), an explicit USD price ($0.005), OR a market cap ($150M). If they don't specify, ASK first with a concrete suggestion ("Want me to set it at 2× current? Or pick a specific price?"). After arming, the engine autonomously closes + sells the moment the target hits — explain this is "hands-off, you don't have to babysit." 1% protocol fee on proceeds. RWA / xStock collateral isn't supported in v1 (return the error message; don't propose).
-- User says "stop loss", "stoploss", "sl at X", "set a stop", "auto-exit if it dumps", "sell if BONK drops X%", "protect downside at $Y" → \`propose_stop_loss\`. CRITICAL: never guess the floor. User must specify a multiplier (< 1, e.g. 0.7x = 70% of current), an explicit USD price floor ($0.001), OR a market cap floor ($10M). If they don't specify, ASK with a concrete suggestion ("Want me to set it at 0.7x current — that's a 30% drop?"). After arming, the engine autonomously closes + sells if the floor breaks. 1% protocol fee. TP + SL on the same loan IS allowed — if user wants both, call propose_take_profit then propose_stop_loss in sequence.
+- User says "take profit", "set a limit order", "sell when X 2x's", "auto-sell at $Y", "lock in if it moons" → \`propose_take_profit\`. **STRIKE PARSING:** the tool's \`target_text\` argument accepts EVERY natural form: "17M mc", "17,000,000 MC", "17 million market cap", "$0.005", "0.005 usd", "2x", "+50%". Always pass the user's literal phrase as \`target_text\` rather than parsing it yourself — the bot has one canonical parser that matches TG /tp exactly. Only use \`multiplier\` / \`target_usd\` / \`mc_usd\` when YOU computed the value (e.g. "let me set it at 2× current"). If the user is vague ("set a TP"), ASK with a concrete suggestion ("Want me to set it at 2× current? Or pick a specific price?"). After arming, the engine autonomously closes + sells the moment the target hits — explain this is "hands-off, you don't have to babysit." 1% protocol fee on proceeds. **Works on memecoin V1 + xStock V3 collateral** (the engine routes via the loan's engine_program_id automatically — never tell users TP isn't available for their pool type). Multi-target arming IS supported: a user can arm TWO TPs at different prices on the same loan; the first to trigger fires (full close), the other auto-cancels.
+- User says "stop loss", "stoploss", "sl at X", "set a stop", "auto-exit if it dumps", "sell if BONK drops X%", "protect downside at $Y" → \`propose_stop_loss\`. **STRIKE PARSING:** pass user's literal phrase as \`target_text\` ("5M mc", "$0.001", "down 30%", "-30%", "0.7x"). If they're vague, ASK with a concrete suggestion ("Want me to set it at 0.7x current — that's a 30% drop?"). After arming, the engine autonomously closes + sells if the floor breaks. 1% protocol fee. **Works on memecoin V1 + xStock V3 collateral.** TP + SL on the same loan IS allowed (a "bracket") — if user wants both, call propose_take_profit then propose_stop_loss in sequence, OR suggest /bracket as the one-command equivalent.
 - User says "trailing stop", "trail my stop", "trailing 10%", "follow the price up but stop if it drops", "lock in gains with a moving stop" → \`propose_trailing_stop\`. Trailing stops are a stop-loss variant where the floor floats UP with each new high (never down). User specifies a distance (10% means "fire if price drops 10% from the most recent peak"). Default suggestion: 10–15%. Distance must be between 0.5% and 50%. Trailing only works on loans they want to PROTECT (downside) — it's not a take-profit. Explain plainly: "as long as price keeps making new highs, the floor moves with it; the first time price drops your distance, it fires." 1% protocol fee on proceeds, same as TP.
 - User says "show my take profits", "what limits do I have armed", "any take-profits set", "show my stops", "what's protecting my loans" → \`list_my_take_profits\`. After the call, group by loan and label each by its \`kind\` field (take_profit / stop_loss / trailing_stop) NOT just the trigger value. For loans listed in \`bracket_loan_ids\`, narrate "you have a bracket (TP + SL) on loan #X" instead of two independent orders. For trailing orders, surface \`trailing_distance_pct\` and \`peak_price_usd\` so users see the floating floor — e.g. "trailing 10%, peak $0.0047". If empty, suggest setting one with \`propose_take_profit\`, \`propose_stop_loss\`, \`propose_trailing_stop\`, or \`/bracket\`.
 - User says "why did my take profit fire at X%", "what happened with my limit order", "why was the slippage so high", "explain my last take-profit", "did my TP partial fill" → \`explain_my_take_profit\`. Pass order_id when the user names one (e.g. "order #1842"); omit otherwise to default to the most recent. After the call, narrate the lifecycle in 2-3 sentences using the timeline_notes verbatim — never add or guess details. If outcome is non-null, report proceeds_sol and net_to_user_sol from the result. If it's still in flight (status armed / firing / twap_in_progress / awaiting_user), describe current state and what the engine is currently doing. NEVER speculate about token-specific reasons; the tool result is the truth.
@@ -1849,6 +1849,67 @@ call \`list_my_loans\` first — that's the most common intent in support.
 
 After tool results come back, interpret them and answer in plain language.
 Do NOT just dump raw JSON to the user.
+
+═══════════════════════════════════════════════════════════════════
+LIMIT-ORDER DEEP KNOWLEDGE — HOW TP/SL/TRAILING/BRACKETS ACTUALLY WORK
+═══════════════════════════════════════════════════════════════════
+This block exists so users can ask you ANYTHING about limit orders
+and get a confident, correct answer. Internalize it. Refer back to it
+when users ask "what happens if...", "can I...", "what about...".
+
+POOL COVERAGE (always-current as of 2026-06-14):
+- TP/SL/trailing/bracket all work on **V1 (memecoin)** and **V3 (RWA — xStocks, ETFs, metals)** collateral. V2 (legacy RWA) is still supported for repay/extend on existing V2 loans, but new RWA borrows now route to V3.
+- The engine knows which pool to fire against because every armed order stamps \`engine_program_id\` at arm time (sourced from the loan's on-chain owner). Cross-pool fires are structurally impossible.
+- Users NEVER need to know which pool their loan is in. Don't surface pool details unless they ask explicitly.
+
+WHAT THE ENGINE ACTUALLY DOES ON FIRE (TP or SL):
+1. Re-confirms trigger is still hit via cross-sourced oracle (Jupiter + DexScreener + Pyth) — single-source disagreement reverts the order; both must agree.
+2. Runs a Jupiter pre-flight quote to confirm the swap would clear at the slippage cap.
+3. Pulls SOL from operator's reserve wallet to cover the borrower's repay (if borrower wallet is low) — borrower repays the operator from sale proceeds at settlement, netted out automatically.
+4. Calls \`repay_loan\` on-chain (closes loan, releases collateral to borrower's ATA).
+5. Swaps the released collateral via Jupiter to the user's chosen destination (SOL default, USDC optional).
+6. Sends net proceeds (after 1% protocol fee + reserve refund) to user.
+- Whole sequence is typically 5-10 seconds end-to-end.
+
+FILL GUARANTEE LADDER (Layer 1 → 2 → 3):
+- Layer 1: if single-block proceeds don't cover loan + fee at the user's slippage, the engine auto-escalates slippage 1.5× per attempt, up to the user's stated cap.
+- Layer 2: at cap, the engine slices into N TWAP chunks and fires one per tick.
+- Layer 3: if even TWAP can't fit at cap, the engine DMs the user asking permission to widen the cap. Never widens silently.
+
+ORDER STATUSES (what you might see):
+- \`armed\`: waiting for trigger.
+- \`firing\`: claimed by an engine tick; about to send the repay tx.
+- \`twap_in_progress\`: filling in chunks. Each chunk fires one per tick.
+- \`awaiting_user\`: Layer 3 — engine DMed the user for permission to widen slippage. Order is paused until they answer.
+- \`fired\`: successfully closed + sold. Proceeds in wallet.
+- \`partial_fired\`: TWAP didn't fill all chunks before time ran out — partial proceeds delivered.
+- \`failed\`: terminal failure — collateral may be in user's wallet if repay succeeded but swap didn't. Read \`explain_my_take_profit\` for the lifecycle.
+- \`cancelled\`: user-cancelled or sibling auto-cancelled.
+- \`expired\`: hit \`expires_at\` without triggering.
+
+DIRECTIONS:
+- TP (\`trigger_direction='above'\`): fires when price reaches OR EXCEEDS the trigger.
+- SL (\`trigger_direction='below'\`): fires when price reaches OR FALLS BELOW the trigger.
+- Trailing SL (\`trailing_distance_bps\` is set, direction='below'): the floor floats with each new peak — once price drops by the distance from the most recent peak, it fires. Never moves down.
+
+MULTI-TARGET ARMING (today's semantics):
+- A user can arm TWO TPs on the same loan at different prices, AND two SLs, AND a trailing stop. The engine fires whichever triggers first; the rest auto-cancel because the loan closes after the first fire.
+- Use case: "TP at 1.5x AND a backup TP at 2x" — whichever hits first wins.
+- The TRUE partial-sell ladder ("sell 70% at 16M, 10% at 17M, etc.") is being built but ships LATER. For now, every armed leg is implicitly full-close on first trigger. If a user asks for a partial-sell ladder, tell them: "Multi-target arming is live today (set N targets, first to hit closes the position). True partial sells across multiple price points are coming in a follow-up — would the first-to-hit version work for now?"
+
+BRACKETS:
+- /bracket arms a TP + SL atomically. Both stay armed; first to trigger fires; the other auto-cancels with reason='sibling_order_fired'. Use \`/bracket\` (TG) or call propose_take_profit then propose_stop_loss in sequence (Pip).
+
+WHAT CAN'T HAPPEN (so don't tell users it might):
+- Cross-pool fire: order armed against a V1 loan WILL NOT fire against a V3 loan. Bound at arm time.
+- Silent slippage widening: engine never exceeds the user's stated max_slippage_bps_cap without DMing first.
+- Drain via outer-tx attack: cosign-borrow allowlist + engine fire-path program allowlist (V1, V2, V3 only) block this structurally.
+
+COSTS THE USER ACTUALLY PAYS:
+- 1% protocol fee on proceeds at fire time.
+- Swap slippage (capped at their stated max).
+- ~0.005-0.01 SOL in priority fees + ATA rent (refunded as much as possible from reserve).
+- NO origination fee on the limit order itself — that fee was paid at borrow time.
 
 ═══════════════════════════════════════════════════════════════════
 INQUIRY PLAYBOOK — HOW TO TRIAGE WHAT USERS ACTUALLY WANT
@@ -2075,15 +2136,17 @@ const TOOLS = [
     description:
       "Prepare a TAKE-PROFIT (limit-close-and-sell) proposal the user can arm with one tap on the site. Use when the user wants to set an autonomous sell-on-target on an active loan — 'sell my $PEPE when it 2x's', 'auto take profit at $0.005', 'lock in if BONK goes 4x', 'set a limit order'. " +
       "The site renders an inline confirmation card with the resolved target USD price + slippage cap + an Arm take-profit button. Pip does NOT execute the arm — the borrower wallet signs the magpie: limit-close-arm/v1 envelope which the bot validates + INSERTs. " +
-      "EXACTLY ONE of multiplier OR target_usd OR mc_usd must be set: multiplier=2 means '2× current price'; target_usd=0.005 means 'sell at $0.005/token'; mc_usd=150000000 means 'sell when MC hits $150M'. " +
+      "PASS ONE of: multiplier OR target_usd OR mc_usd OR target_text. target_text is the EASIEST option — pass the user's literal phrase like '17M mc', '17,000,000 MC', '17 million market cap', '$0.005', or '2x' and the bot parses it the same way TG /tp does. Use target_text whenever the user gives you a free-form strike; only use the structured fields when YOU computed the value (e.g. 2x of current price). " +
+      "multiplier=2 means '2× current price'; target_usd=0.005 means 'sell at $0.005/token'; mc_usd=150000000 means 'sell when MC hits $150M'. " +
       "If the user only says 'set a take-profit' without a target, ask them what target (default suggestion: 2x).",
     input_schema: {
       type: "object",
       properties: {
         loan_id: { type: "string", description: "The numeric loan ID to arm a take-profit on. Required." },
-        multiplier: { type: "number", description: "Multiplier of current price (e.g. 2 for 2x). Server resolves to a concrete USD price at arm time." },
-        target_usd: { type: "number", description: "Explicit USD price per token (e.g. 0.005)." },
-        mc_usd: { type: "number", description: "Explicit market cap in USD (e.g. 150000000 for $150M)." },
+        target_text: { type: "string", description: "Natural-language strike — pass the user's literal phrase. Examples: '17M mc', '17,000,000 MC', '17 million market cap', '$0.005', '0.005 usd', '2x', '+50%'. Preferred over structured fields when the user provides a free-form target." },
+        multiplier: { type: "number", description: "Multiplier of current price (e.g. 2 for 2x). Use when YOU compute the multiplier; prefer target_text for user input." },
+        target_usd: { type: "number", description: "Explicit USD price per token (e.g. 0.005). Use when YOU computed it." },
+        mc_usd: { type: "number", description: "Explicit market cap in USD (e.g. 150000000 for $150M). Use when YOU computed it." },
         slippage_pct: { type: "number", description: "Slippage cap as a percent (e.g. 2 for 2%). Default 2%. Range 0.5..10." },
         sell_to: { type: "string", enum: ["sol", "usdc"], description: "Sell proceeds destination. Default 'sol'." },
         expire: { type: "string", description: "Order expiration as Nd or Nh (e.g. '30d', '12h'). Optional — no expiry by default." },
@@ -2095,15 +2158,17 @@ const TOOLS = [
     name: "propose_stop_loss",
     description:
       "Prepare a STOP-LOSS (downside limit-close) proposal the user can arm with one tap. Use when the user wants to set an autonomous downside exit: 'set a stop loss at -30%', 'auto-exit if BONK drops 40%', 'protect downside at $0.001', 'sl at 0.7x'. " +
-      "EXACTLY ONE of multiplier OR target_usd OR mc_usd must be set: multiplier=0.7 means 'sell at 70% of current price' (must be < 1); target_usd=0.001 means 'sell if price drops to $0.001/token'; mc_usd=10000000 means 'sell if MC falls to $10M'. " +
+      "PASS ONE of: multiplier OR target_usd OR mc_usd OR target_text. target_text is the EASIEST option — pass the user's literal phrase like '5M mc', '5,000,000 MC', '$0.001', 'down 30%', '-30%', '0.7x' and the bot parses it the same way TG /sl does. " +
+      "multiplier=0.7 means 'sell at 70% of current price' (must be < 1); target_usd=0.001 means 'sell if price drops to $0.001/token'; mc_usd=10000000 means 'sell if MC falls to $10M'. " +
       "If the user only says 'set a stop loss' without a level, ASK with a concrete suggestion ('Want me to set it at 0.7x current — that's a 30% drop?'). After arming, the engine autonomously sells if the floor breaks. 1% protocol fee on proceeds. Pairs with propose_take_profit on the same loan — TP + SL together is allowed.",
     input_schema: {
       type: "object",
       properties: {
         loan_id: { type: "string", description: "The numeric loan ID to arm a stop-loss on. Required." },
-        multiplier: { type: "number", description: "Multiplier of current price (e.g. 0.7 for 70%). Must be < 1." },
-        target_usd: { type: "number", description: "Explicit USD price floor per token (e.g. 0.001)." },
-        mc_usd: { type: "number", description: "Explicit market cap floor in USD (e.g. 10000000 for $10M)." },
+        target_text: { type: "string", description: "Natural-language downside strike — pass the user's literal phrase. Examples: '5M mc', '5,000,000 MC', '$0.001', 'down 30%', '-30%', '0.7x'. Preferred over structured fields when the user provides a free-form target." },
+        multiplier: { type: "number", description: "Multiplier of current price (e.g. 0.7 for 70%). Must be < 1. Use when YOU computed it." },
+        target_usd: { type: "number", description: "Explicit USD price floor per token (e.g. 0.001). Use when YOU computed it." },
+        mc_usd: { type: "number", description: "Explicit market cap floor in USD (e.g. 10000000 for $10M). Use when YOU computed it." },
         slippage_pct: { type: "number", description: "Slippage cap as a percent (e.g. 2 for 2%). Default 2%. Range 0.5..10." },
         sell_to: { type: "string", enum: ["sol", "usdc"], description: "Sell proceeds destination. Default 'sol'." },
         expire: { type: "string", description: "Order expiration as Nd or Nh (e.g. '30d', '12h'). Optional — no expiry by default." },
@@ -2817,7 +2882,26 @@ const TOOL_HANDLERS = {
     };
   },
 
-  propose_take_profit: async ({ loan_id, multiplier, target_usd, mc_usd, slippage_pct, sell_to, expire }, { userId, signerPubkey }) => {
+  propose_take_profit: async ({ loan_id, multiplier, target_usd, mc_usd, target_text, slippage_pct, sell_to, expire }, { userId, signerPubkey }) => {
+    // If the user gave a natural-language strike, parse it now so the rest
+    // of this handler sees structured (multiplier / target_usd / mc_usd).
+    // See [[feedback_single_source_of_truth]] — same parser as TG /tp.
+    if (target_text && [multiplier, target_usd, mc_usd].every((x) => x == null)) {
+      const { parseStrike } = await import("../lib/strike-price-parser.js");
+      const parsed = parseStrike(target_text, { bareNumberDefaultKind: "mc_usd" });
+      if (!parsed.ok) {
+        return toolError("bad_target_text", parsed.error,
+          `Couldn't understand the target "${target_text}". Ask the user for a specific value like "$17M mc", "$0.005", or "2x".`);
+      }
+      if (parsed.impliedDirection === "below") {
+        return toolError("downside_target_in_tp", null,
+          "That's a downside target — use propose_stop_loss, not propose_take_profit.");
+      }
+      if (parsed.kind === "multiplier") multiplier = parsed.multiplier;
+      else if (parsed.kind === "mc_usd") mc_usd = Number(parsed.valueMicro) / 1e6;
+      else if (parsed.kind === "price_usd") target_usd = Number(parsed.valueMicro) / 1e6;
+      else return toolError("unsupported_target_kind", parsed.kind, "Use an explicit price or market cap.");
+    }
     // Validate target: exactly ONE of multiplier / target_usd / mc_usd
     const targetCount = [multiplier, target_usd, mc_usd].filter((x) => x != null).length;
     if (targetCount !== 1) {
@@ -2915,7 +2999,24 @@ const TOOL_HANDLERS = {
   // envelope, just a different direction byte). Pip surfaces both the
   // resolved floor and the current price so the user has a clear
   // "drop of X% from here" mental model before signing.
-  propose_stop_loss: async ({ loan_id, multiplier, target_usd, mc_usd, slippage_pct, sell_to, expire }, { userId, signerPubkey }) => {
+  propose_stop_loss: async ({ loan_id, multiplier, target_usd, mc_usd, target_text, slippage_pct, sell_to, expire }, { userId, signerPubkey }) => {
+    // Natural-language strike → structured. Same parser as TG /sl + propose_take_profit.
+    if (target_text && [multiplier, target_usd, mc_usd].every((x) => x == null)) {
+      const { parseStrike } = await import("../lib/strike-price-parser.js");
+      const parsed = parseStrike(target_text, { bareNumberDefaultKind: "price_usd" });
+      if (!parsed.ok) {
+        return toolError("bad_target_text", parsed.error,
+          `Couldn't understand the target "${target_text}". Ask the user for a specific value like "$0.001", "$5M mc", "down 30%", or "0.7x".`);
+      }
+      if (parsed.impliedDirection === "above") {
+        return toolError("upside_target_in_sl", null,
+          "That's an upside target — use propose_take_profit, not propose_stop_loss.");
+      }
+      if (parsed.kind === "multiplier") multiplier = parsed.multiplier;
+      else if (parsed.kind === "mc_usd") mc_usd = Number(parsed.valueMicro) / 1e6;
+      else if (parsed.kind === "price_usd") target_usd = Number(parsed.valueMicro) / 1e6;
+      else return toolError("unsupported_target_kind", parsed.kind, "Use an explicit price or market cap.");
+    }
     const targetCount = [multiplier, target_usd, mc_usd].filter((x) => x != null).length;
     if (targetCount !== 1) {
       return toolError(


### PR DESCRIPTION
## Summary

Operator UX mandate: "easy to recognize the take-profit price they specify… 17M mc, 17,000,000 MC — all the same."

ONE canonical strike parser used by TG, Pip, and the site. Plus a comprehensive limit-order knowledge block in Pip's system prompt so users can ask anything and get correct answers.

### What ships

**1. `src/lib/strike-price-parser.js`** (new)
- Accepts: \`17m mc\`, \`17M MC\`, \`17,000,000 MC\`, \`17 million market cap\`, \`17_000_000 mc\`, \`\$17m mc\`, \`\$0.005\`, \`0.005 usd\`, \`0.0025 sol\`, \`2x\`, \`0.7x\`, \`-30%\`, \`down 30%\`, \`+50%\`, \`up 50%\`
- Returns structured \`{kind, valueMicro, multiplier, impliedDirection, normalizedDisplay}\`
- Bare numbers default to MC for big values (≥100k), USD price for small (<100k)
- All 25 example inputs parse correctly (verified in dev)

**2. TG /takeprofit /stoploss**
- Slurps multi-token values after "at" so \`at 17 million market cap\` works
- Passes everything through the shared parser
- Rejects direction mismatches loudly ("that's a downside target — use /stoploss")

**3. Pip propose_take_profit / propose_stop_loss**
- Accept new optional \`target_text\` param (preferred over structured fields when user provides free-form input)
- Server-side parsing identical to TG
- Tool descriptions updated to guide the LLM

**4. Pip system prompt — new "LIMIT-ORDER DEEP KNOWLEDGE" section**
- Pool coverage (V1 + V3, V2 legacy) — Pip will never again wrongly say "TP isn't available on RWA"
- Engine fire sequence end-to-end
- Fill-guarantee ladder (escalation → TWAP → user prompt)
- All 9 order statuses + what each means
- Direction semantics
- Multi-target arming + brackets
- "What can't happen" (cross-pool fire, silent slippage widening, drain attack)
- Cost breakdown

### Cross-pool safety

Pip's prompt now reflects the post-#226 reality: arm-core stamps engine_program_id per order, engine matches on it, cross-pool fires are structurally impossible. Pip will never confuse pools when answering.

### Test plan

- [ ] CI passes
- [ ] TG: \`/takeprofit 1234 at 17,000,000 MC\` parses correctly
- [ ] TG: \`/takeprofit 1234 at 17 million market cap\` parses correctly
- [ ] Pip: "set TP at 17M mc on loan 1234" → tool call with target_text="17M mc"
- [ ] Pip: "what statuses do orders have?" → references the deep-knowledge block accurately