### PR TITLE
fix(v4): pre-fire DM nudges users to keep liquid SOL for V4 repay

### DIFF
--- a/src/services/limit-close-near-trigger-watcher.js
+++ b/src/services/limit-close-near-trigger-watcher.js
@@ -64,7 +64,9 @@ async function fetchCandidates() {
             COALESCE(o.trigger_direction, 'above') AS trigger_direction,
             o.armed_at, o.slippage_bps,
             o.sell_destination,
+            o.engine_program_id,
             l.collateral_mint, l.loan_id AS loan_id_chain,
+            l.original_loan_amount_lamports::text AS owed_lamports,
             m.symbol AS collateral_symbol,
             u.telegram_id, u.proactive_dms_disabled
        FROM limit_close_orders o
@@ -123,6 +125,12 @@ async function enqueueNudge(order, distancePct) {
       collateral_symbol: order.collateral_symbol || "your token",
       slippage_bps: order.slippage_bps,
       distance_pct: Math.round(distancePct * 10) / 10, // 1 decimal
+      // V4-aware DM text: the renderer swaps "auto-repay+sell" → "convert
+      // in-vault" wording AND appends a liquid-SOL reminder so the user
+      // can fund the eventual repay. Pass through the program id + the
+      // original owed amount; the renderer derives the message.
+      engine_program_id: order.engine_program_id || null,
+      owed_lamports: order.owed_lamports || null,
     })],
   );
 }

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -250,15 +250,32 @@ function renderLimitCloseStalenessNudge(p) {
 function renderLimitCloseNearTrigger(p) {
   const dirLabel = p.trigger_direction === "below" ? "stop-loss" : "take-profit";
   const moveDir  = p.trigger_direction === "below" ? "drops" : "moves up";
-  return [
+  const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
+  const isV4 = !!v4ProgramId && p.engine_program_id === v4ProgramId;
+  const owedSol = p.owed_lamports
+    ? (Number(p.owed_lamports) / 1e9).toFixed(3)
+    : null;
+  const fireAction = isV4
+    ? "the engine will sell that slice on-chain and accumulate the SOL inside your loan"
+    : "the engine will repay the loan and sell your collateral";
+  const lines = [
     `*Your ${dirLabel} is close to firing*`,
     "",
-    `${p.collateral_symbol} is within ~${p.distance_pct}% of your trigger on order #${p.order_id}. If price ${moveDir} a touch more, the engine will repay the loan and sell automatically.`,
+    `${p.collateral_symbol} is within ~${p.distance_pct}% of your trigger on order #${p.order_id}. If price ${moveDir} a touch more, ${fireAction}.`,
+  ];
+  if (isV4 && owedSol) {
+    lines.push(
+      "",
+      `*Heads up:* this loan is on V4 (in-vault auto-sell). When you eventually decide to close, you'll need *~${owedSol} SOL liquid* in your wallet — the sell proceeds accumulate inside the loan and flow back to you at repay, but they don't pre-pay the loan itself.`,
+    );
+  }
+  lines.push(
     "",
     `If your plan changed, you can /modify ${p.order_id} (tighten or widen the trigger) or /cancel ${p.order_id} now. Otherwise sit tight — we've got it.`,
     "",
     `_One-time nudge per arm — you won't see this again until you re-arm or modify._`,
-  ].join("\n");
+  );
+  return lines.join("\n");
 }
 
 function renderEnginePreflightFailed(p) {


### PR DESCRIPTION
Extends the existing within-10-percent-of-trigger DM to be V4-aware. When the order is on V4, the DM now says the engine will sell that slice in-vault (not repay-and-sell, which is wrong for V4) AND appends a clear liquid-SOL reminder so the user can fund the eventual repay. V1/V2/V3 DM text unchanged. Threads engine_program_id and owed_lamports through the watcher payload so the renderer can do this lookup.