### PR TITLE
fix(lc): derive fee from proceeds-net_to_user (column did not exist)

### DIFF
--- a/src/commands/lc-status.js
+++ b/src/commands/lc-status.js
@@ -135,7 +135,8 @@ async function showFired(ctx) {
     `SELECT lc.id, lc.loan_id, l.collateral_mint, sm.symbol,
             COALESCE(lc.trigger_direction, 'above') AS dir,
             lc.status, lc.fired_at, lc.tx_signature_repay, lc.tx_signature_swap,
-            lc.proceeds_lamports::text AS proceeds, lc.fee_lamports::text AS fee,
+            lc.proceeds_lamports::text AS proceeds,
+            (lc.proceeds_lamports - COALESCE(lc.net_to_user_lamports, lc.proceeds_lamports))::text AS fee,
             lc.source
        FROM limit_close_orders lc
        JOIN loans l ON l.id = lc.loan_id

--- a/src/services/lc-operator-alerts.js
+++ b/src/services/lc-operator-alerts.js
@@ -62,7 +62,12 @@ async function tick(bot) {
             COALESCE(lc.trigger_direction, 'above') AS dir,
             lc.status, lc.fired_at, lc.updated_at,
             lc.tx_signature_repay, lc.tx_signature_swap,
-            lc.proceeds_lamports::text AS proceeds, lc.fee_lamports::text AS fee,
+            lc.proceeds_lamports::text AS proceeds,
+            -- fee_lamports column doesn't exist on limit_close_orders.
+            -- Derive: fee = proceeds - net_to_user (1% protocol take).
+            -- NULL-safe via COALESCE so partial-fired rows without
+            -- net_to_user yet still report fee as NULL instead of NaN.
+            (lc.proceeds_lamports - COALESCE(lc.net_to_user_lamports, lc.proceeds_lamports))::text AS fee,
             lc.failure_reason, lc.failure_count,
             lc.source, lc.source_agent_pubkey
        FROM limit_close_orders lc


### PR DESCRIPTION
lc-operator-alerts watcher was throwing every tick on missing column. Two queries fixed; no schema change.