### PR TITLE
V4 Wave 5 C1+C4 bot — IDL + repay + liquidate accounts

### DIFF
--- a/src/services/keeper.js
+++ b/src/services/keeper.js
@@ -20,6 +20,8 @@ import {
   Keypair,
   Transaction,
   ComputeBudgetProgram,
+  SystemProgram,
+  SYSVAR_RENT_PUBKEY,
 } from "@solana/web3.js";
 import {
   TOKEN_PROGRAM_ID,
@@ -169,11 +171,19 @@ async function liquidateLoan(program, keeper, loan, pool) {
     const authorityWsolAta = getAssociatedTokenAddressSync(
       NATIVE_MINT, pool.authority, false, TOKEN_PROGRAM_ID,
     );
+    // V4 Wave 5 C1 (2026-06-15): liquidate_loan now also needs
+    // wsol_mint + system_program + rent because sol_proceeds_vault
+    // is `init_if_needed` (so V4 loans whose auto-sell never fired
+    // can still be liquidated — Anchor needs system_program to
+    // allocate, rent to size it).
     v4ExtraAccounts = {
       solProceedsVault: solProceedsVaultPda,
       keeperLoanTokenAccount: keeperWsolAta,
       authorityLoanTokenAccount: authorityWsolAta,
       loanTokenProgram: TOKEN_PROGRAM_ID,
+      wsolMint: NATIVE_MINT,
+      systemProgram: SystemProgram.programId,
+      rent: SYSVAR_RENT_PUBKEY,
     };
     // Create the wSOL ATAs idempotently — keeper pays.
     preIxs.push(

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -433,6 +433,26 @@ export async function executeRepay({ userId, loanDbRow }) {
     ),
   ];
 
+  // V4 Wave 5 C1 (2026-06-15): V4's repayLoan now requires the
+  // sol_proceeds_vault + wsol_mint + system_program + rent accounts so
+  // it can `init_if_needed` the vault for loans whose auto-sell never
+  // fired. Without these the V4 repay tx fails AccountNotEnoughKeys.
+  // V1/V2/V3 paths unchanged.
+  const isV4 = !!PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4);
+  let v4ExtraAccounts = {};
+  if (isV4) {
+    const [solProceedsVault] = PublicKey.findProgramAddressSync(
+      [Buffer.from("sol-proceeds"), loanPdaPk.toBuffer()],
+      programId,
+    );
+    v4ExtraAccounts = {
+      solProceedsVault,
+      wsolMint: NATIVE_MINT,
+      systemProgram: SystemProgram.programId,
+      rent: SYSVAR_RENT_PUBKEY,
+    };
+  }
+
   const sig = await program.methods
     .repayLoan()
     .accounts({
@@ -446,6 +466,7 @@ export async function executeRepay({ userId, loanDbRow }) {
       borrower: borrower.publicKey,
       tokenProgram: collateralTokenProgram,
       loanTokenProgram,
+      ...v4ExtraAccounts,
     })
     .preInstructions(preIxs)
     .postInstructions(postIxs)

--- a/src/solana/idl/magpie-v4.json
+++ b/src/solana/idl/magpie-v4.json
@@ -551,7 +551,16 @@
         },
         {
           "name": "fee_wallet_token_account",
-          "writable": true
+          "docs": [
+            "Wave 5 C4 (2026-06-15): hardcoded `address` constraint closes",
+            "the audit finding — without it a borrower extending their V4",
+            "loan could pass own wSOL ATA and keep the 1% extension fee.",
+            "Now restricted to the canonical Magpie fee wallet only.",
+            "(Wave 3 added this to RequestLoan + ConvertCollateralSlice but",
+            "MISSED ExtendLoan — caught in the post-Wave-4 final audit.)"
+          ],
+          "writable": true,
+          "address": "3wk75XDABdEEec28c9ES6KdH2V9zh8h76Q8oTitEe4TE"
         },
         {
           "name": "borrower",
@@ -836,8 +845,9 @@
           "docs": [
             "v4 — sol_proceeds_vault holding accumulated SOL from auto-sells.",
             "Same seeds + authority pattern as the SPL collateral vault.",
-            "Always passed in even if no auto-sells fired (zero-balance is fine);",
-            "keeps account ordering stable."
+            "Wave 5 C1 (2026-06-15): `init_if_needed` so V4 loans whose",
+            "auto-sell never fired can still be liquidated. Keeper pays the",
+            "small ATA rent (~0.002 SOL); recovered on the close path."
           ],
           "writable": true,
           "pda": {
@@ -889,11 +899,28 @@
           "signer": true
         },
         {
+          "name": "wsol_mint",
+          "docs": [
+            "wSOL mint — needed by the `init_if_needed` on sol_proceeds_vault."
+          ]
+        },
+        {
           "name": "token_program"
         },
         {
           "name": "loan_token_program",
           "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Wave 5 C1 — required by init_if_needed on sol_proceeds_vault."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
         }
       ],
       "args": []
@@ -1107,7 +1134,17 @@
             "lazily on first convert_collateral_slice; here in repay it gets",
             "drained back to the borrower along with any remaining SPL.",
             "Authority = collateral_vault PDA (same seeds as the SPL vault),",
-            "so the program can sign for withdrawals using vault_seeds."
+            "so the program can sign for withdrawals using vault_seeds.",
+            "",
+            "Wave 5 C1 (2026-06-15): `init_if_needed` so V4 loans whose",
+            "auto-sell never fired (price never hit trigger) can still be",
+            "repaid. Without this, every never-fired V4 loan is unrepayable",
+            "— sol_proceeds_vault is only init'd lazily inside",
+            "convert_collateral_slice, so a loan that didn't auto-sell has",
+            "no vault account and Anchor fails with AccountNotInitialized",
+            "(3012) at repay time. wsol_mint param added below for the init.",
+            "Borrower pays the small ATA rent (~0.002 SOL); on close path",
+            "the rent is recovered."
           ],
           "writable": true,
           "pda": {
@@ -1137,11 +1174,30 @@
           }
         },
         {
+          "name": "wsol_mint",
+          "docs": [
+            "wSOL mint (canonical pubkey So11111…). Used to gate the",
+            "init_if_needed on sol_proceeds_vault. Read-only."
+          ]
+        },
+        {
           "name": "token_program"
         },
         {
           "name": "loan_token_program",
           "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Wave 5 C1 — needed because init_if_needed allocates a new",
+            "account, which requires the system_program to be passed."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
         }
       ],
       "args": []


### PR DESCRIPTION
V4 program upgraded with Wave 5 C1+C4 fixes. Bot IDL bumped; executeRepay V4 branch passes 4 new accounts (sol_proceeds_vault, wsol_mint, system_program, rent); keeper liquidate V4 branch passes new wsol_mint + system_program + rent. V1/V2/V3 paths unchanged.