### PR TITLE
ladder phase 2 (bot): ladder_group_id + original_collateral_amount + sum-cap trigger

### DIFF
--- a/migrations/065_ladder_reborrow_columns.sql
+++ b/migrations/065_ladder_reborrow_columns.sql
@@ -1,0 +1,117 @@
+-- migration 065: TP/SL ladder re-borrow orchestration columns + sum-cap trigger
+--
+-- This migration adds the storage shape the engine needs to deliver a
+-- TRUE partial-sell ladder via the re-borrow orchestration approach.
+--
+-- Why re-borrow:
+--   V1/V3 partial_repay only reduces debt; it does NOT release
+--   fractional collateral. So a "sell 70% at 16M MC, 10% at 17M, 10%
+--   at 18M, 10% at 19M" ladder cannot be done in a single on-chain
+--   step. The engine instead does, per leg fire:
+--     1. repay_loan in full → all collateral to borrower ATA
+--     2. swap (slice_pct / 10000) × original_collateral_amount via
+--        Jupiter → SOL → send to borrower (less 1% protocol fee)
+--     3. re-borrow with the REMAINING collateral as the new loan, at
+--        the same tier as the original. NEW loan_id is assigned.
+--     4. MIGRATE sibling armed orders (same ladder_group_id) to the
+--        new loan_id so the ladder continues seamlessly.
+--   If remaining collateral falls below MIN_LOAN_LAMPORTS (1 SOL
+--   value), skip the re-borrow and cancel sibling armed orders with
+--   reason='ladder_complete' — the user's collateral has fully sold
+--   out across the ladder.
+--
+-- Pool coverage:
+--   The engine re-borrows against the same program_id (V1, V2, or V3)
+--   the original loan used. engine_program_id stays stamped on each
+--   armed order so cross-pool fires are still structurally impossible.
+--
+-- Columns added:
+--
+--   ladder_group_id UUID
+--     NULL for single-leg full-close orders (slice_pct=10000). Non-NULL
+--     and shared across all legs of a ladder. The engine uses it to
+--     find sibling armed orders that need migration after a leg fires.
+--
+--   original_collateral_amount NUMERIC
+--     Snapshot of loan.collateral_amount taken at arm time. Used so
+--     slice_pct semantics stay absolute across multiple re-borrows.
+--     "10%" always means "10% of the original collateral" — never
+--     drifts as the loan size shrinks per leg.
+--
+--   migrated_from_loan_id BIGINT
+--     Set when an order survives a leg fire and is migrated to the
+--     newly-opened loan's id. Audit trail so /lc-perf and ops can
+--     reconstruct ladder lifecycle.
+--
+-- Sum-cap trigger:
+--   Enforces SUM(slice_pct) <= 10000 across (loan_id, trigger_direction)
+--   armed orders. Previously dropped in migration 064 because it was
+--   meaningless without the engine actually honoring slice<100%; re-
+--   added here now that the engine's re-borrow path makes it meaningful.
+
+ALTER TABLE limit_close_orders
+  ADD COLUMN IF NOT EXISTS ladder_group_id UUID,
+  ADD COLUMN IF NOT EXISTS original_collateral_amount NUMERIC,
+  ADD COLUMN IF NOT EXISTS migrated_from_loan_id BIGINT;
+
+-- Index for sibling-migration lookup on leg fire. We always query by
+-- ladder_group_id WHERE status='armed', so a partial index keeps it tiny.
+CREATE INDEX IF NOT EXISTS limit_close_orders_ladder_group_armed_idx
+  ON limit_close_orders(ladder_group_id, status)
+  WHERE ladder_group_id IS NOT NULL AND status = 'armed';
+
+-- Sum-cap trigger (the version dropped in 064).
+CREATE OR REPLACE FUNCTION limit_close_orders_validate_slice_sum()
+RETURNS TRIGGER AS $$
+DECLARE
+  total_pct INT;
+  effective_direction TEXT;
+BEGIN
+  -- Only enforce on rows in 'armed' state. Fired / cancelled / expired
+  -- legs have already consumed (or released) their slice budget.
+  IF NEW.status IS DISTINCT FROM 'armed' THEN
+    RETURN NEW;
+  END IF;
+
+  effective_direction := COALESCE(NEW.trigger_direction, 'above');
+
+  SELECT COALESCE(SUM(slice_pct), 0)
+    INTO total_pct
+    FROM limit_close_orders
+   WHERE loan_id = NEW.loan_id
+     AND COALESCE(trigger_direction, 'above') = effective_direction
+     AND status = 'armed'
+     AND id IS DISTINCT FROM NEW.id;   -- exclude self on UPDATE
+
+  IF total_pct + NEW.slice_pct > 10000 THEN
+    RAISE EXCEPTION
+      'TP/SL ladder exceeds 100%%: existing armed legs sum to % bps (loan_id=%, direction=%); incoming leg of % bps would push to %.',
+      total_pct, NEW.loan_id, effective_direction, NEW.slice_pct, total_pct + NEW.slice_pct
+    USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS limit_close_orders_slice_sum_check ON limit_close_orders;
+
+CREATE TRIGGER limit_close_orders_slice_sum_check
+  BEFORE INSERT OR UPDATE OF status, slice_pct, trigger_direction, loan_id
+  ON limit_close_orders
+  FOR EACH ROW
+  EXECUTE FUNCTION limit_close_orders_validate_slice_sum();
+
+COMMENT ON COLUMN limit_close_orders.ladder_group_id IS
+  'Groups legs of the same ladder (e.g. 70/10/10/10 split). The engine
+   uses this to migrate sibling armed orders to the new loan_id after
+   a leg fires + re-borrows on remaining collateral. NULL for legacy
+   single-leg orders.';
+COMMENT ON COLUMN limit_close_orders.original_collateral_amount IS
+  'Snapshot of loan.collateral_amount at arm time, in mint native
+   units (raw). Used so slice_pct semantics stay absolute across
+   re-borrows — "10%" always means 10% of the ORIGINAL collateral.';
+COMMENT ON COLUMN limit_close_orders.migrated_from_loan_id IS
+  'When the engine re-borrows after a leg fires, sibling armed orders
+   are UPDATEd to point at the new loan_id. This column preserves the
+   chain so /lc-perf and ops can trace the ladder lifecycle.';

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -383,7 +383,9 @@ export async function handleLimitClose(ctx, direction = "above") {
         case "invalid_slice_pct":
           return `Slice must be between 0.01% and 100%. Try \`slice=25%\` for a 25% leg.`;
         case "fractional_slice_not_supported_today":
-          return `Today's on-chain protocol only supports full close per leg. Multi-target arming at different prices IS supported — e.g. \`/takeprofit ${loan_id} at 1.5x\` AND \`/takeprofit ${loan_id} at 2x\`. First to trigger fires; the other auto-cancels.`;
+          return `Partial-slice TP/SL is rolling out. For now, slice must be 100%. Multi-target arming at different prices IS supported today — e.g. \`/takeprofit ${loan_id} at 1.5x\` AND \`/takeprofit ${loan_id} at 2x\`.`;
+        case "ladder_sum_exceeds_100":
+          return `You already have armed legs on this loan/direction totaling near 100%. Cancel one or shrink your slice.`;
         case "rwa_collateral_not_supported_in_v1":
           // Unreachable since 2026-06-13 (PR C flipped the arm-core
           // gate; RWA collateral is now arm-eligible end-to-end via the

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -184,19 +184,20 @@ export async function armOrder({
   }
   // Migration 064 keeps slice_pct as scaffolding: the column exists but
   // every armed leg is implicitly full-close (slice = 10000) until a
-  // future on-chain instruction supports fractional collateral release.
-  // Today's on-chain partial_repay only reduces debt — it doesn't
-  // release fractional collateral — so a slice<100% arm can't be
-  // honored end-to-end. Refuse it explicitly so users never see a
-  // misleading "armed" status on something the engine can't fire as
-  // promised. The env flag is here for the day the partial-close
-  // instruction lands; flipping it to true is part of that rollout.
+  // ladder semantics — when LIMIT_CLOSE_LADDER_ENABLED=true and the
+  // paired engine PR has rolled out, slice<100% arms a real ladder
+  // leg. The engine fires it by: full repay → swap slice → re-borrow
+  // remainder → migrate sibling armed orders to new loan_id. See
+  // migration 065 for the columns + sum-cap trigger that store this.
+  // When the env flag is OFF (default), refuse slice<100% with a
+  // clear message so users never see a misleading "armed" status on
+  // something the engine can't honor end-to-end.
   const LADDER_ENABLED = process.env.LIMIT_CLOSE_LADDER_ENABLED === "true";
   if (slicePct < 10000 && !LADDER_ENABLED) {
     return {
       ok: false,
       error: "fractional_slice_not_supported_today",
-      detail: "Today's on-chain protocol only supports full close per leg. For now, every TP/SL leg is implicitly 100%. Multi-target arming at different prices IS supported — arm a TP at 1.5x AND another at 2x; first to trigger fires, the other auto-cancels.",
+      detail: "Partial-slice TP/SL is rolling out. For now, slice must be 100%. Multi-target arming at different prices IS supported today — arm a TP at 1.5x AND another at 2x; first to trigger fires, the other auto-cancels.",
     };
   }
   // Trailing validation. Bounded same as the migration's CHECK constraint.
@@ -516,6 +517,38 @@ export async function armOrder({
     ? (currentMicrosForLater != null ? currentMicrosForLater : triggerBI)
     : null;
 
+  // ── Ladder group resolution (migration 065) ──────────────────
+  // When slice<100% (LIMIT_CLOSE_LADDER_ENABLED), this arm is a ladder
+  // leg. Find an existing ladder group on the same (loan_id, direction)
+  // and JOIN it — that way all legs share the same group UUID and the
+  // engine can migrate them together to a new loan_id after a leg
+  // fires + re-borrows on remainder. If no existing group, create one
+  // and snapshot the loan's collateral_amount as the absolute reference
+  // ("10%" always means 10% of THIS amount, never drifts).
+  let ladderGroupId = null;
+  let originalCollateralAmountForArm = null;
+  if (slicePct < 10000) {
+    const { rows: [existingGroup] } = await query(
+      `SELECT ladder_group_id, original_collateral_amount::text AS original_amount
+         FROM limit_close_orders
+        WHERE loan_id = $1
+          AND COALESCE(trigger_direction, 'above') = $2
+          AND status = 'armed'
+          AND ladder_group_id IS NOT NULL
+        LIMIT 1`,
+      [loan.id, triggerDirection],
+    );
+    if (existingGroup?.ladder_group_id) {
+      ladderGroupId = existingGroup.ladder_group_id;
+      originalCollateralAmountForArm = existingGroup.original_amount;
+    } else {
+      // New ladder group — generate UUID, snapshot collateral.
+      const { randomUUID } = await import("node:crypto");
+      ladderGroupId = randomUUID();
+      originalCollateralAmountForArm = loan.collateral_amount_raw;
+    }
+  }
+
   let inserted;
   try {
     inserted = await query(
@@ -529,6 +562,8 @@ export async function armOrder({
           engine_program_id,
           trailing_distance_bps, peak_price_micros,
           slice_pct,
+          ladder_group_id,
+          original_collateral_amount,
           notes)
        VALUES ($1, $2, $3, $4,
                $5,
@@ -539,7 +574,9 @@ export async function armOrder({
                $17,
                $18, $19,
                $20,
-               $21)
+               $21,
+               $22,
+               $23)
        RETURNING id, armed_at`,
       [userId, loan.id, triggerKind, triggerBI.toString(),
        triggerDirection,
@@ -549,27 +586,32 @@ export async function armOrder({
        advisory ? null : effectiveCap,
        advisory ? null : (preflight.proceedsLamports || null),
        advisory ? null : (preflight.quotedAtIso || new Date().toISOString()),
-       // engine_program_id: source-of-truth for which Solana program the
-       // fill engine targets when this order fires. Pulled from the
-       // loan row (loans.program_id) which is itself derived from the
-       // on-chain owner of the loan PDA at recordLoan time. Engine
-       // treats NULL as legacy-V1 for back-compat with pre-2026-06-13
-       // rows; new arms always populate this.
        loan.program_id || null,
        trailingDistanceBps,
        peakAtArm != null ? peakAtArm.toString() : null,
        slicePct,
+       ladderGroupId,
+       originalCollateralAmountForArm,
        armNote
          || (appliedInitialBps !== originalInitialBps
-           ? `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}${slicePct < 10000 ? ` slice=${slicePct/100}%` : ""}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
-           : `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}${slicePct < 10000 ? ` slice=${slicePct/100}%` : ""}`)],
+           ? `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}${slicePct < 10000 ? ` slice=${slicePct/100}% ladder=${ladderGroupId?.slice(0,8)}` : ""}; initial slippage bumped ${originalInitialBps}->${appliedInitialBps} bps for ${mintRow.symbol || "thin token"} (liquidity_usd=$${Math.round(liqUsd)})`
+           : `armed via ${source}; ${triggerDirection === "below" ? (trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : "STOP-LOSS") : "TP"}${slicePct < 10000 ? ` slice=${slicePct/100}% ladder=${ladderGroupId?.slice(0,8)}` : ""}`)],
     );
   } catch (err) {
+    // Migration 065's sum-cap trigger: SUM(slice_pct) > 10000 across
+    // armed legs per (loan_id, direction). Surface as a structured
+    // error so the UI shows the over-allocation cleanly.
+    if (/TP\/SL ladder exceeds 100/i.test(err.message || "")) {
+      return {
+        ok: false,
+        error: "ladder_sum_exceeds_100",
+        detail: err.message?.slice(0, 240),
+      };
+    }
     // Migration 047's per-direction UNIQUE is dropped by 064 so multi-
     // target arming is allowed. Tolerate the duplicate-key signal in
     // case a stale replica is still using the pre-064 schema during
-    // rollout. The 064 deploy is single-step (no overlap window
-    // expected) so this branch should never fire in practice.
+    // rollout.
     if (/duplicate key value violates unique constraint/i.test(err.message || "")) {
       return {
         ok: false,


### PR DESCRIPTION
## Summary

Bot-side schema + arm-core support for the TRUE partial-sell ladder ("70% at 16M, 10% at 17M, 10% at 18M, 10% at 19M"). Paired with the magpie-limitclose engine PR (separate). Schema in place; the env flag stays OFF until the engine ships.

### Migration 065

- `ladder_group_id UUID` — shared across all legs; engine uses it to migrate sibling armed orders to the new loan_id after a leg fires + re-borrows on remainder.
- `original_collateral_amount NUMERIC` — snapshot at arm time. Slice_pct stays absolute across re-borrows ("10%" always = 10% of the original collateral, never drifts).
- `migrated_from_loan_id BIGINT` — preserves ladder lifecycle.
- Partial index on `(ladder_group_id, status) WHERE status='armed'` for fast sibling lookup.
- SUM(slice_pct) ≤ 10000 trigger re-added (dropped in 064; meaningful again now).

### arm-core

- When `slicePct<10000` + `LIMIT_CLOSE_LADDER_ENABLED=true`:
  - Looks up existing ladder group on (loan_id, direction) — joins it OR generates a fresh UUID + snapshots `loan.collateral_amount`.
  - All legs of the same ladder share the SAME `ladder_group_id` + `original_collateral_amount`.
- INSERT includes the new columns.
- Catches the sum-cap RAISE EXCEPTION → structured `ladder_sum_exceeds_100` error.

### Pool coverage (V1/V2/V3)

Works uniformly across pools: engine reads `loan.program_id` and re-borrows against the same pool. `engine_program_id` stays stamped on each migrated sibling so cross-pool fires remain structurally impossible across the entire ladder lifecycle.

### Test plan

- [ ] CI passes
- [ ] Migration 065 applies cleanly + idempotent
- [ ] With env unset: `slice=25%` arm returns `fractional_slice_not_supported_today`
- [ ] With env set + engine deployed: two `slice=50%` TPs at different prices both arm with the same ladder_group_id
- [ ] Third 50%-slice arm in same direction returns `ladder_sum_exceeds_100`