### PR TITLE
V3 sweep: /stats + /lc-perf + /tx-lookup + Pip narration

### DIFF
--- a/src/commands/lc-perf.js
+++ b/src/commands/lc-perf.js
@@ -137,20 +137,22 @@ async function showPerf(ctx, windowKey) {
       GROUP BY source ORDER BY n DESC`,
   );
 
-  // ── Pool breakdown (V1 memecoin vs V2 RWA) — PR B follow-up ──
-  // engine_program_id (added in migration 050, PR #157) discriminates
-  // V1 vs V2 fills. Pre-2026-06-13 orders have NULL — counted as
-  // "v1_legacy" since the engine treats NULL as V1 for back-compat.
-  // The split tells the operator how RWA adoption is tracking now
-  // that the gate flipped in PR #161.
+  // ── Pool breakdown (V1 / V2 / V3) ──
+  // engine_program_id (added in migration 050) discriminates V1 / V2 /
+  // V3 fills. Pre-2026-06-13 orders have NULL — counted as 'v1_legacy'
+  // since the engine treats NULL as V1 for back-compat. The split tells
+  // the operator how RWA + memecoin adoption is tracking across all
+  // three pools now that V3 is live.
   const V1_PROGRAM_ID = process.env.PROGRAM_ID || "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh";
   const V2_PROGRAM_ID = process.env.PROGRAM_ID_V2 || null;
+  const V3_PROGRAM_ID = process.env.PROGRAM_ID_V3 || null;
   const { rows: poolRows } = await query(
     `SELECT
         CASE
           WHEN engine_program_id IS NULL THEN 'v1_legacy'
           WHEN engine_program_id = $1 THEN 'v1'
           WHEN engine_program_id = $2 THEN 'v2'
+          WHEN engine_program_id = $3 THEN 'v3'
           ELSE 'unknown'
         END AS pool,
         COUNT(*)::int AS n,
@@ -159,7 +161,7 @@ async function showPerf(ctx, windowKey) {
        FROM limit_close_orders
       WHERE 1=1 ${sqlClause}
       GROUP BY 1 ORDER BY n DESC`,
-    [V1_PROGRAM_ID, V2_PROGRAM_ID],
+    [V1_PROGRAM_ID, V2_PROGRAM_ID, V3_PROGRAM_ID],
   );
 
   // ── Trailing-stop telemetry ──
@@ -340,15 +342,16 @@ async function showPerf(ctx, windowKey) {
     "*Source breakdown:*",
     ...sources.map((s) => `• ${s.source.padEnd(12)} ${s.n}`),
     "",
-    "*Pool breakdown (V1 memecoin / V2 RWA):*",
+    "*Pool breakdown (V1 / V2 / V3):*",
     ...(poolRows.length === 0
       ? ["• (no orders in window)"]
       : poolRows.map((p) => {
           const label = p.pool === "v1" ? "v1 (memecoin)"
-                      : p.pool === "v2" ? "v2 (RWA)"
-                      : p.pool === "v1_legacy" ? "v1 (pre-PR#157)"
+                      : p.pool === "v2" ? "v2 (RWA legacy)"
+                      : p.pool === "v3" ? "v3 (RWA + memecoin)"
+                      : p.pool === "v1_legacy" ? "v1 (pre-mig050)"
                       : `unknown`;
-          return `• ${label.padEnd(20)} total ${p.n}  fired ${p.fired}  armed ${p.armed}`;
+          return `• ${label.padEnd(22)} total ${p.n}  fired ${p.fired}  armed ${p.armed}`;
         })),
     "",
     ...(trailingSummary ? [

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -1,5 +1,5 @@
 import { PublicKey } from "@solana/web3.js";
-import { getReadOnlyProgram, PROGRAM_ID, PROGRAM_ID_V2 } from "../solana/program.js";
+import { getReadOnlyProgram, PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3 } from "../solana/program.js";
 import { lendingPoolPda, loanTokenVaultPda } from "../solana/pdas.js";
 import { connection } from "../solana/connection.js";
 import { query } from "../db/pool.js";
@@ -64,31 +64,34 @@ export async function handleStats(ctx) {
   if (!lenderPubkey) return ctx.reply("Stats not configured (LENDER_PUBKEY missing).");
 
   try {
-    // Read BOTH pool snapshots in parallel. V2 is the RWA-capable pool
-    // (tokenized stocks etc.); fees flow to the same LENDER_PUBKEY wSOL
-    // ATA via the authority-signed borrow path, so the protocol view of
-    // fees-earned is V1 + V2. If V2 is not configured (env missing), we
-    // gracefully skip — keeps /stats working in dev / staging where only
-    // V1 is set up.
-    const [v1] = await Promise.all([
-      fetchPoolSnapshot(PROGRAM_ID),
-    ]);
+    // Read all three pool snapshots in parallel. V2 is legacy RWA; V3
+    // is the live RWA + memecoin dual-tier pool. Fees flow to the same
+    // LENDER_PUBKEY wSOL ATA across all three programs, so the protocol
+    // view of fees-earned is V1 + V2 + V3. If V2 or V3 is not configured
+    // (env missing) or RPC blips on a per-pool read, we gracefully
+    // continue with whatever loaded — keeps /stats working in dev /
+    // staging where only a subset of pools may be deployed.
+    const v1 = await fetchPoolSnapshot(PROGRAM_ID);
     let v2 = null;
     if (PROGRAM_ID_V2) {
       try { v2 = await fetchPoolSnapshot(PROGRAM_ID_V2); }
       catch (err) {
-        // Don't fail the whole /stats if V2 is uninitialized or RPC blips
-        // on it — just report what we have. Logged so we notice persistent
-        // V2 read failures.
-        console.warn("[stats] V2 pool read failed (continuing with V1 only):", err.message);
+        console.warn("[stats] V2 pool read failed:", err.message);
+      }
+    }
+    let v3 = null;
+    if (PROGRAM_ID_V3) {
+      try { v3 = await fetchPoolSnapshot(PROGRAM_ID_V3); }
+      catch (err) {
+        console.warn("[stats] V3 pool read failed:", err.message);
       }
     }
 
-    const totalDeposits = v1.totalDeposits + (v2?.totalDeposits ?? 0n);
-    const totalFeesEarned = v1.totalFeesEarned + (v2?.totalFeesEarned ?? 0n);
-    const totalLoansIssued = v1.totalLoansIssued + (v2?.totalLoansIssued ?? 0n);
-    const totalLiquidations = v1.totalLiquidations + (v2?.totalLiquidations ?? 0n);
-    const totalVaultUi = (v1.vaultUiSol ?? 0) + (v2?.vaultUiSol ?? 0);
+    const totalDeposits = v1.totalDeposits + (v2?.totalDeposits ?? 0n) + (v3?.totalDeposits ?? 0n);
+    const totalFeesEarned = v1.totalFeesEarned + (v2?.totalFeesEarned ?? 0n) + (v3?.totalFeesEarned ?? 0n);
+    const totalLoansIssued = v1.totalLoansIssued + (v2?.totalLoansIssued ?? 0n) + (v3?.totalLoansIssued ?? 0n);
+    const totalLiquidations = v1.totalLiquidations + (v2?.totalLiquidations ?? 0n) + (v3?.totalLiquidations ?? 0n);
+    const totalVaultUi = (v1.vaultUiSol ?? 0) + (v2?.vaultUiSol ?? 0) + (v3?.vaultUiSol ?? 0);
 
     const { rows: counts } = await query(
       `SELECT
@@ -250,7 +253,7 @@ export async function handleStats(ctx) {
       row("Repaid", String(r.repaid)),
       row("Liquidated", totalLiquidations.toString()),
       ``,
-      `POOL${v2 ? " (V1+V2)" : ""}`,
+      `POOL${(v2 || v3) ? ` (${["V1", v2 ? "V2" : null, v3 ? "V3" : null].filter(Boolean).join("+")})` : ""}`,
       row("LP deposited", `${totalDepositsSol} SOL`),
       row("Fees earned", `${totalFeesSol} SOL`),
       vaultSol ? row("Vault", `${vaultSol} wSOL`) : row("Vault", "—"),

--- a/src/commands/tx-lookup.js
+++ b/src/commands/tx-lookup.js
@@ -16,6 +16,7 @@ import { connection } from "../solana/connection.js";
 const MAGPIE_PROGRAMS = new Set([
   process.env.PROGRAM_ID || "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh",
   process.env.PROGRAM_ID_V2,
+  process.env.PROGRAM_ID_V3,
   "7tapneCmNwRVEtdeZks4649Q2rf8W1t9tshMN9yHX99P",   // magpie-lending
   "BBYtty9sqWjHzTuoXSNfDCpNtLn6ZjfSfhYEoY6MFP2E",   // magpie-credit-oracle
 ].filter(Boolean));

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -772,7 +772,7 @@ WHY THIS IS GAME-CHANGING (your standard articulation when asked):
       loop.
 
    3. Permissionless liquidation (PLANNED — not yet shipped). The in-house
-      keeper handles all liquidations today (V1 + V2 pools as of 2026-06-13).
+      keeper handles all liquidations today (V1 + V2 + V3 pools as of 2026-06-14).
       A future build-liquidate endpoint would let third-party agents
       participate; current state: roadmap, not production.
 


### PR DESCRIPTION
V3 was missing from these admin/user surfaces. Sums + display labels updated; keeper + cosign + arm-core already covered V3 from earlier today. No new exposure or behavior change to existing V1/V2 paths.