### PR TITLE
V4 devnet prep — real IDL + init-pool script

### DIFF
--- a/scripts/init-pool-v4.js
+++ b/scripts/init-pool-v4.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Initialize the v4 lending pool on the target cluster.
+ *
+ * v4 is the in-vault-auto-sell parallel program. Same pool PDA seeds
+ * as v1/v2/v3 (`b"pool" + authority`) but derived under the v4 program
+ * ID, so it gets its own pool account. v1/v2/v3 are untouched.
+ *
+ * Same protocol-fee + keeper-reward parameters as v1/v2/v3 for economic
+ * consistency. Idempotent — re-running after a successful init logs
+ * the existing pool and exits.
+ *
+ * Usage:
+ *   node scripts/init-pool-v4.js <PROGRAM_ID_V4>     # explicit
+ *   PROGRAM_ID_V4=<...> node scripts/init-pool-v4.js # env-driven
+ *
+ * Environment:
+ *   SOLANA_RPC_URL          target cluster (default: mainnet-beta)
+ *   LENDER_KEYPAIR_PATH     path to authority keypair (default ./lender-keypair.json)
+ *   LENDER_PRIVATE_KEY      bs58 private key (overrides LENDER_KEYPAIR_PATH)
+ *
+ * For devnet smoke test:
+ *   SOLANA_RPC_URL=https://api.devnet.solana.com \
+ *   LENDER_KEYPAIR_PATH=~/.config/solana/backups/magpie-devnet-deployer-20260605.json \
+ *   PROGRAM_ID_V4=BGBj6eiY6UszMmmwJiC6tVH13pnfbqxijstHDQgbxJNi \
+ *   node scripts/init-pool-v4.js
+ */
+import "dotenv/config";
+import { readFileSync, existsSync } from "node:fs";
+import {
+  Connection,
+  PublicKey,
+  Keypair,
+  SystemProgram,
+  SYSVAR_RENT_PUBKEY,
+  ComputeBudgetProgram,
+} from "@solana/web3.js";
+import { NATIVE_MINT, TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import bs58 from "bs58";
+import anchor from "@coral-xyz/anchor";
+const { AnchorProvider, Program, Wallet } = anchor;
+
+const V4_PROGRAM_ID_STR = process.argv[2] || process.env.PROGRAM_ID_V4;
+if (!V4_PROGRAM_ID_STR) {
+  console.error("Usage: node scripts/init-pool-v4.js <PROGRAM_ID_V4>");
+  console.error("       OR set PROGRAM_ID_V4 env var");
+  process.exit(1);
+}
+const V4_PROGRAM_ID = new PublicKey(V4_PROGRAM_ID_STR);
+
+const IDL_PATH = "./src/solana/idl/magpie-v4.json";
+if (!existsSync(IDL_PATH)) {
+  console.error(`Missing ${IDL_PATH} — generate it from the v4 anchor build first.`);
+  process.exit(1);
+}
+
+const RPC = process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com";
+
+function loadLender() {
+  const b58 = process.env.LENDER_PRIVATE_KEY;
+  if (b58) {
+    const decode = bs58.decode || (bs58.default && bs58.default.decode);
+    return Keypair.fromSecretKey(decode(b58));
+  }
+  const rawPath = process.env.LENDER_KEYPAIR_PATH || "./lender-keypair.json";
+  const path = rawPath.startsWith("~/")
+    ? rawPath.replace(/^~/, process.env.HOME ?? "")
+    : rawPath;
+  return Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(path, "utf8"))),
+  );
+}
+
+const lender = loadLender();
+console.log(`Lender:     ${lender.publicKey.toBase58()}`);
+console.log(`RPC:        ${RPC}`);
+console.log(`v4 program: ${V4_PROGRAM_ID.toBase58()}`);
+
+const connection = new Connection(RPC, "confirmed");
+const idl = JSON.parse(readFileSync(IDL_PATH, "utf8"));
+// Anchor 0.30+ Program constructor reads address from idl.address; we
+// also pin it explicitly so a stale/placeholder address in the IDL can't
+// cause a silent wrong-program dispatch.
+idl.address = V4_PROGRAM_ID.toBase58();
+const provider = new AnchorProvider(connection, new Wallet(lender), { commitment: "confirmed" });
+const program = new Program(idl, provider);
+
+const [poolPda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("pool"), lender.publicKey.toBuffer()],
+  V4_PROGRAM_ID,
+);
+const [loanTokenVaultPda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("loan-token-vault"), poolPda.toBuffer()],
+  V4_PROGRAM_ID,
+);
+
+console.log(`\nv4 pool PDA:             ${poolPda.toBase58()}`);
+console.log(`v4 loan token vault PDA: ${loanTokenVaultPda.toBase58()}`);
+
+const existing = await connection.getAccountInfo(poolPda);
+if (existing) {
+  console.log(`\nv4 pool already initialized (size ${existing.data.length}b). Nothing to do.`);
+  process.exit(0);
+}
+
+const protocolFeeBps = 2000; // 20% — matches v1/v2/v3
+const keeperRewardBps = 500; // 5%  — matches v1/v2/v3
+console.log(`\nInitializing v4 pool with protocol_fee=${protocolFeeBps}bps, keeper_reward=${keeperRewardBps}bps...`);
+
+try {
+  const sig = await program.methods
+    .initializePool(protocolFeeBps, keeperRewardBps)
+    .accounts({
+      pool: poolPda,
+      loanTokenVault: loanTokenVaultPda,
+      loanTokenMint: NATIVE_MINT,
+      authority: lender.publicKey,
+      systemProgram: SystemProgram.programId,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      rent: SYSVAR_RENT_PUBKEY,
+    })
+    .preInstructions([
+      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }),
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }),
+    ])
+    .rpc({ commitment: "confirmed" });
+
+  console.log(`\nv4 pool initialized`);
+  console.log(`  tx: ${sig}`);
+  console.log(`  pool: ${poolPda.toBase58()}`);
+  console.log(`  loan_token_vault: ${loanTokenVaultPda.toBase58()}`);
+  console.log(`\nNext steps:`);
+  console.log(`  1. Set PROGRAM_ID_V4=${V4_PROGRAM_ID.toBase58()} on Railway`);
+  console.log(`  2. Set ENGINE_AUTHORITY_V4 in engine env (must match on-chain ENGINE_AUTHORITY)`);
+  console.log(`  3. Restart the bot — preflight registers v4`);
+  console.log(`  4. Fund the pool: run scripts/move-pool-v2-to-v4.mjs once you're ready`);
+  console.log(`  5. Flip ROUTE_MEMECOINS_TO_V4=true and ROUTE_RWA_TO_V4=true after operator canary`);
+} catch (e) {
+  console.error(`\nPool init failed: ${e.message}`);
+  if (e.logs) {
+    console.error("Logs (last 10):");
+    for (const l of e.logs.slice(-10)) console.error("  " + l);
+  }
+  process.exit(1);
+}

--- a/src/solana/idl/magpie-v4.json
+++ b/src/solana/idl/magpie-v4.json
@@ -1,10 +1,10 @@
 {
-  "address": "B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP",
+  "address": "BGBj6eiY6UszMmmwJiC6tVH13pnfbqxijstHDQgbxJNi",
   "metadata": {
     "name": "magpie_lending",
     "version": "0.1.0",
     "spec": "0.1.0",
-    "description": "Magpie lending v3 — on-chain TWAP variant. Stores rolling price samples in a ring buffer per mint and validates borrow LTV against the time-weighted average instead of single-spot. Defeats pump-and-borrow oracle manipulation. v1/v2 programs continue serving existing loans untouched; v3 is a parallel deploy."
+    "description": "Magpie lending v4 — adds in-vault auto-sell conversion."
   },
   "instructions": [
     {
@@ -179,6 +179,196 @@
         {
           "name": "amount",
           "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "convert_collateral_slice",
+      "docs": [
+        "v4 ── auto-sell a slice of SPL collateral and store the SOL in the",
+        "loan vault. The loan stays ACTIVE; principal, fee, and due_timestamp",
+        "are unchanged. Only the engine authority can call this. Pattern B",
+        "CPI: the caller provides the swap program + accounts in",
+        "`remaining_accounts` and the swap-instruction data via `swap_ix_data`;",
+        "this function invokes the swap and validates the SOL came back ≥",
+        "min_sol_out. Aggregator-agnostic.",
+        "",
+        "State changes (atomic — all or none):",
+        "loan.current_collateral_amount -= slice_amount",
+        "loan.sol_proceeds_amount       += sol_received - protocol_fee",
+        "loan.auto_sells_fired          += 1",
+        "",
+        "The 1% protocol fee is skimmed in-program and sent to the fee",
+        "wallet (same wSOL ATA the borrow-side fee flows to). The slice",
+        "is expressed in basis points of the ORIGINAL collateral amount,",
+        "not the remaining — so \"70% / 20% / 10%\" ladders compose",
+        "arithmetically without per-leg drift.",
+        "",
+        "Safety guarantees:",
+        "- Only ENGINE_AUTHORITY may sign (constraint on ConvertCollateralSlice)",
+        "- slice_bps clamped to (0, 10_000]",
+        "- slice_amount clamped to remaining collateral",
+        "- SOL deposit verified against vault delta (not trusting the swap)",
+        "- min_sol_out enforced after the swap (slippage cap)",
+        "- Fee skim arithmetic uses u128 intermediate (no overflow)"
+      ],
+      "discriminator": [
+        253,
+        2,
+        10,
+        59,
+        245,
+        38,
+        24,
+        72
+      ],
+      "accounts": [
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint (for transfer_checked decimals + Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "docs": [
+            "SPL collateral vault — source of the slice being sold."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_proceeds_vault",
+          "docs": [
+            "wSOL vault — destination for swap proceeds. Initialized lazily so",
+            "loans that never auto-sell don't pay the rent overhead. Authority",
+            "is the collateral_vault PDA (program-signed via vault_seeds).",
+            "The mint MUST be native wSOL — checked by the constraint."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  45,
+                  112,
+                  114,
+                  111,
+                  99,
+                  101,
+                  101,
+                  100,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "engine_collateral_account",
+          "docs": [
+            "Engine's SPL ATA — receives the slice that the swap will then",
+            "consume. Owner must be the engine signer. Mint must match the",
+            "loan's collateral mint."
+          ],
+          "writable": true
+        },
+        {
+          "name": "fee_wallet",
+          "docs": [
+            "Fee wallet (same wSOL ATA the borrow-side fee flows to)."
+          ],
+          "writable": true
+        },
+        {
+          "name": "wsol_mint",
+          "docs": [
+            "wSOL mint (canonical pubkey So11111...). Used to gate the",
+            "sol_proceeds_vault init."
+          ]
+        },
+        {
+          "name": "engine",
+          "docs": [
+            "Engine authority — the ONLY pubkey allowed to call this.",
+            "Constraint compares against the hardcoded ENGINE_AUTHORITY",
+            "constant; this is the least-privilege seam."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "APT56uQDXvCXHH1khb6PqiYg5sydBnkX1bVPwx5vfYif"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "slice_bps",
+          "type": "u16"
+        },
+        {
+          "name": "min_sol_out",
+          "type": "u64"
+        },
+        {
+          "name": "swap_ix_data",
+          "type": "bytes"
         }
       ]
     },
@@ -637,6 +827,55 @@
           "writable": true
         },
         {
+          "name": "sol_proceeds_vault",
+          "docs": [
+            "v4 — sol_proceeds_vault holding accumulated SOL from auto-sells.",
+            "Same seeds + authority pattern as the SPL collateral vault.",
+            "Always passed in even if no auto-sells fired (zero-balance is fine);",
+            "keeps account ordering stable."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  45,
+                  112,
+                  114,
+                  111,
+                  99,
+                  101,
+                  101,
+                  100,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "keeper_loan_token_account",
+          "docs": [
+            "v4 — keeper's wSOL ATA for the SOL-pot bounty."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority_loan_token_account",
+          "docs": [
+            "v4 — authority's wSOL ATA for the SOL-pot residual."
+          ],
+          "writable": true
+        },
+        {
           "name": "keeper",
           "docs": [
             "The keeper (liquidator) — permissionless, any wallet can sign"
@@ -646,6 +885,10 @@
         },
         {
           "name": "token_program"
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -851,6 +1094,42 @@
           "relations": [
             "loan"
           ]
+        },
+        {
+          "name": "sol_proceeds_vault",
+          "docs": [
+            "v4 — wSOL vault where auto-sell proceeds accumulate. Initialized",
+            "lazily on first convert_collateral_slice; here in repay it gets",
+            "drained back to the borrower along with any remaining SPL.",
+            "Authority = collateral_vault PDA (same seeds as the SPL vault),",
+            "so the program can sign for withdrawals using vault_seeds."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  45,
+                  112,
+                  114,
+                  111,
+                  99,
+                  101,
+                  101,
+                  100,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
         },
         {
           "name": "token_program"
@@ -1406,6 +1685,19 @@
       ]
     },
     {
+      "name": "CollateralConverted",
+      "discriminator": [
+        31,
+        54,
+        10,
+        182,
+        111,
+        73,
+        67,
+        210
+      ]
+    },
+    {
       "name": "Deposited",
       "discriminator": [
         111,
@@ -1641,6 +1933,36 @@
       "code": 6020,
       "name": "AdminWithdrawWouldDrainLpFunds",
       "msg": "admin_withdraw refused: would drain share-backed LP deposits. Only excess (vault_balance - total_deposits) is admin-withdrawable."
+    },
+    {
+      "code": 6021,
+      "name": "InvalidSlice",
+      "msg": "slice_bps must be in (0, 10000]."
+    },
+    {
+      "code": 6022,
+      "name": "SliceTooSmall",
+      "msg": "Computed slice amount is zero — collateral too small for this slice_bps."
+    },
+    {
+      "code": 6023,
+      "name": "SliceExceedsRemaining",
+      "msg": "Slice exceeds remaining collateral. Some auto-sells already fired and reduced the pool."
+    },
+    {
+      "code": 6024,
+      "name": "SlippageExceeded",
+      "msg": "Swap returned less than min_sol_out. Slippage exceeded the cap you specified."
+    },
+    {
+      "code": 6025,
+      "name": "SwapMissing",
+      "msg": "convert_collateral_slice requires a swap program + accounts in remaining_accounts. Engine must pre-assemble the swap."
+    },
+    {
+      "code": 6026,
+      "name": "EngineUnauthorized",
+      "msg": "Only the designated engine authority can call convert_collateral_slice. Refusing."
     }
   ],
   "types": [
@@ -1660,6 +1982,55 @@
           {
             "name": "new_total",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollateralConverted",
+      "docs": [
+        "v4 — Emitted on every convert_collateral_slice call. Captures both",
+        "the gross (pre-fee) and net (post-fee) so off-chain accounting can",
+        "reconcile fee accrual without re-querying state."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "slice_bps",
+            "type": "u16"
+          },
+          {
+            "name": "slice_amount_sold",
+            "type": "u64"
+          },
+          {
+            "name": "sol_received_gross",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "net_sol_to_vault",
+            "type": "u64"
+          },
+          {
+            "name": "remaining_collateral",
+            "type": "u64"
+          },
+          {
+            "name": "total_sol_proceeds",
+            "type": "u64"
+          },
+          {
+            "name": "auto_sells_fired",
+            "type": "u8"
           }
         ]
       }
@@ -1979,6 +2350,36 @@
               "Loan category (0 = memecoin, 1 = RWA). Used by extend_loan to",
               "pick the right tier ladder without a round-trip to off-chain",
               "metadata."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "current_collateral_amount",
+            "docs": [
+              "SPL collateral remaining in the vault. Equals collateral_amount",
+              "at borrow time, decreases as convert_collateral_slice fires.",
+              "Reaches 0 when the position is fully auto-sold. At repay /",
+              "liquidation time, whatever is here gets returned to the borrower",
+              "(alongside sol_proceeds_amount)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sol_proceeds_amount",
+            "docs": [
+              "SOL accumulated from auto-sells (in lamports, net of the 1%",
+              "protocol fee). Sits in a vault-owned wSOL token account whose",
+              "authority is the loan's collateral_vault PDA, so the engine",
+              "can credit it on conversions but only the borrower can claim it",
+              "(via repay) or the keeper can claim it (via liquidate)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auto_sells_fired",
+            "docs": [
+              "Number of times convert_collateral_slice has fired against this",
+              "loan. Diagnostics only — no contract invariant depends on it."
             ],
             "type": "u8"
           }


### PR DESCRIPTION
## Summary
- Replaces placeholder V4 IDL (was a V3 copy) with real one from anchor idl build
- IDL now exposes V4's convert_collateral_slice + extended Loan struct (current_collateral_amount, sol_proceeds_amount, auto_sells_fired)
- Adds scripts/init-pool-v4.js — same fee params as V1/V2/V3 (protocol_fee=2000bps, keeper_reward=500bps)

## Devnet deploy status
Program builds clean (579KB .so), keypairs generated, declare_id + ENGINE_AUTHORITY swapped to real devnet pubkeys. Deploy itself blocked on public-faucet airdrop rate limit (deployer at 2 SOL, needs ~4.04 SOL). When SOL lands, deploy + init runs end-to-end with this script.

## Devnet pubkeys
- Program: BGBj6eiY6UszMmmwJiC6tVH13pnfbqxijstHDQgbxJNi
- Engine authority: APT56uQDXvCXHH1khb6PqiYg5sydBnkX1bVPwx5vfYif
- Deployer: 3h2pW9pXTcdj8bfqKFa6WyuTMxgRUJXzH9hwmcSA4KMq

## Test plan
- [ ] Devnet deploy lands (pending SOL)
- [ ] init-pool-v4.js initializes the pool PDA
- [ ] Bot's getV4Idl() loads the new IDL without parse error