### PR TITLE
fix(bot): sweep stale pre-MGP-001 numbers in nudges + comments

### DIFF
--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -320,12 +320,13 @@ export async function applyStartupPatches() {
        added_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
      )`,
 
-    // ─────── LP LOYALTY BONUS POOL ───────
-    // 2% of every loan fee accrues to this pool, distributed pro-rata to
-    // each LP's share-seconds (shares × time held). Long-term holders
-    // earn meaningfully more than flippers on top of the base 80% LP
-    // yield. Sourced from the protocol's 5% slice (drops to 3%); LPs
-    // keep their full 80%.
+    // ─────── LP LOYALTY POOL ───────
+    // Post-MGP-001 (ratified 2026-06-13): 10% of every loan fee accrues
+    // to this pool — it IS the LP yield stream (the prior "base 80%
+    // share-price growth" model was eliminated when voters chose to
+    // reweight more aggressively toward $MAGPIE holders). Distributed
+    // pro-rata to each LP's share-seconds (shares × time held). Long-
+    // term LPs earn meaningfully more than flippers.
     `CREATE TABLE IF NOT EXISTS lp_loyalty_pool (
        id INTEGER PRIMARY KEY,
        accrued_lamports NUMERIC(30,0) NOT NULL DEFAULT 0,

--- a/src/services/idle-sol-nudge.js
+++ b/src/services/idle-sol-nudge.js
@@ -69,7 +69,7 @@ async function nudgeUser(bot, user, idleSol) {
     "",
     `Drop it in the lending pool at *magpie.capital/earn* and it earns share-based yield from every loan fee on the protocol. No lock-up — withdraw any time the pool has liquidity.`,
     "",
-    `_80% of all loan fees flow to LPs pro-rata to their share-seconds. The longer you stay, the more you earn._`,
+    `_Per MGP-001 (ratified 2026-06-13), 10% of every loan fee flows to LPs via the LP loyalty pool — pro-rata by shares × time held. The longer you stay, the more you earn._`,
     "",
     `_One-time nudge. Tap "Don't show again" below if you'd rather not get these._`,
   ].join("\n");

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -700,7 +700,9 @@ export async function recordLoan({
     console.error("[loans] referral accrual on borrow failed (continuing):", err.message);
   }
 
-  // $MAGPIE holder pool accrual (10% of fee)
+  // $MAGPIE holder pool accrual — 70% of fee post-MGP-001 (the bps is
+  // read from governance_config at accrual time; comment kept current
+  // so future readers don't think this is the legacy 10% share).
   try {
     const { accrueToHolderPool } = await import("./magpie-holder-rewards.js");
     if (feeLamports > 0n) {

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -1,9 +1,12 @@
 /**
  * LP Loyalty Bonus Pool.
  *
- * Mechanic:
- *   - 2% of every loan fee accrues to the lp_loyalty_pool (source: the
- *     protocol's 5% slice — LPs keep their full 80% base yield).
+ * Mechanic (post-MGP-001 ratified 2026-06-13):
+ *   - 10% of every loan fee accrues to the lp_loyalty_pool. This IS
+ *     the LP yield stream — there is no separate "base 80% share"
+ *     anymore. The fee split is now 70% holders / 10% LP loyalty /
+ *     10% referrer / 10% protocol reserve, with 0% retained in the
+ *     lending pool itself.
  *   - Each LP's "weight" at snapshot time = current shares × seconds
  *     since their weighted_deposit_at (the time-weighted average of
  *     their deposit moments).

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -132,10 +132,12 @@ function loadLenderKeypair() {
 }
 
 /**
- * Add 10% of a loan fee to the holder reward pool. Idempotent NOT
- * guaranteed — caller must ensure they call once per fee event. Safe
- * to call from inside the loan-recording try/catch (errors don't
- * propagate up to the user-facing flow).
+ * Add the holder-share fraction of a loan fee to the holder reward
+ * pool. Fraction is read from governance_config at call time —
+ * currently 70% post-MGP-001 (ratified 2026-06-13), previously 10%.
+ * Idempotent NOT guaranteed — caller must ensure they call once per
+ * fee event. Safe to call from inside the loan-recording try/catch
+ * (errors don't propagate up to the user-facing flow).
  */
 /**
  * Credit a pre-computed lamport amount directly to the holder pool.


### PR DESCRIPTION
Companion to magpie-site MGP-001 sweep. idle-sol-nudge.js was still telling LPs '80% of all loan fees flow to LPs' in a user-facing DM — fixed to 10% LP loyalty per MGP-001. Plus stale code comments in loans.js, magpie-holder-rewards.js, lp-loyalty.js, db/pool.js.