### PR TITLE
fix(v4): suppress TP/SL prompts on V1/V3 loans under exclusive enforcement

### DIFF
--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -953,11 +953,21 @@ export function registerBorrowCallbacks(bot) {
 
     pending.delete(ctx.chat.id);
 
-    // Build inline keyboard. Always include the protect buttons when
-    // an exit failed or wasn't requested — gives the user a one-tap
-    // recovery path.
+    // V4-exclusive guard: when V4_EXIT_EXCLUSIVE_ENFORCE is on, only loans
+    // that landed on V4 can be armed with exits. Showing protect buttons
+    // or "/takeprofit ..." hints on a V1/V3 loan would just route the user
+    // into an exits_require_v4_loan refusal (see limit-close-arm-core.js).
+    // So gate post-borrow exit prompts on the actual program the loan
+    // landed on, not on whether arming was requested.
+    const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
+    const v4Enforced = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
+    const isV4Loan = !!v4ProgramId && result.programId === v4ProgramId;
+    const canArmExits = isV4Loan || !v4Enforced;
+
+    // Build inline keyboard. Show protect buttons only when (a) some leg
+    // didn't arm AND (b) the loan is actually arm-eligible.
     let kb = new InlineKeyboard();
-    if (!allLegsArmed) {
+    if (!allLegsArmed && canArmExits) {
       kb = kb
         .text("Sell at 2x (lock profit)", `borrow:protect:tp:${result.loanId}`).row()
         .text("Sell at 0.7x (cap loss)", `borrow:protect:sl:${result.loanId}`).row()
@@ -1003,15 +1013,17 @@ export function registerBorrowCallbacks(bot) {
       "",
       allLegsArmed
         ? "/positions to check status · /limitorders to manage auto-sells"
-        : "*Want to set an auto-sell?* Tap a button above, or type:",
-      allLegsArmed
+        : canArmExits
+          ? "*Want to set an auto-sell?* Tap a button above, or type:"
+          : "/positions to check status · /share to flex on the timeline",
+      allLegsArmed || !canArmExits
         ? null
         : `\`/takeprofit ${result.loanId} at 2x\` (sell when up 2x)`,
-      allLegsArmed
+      allLegsArmed || !canArmExits
         ? null
         : `\`/stoploss ${result.loanId} at 0.7x\` (sell if down 30%)`,
-      allLegsArmed ? null : "",
-      allLegsArmed ? null : "/positions to check status · /share to flex on the timeline",
+      allLegsArmed || !canArmExits ? null : "",
+      allLegsArmed || !canArmExits ? null : "/positions to check status · /share to flex on the timeline",
     ].filter((l) => l != null);
 
     const plainTextLines = [
@@ -1031,7 +1043,9 @@ export function registerBorrowCallbacks(bot) {
       "",
       allLegsArmed
         ? "Run /positions to check status, /limitorders to manage auto-sells."
-        : "Tap a button below to set up auto-sells, or use /takeprofit and /stoploss.",
+        : canArmExits
+          ? "Tap a button below to set up auto-sells, or use /takeprofit and /stoploss."
+          : "Run /positions to check status.",
     ].filter((l) => l != null);
 
     let renderedOk = false;
@@ -1160,7 +1174,7 @@ export function registerBorrowCallbacks(bot) {
         "",
         `Tier: ${tier.days} days at ${tier.ltv}% LTV`,
         "",
-        "Want to set up an auto-sell now? (Optional — you can always set one up later from the funded-loan screen or /takeprofit.)",
+        "Want to set up an auto-sell now? Loans with auto-sells route to a different pool — they can't be added after the fact. (You can always /borrow again later to open a fresh loan with one.)",
       ].join("\n"),
       {
         parse_mode: "Markdown",

--- a/src/commands/positions.js
+++ b/src/commands/positions.js
@@ -174,8 +174,17 @@ export async function handlePositions(ctx) {
     // sent the user a DM but the user may have dismissed/missed it;
     // /loans reminds them they have a decision pending.
     const existing = orderByLoan.get(loan.id);
+    // V4-exclusive: only suggest /takeprofit when this loan is actually
+    // arm-eligible. V1/V3 loans under V4_EXIT_EXCLUSIVE_ENFORCE would
+    // refuse the arm with exits_require_v4_loan, so don't bait the user.
+    const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
+    const v4Enforced = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
+    const canArmExits =
+      (!!v4ProgramId && loan.program_id === v4ProgramId) || !v4Enforced;
     if (!existing) {
-      lines.push(`   _no take-profit set_ · \`/takeprofit ${loan.loan_id} at 2x\``);
+      if (canArmExits) {
+        lines.push(`   _no take-profit set_ · \`/takeprofit ${loan.loan_id} at 2x\``);
+      }
     } else if (existing.status === "armed") {
       const trig = formatTriggerInline(existing.trigger_kind, existing.trigger_value_micro);
       const slip = (existing.slippage_bps / 100).toFixed(2);

--- a/src/services/upside-watcher.js
+++ b/src/services/upside-watcher.js
@@ -122,6 +122,15 @@ function renderAlertText(loan, tier, appreciationPct, currentValueUsd, collatera
 }
 
 async function processLoan(loan) {
+  // V4-exclusive: under V4_EXIT_EXCLUSIVE_ENFORCE, only loans on V4 can
+  // be armed with TP. Nudging a V1/V3 borrower to /takeprofit would
+  // dead-end at exits_require_v4_loan, so skip the DM entirely.
+  const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
+  const v4Enforced = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
+  const canArmExits =
+    (!!v4ProgramId && loan.program_id === v4ProgramId) || !v4Enforced;
+  if (!canArmExits) return { skipped: "loan_not_v4_eligible" };
+
   const apprec = await computeAppreciation(loan);
   if (!apprec) return { skipped: "no_price_or_ltv" };
   if (apprec.pct < TIERS[0].threshold_pct) {
@@ -200,6 +209,7 @@ export async function tick() {
     const { rows: loans } = await query(
       `SELECT l.id, l.user_id, l.loan_id::text AS loan_id_chain,
               l.collateral_mint, l.collateral_amount, l.ltv_percentage,
+              l.program_id,
               l.original_loan_amount_lamports::text AS original_loan_amount_lamports,
               sm.decimals, sm.symbol AS collateral_symbol
          FROM loans l


### PR DESCRIPTION
## Summary
Operator hit a post-borrow message on a V1 loan that suggested \`/takeprofit\` and \`/stoploss\`. Under \`V4_EXIT_EXCLUSIVE_ENFORCE=true\`, those arms would be refused with \`exits_require_v4_loan\`.

Surfaces fixed:
- \`borrow.js\` — protect buttons and the "Want to set an auto-sell?" prompt are now gated by \`canArmExits\` (loan landed on V4 OR enforcement off). The Markdown card and plain-text fallback both honor it.
- \`borrow.js\` pre-borrow gate text — rewritten to honestly tell users auto-sells must be set at borrow time. They can't be added after the fact under V4-exclusive routing.
- \`positions.js\` — the per-loan "no take-profit set · /takeprofit X at 2x" hint is suppressed for V1/V3 loans.
- \`upside-watcher.js\` — DMs nudging /takeprofit are skipped for V1/V3 loans. (Skip reason: \`loan_not_v4_eligible\`.)

The arm-core gate (\`limit-close-arm-core.js\`) was already correctly refusing these arms — this PR closes the UX gap that was teasing users with a button that errored.

## Test plan
- [ ] Borrow on V1 without exits → funded card has NO protect buttons and NO /takeprofit hint
- [ ] Borrow on V4 with exits → funded card behaves as before (or shows protect buttons if some leg failed to arm)
- [ ] /positions on a V1 loan → no "/takeprofit" hint
- [ ] /positions on a V4 loan with no TP → "no take-profit set · /takeprofit X at 2x" hint shows
- [ ] V1 loan that 2xes → upside-watcher does NOT DM
- [ ] V4 loan that 2xes → upside-watcher DMs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)