### PR TITLE
URGENT: strip Write-tool artifact tail from migration 066

### DIFF
--- a/migrations/066_v4_loan_columns.sql
+++ b/migrations/066_v4_loan_columns.sql
@@ -53,5 +53,3 @@ UPDATE loans
 CREATE INDEX IF NOT EXISTS loans_auto_sells_fired_idx
   ON loans (auto_sells_fired)
   WHERE auto_sells_fired > 0;
-</content>
-</invoke>


### PR DESCRIPTION
## URGENT

Bot is running in **DEGRADED mode** — self-monitor is paging:
\`[migrations] FAILED 066_v4_loan_columns.sql: syntax error at or near "</"\`

Migration file ended with stray \`</content></invoke>\` Write-tool artifact. Truncated at last real SQL line.

## Deploy path
1. **Merge this PR**
2. **Redeploy bot on Railway** — preflight re-runs mig 066, succeeds, marks it applied in schema_migrations
3. Bot exits DEGRADED, self-monitor resets bad-tick counter

## Same artifact class as
2026-06-13 outage. Hardening to follow.