### PR TITLE
hotfix(loans): import PROGRAM_ID_V4 — all repays crashing

### DIFF
--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -24,6 +24,7 @@ import { connection } from "../solana/connection.js";
 import {
   getProgramForSigner,
   PROGRAM_ID,
+  PROGRAM_ID_V4,
   chooseProgramIdForCategory,
   chooseProgramId,
   assertProgramMatchesCategory,


### PR DESCRIPTION
## P0 hotfix

PR #265 introduced a bare-identifier reference to `PROGRAM_ID_V4` at `loans.js:441` without importing the symbol. Every TG /repay (V1/V2/V3/V4) throws `ReferenceError: PROGRAM_ID_V4 is not defined` since the merge at 2026-06-15 12:50Z.

Operator hit it on a V1 $DROOLING repay. This blocks every existing user from repaying.

One-line fix: add `PROGRAM_ID_V4` to the named imports from `../solana/program.js`.

## Test plan
- [ ] V1 repay succeeds end-to-end (operator can complete $DROOLING repay)
- [ ] V4 repay still passes the sol_proceeds_vault + wsol_mint + system_program + rent accounts
