### PR TITLE
feat(v4): observability wave — /v4-status + fire-failure rate watcher

### DIFF
--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -61,6 +61,145 @@ export async function handleResume(ctx) {
   await ctx.reply("▶️ Borrowing resumed.");
 }
 
+/**
+ * /v4-status — V4-only health snapshot for the operator.
+ *
+ * Surfaces at a glance:
+ *   - On-chain pool TVL (total deposits, total borrowed, available)
+ *   - Active V4 loans count + total SOL owed
+ *   - Total accumulated vault SOL across all V4 loans (the spread sitting
+ *     inside loans waiting to be claimed at repay)
+ *   - Engine fire history: total fires, success rate, last fire
+ *   - First-V4-fire milestone state (celebrated yet? failure yet?)
+ *
+ * No on-chain writes; pure read. Safe to spam.
+ */
+export async function handleV4Status(ctx) {
+  if (!(await requireAdmin(ctx, "v4-status"))) return;
+
+  const { PROGRAM_ID_V4 } = await import("../solana/program.js");
+  if (!PROGRAM_ID_V4) {
+    return ctx.reply("V4 not configured (PROGRAM_ID_V4 env unset). Nothing to report.");
+  }
+
+  try {
+    const [poolSnap, dbLoans, dbFires, milestones] = await Promise.all([
+      (async () => {
+        // Inline pool snapshot — keeps this command self-contained.
+        // Mirrors fetchPoolSnapshot in commands/stats.js for V4.
+        try {
+          const { getReadOnlyProgram } = await import("../solana/program.js");
+          const { lendingPoolPda, loanTokenVaultPda } = await import("../solana/pdas.js");
+          const { connection } = await import("../solana/connection.js");
+          const { PublicKey } = await import("@solana/web3.js");
+          const program = getReadOnlyProgram(PROGRAM_ID_V4);
+          const lenderPubkey = new PublicKey(process.env.LENDER_PUBKEY);
+          const [poolPda] = lendingPoolPda(lenderPubkey, PROGRAM_ID_V4);
+          const pool = await program.account.lendingPool.fetch(poolPda);
+          const [vaultPda] = loanTokenVaultPda(poolPda, PROGRAM_ID_V4);
+          const vault = await connection.getTokenAccountBalance(vaultPda).catch(() => null);
+          const totalDeposits = BigInt(pool.totalDeposits.toString());
+          const totalBorrowed = BigInt(pool.totalBorrowed.toString());
+          const availableLiquidity = vault?.value?.amount
+            ? BigInt(vault.value.amount)
+            : (totalDeposits - totalBorrowed);
+          const utilizationRate = totalDeposits > 0n
+            ? Number(totalBorrowed) / Number(totalDeposits)
+            : 0;
+          return {
+            totalDeposits: totalDeposits.toString(),
+            totalBorrowed: totalBorrowed.toString(),
+            availableLiquidity: availableLiquidity.toString(),
+            utilizationRate,
+            paused: !!pool.paused,
+          };
+        } catch (err) {
+          return { error: err.message?.slice(0, 100) };
+        }
+      })(),
+      query(
+        `SELECT
+           COUNT(*)::int AS active_count,
+           COALESCE(SUM(original_loan_amount_lamports), 0)::text AS total_owed_lamports,
+           COALESCE(SUM(sol_proceeds_amount), 0)::text AS total_vault_lamports,
+           COUNT(*) FILTER (WHERE auto_sells_fired > 0)::int AS with_fires
+         FROM loans
+         WHERE program_id = $1
+           AND status = 'active'`,
+        [PROGRAM_ID_V4.toBase58()],
+      ),
+      query(
+        `SELECT
+           COUNT(*) FILTER (WHERE status = 'fired')::int AS fired,
+           COUNT(*) FILTER (WHERE status = 'failed')::int AS failed,
+           COUNT(*) FILTER (WHERE status = 'armed')::int AS armed,
+           MAX(fired_at) AS last_fired_at,
+           COALESCE(SUM(proceeds_lamports) FILTER (WHERE status = 'fired'), 0)::text AS total_proceeds
+         FROM limit_close_orders
+         WHERE engine_program_id = $1`,
+        [PROGRAM_ID_V4.toBase58()],
+      ),
+      query(
+        `SELECT milestone_key, notified_at, reference_id
+           FROM engine_milestone_flags
+          WHERE milestone_key IN ('first_v4_fire', 'first_v4_fire_failure')`,
+      ),
+    ]);
+
+    const fmtSol = (lamportsStr) => (Number(lamportsStr) / 1e9).toFixed(4);
+    const loansRow = dbLoans.rows[0];
+    const firesRow = dbFires.rows[0];
+    const successPct = (firesRow.fired + firesRow.failed) > 0
+      ? ((firesRow.fired * 100) / (firesRow.fired + firesRow.failed)).toFixed(1)
+      : "n/a";
+    const firstFire = milestones.rows.find((r) => r.milestone_key === "first_v4_fire");
+    const firstFail = milestones.rows.find((r) => r.milestone_key === "first_v4_fire_failure");
+
+    const lines = [
+      "*V4 status*",
+      "",
+      `Program: \`${PROGRAM_ID_V4.toBase58().slice(0, 16)}…\``,
+      "",
+      "*Pool (on-chain):*",
+      poolSnap.error
+        ? `  read error: ${poolSnap.error}`
+        : [
+            `  total deposits:  \`${fmtSol(poolSnap.totalDeposits)} SOL\``,
+            `  total borrowed:  \`${fmtSol(poolSnap.totalBorrowed)} SOL\``,
+            `  available liq:   \`${fmtSol(poolSnap.availableLiquidity)} SOL\``,
+            `  utilization:     \`${(poolSnap.utilizationRate * 100).toFixed(1)}%\``,
+            poolSnap.paused ? `  *PAUSED*` : null,
+          ].filter(Boolean).join("\n"),
+      "",
+      "*Active V4 loans (DB):*",
+      `  count:           ${loansRow.active_count}`,
+      `  total owed:      \`${fmtSol(loansRow.total_owed_lamports)} SOL\``,
+      `  vault accrued:   \`${fmtSol(loansRow.total_vault_lamports)} SOL\``,
+      `  with auto-sells fired: ${loansRow.with_fires}`,
+      "",
+      "*Limit-close orders (V4):*",
+      `  armed:    ${firesRow.armed}`,
+      `  fired:    ${firesRow.fired}`,
+      `  failed:   ${firesRow.failed}`,
+      `  success%: ${successPct}`,
+      `  total proceeds (lifetime): \`${fmtSol(firesRow.total_proceeds)} SOL\``,
+      firesRow.last_fired_at
+        ? `  last fired: \`${new Date(firesRow.last_fired_at).toISOString().slice(0, 19)}Z\``
+        : `  last fired: never`,
+      "",
+      "*Milestones:*",
+      `  first_v4_fire:         ${firstFire?.notified_at ? "CELEBRATED " + new Date(firstFire.notified_at).toISOString().slice(0, 19) + "Z" : "pending"}`,
+      `  first_v4_fire_failure: ${firstFail?.notified_at ? "ALERTED " + new Date(firstFail.notified_at).toISOString().slice(0, 19) + "Z" : "none yet"}`,
+    ].filter(Boolean);
+
+    await logAdminCommand(ctx, "v4-status", { outcome: "success" });
+    await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
+  } catch (err) {
+    await logAdminCommand(ctx, "v4-status", { outcome: "error", error: err.message });
+    await ctx.reply(`v4-status read failed: ${err.message?.slice(0, 200)}`);
+  }
+}
+
 export async function handleAdminStatus(ctx) {
   if (!(await requireAdmin(ctx, "admin"))) return;
   const { getGlobalSiteState } = await import("../services/site-global.js");

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,7 @@ import {
   handlePause,
   handleResume,
   handleAdminStatus,
+  handleV4Status,
   handleEnableMint,
   handleDisableMint,
   handleBroadcast,
@@ -182,6 +183,7 @@ import { startLoanReceivedWatchdog } from "./services/loan-received-watchdog.js"
 import { startFirstV2FireWatcher } from "./services/first-v2-fire-watcher.js";
 import { startLimitCloseFirstV3FireWatcher } from "./services/limit-close-first-v3-fire-watcher.js";
 import { startLimitCloseFirstV4FireWatcher } from "./services/limit-close-first-v4-fire-watcher.js";
+import { startV4FireFailureRateWatcher } from "./services/limit-close-v4-fire-failure-rate-watcher.js";
 import { startNeonSync } from "./services/neon-sync.js";
 import { registerTxErrorCallbacks } from "./services/tx-error-callbacks.js";
 import { startAiAgentHealth } from "./services/ai-agent-health.js";
@@ -273,6 +275,7 @@ bot.command("mydistributions", handleDistributions); // alias
 bot.command("pause", handlePause);
 bot.command("resume", handleResume);
 bot.command("adminstatus", handleAdminStatus);
+bot.command(["v4status", "v4-status", "v4"], handleV4Status);
 bot.command(["admincmds", "adminlog"], handleAdminCmds);
 // Limit-close engine observability (operator-facing). Read-only.
 {
@@ -930,6 +933,12 @@ bot.start({
     // which is a brand-new path. Same celebrate/alert two-prong model
     // as V3; closes the V4-engine-readiness gap from the Wave 4 audit.
     setTimeout(() => startLimitCloseFirstV4FireWatcher(bot), 150_000);
+    // V4 fire-failure RATE watcher — complements the first-fire one-shot
+    // by tracking ongoing failure rates per mint and engine-wide. Alerts
+    // when 3+ failures hit one mint or 5+ across all mints in a 1h window.
+    // First-fire watcher catches "V4 wired up?" — this one catches "V4
+    // is wired but something is silently failing repeatedly."
+    setTimeout(() => startV4FireFailureRateWatcher(bot), 180_000);
     // Auto-Protect — opt-in anti-liquidation. Watches every 90s.
     setTimeout(() => startAutoProtect(bot), 50_000);
     // Conditional-borrow watcher — fires agent intents when their

--- a/src/services/limit-close-v4-fire-failure-rate-watcher.js
+++ b/src/services/limit-close-v4-fire-failure-rate-watcher.js
@@ -1,0 +1,131 @@
+/**
+ * V4 fire-failure rate watcher.
+ *
+ * The existing first-V4-fire-watcher only DMs on the VERY FIRST failure
+ * (one-shot, anti-spam). Once it's celebrated/alerted, it stops. That's
+ * correct for the "is V4 wired up at all?" question, but doesn't catch
+ * the "V4 is wired but something is silently failing repeatedly" case.
+ *
+ * This watcher complements it by tracking ONGOING rate of failures and
+ * alerting when either:
+ *   - Same mint fails 3+ times in a rolling window (engine/oracle issue
+ *     specific to that token's V4 feed or Jupiter route)
+ *   - Any 5+ V4 failures across all mints in the window (engine-wide
+ *     problem the canary may have missed)
+ *
+ * Rate-limit: once alerted on a (mint, window) the watcher mutes for
+ * ALERT_MUTE_MS so we don't repeatedly wake the operator on the same
+ * underlying issue. Recovery DM when the window clears.
+ *
+ * Cadence: every 5 min. Cheap query, indexed by (engine_program_id,
+ * status, created_at).
+ *
+ * No emojis per Magpie copy rules.
+ */
+import { query } from "../db/pool.js";
+import { getAdminId, notifyAdmin } from "./admin-notify.js";
+
+const WATCH_INTERVAL_MS = Number(process.env.V4_FAILURE_RATE_INTERVAL_MS) || 5 * 60_000;
+const WINDOW_MS = Number(process.env.V4_FAILURE_RATE_WINDOW_MS) || 60 * 60_000;
+const ALERT_MUTE_MS = Number(process.env.V4_FAILURE_RATE_MUTE_MS) || 6 * 60 * 60_000;
+const PER_MINT_THRESHOLD = Number(process.env.V4_FAILURE_RATE_PER_MINT) || 3;
+const TOTAL_THRESHOLD = Number(process.env.V4_FAILURE_RATE_TOTAL) || 5;
+
+let _timer = null;
+const lastAlertedAt = new Map(); // key → epoch ms
+
+async function tick(bot) {
+  const v4 = process.env.PROGRAM_ID_V4;
+  if (!v4) return; // V4 not configured
+
+  const since = new Date(Date.now() - WINDOW_MS).toISOString();
+  const { rows } = await query(
+    `SELECT
+       COALESCE(l.collateral_mint, 'UNKNOWN') AS mint,
+       sm.symbol,
+       COUNT(*) FILTER (WHERE lc.status = 'failed')::int AS fail_count,
+       MAX(lc.updated_at) AS last_fail
+     FROM limit_close_orders lc
+     LEFT JOIN loans l ON l.id = lc.loan_id
+     LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+     WHERE lc.engine_program_id = $1
+       AND lc.status = 'failed'
+       AND lc.updated_at >= $2
+     GROUP BY l.collateral_mint, sm.symbol`,
+    [v4, since],
+  );
+
+  const totalFailures = rows.reduce((s, r) => s + r.fail_count, 0);
+  const offenders = rows.filter((r) => r.fail_count >= PER_MINT_THRESHOLD);
+  const now = Date.now();
+
+  // Per-mint alerts
+  for (const o of offenders) {
+    const key = `mint:${o.mint}`;
+    const last = lastAlertedAt.get(key) || 0;
+    if (now - last < ALERT_MUTE_MS) continue;
+    const sym = o.symbol || o.mint.slice(0, 8) + "…";
+    await notifyAdmin(
+      bot,
+      [
+        `*V4 fire-failure rate alarm — ${sym}*`,
+        "",
+        `${o.fail_count} V4 fire failures on \`${sym}\` in the last ${Math.round(WINDOW_MS / 60_000)} min.`,
+        `Last fail: \`${new Date(o.last_fail).toISOString().slice(0, 19)}Z\`.`,
+        "",
+        "Likely causes:",
+        "  • V4 price feed for this mint went stale / never warmed",
+        "  • Jupiter routing for this mint thin or unhealthy",
+        "  • Slippage cap too tight for current market conditions",
+        "",
+        "Check: /v4-status, /lc-perf mint=" + (o.symbol || o.mint.slice(0, 8)),
+        `Muted ${Math.round(ALERT_MUTE_MS / 60_000 / 60)}h from now.`,
+      ].join("\n"),
+      { parse_mode: "Markdown" },
+    );
+    lastAlertedAt.set(key, now);
+  }
+
+  // Engine-wide alert (independent of per-mint mutes)
+  if (totalFailures >= TOTAL_THRESHOLD) {
+    const key = "total";
+    const last = lastAlertedAt.get(key) || 0;
+    if (now - last >= ALERT_MUTE_MS) {
+      await notifyAdmin(
+        bot,
+        [
+          "*V4 engine-wide fire-failure alarm*",
+          "",
+          `${totalFailures} V4 fire failures across all mints in the last ${Math.round(WINDOW_MS / 60_000)} min.`,
+          `Spread: ${rows.length} distinct mint(s).`,
+          "",
+          "Likely causes:",
+          "  • Engine RPC / Jupiter outage",
+          "  • V4 program upgrade in flight",
+          "  • Engine authority keypair / wallet ran short of SOL",
+          "",
+          "Check: /v4-status, /lc-perf, railway logs --json | grep v4",
+          `Muted ${Math.round(ALERT_MUTE_MS / 60_000 / 60)}h from now.`,
+        ].join("\n"),
+        { parse_mode: "Markdown" },
+      );
+      lastAlertedAt.set(key, now);
+    }
+  }
+}
+
+export function startV4FireFailureRateWatcher(bot) {
+  if (_timer) return;
+  if (!process.env.PROGRAM_ID_V4) {
+    console.log("[v4-failure-rate-watcher] PROGRAM_ID_V4 not set — disabled");
+    return;
+  }
+  console.log(`[v4-failure-rate-watcher] armed — every ${WATCH_INTERVAL_MS / 60_000}m, window ${WINDOW_MS / 60_000}m, per-mint=${PER_MINT_THRESHOLD}, total=${TOTAL_THRESHOLD}`);
+  // First tick after 2 min so we don't fire on startup state.
+  setTimeout(() => {
+    tick(bot).catch((e) => console.warn("[v4-failure-rate-watcher] first tick threw:", e.message?.slice(0, 80)));
+    _timer = setInterval(() => {
+      tick(bot).catch((e) => console.warn("[v4-failure-rate-watcher] tick threw:", e.message?.slice(0, 80)));
+    }, WATCH_INTERVAL_MS);
+  }, 2 * 60_000);
+}


### PR DESCRIPTION
Two new V4 observability surfaces. /v4-status admin command gives operator at-a-glance V4 health (pool TVL, active loans, vault accrued, fire history, milestones). V4 fire-failure rate watcher alerts when 3+ same-mint failures or 5+ engine-wide failures hit in a 60-min window. Both V4-only. V1/V2/V3 unaffected.