### PR TITLE
V4 Wave 1 bot — priceFeedPda V4 branch + attestor V4 routing + keeper V4 accounts

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -754,14 +754,21 @@ export async function handleCosignBorrow(req) {
         const { attestPrice, initializePriceFeed, getPriceFeedAgeSeconds } =
           await import("../services/price-attestor.js");
         const FRESH_THRESHOLD_SEC = 60;
-        const age = await getPriceFeedAgeSeconds(mintStr);
+        // V4-aware JIT attestation (2026-06-15): use the borrow tx's
+        // own programId so V4 borrows attest V4's PriceHistory PDA
+        // (not the category-default V1/V3). Without this, V4 borrows
+        // surface as "Account state mismatch" because V4's price_feed
+        // PDA was never initialized — bot's category routing never
+        // reaches V4.
+        const borrowProgramId = magpieIxForAttest.programId;
+        const age = await getPriceFeedAgeSeconds(mintStr, borrowProgramId);
         if (age === null || age > FRESH_THRESHOLD_SEC) {
           try {
-            await attestPrice(mintStr, Number(mintRow.decimals));
+            await attestPrice(mintStr, Number(mintRow.decimals), undefined, borrowProgramId);
           } catch (attestErr) {
             if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(attestErr.message)) {
-              await initializePriceFeed(mintStr);
-              await attestPrice(mintStr, Number(mintRow.decimals));
+              await initializePriceFeed(mintStr, borrowProgramId);
+              await attestPrice(mintStr, Number(mintRow.decimals), undefined, borrowProgramId);
             } else {
               throw attestErr;
             }

--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -813,18 +813,30 @@ export function registerBorrowCallbacks(bot) {
     // actually stale. Contract requires <120s; we use a 60s threshold to
     // leave headroom for the borrow tx to land before the contract clock
     // rejects it. Most repeat-borrows skip the attestation entirely.
+    //
+    // V4-aware (2026-06-15): exit-armed borrows land on V4 (regardless
+    // of category), so attest V4's PriceHistory PDA when the wizard
+    // selected any exit. Otherwise attest the category default (V1/V3).
+    // Without this, V4 borrows surface as "Account state mismatch"
+    // because V4's price_feed PDA was never initialized.
+    const hasExitArmingForAttest = !!(state.exits && state.exits.type && state.exits.type !== "skip");
+    let attestProgramId = null;
+    if (hasExitArmingForAttest) {
+      const { PROGRAM_ID_V4 } = await import("../solana/program.js");
+      if (PROGRAM_ID_V4) attestProgramId = PROGRAM_ID_V4;
+    }
     const FRESH_THRESHOLD_SEC = 60;
-    const feedAge = await getPriceFeedAgeSeconds(state.selected.mint);
+    const feedAge = await getPriceFeedAgeSeconds(state.selected.mint, attestProgramId);
     const needsAttest = feedAge === null || feedAge > FRESH_THRESHOLD_SEC;
 
     if (needsAttest) {
       try {
-        await attestPrice(state.selected.mint, state.selected.decimals);
+        await attestPrice(state.selected.mint, state.selected.decimals, undefined, attestProgramId);
       } catch (attestErr) {
         if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(attestErr.message)) {
           try {
-            await initializePriceFeed(state.selected.mint);
-            await attestPrice(state.selected.mint, state.selected.decimals);
+            await initializePriceFeed(state.selected.mint, attestProgramId);
+            await attestPrice(state.selected.mint, state.selected.decimals, undefined, attestProgramId);
           } catch (initErr) {
             pending.delete(ctx.chat.id);
             await say(
@@ -836,7 +848,7 @@ export function registerBorrowCallbacks(bot) {
           // Solana congestion ate the attestation tx. Re-check the feed
           // age — if a previous attest got close enough to land, we may
           // already be within the contract's 120s window.
-          const recheckAge = await getPriceFeedAgeSeconds(state.selected.mint);
+          const recheckAge = await getPriceFeedAgeSeconds(state.selected.mint, attestProgramId);
           if (recheckAge !== null && recheckAge < 110) {
             // Close enough — proceed with the borrow anyway.
           } else {

--- a/src/services/keeper.js
+++ b/src/services/keeper.js
@@ -143,6 +143,49 @@ async function liquidateLoan(program, keeper, loan, pool) {
     collateralTokenProgram,
   );
 
+  // V4-aware liquidation (2026-06-15): V4's liquidate_loan needs 4
+  // extra accounts to distribute the mixed collateral (SPL + accumulated
+  // SOL in sol_proceeds_vault). Without these, every V4 overdue loan
+  // fails with AccountNotEnoughKeys and stays uncollected.
+  const isV4 = PROGRAM_ID_V4 && program.programId.equals(PROGRAM_ID_V4);
+  let v4ExtraAccounts = {};
+  let preIxs = [
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }),
+    ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+  ];
+  if (isV4) {
+    const { NATIVE_MINT } = await import("@solana/spl-token");
+    const { getAssociatedTokenAddressSync, createAssociatedTokenAccountIdempotentInstruction } =
+      await import("@solana/spl-token");
+    const [solProceedsVaultPda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("sol-proceeds"), loanPubkey.toBuffer()],
+      program.programId,
+    );
+    // wSOL ATAs for keeper + authority. SOL pot bounty goes to keeper,
+    // residual to authority.
+    const keeperWsolAta = getAssociatedTokenAddressSync(
+      NATIVE_MINT, keeper.publicKey, false, TOKEN_PROGRAM_ID,
+    );
+    const authorityWsolAta = getAssociatedTokenAddressSync(
+      NATIVE_MINT, pool.authority, false, TOKEN_PROGRAM_ID,
+    );
+    v4ExtraAccounts = {
+      solProceedsVault: solProceedsVaultPda,
+      keeperLoanTokenAccount: keeperWsolAta,
+      authorityLoanTokenAccount: authorityWsolAta,
+      loanTokenProgram: TOKEN_PROGRAM_ID,
+    };
+    // Create the wSOL ATAs idempotently — keeper pays.
+    preIxs.push(
+      createAssociatedTokenAccountIdempotentInstruction(
+        keeper.publicKey, keeperWsolAta, keeper.publicKey, NATIVE_MINT, TOKEN_PROGRAM_ID,
+      ),
+      createAssociatedTokenAccountIdempotentInstruction(
+        keeper.publicKey, authorityWsolAta, pool.authority, NATIVE_MINT, TOKEN_PROGRAM_ID,
+      ),
+    );
+  }
+
   const tx = await program.methods
     .liquidateLoan()
     .accounts({
@@ -154,11 +197,9 @@ async function liquidateLoan(program, keeper, loan, pool) {
       authorityCollateralAccount: authorityCollateralAta.address,
       keeper: keeper.publicKey,
       tokenProgram: collateralTokenProgram,
+      ...v4ExtraAccounts,
     })
-    .preInstructions([
-      ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 100_000 }),
-      ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
-    ])
+    .preInstructions(preIxs)
     .rpc({ commitment: "confirmed" });
 
   return { success: true, txSig: tx };

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -81,19 +81,20 @@ function loadLenderKeypair() {
  * on the wire — which would cause this function to declare the feed
  * "fresh" even when V3's on-chain freshness window has expired.
  */
-export async function getPriceFeedAgeSeconds(mintStr) {
+export async function getPriceFeedAgeSeconds(mintStr, programIdOverride = null) {
   try {
     const mintPk = new PublicKey(mintStr);
     const category = await resolveCategory(mintStr);
-    const programId = chooseProgramIdForCategory(category);
+    const programId = programIdOverride || chooseProgramIdForCategory(category);
     const [pool] = lendingPoolPda(LENDER_PUBKEY, programId);
     const [priceFeed] = priceFeedPda(mintPk, pool, programId);
     const info = await connection.getAccountInfo(priceFeed);
     if (!info) return null;
-    const { PROGRAM_ID_V3 } = await import("../solana/program.js");
+    const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
     const isV3 = PROGRAM_ID_V3 && programId.equals(PROGRAM_ID_V3);
+    const isV4 = PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4);
     let ts;
-    if (isV3) {
+    if (isV3 || isV4) {
       // PriceHistory layout — minimum is disc+mint+pool+authority+
       // head+count+padding = 104, plus at least one 16-byte sample.
       if (info.data.length < 120) return null;
@@ -120,10 +121,17 @@ export async function getPriceFeedAgeSeconds(mintStr) {
 /**
  * Initialize a price feed PDA for a given mint. Idempotent — returns
  * { alreadyExists: true } if the PDA is already on chain.
+ *
+ * `programIdOverride` (optional, 2026-06-15): bypass category routing
+ * and initialize a price feed against a specific program ID. Required
+ * for V4 — exit-armed borrows land on V4 regardless of category, so
+ * the V4 price_feed PDA must be initialized in PARALLEL with the
+ * category default. Without this V4 borrows fail with "Account state
+ * mismatch" at on-chain price validation.
  */
-export async function initializePriceFeed(mintStr) {
+export async function initializePriceFeed(mintStr, programIdOverride = null) {
   const category = await resolveCategory(mintStr);
-  const programId = chooseProgramIdForCategory(category);
+  const programId = programIdOverride || chooseProgramIdForCategory(category);
   const lender = loadLenderKeypair();
   const program = getProgramForSigner(lender, programId);
   const mintPk = new PublicKey(mintStr);
@@ -155,10 +163,14 @@ export async function initializePriceFeed(mintStr) {
  * If `priceSolOverride` is provided, uses it; otherwise fetches from Jupiter.
  * Callers attesting many tokens at once should batch-fetch via
  * getPricesInSolBatch and pass the per-mint price to avoid rate limits.
+ *
+ * `programIdOverride` (optional, 2026-06-15): bypass category routing
+ * and attest against a specific program. Needed for V4 — see
+ * initializePriceFeed for the rationale.
  */
-export async function attestPrice(mintStr, decimals, priceSolOverride) {
+export async function attestPrice(mintStr, decimals, priceSolOverride, programIdOverride = null) {
   const category = await resolveCategory(mintStr);
-  const programId = chooseProgramIdForCategory(category);
+  const programId = programIdOverride || chooseProgramIdForCategory(category);
   const lender = loadLenderKeypair();
   const program = getProgramForSigner(lender, programId);
   const mintPk = new PublicKey(mintStr);

--- a/src/solana/pdas.js
+++ b/src/solana/pdas.js
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
-import { PROGRAM_ID, PROGRAM_ID_V3 } from "./program.js";
+import { PROGRAM_ID, PROGRAM_ID_V3, PROGRAM_ID_V4 } from "./program.js";
 
 // All PDA derivations accept an optional `programId` so v1 and v2 callers
 // can share these functions. Defaulting to v1's PROGRAM_ID keeps every
@@ -44,8 +44,14 @@ export function priceFeedPda(mintPubkey, poolPubkey, programId = PROGRAM_ID) {
   // borrow simulation in Phantom shows StalePriceAttestation.
   // Detected 2026-06-14 when V3 RWA borrows started failing for every
   // Xs-prefixed xStocks mint immediately after V3 routing went live.
+  //
+  // V4 (2026-06-15) inherits the "price_v3" seed name — same TWAP
+  // PriceHistory layout, just a different program ID. Falling through
+  // to the "price" default surfaces as "Account state mismatch" on
+  // every V4 borrow (same audit bug class as the V3 launch day).
   const isV3 = PROGRAM_ID_V3 && programId.equals(PROGRAM_ID_V3);
-  const seedPrefix = isV3 ? "price_v3" : "price";
+  const isV4 = PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4);
+  const seedPrefix = (isV3 || isV4) ? "price_v3" : "price";
   return PublicKey.findProgramAddressSync(
     [Buffer.from(seedPrefix), mintPubkey.toBuffer(), poolPubkey.toBuffer()],
     programId,


### PR DESCRIPTION
## Wave 1 hard blockers
- priceFeedPda V4 branch (was misrouting V4 borrows to wrong PDA - cause of 'Account state mismatch' the operator saw on TG)
- price-attestor: programIdOverride param so V4 borrows attest V4's PriceHistory
- cosign-borrow JIT: uses borrow tx programId so V4 borrows attest V4
- TG /borrow JIT: targets V4 attestor when state.exits is set
- keeper liquidateLoan: V4 needs 4 extra accounts (sol_proceeds_vault, keeper wSOL ATA, authority wSOL ATA, loan_token_program)

V1/V2/V3 paths unchanged - V4 routing purely additive.