### PR TITLE
URGENT: V3 request_and_fund_loan needs extra category u8 arg

### DIFF
--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -266,13 +266,17 @@ export async function buildBorrowTx({
       ),
     ];
 
+    // V3 takes an extra `category` u8 arg; V1/V2 take 4. See
+    // src/services/loans.js for the symmetric branch on the TG borrow
+    // path. Without this, V3 borrows fail with InstructionDidNotDeserialize.
+    const RWA_CATEGORIES = new Set(["stock", "etf", "metal"]);
+    const isV3 = process.env.PROGRAM_ID_V3 && programId.toBase58() === process.env.PROGRAM_ID_V3;
+    const categoryByte = RWA_CATEGORIES.has(mintRow.category) ? 1 : 0;
+    const ixArgs = isV3
+      ? [new BN(collateralAmountRaw), Number(tier), new BN(collateralValLamports.toString()), loanId, categoryByte]
+      : [new BN(collateralAmountRaw), Number(tier), new BN(collateralValLamports.toString()), loanId];
     const ix = await program.methods
-      .requestAndFundLoan(
-        new BN(collateralAmountRaw),
-        Number(tier),
-        new BN(collateralValLamports.toString()),
-        loanId,
-      )
+      .requestAndFundLoan(...ixArgs)
       .accounts({
         pool: lendingPool,
         loanTokenVault,

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -256,13 +256,31 @@ export async function executeBorrow({
   // Authority must co-sign to attest the collateral value
   const lenderKeypair = loadLenderKeypair();
 
+  // V3's request_and_fund_loan takes one additional `category` u8 arg
+  // (0 = memecoin, 1 = RWA stock/etf/metal). V1 + V2 take just the 4
+  // pre-existing args. Picking the right shape per program is the
+  // difference between the on-chain ix deserializing cleanly and the
+  // borrower seeing "InstructionDidNotDeserialize" (operator hit this
+  // on 2026-06-14 borrowing SPCX from TG).
+  const RWA_CATEGORIES = new Set(["stock", "etf", "metal"]);
+  const isV3 = process.env.PROGRAM_ID_V3 && programId.toBase58() === process.env.PROGRAM_ID_V3;
+  const categoryByte = RWA_CATEGORIES.has(category) ? 1 : 0;
+  const ixArgs = isV3
+    ? [
+        new BN(collateralAmountRaw.toString()),
+        loanOption,
+        new BN(collateralValueLamports.toString()),
+        loanId,
+        categoryByte,
+      ]
+    : [
+        new BN(collateralAmountRaw.toString()),
+        loanOption,
+        new BN(collateralValueLamports.toString()),
+        loanId,
+      ];
   const sig = await program.methods
-    .requestAndFundLoan(
-      new BN(collateralAmountRaw.toString()),
-      loanOption,
-      new BN(collateralValueLamports.toString()),
-      loanId,
-    )
+    .requestAndFundLoan(...ixArgs)
     .accounts({
       pool: lendingPool,
       loanTokenVault,


### PR DESCRIPTION
Operator hit InstructionDidNotDeserialize borrowing SPCX from TG. V3 takes 5 args (extra category u8); V1/V2 take 4. The bot's TG borrow path (services/loans.js) and agent endpoint were sending the V1/V2 4-arg shape against V3 → Anchor rejects. Fix adds the category byte branch in both call sites. Symmetric to the site path (PR #95) and engine reborrow path that already emit the V3 shape.