### PR TITLE
fix: wallet → user_id resolver prefers TG-linked user (unblocks /repay for site-borrowed loans)

### DIFF
--- a/src/api/activity-api.js
+++ b/src/api/activity-api.js
@@ -33,14 +33,12 @@ export async function handleActivity(req, url) {
   }
   const limit = Math.min(MAX_LIMIT, Math.max(1, parseInt(url.searchParams.get("limit") || `${DEFAULT_LIMIT}`, 10)));
 
-  const { rows: [u] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [wallet],
-  );
-  if (!u) {
+  const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+  const resolvedUserId = await resolveWalletOwner(wallet);
+  if (!resolvedUserId) {
     return { status: 200, body: { linked: false, events: [] } };
   }
-  const userId = u.user_id;
+  const userId = resolvedUserId;
 
   // Pull each event type independently. Each query is O(few-hundred) at
   // worst given the table sizes, and the indexes on user_id make them

--- a/src/api/agent-repay.js
+++ b/src/api/agent-repay.js
@@ -167,10 +167,9 @@ export async function handleAgentBuildRepay(req) {
   // Per-user lock check (defense-in-depth). Mirrors cosign-borrow +
   // agent-manage. Skip silently if we can't resolve a user_id.
   if (loan.borrower_wallet) {
-    const { rows: [walletRow] } = await query(
-      `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-      [loan.borrower_wallet],
-    );
+    const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+    const resolvedUserId = await resolveWalletOwner(loan.borrower_wallet);
+    const walletRow = resolvedUserId ? { user_id: resolvedUserId } : null;
     if (walletRow?.user_id) {
       const lockReject = await rejectIfLocked(walletRow.user_id);
       if (lockReject) return lockReject;

--- a/src/api/backfill-wallet-loans.js
+++ b/src/api/backfill-wallet-loans.js
@@ -135,10 +135,9 @@ export async function handleBackfillWalletLoans(req) {
   // can spray random pubkeys to learn the wallet↔Magpie-account
   // mapping (same fix pattern as sync-loan PR #52). Log internally
   // for ops visibility but stay opaque to the caller.
-  const { rows: [walletRow] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [walletStr],
-  );
+  const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+  const resolvedUserId = await resolveWalletOwner(walletStr);
+  const walletRow = resolvedUserId ? { user_id: resolvedUserId } : null;
   if (!walletRow) {
     console.error(`[backfill] wallet ${walletStr.slice(0, 8)}... not linked — returning generic noop`);
     return {

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -619,11 +619,16 @@ export async function handleCosignBorrow(req) {
             return { status: 400, body: { error: "Collateral value computed to zero" } };
           }
           const proposedLoanLamports = Math.floor((Number(valueLamports) * ltv) / 100);
-          // Resolve user_id (linked wallet → user; or null if standalone)
-          const { rows: [walletRow] } = await query(
-            `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-            [borrowerPubkeyStr],
-          );
+          // Resolve user_id (linked wallet → user; or null if standalone).
+          // Uses the canonical resolver so we ALWAYS pick the TG-linked
+          // user_id when one exists. Without this, a wallet that has
+          // both a site_native row and an imported-into-TG row would
+          // attribute the loan to the older site_native user — and the
+          // user wouldn't see the loan in TG /repay. Caused operator
+          // report on V3 SPCX loan id=720 on 2026-06-14.
+          const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+          const resolvedUserId = await resolveWalletOwner(borrowerPubkeyStr);
+          const walletRow = resolvedUserId ? { user_id: resolvedUserId } : null;
           // Per-user soft-lock check (operator can lock individual
           // users via /lock_user during investigations). Fires only if
           // we resolved a user_id — unlinked wallets can't be locked
@@ -778,10 +783,12 @@ export async function handleCosignBorrow(req) {
         recordedLoanPda = loanAccountKey.toBase58();
         const onChainLoan = await program.account.loan.fetch(loanAccountKey);
         const borrowerStr = borrowerAccountKey.toBase58();
-        const { rows: [walletRow] } = await query(
-          `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-          [borrowerStr],
-        );
+        // Same TG-preferring resolver as the proposed-loan-lamports gate
+        // above. Both must agree or recordLoan attributes to a different
+        // user than the gates validated.
+        const { resolveWalletOwner: resolveWalletOwnerForRecord } = await import("../services/wallet-owner-resolver.js");
+        const recordUserId = await resolveWalletOwnerForRecord(borrowerStr);
+        const walletRow = recordUserId ? { user_id: recordUserId } : null;
         if (walletRow) {
           await recordLoan({
             userId: walletRow.user_id,

--- a/src/api/prefs-api.js
+++ b/src/api/prefs-api.js
@@ -80,10 +80,9 @@ export async function handlePrefsList(req, url) {
   if (!isValidPubkey(wallet)) {
     return { status: 400, body: { error: "Invalid wallet pubkey" } };
   }
-  const { rows: [u] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [wallet],
-  );
+  const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+  const resolvedUserId = await resolveWalletOwner(wallet);
+  const u = resolvedUserId ? { user_id: resolvedUserId } : null;
   if (!u) {
     return { status: 200, body: { linked: false, prefs: null, recent_actions: [] } };
   }
@@ -207,10 +206,9 @@ export async function handlePrefsSet(req) {
   }
   if (!sigOk) return { status: 401, body: { error: "Signature does not match signer" } };
 
-  const { rows: [linked] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [signerPubkey],
-  );
+  const { resolveWalletOwner: resolveOwner2 } = await import("../services/wallet-owner-resolver.js");
+  const linkedUserId = await resolveOwner2(signerPubkey);
+  const linked = linkedUserId ? { user_id: linkedUserId } : null;
   if (!linked) {
     return { status: 403, body: { error: "Signer wallet is not linked to a Magpie account" } };
   }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -404,10 +404,10 @@ async function handleCreditHistory(req, url) {
     return { status: 400, body: { error: "Provide ?wallet=<address>" } };
   }
 
-  const { rows: [w] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1`, [wallet],
-  );
-  if (!w) return { status: 404, body: { error: "Wallet not found" } };
+  const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+  const wUserId = await resolveWalletOwner(wallet);
+  if (!wUserId) return { status: 404, body: { error: "Wallet not found" } };
+  const w = { user_id: wUserId };
 
   const { getScoreHistory } = await import("../services/credit-score.js");
   const history = await getScoreHistory(w.user_id, 50);
@@ -623,13 +623,13 @@ async function handleLoans(req, url) {
     return { status: 400, body: { error: "Provide ?wallet=<address>" } };
   }
 
-  const { rows: [w] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1`, [wallet],
-  );
-  if (!w) {
+  const { resolveWalletOwner: resolveOwner3 } = await import("../services/wallet-owner-resolver.js");
+  const wUserId2 = await resolveOwner3(wallet);
+  if (!wUserId2) {
     // Unknown wallet — return empty (not an error: dashboard may render zero state)
     return { status: 200, body: { wallet, active: [], history: [] } };
   }
+  const w = { user_id: wUserId2 };
 
   const { rows: allUserRows } = await query(
     `SELECT l.id, l.loan_id, l.loan_pda, l.collateral_mint, l.collateral_amount,

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -214,10 +214,20 @@ async function authSignedEnvelope(req, expectedMagpieHeader, requiredFields = []
     return { ok: false, status: 500, error: "nonce_check_failed" };
   }
 
-  // Wallet ownership + custodial check
+  // Wallet ownership + custodial check.
+  // Prefer the TG-linked wallet row when multiple exist; see
+  // src/services/wallet-owner-resolver.js. We need encrypted_secret
+  // here so we can't use the helper directly — inline the same
+  // ranking so the chosen row is consistent with /repay etc.
   const { rows: [walletRow] } = await query(
-    `SELECT user_id, encrypted_secret, source
-       FROM wallets WHERE public_key = $1 LIMIT 1`,
+    `SELECT w.user_id, w.encrypted_secret, w.source
+       FROM wallets w
+       JOIN users u ON u.id = w.user_id
+      WHERE w.public_key = $1
+      ORDER BY (u.telegram_id IS NOT NULL AND u.telegram_id <> 0) DESC,
+               w.is_active DESC,
+               w.created_at DESC
+      LIMIT 1`,
     [signerPubkey],
   );
   if (!walletRow) {
@@ -248,8 +258,17 @@ export async function handleSiteLimitCloseList(req, url) {
   const wallet = url.searchParams.get("wallet") || "";
   if (!isValidPubkey(wallet)) return { status: 400, body: { error: "invalid_wallet" } };
 
+  // Same TG-preferring ranking as the arm path so the list shows
+  // orders for the wallet's canonical user_id.
   const { rows: [walletRow] } = await query(
-    `SELECT user_id, encrypted_secret FROM wallets WHERE public_key = $1 LIMIT 1`,
+    `SELECT w.user_id, w.encrypted_secret
+       FROM wallets w
+       JOIN users u ON u.id = w.user_id
+      WHERE w.public_key = $1
+      ORDER BY (u.telegram_id IS NOT NULL AND u.telegram_id <> 0) DESC,
+               w.is_active DESC,
+               w.created_at DESC
+      LIMIT 1`,
     [wallet],
   );
   if (!walletRow) {

--- a/src/api/support-api.js
+++ b/src/api/support-api.js
@@ -71,10 +71,9 @@ export async function handleSupportTickets(req, url) {
     return { status: 400, body: { error: "Invalid wallet pubkey" } };
   }
 
-  const { rows: [w] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [wallet],
-  );
+  const { resolveWalletOwner: resolveOwner1 } = await import("../services/wallet-owner-resolver.js");
+  const wUserId = await resolveOwner1(wallet);
+  const w = wUserId ? { user_id: wUserId } : null;
   if (!w) {
     return { status: 200, body: { linked: false, tickets: [] } };
   }
@@ -190,10 +189,9 @@ export async function handleSupportDeleteTicket(req) {
   if (!sigOk) return { status: 401, body: { error: "Signature does not match signer" } };
 
   // Look up user to gate on the kill-switch BEFORE consuming a nonce.
-  const { rows: [linked] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [signerPubkey],
-  );
+  const { resolveWalletOwner: resolveOwner2 } = await import("../services/wallet-owner-resolver.js");
+  const linkedUserId = await resolveOwner2(signerPubkey);
+  const linked = linkedUserId ? { user_id: linkedUserId } : null;
   if (!linked) {
     return { status: 403, body: { error: "Signer wallet is not linked to a Magpie account" } };
   }
@@ -217,13 +215,16 @@ export async function handleSupportDeleteTicket(req) {
   // Single statement so a non-owner / wrong-status case gets the same
   // 404 as a non-existent id (no enumeration disclosure). Return user_id
   // so we can fire the security alert after deletion.
+  // We already resolved linked.user_id via the canonical resolver above,
+  // so use it directly here instead of the bug-prone inline LIMIT-1 sub-
+  // query. Keeps tickets deletable by the SAME user whose ban-check ran.
   const { rows } = await query(
     `DELETE FROM support_tickets
        WHERE id = $2
          AND status = 'closed'
-         AND user_id = (SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1)
+         AND user_id = $3
        RETURNING user_id`,
-    [signerPubkey, ticketId],
+    [signerPubkey, ticketId, linked.user_id],
   );
   if (rows.length === 0) {
     return {

--- a/src/api/sync-loan.js
+++ b/src/api/sync-loan.js
@@ -181,10 +181,13 @@ export async function handleSyncLoan(req) {
       };
     }
     const borrowerStr = onChainNew.borrower.toBase58();
-    const { rows: [walletRow] } = await query(
-      `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-      [borrowerStr],
-    );
+    // Resolve to the TG-linked user_id when available — same wallet
+    // can have multiple rows in wallets (site_native + imported); we
+    // want the user who'll actually run /repay etc. See
+    // src/services/wallet-owner-resolver.js.
+    const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+    const resolvedUserId = await resolveWalletOwner(borrowerStr);
+    const walletRow = resolvedUserId ? { user_id: resolvedUserId } : null;
     if (!walletRow) {
       // Borrower's wallet isn't linked to a Magpie account — likely an
       // agent borrow whose synthetic user was already created by the

--- a/src/api/wallets-api.js
+++ b/src/api/wallets-api.js
@@ -70,10 +70,11 @@ export async function handleWalletsList(req, url) {
   if (!isValidPubkey(wallet)) {
     return { status: 400, body: { error: "Invalid wallet pubkey" } };
   }
-  const { rows: [linked] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [wallet],
-  );
+  // Prefer TG-linked user (canonical), site_native otherwise. See
+  // src/services/wallet-owner-resolver.js.
+  const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+  const resolvedUserId = await resolveWalletOwner(wallet);
+  const linked = resolvedUserId ? { user_id: resolvedUserId } : null;
   if (!linked) {
     return { status: 200, body: { linked: false, wallets: [] } };
   }

--- a/src/api/withdraw.js
+++ b/src/api/withdraw.js
@@ -222,10 +222,11 @@ export async function handleSiteWithdraw(req) {
   }
 
   // ── Gate 5: ownership — signer must be a linked wallet ──
-  const { rows: [walletRow] } = await query(
-    `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
-    [signerPubkey],
-  );
+  // Prefer the TG-linked user_id when present so withdraw activity
+  // is attributed to the human's TG identity (matches /repay et al).
+  const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+  const resolvedUserId = await resolveWalletOwner(signerPubkey);
+  const walletRow = resolvedUserId ? { user_id: resolvedUserId } : null;
   if (!walletRow) {
     return {
       status: 403,

--- a/src/services/wallet-owner-resolver.js
+++ b/src/services/wallet-owner-resolver.js
@@ -1,0 +1,91 @@
+/**
+ * Wallet → user_id resolver — the ONE correct way to look up which
+ * Magpie user owns a given Solana pubkey.
+ *
+ * Why this exists:
+ *
+ *   A wallet pubkey can have MULTIPLE rows in the `wallets` table —
+ *   one per (user_id, public_key) pair. This is by design: the site
+ *   auto-creates a "site_native" user the first time someone connects
+ *   a Phantom wallet, AND a separate "imported" row appears when the
+ *   user later links that same wallet to their Telegram account.
+ *
+ *   Before this helper, the codebase had ~15 spots doing
+ *     `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`
+ *   with NO `ORDER BY`. Postgres returned whichever row it pleased,
+ *   which was usually the older `site_native` row. New loans (and
+ *   especially V3 RWA loans borrowed via the site) ended up under
+ *   the site-only user_id rather than the TG-linked one. When the
+ *   user ran /repay in Telegram, the loan didn't show up.
+ *
+ *   This helper picks the RIGHT user_id deterministically:
+ *
+ *     1. Prefer the row whose owning user has a non-null/non-zero
+ *        telegram_id (that's the human controlling the wallet from TG).
+ *     2. Among those, prefer is_active=TRUE rows (the user explicitly
+ *        chose this wallet as their active one).
+ *     3. Among those, prefer the most-recently-created row (the most
+ *        recent intent wins).
+ *     4. Fall back to any wallet row if no TG-linked rows exist (site-
+ *        only users still get a valid user_id).
+ *
+ *   The bot's /repay, /topup, /extend, etc. all scope by user_id. Picking
+ *   the TG-linked user_id whenever possible means loans always land in
+ *   the correct user's TG-visible scope.
+ *
+ * Use this for every wallet → user_id lookup:
+ *
+ *     import { resolveWalletOwner } from "./wallet-owner-resolver.js";
+ *     const userId = await resolveWalletOwner(borrowerPubkey);
+ */
+
+import { query } from "../db/pool.js";
+
+/**
+ * Look up the canonical user_id for a wallet pubkey.
+ *
+ * Returns the resolved user_id (string) or null if no wallet row exists.
+ *
+ * Implementation detail: a single ranked SELECT keeps this to one
+ * round-trip. ORDER BY:
+ *   - tg-linked rows first (NULLS LAST so a NULL telegram_id loses)
+ *   - is_active DESC so explicit-current-wallet wins
+ *   - created_at DESC so most-recent linkage wins on ties
+ */
+export async function resolveWalletOwner(publicKey) {
+  if (!publicKey || typeof publicKey !== "string") return null;
+  const { rows } = await query(
+    `SELECT w.user_id
+       FROM wallets w
+       JOIN users u ON u.id = w.user_id
+      WHERE w.public_key = $1
+      ORDER BY (u.telegram_id IS NOT NULL AND u.telegram_id <> 0) DESC,
+               w.is_active DESC,
+               w.created_at DESC
+      LIMIT 1`,
+    [publicKey],
+  );
+  return rows[0]?.user_id ?? null;
+}
+
+/**
+ * Variant that returns the full wallet row (user_id + metadata) so
+ * callers that need more than just the id (e.g. cosign-borrow checking
+ * is_active) don't have to re-query.
+ */
+export async function resolveWalletOwnerRow(publicKey) {
+  if (!publicKey || typeof publicKey !== "string") return null;
+  const { rows } = await query(
+    `SELECT w.user_id, w.public_key, w.is_active, w.source, w.label,
+            w.created_at, u.telegram_id
+       FROM wallets w
+       JOIN users u ON u.id = w.user_id
+      WHERE w.public_key = $1
+      ORDER BY (u.telegram_id IS NOT NULL AND u.telegram_id <> 0) DESC,
+               w.is_active DESC,
+               w.created_at DESC
+      LIMIT 1`,
+    [publicKey],
+  );
+  return rows[0] ?? null;
+}


### PR DESCRIPTION
## Symptom

Operator reported: \"/repay on TG doesn't show my V3 SPCX 30-day loan.\" Wallet \`HCvMUH...\` has an active V3 loan but TG can't see it.

## Root cause

A wallet pubkey can have multiple rows in the \`wallets\` table — a \`site_native\` row created when the user first connects via the site, AND an \`imported\` row created when the user later links the same wallet to their TG account. The codebase had ~15 spots doing:

\`\`\`sql
SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1
\`\`\`

…with NO \`ORDER BY\`. Postgres returned whichever row it wanted — usually the older \`site_native\` row, because it was inserted first. Result: new loans (especially V3 RWA loans borrowed from the site) ended up under the site-only ghost user_id rather than the TG-linked account. /repay's \`WHERE user_id = $1\` then couldn't find them.

## Fix

- **New helper** \`src/services/wallet-owner-resolver.js\` exports \`resolveWalletOwner(publicKey)\` with the canonical ranking:
  1. TG-linked user wins (\`telegram_id IS NOT NULL AND <> 0\`)
  2. \`is_active=TRUE\` wins on ties
  3. \`created_at DESC\` wins on ties
- **11 call sites patched** to route through it:
  - \`cosign-borrow.js\` ×2 (the original bug — both loan_user_id resolution AND recordLoan paths)
  - \`sync-loan.js\`, \`agent-repay.js\`, \`withdraw.js\`, \`wallets-api.js\`, \`support-api.js\` ×3, \`backfill-wallet-loans.js\`, \`activity-api.js\`, \`prefs-api.js\` ×2, \`server.js\` ×2
- **site-limit-close.js** needs \`encrypted_secret\` alongside user_id; same ranking inlined directly for consistency.

## Data repair (already applied)

3 mis-attributed active loans moved to the correct user_id 948:
| Loan id | Pool | Collateral | Was | Now |
|---|---|---|---|---|
| 720 | V3 | SPCX (xStock) | 15196 | 948 |
| 668 | V2 | SPCX (xStock) | 15236 | 948 |
| 727 | V1 | $MAGPIE | 15236 | 948 |

User can now /repay all three.

## Test plan

- [ ] CI passes
- [ ] After deploy: a fresh borrow from the site on a wallet that has both site_native + TG-imported rows lands under the TG user_id
- [ ] Sweep for any other mis-attributed loans the deploy might surface (\`/repay\` works for previously-affected users)