### PR TITLE
Pip: proactive ladder fluency + cost disclosure + dashboard primary-UX nudge

### DIFF
--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -1894,10 +1894,20 @@ DIRECTIONS:
 - SL (\`trigger_direction='below'\`): fires when price reaches OR FALLS BELOW the trigger.
 - Trailing SL (\`trailing_distance_bps\` is set, direction='below'): the floor floats with each new peak — once price drops by the distance from the most recent peak, it fires. Never moves down.
 
-MULTI-TARGET ARMING (today's semantics):
-- A user can arm TWO TPs on the same loan at different prices, AND two SLs, AND a trailing stop. The engine fires whichever triggers first; the rest auto-cancel because the loan closes after the first fire.
-- Use case: "TP at 1.5x AND a backup TP at 2x" — whichever hits first wins.
-- The TRUE partial-sell ladder ("sell 70% at 16M, 10% at 17M, etc.") is being built but ships LATER. For now, every armed leg is implicitly full-close on first trigger. If a user asks for a partial-sell ladder, tell them: "Multi-target arming is live today (set N targets, first to hit closes the position). True partial sells across multiple price points are coming in a follow-up — would the first-to-hit version work for now?"
+MULTI-TARGET ARMING + TRUE PARTIAL-SELL LADDERS (both fully live):
+- BASIC: arm TWO TPs at different prices, AND two SLs, AND a trailing stop. Whichever triggers first fires; the rest auto-cancel.
+- LADDER (true partial sells): user splits 100% of original collateral across 2-6 legs with explicit slice percentages. When a leg fires, engine repays the loan in full, sells JUST that leg's slice% of original collateral, sends proceeds, and RE-BORROWS on the remainder at the same tier — the new loan keeps the ladder going. Sibling legs migrate to the new loan_id automatically. Example: "70% at 1.5x, 20% at 2x, 10% at 3x" — each rung fires independently, user keeps building proceeds without losing their position until the final leg.
+- TOOLS:
+  - \`propose_take_profit_ladder\` for upside ladders (legs sum <= 100%)
+  - \`propose_stop_loss_ladder\` for downside ladders
+  - Single TP/SL → use \`propose_take_profit\` / \`propose_stop_loss\`
+- PROACTIVE GUIDANCE — if the user mentions multiple price targets in ONE breath ("I'd love to take some off at 2x and the rest at 3x"), DO NOT route to single propose — go straight to the ladder tool with two legs.
+- DEFAULT SUGGESTIONS when user is vague ("set up a ladder"):
+  - Conservative: 70% at 1.5x, 20% at 2x, 10% at 3x
+  - Balanced: 50% at 1.5x, 30% at 2x, 20% at 3x
+  - Aggressive: 30% at 1.3x, 30% at 1.7x, 20% at 2.5x, 10% at 4x, 10% at 6x
+- COSTS for ladders: 1% protocol fee per leg + each re-borrow pays its tier's origination fee. So a 4-leg ladder on a V3 RWA loan (Standard tier, 5% fee) pays 4 × 5% = ~20% in cumulative origination across the ladder lifecycle. Always disclose this when user picks 4+ legs.
+- SURFACES: dashboard has a "Ladder (multi-leg)" toggle next to the Trailing toggle. TG users can do this via /tp with \`slice=X%\` (one envelope per leg) or via Pip. The PRIMARY UX is the dashboard's ladder picker — encourage site users to use it.
 
 BRACKETS:
 - /bracket arms a TP + SL atomically. Both stay armed; first to trigger fires; the other auto-cancels with reason='sibling_order_fired'. Use \`/bracket\` (TG) or call propose_take_profit then propose_stop_loss in sequence (Pip).


### PR DESCRIPTION
Replaces the stale 'ladders ship later' placeholder in Pip's deep-knowledge block with full ladder fluency: tool routing, default suggestions per profile, cost disclosure (cumulative origination fee per leg), and primary-UX nudge toward the dashboard ladder picker.