### PR TITLE
fix(bot): drop orphan 10% cap constraint + strip Profit-leg disclaimer

### DIFF
--- a/migrations/069_drop_orphan_cap_in_range_constraint.sql
+++ b/migrations/069_drop_orphan_cap_in_range_constraint.sql
@@ -1,0 +1,39 @@
+-- 069_drop_orphan_cap_in_range_constraint.sql
+--
+-- BACKGROUND
+-- ──────────────────────────────────────────────────────────────────
+-- Migration 027 added a CHECK constraint named
+--     limit_close_orders_cap_in_range
+-- capping max_slippage_bps_cap at 1000 bps (10%).
+--
+-- Migration 031 was supposed to widen that ceiling to 5000 bps (50%)
+-- so V3 RWA + V4 thin tokens could pass the thin-token slippage bump.
+-- But 031's DROP/ADD pair targeted a DIFFERENT name —
+--     limit_close_orders_max_slippage_cap_in_range
+-- — because of a copy-paste typo in the constraint name. So the OLD
+-- 10% constraint was never dropped. Both constraints have been live
+-- since 2026-04, and the stricter (10%) one silently blocks every
+-- insert whose cap exceeds 1000 bps.
+--
+-- IMPACT
+-- ──────────────────────────────────────────────────────────────────
+-- This is the actual reason the operator's 2026-06-15 V4 $TROLL
+-- ladder failed with `insert_failed`. arm-core computes a thin-token
+-- cap that lands in the 10–50% range. The new constraint accepted
+-- it; the orphaned old one rejected it.
+--
+-- FIX
+-- ──────────────────────────────────────────────────────────────────
+-- Drop the orphaned `limit_close_orders_cap_in_range` constraint.
+-- The wider replacement `limit_close_orders_max_slippage_cap_in_range`
+-- (5000 bps ceiling) from 031 remains in place and is sufficient.
+--
+-- This is a pure constraint removal — no row touched, no data lost,
+-- no existing behavior changes for any row already under the wider
+-- 50% ceiling.
+--
+-- Idempotent: IF EXISTS guard so re-running on a DB where the
+-- constraint was already dropped is a no-op.
+
+ALTER TABLE limit_close_orders
+  DROP CONSTRAINT IF EXISTS limit_close_orders_cap_in_range;

--- a/scripts/recent-arm-attempts.mjs
+++ b/scripts/recent-arm-attempts.mjs
@@ -1,0 +1,13 @@
+import { query } from "../src/db/pool.js";
+const wallet = process.argv[2];
+if (!wallet) { console.error("usage: node scripts/recent-arm-attempts.mjs <wallet>"); process.exit(1); }
+const u = await query(`SELECT u.id FROM users u JOIN wallets w ON w.user_id=u.id WHERE w.public_key=$1`, [wallet]);
+if (!u.rows.length) { console.log("no user"); process.exit(0); }
+const r = await query(
+  `SELECT id, loan_id_chain, direction, target_kind, target_value_micro::text AS val,
+          slice_pct, outcome, error_code, error_detail, source, created_at
+     FROM limit_close_arm_attempts
+    WHERE user_id=$1 ORDER BY created_at DESC LIMIT 20`, [u.rows[0].id]);
+console.log(`attempts: ${r.rows.length}`);
+for (const a of r.rows) console.log(JSON.stringify(a, null, 1));
+process.exit(0);

--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -947,7 +947,10 @@ export function registerBorrowCallbacks(bot) {
       console.warn("[borrow] armConfiguredExits threw:", err.message);
       return [{ ok: false, label: "Auto-arm", error: "internal_error" }];
     });
-    const exitsSummary = renderExitsSummary(exitArmResults);
+    // exitsSummary used to be embedded in the borrow card — removed
+    // 2026-06-15 per operator's "bad look" feedback. The per-leg
+    // outcomes now ride on the limit_close_armed / limit_close_arm_failed
+    // DM pipeline (migration 068) instead.
     const allLegsArmed = exitArmResults.length > 0 && exitArmResults.every((r) => r.ok);
     const anyExitFailed = exitArmResults.some((r) => !r.ok);
 
@@ -1006,10 +1009,14 @@ export function registerBorrowCallbacks(bot) {
       `Term: ${tier.days} days at ${tier.ltv}% LTV`,
       "",
       `[View tx](https://solscan.io/tx/${result.signature})`,
-      exitsSummary ? "" : null,
-      exitsSummary,
-      anyExitFailed ? "" : null,
-      anyExitFailed ? "*One of your auto-sells didn't go through — tap a button below to set a default, or use /takeprofit / /stoploss to retry the exact target.*" : null,
+      // Per-leg arm results intentionally NOT shown on the borrow card —
+      // operator's 2026-06-15 directive: "I thought we GOT RID of that
+      // Profit Leg disclaimer at the bottom. It's a bad look." Failed
+      // legs are surfaced in their own `limit_close_arm_failed` DM via
+      // the audit pipeline (migration 068), and successful ones in the
+      // existing `limit_close_armed` DM — both arrive within seconds.
+      // The borrow card stays clean. Retry buttons below still appear
+      // when an exit didn't land, so users have a single-tap recovery.
       "",
       allLegsArmed
         ? "/positions to check status · /limitorders to manage auto-sells"
@@ -1035,11 +1042,7 @@ export function registerBorrowCallbacks(bot) {
       `Loan #${result.loanId}`,
       "",
       `Tx: https://solscan.io/tx/${result.signature}`,
-      exitsSummary ? "" : null,
-      // Strip markdown stars from the summary for the plain-text version.
-      exitsSummary ? exitsSummary.replace(/\*/g, "") : null,
-      anyExitFailed ? "" : null,
-      anyExitFailed ? "One of your auto-sells didn't go through — tap a button below to set a default, or use /takeprofit / /stoploss to retry the exact target." : null,
+      // Same omission as the Markdown card — leg results go via DM.
       "",
       allLegsArmed
         ? "Run /positions to check status, /limitorders to manage auto-sells."


### PR DESCRIPTION
Migration 069 drops orphaned 10%-cap CHECK constraint (typo'd DROP in 031). Removes leg-level outcome lines from borrow card per operator (audit DM covers it).  ladder will now insert; borrow card stays clean.