### PR TITLE
feat(arm): server-side audit log + failure DM on every armOrder

### DIFF
--- a/migrations/068_limit_close_arm_attempts.sql
+++ b/migrations/068_limit_close_arm_attempts.sql
@@ -1,0 +1,67 @@
+-- 068_limit_close_arm_attempts.sql
+--
+-- Server-side audit log for every limit-close arm attempt (success
+-- AND failure), regardless of source (site / tg / agent_x402).
+--
+-- Forcing function: operator's 2026-06-15 V4 SPCX ladder. The user
+-- believed they armed a ladder, the SPCX strike was hit, no fire
+-- happened. Investigation found ZERO rows in limit_close_orders for
+-- their account across ALL loans, ever — every prior arm attempt
+-- silently failed before reaching the INSERT statement.
+--
+-- Without an audit table, "did my arm even reach the server?" is
+-- unanswerable. With it, every site/tg/agent arm attempt writes
+-- one row with:
+--   - WHO  (user_id, source, source_agent_pubkey)
+--   - WHAT (loan, direction, target, slice, ladder_group_id)
+--   - OUTCOME (success → order_id, failure → error_code + detail)
+--
+-- The notification-sender additionally fires a Telegram DM on every
+-- failure, so the user gets ground-truth feedback in seconds.
+--
+-- READS this table:
+--   - notification-sender (fail DM render)
+--   - dashboard via /api/v1/site/limit-close (recent failures banner)
+--   - operator /lc-perf admin command (future)
+
+CREATE TABLE IF NOT EXISTS limit_close_arm_attempts (
+  id                  BIGSERIAL PRIMARY KEY,
+  user_id             BIGINT NOT NULL,
+
+  -- Loan identification — keep BOTH the chain-side and the DB-side
+  -- loan_id because some failure modes (e.g. loan_not_found_for_user)
+  -- happen before we resolve the DB row, so loan_db_id can be NULL.
+  loan_id_chain       TEXT NULL,
+  loan_db_id          BIGINT NULL,
+
+  -- Trigger
+  direction           TEXT NOT NULL CHECK (direction IN ('above', 'below')),
+  target_kind         TEXT NULL,
+  target_value_micro  NUMERIC(30, 0) NULL,
+  slice_pct           INTEGER NULL,
+  ladder_group_id     UUID NULL,
+
+  -- Provenance — same enum as limit_close_orders.source
+  source              TEXT NULL,
+  source_agent_pubkey TEXT NULL,
+
+  -- Outcome
+  outcome             TEXT NOT NULL CHECK (outcome IN ('success', 'failed')),
+  order_id            BIGINT NULL,  -- set when outcome = 'success'
+  error_code          TEXT NULL,    -- set when outcome = 'failed'
+  error_detail        TEXT NULL,    -- bounded; truncate caller-side to ~400 chars
+
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- "What recently happened on this loan / for this user" — the
+-- dashboard banner reads (user_id, recent) to surface failed attempts
+-- in the last hour.
+CREATE INDEX IF NOT EXISTS idx_arm_attempts_user_recent
+  ON limit_close_arm_attempts (user_id, created_at DESC);
+
+-- Operator + watchers want to focus on failures, so add a partial
+-- index for just the failed rows.
+CREATE INDEX IF NOT EXISTS idx_arm_attempts_failures_recent
+  ON limit_close_arm_attempts (created_at DESC)
+  WHERE outcome = 'failed';

--- a/scripts/inspect-limit-close-for-wallet.mjs
+++ b/scripts/inspect-limit-close-for-wallet.mjs
@@ -1,0 +1,73 @@
+/**
+ * Read-only diagnostic: list every limit_close_orders row for a
+ * wallet's loans, regardless of status. Used to debug "I armed a
+ * ladder but the dashboard shows nothing" cases — distinguishes
+ * arm-failure (no rows at all), wrong-loan (rows on a different
+ * loan_id), and fire-already-happened (rows with status='fired').
+ *
+ * Usage:
+ *   node scripts/inspect-limit-close-for-wallet.mjs <wallet>
+ */
+import { query } from "../src/db/pool.js";
+
+const wallet = process.argv[2];
+if (!wallet) {
+  console.error("usage: node scripts/inspect-limit-close-for-wallet.mjs <wallet>");
+  process.exit(1);
+}
+
+const u = await query(
+  `SELECT u.id AS user_id, u.telegram_id
+     FROM users u
+     JOIN wallets w ON w.user_id = u.id
+    WHERE w.public_key = $1`,
+  [wallet],
+);
+if (u.rows.length === 0) {
+  console.log("no user for wallet");
+  process.exit(0);
+}
+const userId = u.rows[0].user_id;
+console.log("user_id:", userId, "telegram_id:", u.rows[0].telegram_id);
+
+const loans = await query(
+  `SELECT id, loan_id, collateral_mint, status, borrower_wallet, start_timestamp
+     FROM loans
+    WHERE user_id = $1 AND borrower_wallet = $2
+    ORDER BY id DESC
+    LIMIT 30`,
+  [userId, wallet],
+);
+console.log(`\nLOANS (${loans.rows.length}):`);
+for (const l of loans.rows) {
+  console.log(`  id=${l.id} chain=${l.loan_id} mint=${l.collateral_mint?.slice(0,8)} status=${l.status}`);
+}
+
+const loanIds = loans.rows.map((r) => r.id);
+if (loanIds.length === 0) {
+  console.log("no loans");
+  process.exit(0);
+}
+
+const orders = await query(
+  `SELECT id, loan_id, trigger_kind, trigger_value_micro::text AS val,
+          trigger_direction, status, slice_pct, ladder_group_id,
+          armed_at, fired_at, source,
+          proceeds_lamports::text AS proceeds,
+          tx_signature_swap, tx_signature_repay,
+          failure_reason
+     FROM limit_close_orders
+    WHERE loan_id = ANY($1::bigint[])
+    ORDER BY armed_at DESC NULLS LAST
+    LIMIT 100`,
+  [loanIds],
+);
+
+console.log(`\nORDERS (${orders.rows.length}):`);
+for (const o of orders.rows) {
+  console.log(
+    `  id=${o.id} loan=${o.loan_id} dir=${o.trigger_direction} status=${o.status} kind=${o.trigger_kind} val=${o.val} slice=${o.slice_pct} group=${o.ladder_group_id ? o.ladder_group_id.slice(0,8) : '-'} src=${o.source} armed=${o.armed_at?.toISOString?.()} fired=${o.fired_at?.toISOString?.() || '-'} proceeds=${o.proceeds || '-'} swap=${o.tx_signature_swap?.slice(0,8) || '-'} fail=${o.failure_reason || '-'}`,
+  );
+}
+
+process.exit(0);

--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -320,12 +320,13 @@ export async function applyStartupPatches() {
        added_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
      )`,
 
-    // ─────── LP LOYALTY BONUS POOL ───────
-    // 2% of every loan fee accrues to this pool, distributed pro-rata to
-    // each LP's share-seconds (shares × time held). Long-term holders
-    // earn meaningfully more than flippers on top of the base 80% LP
-    // yield. Sourced from the protocol's 5% slice (drops to 3%); LPs
-    // keep their full 80%.
+    // ─────── LP LOYALTY POOL ───────
+    // Post-MGP-001 (ratified 2026-06-13): 10% of every loan fee accrues
+    // to this pool — it IS the LP yield stream (the prior "base 80%
+    // share-price growth" model was eliminated when voters chose to
+    // reweight more aggressively toward $MAGPIE holders). Distributed
+    // pro-rata to each LP's share-seconds (shares × time held). Long-
+    // term LPs earn meaningfully more than flippers.
     `CREATE TABLE IF NOT EXISTS lp_loyalty_pool (
        id INTEGER PRIMARY KEY,
        accrued_lamports NUMERIC(30,0) NOT NULL DEFAULT 0,

--- a/src/services/idle-sol-nudge.js
+++ b/src/services/idle-sol-nudge.js
@@ -69,7 +69,7 @@ async function nudgeUser(bot, user, idleSol) {
     "",
     `Drop it in the lending pool at *magpie.capital/earn* and it earns share-based yield from every loan fee on the protocol. No lock-up — withdraw any time the pool has liquidity.`,
     "",
-    `_80% of all loan fees flow to LPs pro-rata to their share-seconds. The longer you stay, the more you earn._`,
+    `_Per MGP-001 (ratified 2026-06-13), 10% of every loan fee flows to LPs via the LP loyalty pool — pro-rata by shares × time held. The longer you stay, the more you earn._`,
     "",
     `_One-time nudge. Tap "Don't show again" below if you'd rather not get these._`,
   ].join("\n");

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -110,7 +110,60 @@ const DEFAULT_CAP_MULTIPLIER = 8;         // cap = max(floor, slip × 8) capped 
 // shared with internal-agent-limitclose.js and the DB CHECK constraint.
 const MAX_INITIAL_SLIPPAGE_BPS = MAX_PROTOCOL_SLIPPAGE_BPS; // 25% — allow aggressive initial for moon-pump UX
 
-export async function armOrder({
+/**
+ * Public entry point — wraps the real implementation with a server-
+ * side audit log + a failure DM so the caller cannot silently die.
+ *
+ * Forcing function (2026-06-15): operator's V4 SPCX ladder. The user
+ * believed they armed a ladder, the strike was hit, no fire happened.
+ * Investigation revealed ZERO rows in limit_close_orders for the
+ * account, ever — every prior arm attempt failed BEFORE reaching the
+ * INSERT statement. Without an audit trail, those failures were
+ * invisible. This wrapper writes one row per attempt + DMs the user
+ * on every failure regardless of which caller (site/tg/agent_x402)
+ * invoked us.
+ *
+ * Contract preserved: identical args + identical return shape as the
+ * legacy armOrder. Wrapper is best-effort — audit failure does NOT
+ * mask a real arm result.
+ */
+export async function armOrder(args) {
+  let result;
+  try {
+    result = await armOrderImpl(args);
+  } catch (err) {
+    // Defensive: anything thrown out of armOrderImpl becomes a normal
+    // failure result so the audit/DM paths still fire and the caller
+    // gets a consistent shape.
+    console.error("[arm-core] unexpected exception inside armOrderImpl:", err?.stack || err?.message || err);
+    result = {
+      ok: false,
+      error: "exception",
+      detail: (err?.message || String(err)).slice(0, 400),
+    };
+  }
+
+  // Audit (best-effort, swallowed on error so we never mask the real result).
+  try {
+    await recordArmAttempt(args, result);
+  } catch (auditErr) {
+    console.warn("[arm-core] audit insert failed:", auditErr.message?.slice(0, 200));
+  }
+
+  // Failure-DM (best-effort, same swallow). Success DM is enqueued by
+  // the caller after this returns ok:true — preserves current contract.
+  if (!result.ok) {
+    try {
+      await enqueueArmFailedDm(args, result);
+    } catch (dmErr) {
+      console.warn("[arm-core] failure-DM enqueue failed:", dmErr.message?.slice(0, 200));
+    }
+  }
+
+  return result;
+}
+
+async function armOrderImpl({
   userId,
   source,                  // 'tg' | 'site' | 'agent_x402'
   sourceAgentPubkey = null,
@@ -1022,4 +1075,93 @@ export async function enqueueArmedDm({
   } catch (err) {
     console.warn("[arm-core] arm-DM enqueue failed:", err.message?.slice(0, 200));
   }
+}
+
+/* ────────────────────────────────────────────────────────────────
+ * Audit log + failure DM (operator-mandated 2026-06-15)
+ *
+ * recordArmAttempt: one row per armOrder call, success OR failure.
+ *   - On success: order_id populated, error_code/detail NULL.
+ *   - On failure: error_code = result.error, error_detail truncated.
+ *
+ * enqueueArmFailedDm: one DM per failure. The user gets ground-truth
+ *   feedback in seconds instead of staring at a silent dashboard.
+ * ──────────────────────────────────────────────────────────────── */
+
+function safeTruncate(s, n) {
+  if (s == null) return null;
+  const str = String(s);
+  return str.length > n ? str.slice(0, n) : str;
+}
+
+function jsonStringifyError(detail) {
+  if (detail == null) return null;
+  if (typeof detail === "string") return detail;
+  try { return JSON.stringify(detail); } catch { return String(detail); }
+}
+
+async function recordArmAttempt(args, result) {
+  // We deliberately NEVER throw from here — caller wraps in try/catch
+  // anyway, but defensive serialization keeps the audit path resilient.
+  const triggerValueStr =
+    args.triggerValueMicro != null
+      ? (typeof args.triggerValueMicro === "bigint"
+          ? args.triggerValueMicro.toString()
+          : String(args.triggerValueMicro))
+      : null;
+  const ladderGroupId =
+    args.ladderGroupId && /^[0-9a-f-]{36}$/i.test(String(args.ladderGroupId))
+      ? args.ladderGroupId
+      : null;
+
+  await query(
+    `INSERT INTO limit_close_arm_attempts
+       (user_id, loan_id_chain, loan_db_id, direction,
+        target_kind, target_value_micro, slice_pct, ladder_group_id,
+        source, source_agent_pubkey,
+        outcome, order_id, error_code, error_detail)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+    [
+      args.userId || null,
+      args.loanIdChain != null ? String(args.loanIdChain) : null,
+      result?.ok && result?.loan?.id ? result.loan.id : null,
+      args.triggerDirection || (args.direction || "above"),
+      args.triggerKind || null,
+      triggerValueStr,
+      args.slicePct ?? null,
+      ladderGroupId,
+      args.source || null,
+      args.sourceAgentPubkey || null,
+      result?.ok ? "success" : "failed",
+      result?.ok ? result.orderId || null : null,
+      result?.ok ? null : safeTruncate(result?.error, 64),
+      result?.ok ? null : safeTruncate(jsonStringifyError(result?.detail), 400),
+    ],
+  );
+}
+
+async function enqueueArmFailedDm(args, result) {
+  // Resolve TG chat — notification-sender reads users.telegram_id by
+  // user_id, so we don't need to lookup here. Just enqueue.
+  if (!args.userId) return;
+
+  const payload = {
+    direction: args.triggerDirection || args.direction || "above",
+    trigger_kind: args.triggerKind || null,
+    trigger_value_micro: args.triggerValueMicro != null
+      ? String(args.triggerValueMicro)
+      : null,
+    slice_pct: args.slicePct ?? null,
+    ladder_group_id: args.ladderGroupId || null,
+    source: args.source || null,
+    loan_id_chain: args.loanIdChain != null ? String(args.loanIdChain) : null,
+    error_code: safeTruncate(result?.error, 64),
+    error_detail: safeTruncate(jsonStringifyError(result?.detail), 400),
+  };
+
+  await query(
+    `INSERT INTO pending_notifications (user_id, channel, kind, payload, status)
+       VALUES ($1, 'tg', 'limit_close_arm_failed', $2::jsonb, 'pending')`,
+    [args.userId, JSON.stringify(payload)],
+  );
 }

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -700,7 +700,9 @@ export async function recordLoan({
     console.error("[loans] referral accrual on borrow failed (continuing):", err.message);
   }
 
-  // $MAGPIE holder pool accrual (10% of fee)
+  // $MAGPIE holder pool accrual — 70% of fee post-MGP-001 (the bps is
+  // read from governance_config at accrual time; comment kept current
+  // so future readers don't think this is the legacy 10% share).
   try {
     const { accrueToHolderPool } = await import("./magpie-holder-rewards.js");
     if (feeLamports > 0n) {

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -1,9 +1,12 @@
 /**
  * LP Loyalty Bonus Pool.
  *
- * Mechanic:
- *   - 2% of every loan fee accrues to the lp_loyalty_pool (source: the
- *     protocol's 5% slice — LPs keep their full 80% base yield).
+ * Mechanic (post-MGP-001 ratified 2026-06-13):
+ *   - 10% of every loan fee accrues to the lp_loyalty_pool. This IS
+ *     the LP yield stream — there is no separate "base 80% share"
+ *     anymore. The fee split is now 70% holders / 10% LP loyalty /
+ *     10% referrer / 10% protocol reserve, with 0% retained in the
+ *     lending pool itself.
  *   - Each LP's "weight" at snapshot time = current shares × seconds
  *     since their weighted_deposit_at (the time-weighted average of
  *     their deposit moments).

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -132,10 +132,12 @@ function loadLenderKeypair() {
 }
 
 /**
- * Add 10% of a loan fee to the holder reward pool. Idempotent NOT
- * guaranteed — caller must ensure they call once per fee event. Safe
- * to call from inside the loan-recording try/catch (errors don't
- * propagate up to the user-facing flow).
+ * Add the holder-share fraction of a loan fee to the holder reward
+ * pool. Fraction is read from governance_config at call time —
+ * currently 70% post-MGP-001 (ratified 2026-06-13), previously 10%.
+ * Idempotent NOT guaranteed — caller must ensure they call once per
+ * fee event. Safe to call from inside the loan-recording try/catch
+ * (errors don't propagate up to the user-facing flow).
  */
 /**
  * Credit a pre-computed lamport amount directly to the holder pool.

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -96,6 +96,100 @@ function renderLimitCloseArmed(p) {
 }
 
 /**
+ * Arm-attempt failure DM. Fired by limit-close-arm-core's wrapper on
+ * EVERY failed armOrder() call, regardless of source (site / tg /
+ * agent_x402). Forcing function: operator's 2026-06-15 V4 SPCX ladder
+ * incident — the user thought they armed a ladder, the strike was
+ * hit, no fire happened, no signal anywhere on the dashboard. Now
+ * they get the truth in their DMs within seconds.
+ */
+function renderLimitCloseArmFailed(p) {
+  // Human-readable explanation for known error codes. Falls back to
+  // the raw error_code + detail so we never silently drop info.
+  const why = humanizeArmFailure(p.error_code, p.error_detail);
+
+  // Format the target the user tried to arm, when we have enough to
+  // reconstruct it. Otherwise a generic "your auto-sell".
+  const target = formatAttemptedTarget(p);
+
+  const dirLabel = p.direction === "below" ? "stop-loss" : "take-profit";
+  const sliceTxt = p.slice_pct && p.slice_pct < 10000
+    ? ` (${(p.slice_pct / 100).toFixed(0)}% slice)`
+    : "";
+
+  return [
+    `*Auto-sell didn't arm*`,
+    ``,
+    `What you tried to set: ${target}${sliceTxt} — ${dirLabel}`,
+    p.loan_id_chain ? `Loan: #${p.loan_id_chain}` : null,
+    ``,
+    `Why it failed: ${why}`,
+    ``,
+    `Nothing is armed on the chain. Tap "Try again" in the dashboard or DM me ("/help") if you'd like a walk-through.`,
+  ].filter((s) => s !== null).join("\n");
+}
+
+function formatAttemptedTarget(p) {
+  if (!p.trigger_kind || p.trigger_value_micro == null) return "your auto-sell";
+  const n = Number(p.trigger_value_micro);
+  if (!Number.isFinite(n)) return "your auto-sell";
+  if (p.trigger_kind === "mc_usd") {
+    const usd = n / 1e6;
+    if (usd >= 1e9) return `$${(usd / 1e9).toFixed(2)}B mc`;
+    if (usd >= 1e6) return `$${(usd / 1e6).toFixed(2)}M mc`;
+    if (usd >= 1e3) return `$${(usd / 1e3).toFixed(2)}K mc`;
+    return `$${usd.toFixed(2)} mc`;
+  }
+  if (p.trigger_kind === "price_usd") {
+    const usd = n / 1e6;
+    if (usd >= 1) return `$${usd.toFixed(2)}`;
+    if (usd >= 0.01) return `$${usd.toFixed(4)}`;
+    return `$${usd.toFixed(8)}`;
+  }
+  return `${(n / 1e9).toFixed(6)} SOL`;
+}
+
+function humanizeArmFailure(code, detail) {
+  switch (code) {
+    case "loan_not_found_for_user":
+      return "We couldn't find that loan on your account. If you just borrowed, give it ~5 seconds and try again — the loan may not have propagated yet.";
+    case "loan_not_active":
+      return "That loan isn't active anymore. It may have been repaid or liquidated.";
+    case "loan_below_minimum_size":
+      return "Loans under 1 SOL aren't eligible for auto-sells right now.";
+    case "collateral_not_enabled":
+      return "This collateral token is currently disabled for new auto-sells. Ping @MagpieLoans if you think this is a mistake.";
+    case "take_profit_already_armed":
+    case "stop_loss_already_armed":
+    case "loan_already_has_active_order":
+      return "You already have an active auto-sell on this loan in this direction. Cancel the existing one first if you want to change it.";
+    case "trigger_would_fire_immediately":
+      return "Your target is on the wrong side of the current price — it would fire as soon as it armed. Pick a target above the current price for take-profit (or below it for stop-loss).";
+    case "user_concurrency_cap_reached":
+      return "You've hit the per-user cap of 10 active auto-sells. Cancel an existing one and try again.";
+    case "invalid_slippage_bps":
+      return "The slippage allowance was outside the protocol bounds.";
+    case "invalid_slice_pct":
+      return "Ladder slice has to add up correctly — each leg between 0.01% and 100%, total ≤ 100%.";
+    case "invalid_trigger_value":
+    case "trigger_value_out_of_range":
+      return "The price target looked malformed. Try entering it as a USD value (e.g. \"180\") or a market-cap (\"145M mc\").";
+    case "invalid_trailing_distance_bps":
+      return "Trailing distance must be between 0.5% and 50%.";
+    case "trailing_only_valid_on_stop_loss":
+      return "Trailing distance only applies to stop-loss orders, not take-profit.";
+    case "insert_failed":
+      return `The database refused the order at the last step. Detail: ${detail || "(none provided)"}`;
+    case "exception":
+      return `An unexpected error happened on the server. Detail: ${detail || "(none provided)"}`;
+    default:
+      return code
+        ? `${code}${detail ? ` — ${detail}` : ""}`
+        : "Unknown failure (we logged it).";
+  }
+}
+
+/**
  * V4 fire DM — fundamentally different message from legacy fire.
  *
  * Legacy V1/V3 fire: engine repaid loan + sold collateral + sent SOL to
@@ -360,6 +454,7 @@ function renderEnginePreflightFailed(p) {
 
 const RENDERERS = {
   limit_close_armed:        renderLimitCloseArmed,
+  limit_close_arm_failed:   renderLimitCloseArmFailed,
   limit_close_fired:           renderLimitCloseFired,
   limit_close_v4_fired:        renderLimitCloseV4Fired,
   limit_close_failed:          renderLimitCloseFailed,


### PR DESCRIPTION
Forcing function: operator's 2026-06-15 V4 SPCX ladder went silent. Every armOrder() call now writes one row + DMs the user on failure. Renames body to armOrderImpl; new armOrder wrapper preserves return shape. New limit_close_arm_failed renderer with humanizeArmFailure for every known error code.