### PR TITLE
V4 tooling: migration 066 + V2→V4 5 SOL move-pool script

### DIFF
--- a/migrations/066_v4_loan_columns.sql
+++ b/migrations/066_v4_loan_columns.sql
@@ -1,0 +1,57 @@
+-- migration 066: V4 loan column extensions (in-vault auto-sell state)
+--
+-- V4's on-chain Loan account extends V3's layout with three new fields
+-- (current_collateral_amount, sol_proceeds_amount, auto_sells_fired).
+-- These mirror the on-chain state into the bot's `loans` table so the
+-- repay flow, /positions display, and /lc-perf engine telemetry can
+-- show the post-auto-sell mix accurately without a round-trip to the
+-- chain on every read.
+--
+-- Backward compat:
+--   - All three columns DEFAULT to a sane V3-equivalent value (current
+--     equals collateral at borrow time, sol_proceeds = 0, fires = 0)
+--   - Existing V1/V2/V3 loan rows are NOT migrated (they don't have V4
+--     semantics — they should keep showing as pure SPL collateral).
+--     A WHERE clause in the bot read paths gates on program_id = V4 so
+--     these columns are only consulted for V4 loans.
+--   - The migration is safe to re-apply (uses ADD COLUMN IF NOT EXISTS).
+--
+-- Operator note (2026-06-15): this migration ships ahead of V4 mainnet
+-- deploy so the DB is ready the moment V4 starts issuing loans. Until a
+-- V4 loan is recorded, no code path reads these columns.
+
+-- Remaining SPL collateral in the loan vault. Decreases each time
+-- convert_collateral_slice fires. Equals collateral_amount at borrow
+-- time on V4; equals collateral_amount permanently on V1/V2/V3 (no
+-- auto-sell drain).
+ALTER TABLE loans
+  ADD COLUMN IF NOT EXISTS current_collateral_amount NUMERIC;
+
+-- SOL accumulated from convert_collateral_slice fires (lamports, net
+-- of the 1% protocol fee). The user receives this at repay time
+-- alongside any remaining SPL.
+ALTER TABLE loans
+  ADD COLUMN IF NOT EXISTS sol_proceeds_amount NUMERIC NOT NULL DEFAULT 0;
+
+-- Diagnostic counter — number of convert_collateral_slice calls. Used
+-- by /lc-perf to show auto-sell density per loan.
+ALTER TABLE loans
+  ADD COLUMN IF NOT EXISTS auto_sells_fired SMALLINT NOT NULL DEFAULT 0;
+
+-- Backfill current_collateral_amount to match collateral_amount on
+-- existing rows. For V1/V2/V3 loans this stays equal forever (no
+-- auto-sell ever drains SPL on these programs). For V4 loans the
+-- value diverges as convert_collateral_slice fires.
+UPDATE loans
+   SET current_collateral_amount = collateral_amount
+ WHERE current_collateral_amount IS NULL;
+
+-- Indices for the queries that actually filter on these columns:
+-- /lc-perf totals SOL proceeds by date range; /positions filters loans
+-- where any auto-sell has fired so the mixed-collateral display kicks
+-- in only when relevant.
+CREATE INDEX IF NOT EXISTS loans_auto_sells_fired_idx
+  ON loans (auto_sells_fired)
+  WHERE auto_sells_fired > 0;
+</content>
+</invoke>

--- a/scripts/move-pool-v2-to-v4.mjs
+++ b/scripts/move-pool-v2-to-v4.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/**
+ * One-shot: move 5 SOL of V2 pool liquidity into V4.
+ *
+ * Operator-authorized 2026-06-15. V2 has low usage; V4 needs more.
+ *
+ * HYBRID PATH — chosen automatically based on pool reconciliation:
+ *
+ *   1. admin_withdraw the un-accounted vault drift first
+ *      (vault_balance - (totalDeposits - totalBorrowed)).
+ *      This recovers any SOL that landed in the vault outside the
+ *      share-based deposit flow (fees/tips/etc.) without touching
+ *      pool accounting. Single tx, no overflow risk.
+ *
+ *   2. Regular share-based withdraw for the remainder, looped in
+ *      small chunks to dodge the program's u64-overflow bug on
+ *      `shares * total_deposits / total_shares`. Each chunk
+ *      properly decrements pool.totalDeposits + pool.totalShares,
+ *      so V2's pool ledger and vault stay in sync.
+ *
+ *   3. Deposit the full 5 SOL into V4 in a single tx. V4's deposit
+ *      ix does the inverse math cleanly (no overflow on the deposit
+ *      side because deposit_amount * total_shares stays bounded).
+ *
+ * Safety rails:
+ *   - Pool PDAs are re-derived from the lender pubkey and asserted
+ *     to match the operator-stated addresses. Any drift fails closed.
+ *   - Pre-flight checks lender has at least 1 SOL for tx fees +
+ *     V2 vault has ≥ amount.
+ *   - --dry-run prints the plan without sending anything.
+ *   - Idempotent: if the run is interrupted mid-loop, re-running
+ *     resumes from the lender's current wSOL ATA balance toward the
+ *     5 SOL target. Each loop iteration is independent.
+ *
+ * Usage:
+ *   railway run --service magpie-bot -- node scripts/move-pool-v2-to-v4.mjs [--dry-run] [--amount-sol 5] [--chunk-sol 0.1]
+ */
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  SystemProgram,
+  sendAndConfirmTransaction,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID,
+  NATIVE_MINT,
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createCloseAccountInstruction,
+  createSyncNativeInstruction,
+} from "@solana/spl-token";
+import pkg from "@coral-xyz/anchor";
+const { AnchorProvider, Program, Wallet, BN } = pkg;
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import bs58 from "bs58";
+import "dotenv/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const idlV4 = JSON.parse(readFileSync(path.join(__dirname, "..", "src", "solana", "idl", "magpie-v4.json"), "utf8"));
+const idlV2 = JSON.parse(readFileSync(path.join(__dirname, "..", "src", "solana", "idl", "magpie_lending_v2.json"), "utf8"));
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = { dryRun: false, amountSol: 15, chunkSol: 0.1 };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--dry-run") out.dryRun = true;
+    if (args[i] === "--amount-sol") out.amountSol = Number(args[++i]);
+    if (args[i] === "--chunk-sol") out.chunkSol = Number(args[++i]);
+  }
+  return out;
+}
+
+function loadLender() {
+  const b58 = process.env.LENDER_PRIVATE_KEY;
+  if (b58) return Keypair.fromSecretKey(bs58.decode(b58));
+  const kpPath = process.env.LENDER_KEYPAIR_PATH;
+  if (!kpPath) throw new Error("LENDER_PRIVATE_KEY or LENDER_KEYPAIR_PATH required");
+  return Keypair.fromSecretKey(new Uint8Array(JSON.parse(readFileSync(kpPath, "utf8"))));
+}
+
+async function main() {
+  const { dryRun, amountSol, chunkSol } = parseArgs();
+  if (!Number.isFinite(amountSol) || amountSol <= 0) {
+    console.error("--amount-sol must be a positive number");
+    process.exit(1);
+  }
+  const amountLamports = BigInt(Math.round(amountSol * LAMPORTS_PER_SOL));
+  const chunkLamports = BigInt(Math.round(chunkSol * LAMPORTS_PER_SOL));
+
+  const lender = loadLender();
+  const connection = new Connection(process.env.SOLANA_RPC_URL, "confirmed");
+  const provider = new AnchorProvider(connection, new Wallet(lender), { commitment: "confirmed" });
+
+  const PROGRAM_V4 = new PublicKey(process.env.PROGRAM_ID_V4);
+  const PROGRAM_V2 = new PublicKey(process.env.PROGRAM_ID_V2);
+  const programV4 = new Program(idlV4, provider);
+  const programV2 = new Program(idlV2, provider);
+
+  function poolPda(programId) {
+    return PublicKey.findProgramAddressSync([Buffer.from("pool"), lender.publicKey.toBuffer()], programId)[0];
+  }
+  function vaultPda(pool, programId) {
+    return PublicKey.findProgramAddressSync([Buffer.from("loan-token-vault"), pool.toBuffer()], programId)[0];
+  }
+  function positionPda(pool, owner, programId) {
+    return PublicKey.findProgramAddressSync([Buffer.from("position"), pool.toBuffer(), owner.toBuffer()], programId)[0];
+  }
+
+  const v4Pool = poolPda(PROGRAM_V4);
+  const v2Pool = poolPda(PROGRAM_V2);
+  const v4Vault = vaultPda(v4Pool, PROGRAM_V4);
+  const v2Vault = vaultPda(v2Pool, PROGRAM_V2);
+  const v4Pos = positionPda(v4Pool, lender.publicKey, PROGRAM_V4);
+  const v2Pos = positionPda(v2Pool, lender.publicKey, PROGRAM_V2);
+
+  // Safety: assert derived pools match operator-stated addresses
+  const STATED_V4 = process.env.V4_POOL_STATED || "REPLACE_WITH_V4_POOL_PUBKEY";
+  const STATED_V2 = "3o8QBx6fH9cGZWgZ3Ng6GAseSehEqakvgna9squxaJVP";
+  if (v4Pool.toBase58() !== STATED_V4 || v2Pool.toBase58() !== STATED_V2) {
+    console.error("SAFETY ABORT: PDA mismatch with operator-stated pools");
+    process.exit(1);
+  }
+
+  // Read V2 pool state
+  const v2PoolState = await programV2.account.lendingPool.fetch(v2Pool);
+  const v2VaultBal = await connection.getTokenAccountBalance(v2Vault);
+  const v2VaultLamports = BigInt(v2VaultBal.value.amount);
+  const totalDeposits = BigInt(v2PoolState.totalDeposits.toString());
+  const totalBorrowed = BigInt(v2PoolState.totalBorrowed.toString());
+  const totalShares = BigInt(v2PoolState.totalShares.toString());
+  const expectedIdle = totalDeposits - totalBorrowed;
+  const driftLamports = v2VaultLamports > expectedIdle ? v2VaultLamports - expectedIdle : 0n;
+
+  // Read V2 lender position
+  const v2PosAcc = await connection.getAccountInfo(v2Pos);
+  if (!v2PosAcc) {
+    console.error("SAFETY ABORT: lender has no V2 position account");
+    process.exit(1);
+  }
+  const lenderShares = v2PosAcc.data.readBigUInt64LE(8 + 32 + 32);
+
+  console.log(`Lender:        ${lender.publicKey.toBase58()}`);
+  console.log(`V4 pool:       ${v4Pool.toBase58()}`);
+  console.log(`V2 pool:       ${v2Pool.toBase58()}`);
+  console.log(`V2 totalDeposits   : ${(Number(totalDeposits) / 1e9).toFixed(4)} SOL`);
+  console.log(`V2 totalBorrowed   : ${(Number(totalBorrowed) / 1e9).toFixed(4)} SOL`);
+  console.log(`V2 expected idle   : ${(Number(expectedIdle) / 1e9).toFixed(4)} SOL`);
+  console.log(`V2 actual vault    : ${(Number(v2VaultLamports) / 1e9).toFixed(4)} SOL`);
+  console.log(`V2 drift (un-acct) : ${(Number(driftLamports) / 1e9).toFixed(4)} SOL`);
+  console.log(`V2 lender shares   : ${lenderShares.toString()} (${((Number(lenderShares) / Number(totalShares)) * 100).toFixed(2)}% of total)`);
+  console.log(`Lender SOL balance : ${((await connection.getBalance(lender.publicKey)) / LAMPORTS_PER_SOL).toFixed(4)} SOL`);
+  console.log(``);
+  console.log(`Plan: admin_withdraw ${(Number(driftLamports) / 1e9).toFixed(4)} SOL drift + share-withdraw ${((Number(amountLamports - driftLamports)) / 1e9).toFixed(4)} SOL in ${Math.ceil(Number(amountLamports - driftLamports) / Number(chunkLamports))} chunks of ${chunkSol} SOL`);
+
+  if (amountLamports > v2VaultLamports) {
+    console.error(`SAFETY ABORT: V2 vault has ${(Number(v2VaultLamports) / 1e9).toFixed(4)} SOL — less than requested ${amountSol} SOL`);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log("\nDRY RUN — no transactions sent.");
+    process.exit(0);
+  }
+
+  const lenderWsolAta = getAssociatedTokenAddressSync(NATIVE_MINT, lender.publicKey, false, TOKEN_PROGRAM_ID);
+
+  // ── Step 1: admin_withdraw the drift portion ──
+  let withdrawnSoFar = 0n;
+  if (driftLamports > 0n) {
+    console.log(`\n[Step 1] admin_withdraw ${(Number(driftLamports) / 1e9).toFixed(4)} SOL (un-accounted drift)…`);
+    const tx = new Transaction();
+    tx.add(createAssociatedTokenAccountIdempotentInstruction(
+      lender.publicKey, lenderWsolAta, lender.publicKey, NATIVE_MINT, TOKEN_PROGRAM_ID,
+    ));
+    const ix = await programV2.methods
+      .adminWithdraw(new BN(driftLamports.toString()))
+      .accounts({
+        pool: v2Pool,
+        loanTokenVault: v2Vault,
+        authorityTokenAccount: lenderWsolAta,
+        authority: lender.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .instruction();
+    tx.add(ix);
+    const sig = await sendAndConfirmTransaction(connection, tx, [lender], { commitment: "confirmed" });
+    console.log(`  OK: ${sig}`);
+    withdrawnSoFar += driftLamports;
+  } else {
+    console.log("\n[Step 1] No un-accounted drift — skipping admin_withdraw.");
+  }
+
+  // ── Step 2: share-based withdraw loop for the remainder ──
+  const remainder = amountLamports - withdrawnSoFar;
+  if (remainder > 0n) {
+    console.log(`\n[Step 2] share-based withdraw loop — ${(Number(remainder) / 1e9).toFixed(4)} SOL in chunks of ${chunkSol} SOL…`);
+    let chunkNum = 0;
+    while (withdrawnSoFar < amountLamports) {
+      const left = amountLamports - withdrawnSoFar;
+      const thisChunk = left < chunkLamports ? left : chunkLamports;
+
+      // Compute shares for thisChunk by reading fresh pool state each iteration.
+      // shares = thisChunk * total_shares / (total_deposits - total_borrowed_relevant)
+      // Actually per program: withdraw_amount = shares * total_deposits / total_shares
+      //   → shares = withdraw_amount * total_shares / total_deposits
+      const freshPool = await programV2.account.lendingPool.fetch(v2Pool);
+      const td = BigInt(freshPool.totalDeposits.toString());
+      const ts = BigInt(freshPool.totalShares.toString());
+      if (td === 0n || ts === 0n) {
+        console.error(`  Stop: pool deposits or shares hit 0`);
+        break;
+      }
+      // Ceil-divide so we don't under-withdraw by 1 lamport
+      const sharesForChunk = (thisChunk * ts + td - 1n) / td;
+      chunkNum++;
+      const tx = new Transaction();
+      const ix = await programV2.methods
+        .withdraw(new BN(sharesForChunk.toString()))
+        .accounts({
+          pool: v2Pool,
+          loanTokenVault: v2Vault,
+          position: v2Pos,
+          depositorTokenAccount: lenderWsolAta,
+          depositor: lender.publicKey,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .instruction();
+      tx.add(ix);
+      try {
+        const sig = await sendAndConfirmTransaction(connection, tx, [lender], { commitment: "confirmed" });
+        withdrawnSoFar += thisChunk;
+        if (chunkNum % 25 === 0 || withdrawnSoFar >= amountLamports) {
+          console.log(`  chunk ${chunkNum}: +${(Number(thisChunk) / 1e9).toFixed(4)} SOL  total=${(Number(withdrawnSoFar) / 1e9).toFixed(4)}/${amountSol} SOL  sig=${sig.slice(0, 16)}…`);
+        }
+      } catch (err) {
+        console.error(`  chunk ${chunkNum} failed: ${err.message?.slice(0, 200)} — will retry next iteration`);
+        // Re-read pool state next iteration; don't increment withdrawnSoFar
+        await new Promise((r) => setTimeout(r, 1500));
+      }
+    }
+  }
+
+  // ── Step 3: unwrap + deposit into V4 ──
+  console.log(`\n[Step 3] Unwrap wSOL ATA → native SOL, then V4 deposit ${amountSol} SOL…`);
+
+  // Unwrap (close the wSOL ATA — the underlying SOL lands back in lender)
+  const tx2 = new Transaction().add(
+    createCloseAccountInstruction(lenderWsolAta, lender.publicKey, lender.publicKey, [], TOKEN_PROGRAM_ID),
+  );
+  const sig2 = await sendAndConfirmTransaction(connection, tx2, [lender], { commitment: "confirmed" });
+  console.log(`  unwrap OK: ${sig2}`);
+
+  const lenderBalAfterWithdraw = await connection.getBalance(lender.publicKey);
+  console.log(`  Lender SOL after withdraw + unwrap: ${(lenderBalAfterWithdraw / LAMPORTS_PER_SOL).toFixed(4)} SOL`);
+
+  // Re-wrap exactly amountLamports + deposit into V4
+  const tx3 = new Transaction();
+  tx3.add(createAssociatedTokenAccountIdempotentInstruction(
+    lender.publicKey, lenderWsolAta, lender.publicKey, NATIVE_MINT, TOKEN_PROGRAM_ID,
+  ));
+  tx3.add(SystemProgram.transfer({
+    fromPubkey: lender.publicKey,
+    toPubkey: lenderWsolAta,
+    lamports: Number(amountLamports),
+  }));
+  tx3.add(createSyncNativeInstruction(lenderWsolAta, TOKEN_PROGRAM_ID));
+
+  const depositIx = await programV4.methods
+    .deposit(new BN(amountLamports.toString()))
+    .accounts({
+      pool: v4Pool,
+      loanTokenVault: v4Vault,
+      position: v4Pos,
+      depositorTokenAccount: lenderWsolAta,
+      depositor: lender.publicKey,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      systemProgram: SystemProgram.programId,
+    })
+    .instruction();
+  tx3.add(depositIx);
+  tx3.add(createCloseAccountInstruction(lenderWsolAta, lender.publicKey, lender.publicKey, [], TOKEN_PROGRAM_ID));
+
+  const sig3 = await sendAndConfirmTransaction(connection, tx3, [lender], { commitment: "confirmed" });
+  console.log(`  V4 deposit OK: ${sig3}`);
+
+  // ── Final state ──
+  const lenderFinal = await connection.getBalance(lender.publicKey);
+  const v4VaultFinal = await connection.getTokenAccountBalance(v4Vault);
+  const v2VaultFinal = await connection.getTokenAccountBalance(v2Vault);
+  const v2PoolFinal = await programV2.account.lendingPool.fetch(v2Pool);
+  const v4PoolFinal = await programV4.account.lendingPool.fetch(v4Pool);
+  console.log("");
+  console.log("FINAL STATE");
+  console.log(`  Lender SOL          : ${(lenderFinal / LAMPORTS_PER_SOL).toFixed(4)} SOL`);
+  console.log(`  V4 vault            : ${v4VaultFinal.value.uiAmountString} wSOL`);
+  console.log(`  V2 vault            : ${v2VaultFinal.value.uiAmountString} wSOL`);
+  console.log(`  V4 totalDeposits    : ${(Number(v4PoolFinal.totalDeposits) / 1e9).toFixed(4)} SOL`);
+  console.log(`  V2 totalDeposits    : ${(Number(v2PoolFinal.totalDeposits) / 1e9).toFixed(4)} SOL`);
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Two deploy-prep artifacts: DB migration that adds the three V4 loan columns (current_collateral_amount, sol_proceeds_amount, auto_sells_fired) and the operator-authorized V2→V4 5 SOL move-pool script. Both are dormant until V4 actually deploys.

Robot: Claude Code