### PR TITLE
fix(health-watcher): skip thresholds above loan's starting health + extend limit-close API

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -301,7 +301,11 @@ export async function handleSiteLimitCloseList(req, url) {
     [walletRow.user_id, wallet],
   );
 
-  // Armed orders for those loans.
+  // Orders for those loans. Returns BOTH currently-active AND fired/
+  // cancelled orders within the loan's lifetime so the dashboard can
+  // show ladder progression (e.g. "80% leg fired @ $180 ✓ | 20% leg
+  // armed @ $182"). Slice_pct is included so the UI can render the
+  // ladder composition (default 10000 = 100% if column NULL).
   const loanIds = loans.map((l) => l.id);
   let orders = [];
   if (loanIds.length > 0) {
@@ -313,11 +317,22 @@ export async function handleSiteLimitCloseList(req, url) {
               max_slippage_bps_cap, auto_escalate_slippage,
               source, source_agent_pubkey,
               trailing_distance_bps,
-              peak_price_micros::text AS peak_price_micros
+              peak_price_micros::text AS peak_price_micros,
+              COALESCE(slice_pct, 10000) AS slice_pct,
+              ladder_group_id,
+              -- Fire details (NULL for non-fired orders)
+              fired_at,
+              proceeds_lamports::text AS proceeds_lamports,
+              net_to_user_lamports::text AS net_to_user_lamports,
+              tx_signature_swap,
+              tx_signature_repay
          FROM limit_close_orders
         WHERE loan_id = ANY($1::bigint[])
-          AND status IN ('armed','firing','twap_in_progress','awaiting_user')
-        ORDER BY armed_at DESC`,
+          AND status IN ('armed','firing','twap_in_progress','awaiting_user','fired','cancelled')
+        ORDER BY
+          -- Active states sort first by armed_at DESC, history by fired_at DESC
+          CASE WHEN status IN ('fired','cancelled') THEN 1 ELSE 0 END,
+          armed_at DESC`,
       [loanIds],
     );
     orders = r.rows;

--- a/src/services/health-watcher.js
+++ b/src/services/health-watcher.js
@@ -101,10 +101,25 @@ const THRESHOLDS = [
   { ratio: 1.1, emoji: "🔴", label: "Imminent liquidation risk." },
 ];
 
-function alertFor(ratio, lastAlertedAt) {
-  // Pick the lowest threshold the loan is now under, that we haven't warned
-  // the user about yet.
+function alertFor(ratio, lastAlertedAt, ltvPercentage = null) {
+  // Compute starting health for this loan based on its LTV. A loan at
+  // 70% LTV starts at 1/0.70 ≈ 1.43x — already BELOW our 1.5x "heads up"
+  // threshold. Without this gate, every 70% LTV RWA loan would fire a
+  // health alert the moment it was borrowed, regardless of price action.
+  // Operator-reported 2026-06-15 after the first SPCX 70% LTV V4 borrow
+  // triggered an immediate health DM.
+  //
+  // Rule: skip any threshold that is >= the loan's STARTING health. The
+  // alert should fire on a meaningful drop FROM origination, not on a
+  // condition that was true at borrow time.
+  const startingHealth = ltvPercentage && ltvPercentage > 0
+    ? 100 / ltvPercentage
+    : null;
+
   for (const t of THRESHOLDS) {
+    // Skip thresholds at or above starting health — they'd fire on a
+    // flat or even slightly-up market. Annoying, not informative.
+    if (startingHealth != null && t.ratio >= startingHealth) continue;
     if (ratio < t.ratio) {
       if (lastAlertedAt == null || Number(lastAlertedAt) > t.ratio) {
         return t;


### PR DESCRIPTION
## Summary

**Health alerts**: Operator just took a 70% LTV SPCX V4 loan and got an immediate "health below 1.5x" DM at borrow time on a flat market. A 70% LTV loan starts at 1/0.7 ≈ 1.43x — already below the 1.5x heads-up threshold, so the alert was firing on a condition that was true at origination.

\`alertFor()\` now takes \`ltvPercentage\` and skips any threshold \`>= 100/ltv\`. For 70% LTV loans (start 1.43x): 1.5x skipped, 1.3x / 1.2x / 1.1x still fire on real drops. For 30%/50% LTV loans (start 3.33x / 2x) nothing changes — their starting health is well above 1.5x.

**API extension**: \`/api/v1/site/limit-close\` now returns fired + cancelled orders alongside armed, plus \`slice_pct\`, \`ladder_group_id\`, \`fired_at\`, \`proceeds_lamports\`, and the two tx signatures. Site dashboard can now render per-leg ladder progression (e.g. "80% leg fired green at \$180 / 20% leg still armed at \$182"). UI component lands in a follow-up site PR.

## Test plan
- [ ] Take a 70% LTV RWA loan on a stable price — confirm NO health DM at borrow
- [ ] Simulate health drop to 1.25x on that loan — confirm 1.3x DM fires
- [ ] Confirm 30%/50% LTV loans still get the 1.5x heads-up
- [ ] Hit /api/v1/site/limit-close — confirm response includes fired/cancelled orders and new fields