### PR TITLE
fix(routing): revert V3 fallback — BLOCK Token-2022 + exits until V4.x ships

### DIFF
--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -227,17 +227,10 @@ export async function buildBorrowTx({
     };
   }
 
-  // Exit-armed borrows route by Token-2022 vs classic SPL:
-  //   - classic SPL (memecoins) + exit → V4 (in-vault model)
-  //   - Token-2022 (RWA tokens) + exit → V3 (legacy fire-and-close)
-  // V4 currently fails repay simulation for Token-2022 collateral
-  // (operator loan 763, 2026-06-15). Until V4 is patched non-
-  // invasively, Token-2022 + exit lives on V3.
-  const { TOKEN_2022_PROGRAM_ID } = await import("@solana/spl-token");
-  const isToken2022 = mintRow.token_program === TOKEN_2022_PROGRAM_ID.toBase58();
+  // Exit-armed borrows force V4; plain borrows take the category path.
   let programId;
   try {
-    programId = chooseProgramId(mintRow.category, { hasExitArming, isToken2022 });
+    programId = chooseProgramId(mintRow.category, { hasExitArming });
   } catch (err) {
     return { blocked: true, status: 503, body: { error: "v4_not_available", detail: err.message } };
   }

--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -227,11 +227,22 @@ export async function buildBorrowTx({
     };
   }
 
-  // Exit-armed borrows force V4; plain borrows take the category path.
+  // Exit-armed borrows force V4. Token-2022 + exits is BLOCKED until
+  // V4.x ships (operator-mandated V4 in-vault thesis 2026-06-15 PM —
+  // no V3 fallback because V3 uses the legacy fire-and-close model
+  // that the V4 thesis exists to replace). Plain borrows take the
+  // category path normally.
+  const { TOKEN_2022_PROGRAM_ID } = await import("@solana/spl-token");
+  const isToken2022 = mintRow.token_program === TOKEN_2022_PROGRAM_ID.toBase58();
   let programId;
   try {
-    programId = chooseProgramId(mintRow.category, { hasExitArming });
+    programId = chooseProgramId(mintRow.category, { hasExitArming, isToken2022 });
   } catch (err) {
+    // Distinguish the deliberate Token-2022 block (422 — caller should
+    // retry without the exit, not later) from v4-not-deployed (503).
+    if (err.message?.startsWith("TOKEN2022_EXIT_ARMING_TEMPORARILY_BLOCKED")) {
+      return { blocked: true, status: 422, body: { error: "token2022_exit_blocked", detail: err.message } };
+    }
     return { blocked: true, status: 503, body: { error: "v4_not_available", detail: err.message } };
   }
   try {

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -361,32 +361,8 @@ export async function handleSiteLimitCloseList(req, url) {
   // the ineligibility BEFORE the user signs an envelope that would
   // just bounce. Operator hit this on 2026-06-15 with $KINS and $PUMP
   // V1 loans that still showed the "Set upside auto-sell" CTA.
-  //
-  // 2026-06-15 PM: Token-2022 collateral exception. SPCX-class loans
-  // can't repay on V4 due to a program bug we can't redeploy around,
-  // so Token-2022 + exit-armed borrows route to V3. V3 loans with
-  // Token-2022 collateral must be ELIGIBLE for new arms here too.
   const v4EnforceOn = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
   const v4ProgramIdStr = process.env.PROGRAM_ID_V4 ?? null;
-  // Pre-fetch token-program for each collateral mint so the per-loan
-  // check below is sync-friendly. One query, multi-row, indexed.
-  const token2022ByMint = new Set();
-  if (v4EnforceOn && loans.length > 0) {
-    try {
-      const mints = [...new Set(loans.map((l) => l.collateral_mint).filter(Boolean))];
-      const { rows: mintRows } = await query(
-        `SELECT mint, token_program FROM supported_mints WHERE mint = ANY($1::text[])`,
-        [mints],
-      );
-      const { TOKEN_2022_PROGRAM_ID } = await import("@solana/spl-token");
-      const t22 = TOKEN_2022_PROGRAM_ID.toBase58();
-      for (const r of mintRows) {
-        if (r.token_program === t22) token2022ByMint.add(r.mint);
-      }
-    } catch (err) {
-      console.warn("[site-limit-close] token-program lookup failed (defaulting to V4-only):", err.message);
-    }
-  }
 
   const annotated = loans.map((l) => {
     const baseReasons = [];
@@ -395,17 +371,7 @@ export async function handleSiteLimitCloseList(req, url) {
     // V4 enforcement: non-V4 loans can't take new exits. NOTE: this
     // intentionally does NOT touch already-armed orders — those keep
     // firing through their legacy path. Only blocks NEW arms.
-    //
-    // Exception: Token-2022 collateral routes to V3 (not V4) because
-    // of the V4 + sol_proceeds_vault init bug. V3 loans with
-    // Token-2022 collateral can be armed normally.
-    if (
-      v4EnforceOn &&
-      v4ProgramIdStr &&
-      l.program_id &&
-      l.program_id !== v4ProgramIdStr &&
-      !token2022ByMint.has(l.collateral_mint)
-    ) {
+    if (v4EnforceOn && v4ProgramIdStr && l.program_id && l.program_id !== v4ProgramIdStr) {
       baseReasons.push("exits_require_v4_loan");
     }
     // 2026-06-13 (PR C): RWA categories (stock/etf/metal) are NOW eligible

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -378,25 +378,7 @@ async function armOrderImpl({
         detail: "V4_EXIT_EXCLUSIVE_ENFORCE is on but PROGRAM_ID_V4 isn't set on this host. Either deploy V4 first, or unset V4_EXIT_EXCLUSIVE_ENFORCE.",
       };
     }
-    // 2026-06-15: Token-2022 collateral (SPCX etc.) fails V4 repay
-    // simulation due to a V4 program bug we can't redeploy around.
-    // Token-2022 + exit-armed borrows now route to V3 instead, so
-    // V3 loans with Token-2022 collateral MUST be allowed to arm.
-    // Detect by collateral_mint's token program owner.
-    let isToken2022 = false;
-    try {
-      const { getMintTokenProgram } = await import("./loans.js");
-      const { TOKEN_2022_PROGRAM_ID } = await import("@solana/spl-token");
-      const mintProgram = await getMintTokenProgram(loan.collateral_mint);
-      isToken2022 = mintProgram.equals(TOKEN_2022_PROGRAM_ID);
-    } catch (err) {
-      console.warn("[arm-core] token-program check failed (defaulting to V4-only):", err.message);
-    }
-    if (
-      loan.program_id &&
-      loan.program_id !== v4ProgramIdStr &&
-      !isToken2022
-    ) {
+    if (loan.program_id && loan.program_id !== v4ProgramIdStr) {
       return {
         ok: false,
         error: "exits_require_v4_loan",

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -177,8 +177,16 @@ export async function executeBorrow({
     [collateralMint],
   );
   const category = catRows[0]?.category ?? "memecoin";
-  // Exit-armed borrows force V4. Plain borrows take the category path.
-  const programId = chooseProgramId(category, { hasExitArming });
+  // Detect Token-2022 collateral. Token-2022 + exit-armed borrows are
+  // temporarily BLOCKED (operator-mandated V4 in-vault thesis 2026-06-15
+  // PM) until V4.x ships with the Token-2022 repay fix. Plain (no exit)
+  // borrows of Token-2022 collateral continue routing to V3 normally.
+  const collateralTokenProgram = await getMintTokenProgram(collateralMint);
+  const { TOKEN_2022_PROGRAM_ID } = await import("@solana/spl-token");
+  const isToken2022 = collateralTokenProgram.equals(TOKEN_2022_PROGRAM_ID);
+  // Exit-armed borrows force V4 (refuses with TOKEN2022_EXIT_ARMING_TEMPORARILY_BLOCKED
+  // if Token-2022). Plain borrows take the category path.
+  const programId = chooseProgramId(category, { hasExitArming, isToken2022 });
   // Hard safety stop — refuse to open a loan if the program/category
   // pairing is wrong. The v2 pool must NEVER hold memecoin collateral,
   // and v1 must never hold RWA. Throws if violated; caller surfaces

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -177,17 +177,8 @@ export async function executeBorrow({
     [collateralMint],
   );
   const category = catRows[0]?.category ?? "memecoin";
-  // Determine whether the collateral mint is Token-2022. SPCX-class
-  // (tokenized stocks/ETFs/metals) live on Token-2022; classic SPL
-  // memecoins use the legacy Token program. Token-2022 + exit arming
-  // currently fails V4 repay simulation (sol_proceeds_vault init
-  // bug — operator loan 763, 2026-06-15) so we route Token-2022 +
-  // exit-armed borrows to V3 instead. Memecoin (classic SPL) + exit
-  // continues to V4.
-  const collateralTokenProgram = await getMintTokenProgram(collateralMint);
-  const { TOKEN_2022_PROGRAM_ID } = await import("@solana/spl-token");
-  const isToken2022 = collateralTokenProgram.equals(TOKEN_2022_PROGRAM_ID);
-  const programId = chooseProgramId(category, { hasExitArming, isToken2022 });
+  // Exit-armed borrows force V4. Plain borrows take the category path.
+  const programId = chooseProgramId(category, { hasExitArming });
   // Hard safety stop — refuse to open a loan if the program/category
   // pairing is wrong. The v2 pool must NEVER hold memecoin collateral,
   // and v1 must never hold RWA. Throws if violated; caller surfaces

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -150,12 +150,31 @@ export function isRwaCategory(category) {
  * Fail-safe for the no-exit path: when in doubt, return v1.
  */
 export function chooseProgramId(category, opts = {}) {
-  const { hasExitArming = false } = opts;
+  const { hasExitArming = false, isToken2022 = false } = opts;
   if (hasExitArming) {
     if (!PROGRAM_ID_V4) {
       throw new Error(
         "EXIT_ARMING_REQUIRES_V4: exit-armed borrow requested but PROGRAM_ID_V4 is not configured. " +
         "Either complete the V4 deploy / env setup, or build a plain borrow without an exit.",
+      );
+    }
+    // V4 IN-VAULT THESIS IS NON-NEGOTIABLE (operator-mandated 2026-06-15 PM,
+    // feedback_v4_in_vault_thesis_non_negotiable.md). When the currently-
+    // deployed V4 program version has a bug specific to Token-2022 collateral
+    // (operator hit it on loan id=763 SPCX V4: `incorrect program id for
+    // instruction` at RepayLoan), the answer is NOT to route around it via
+    // V3's legacy fire-and-close model — V3's model violates the V4 thesis
+    // by sending proceeds to the user wallet on fire. The answer is to
+    // BLOCK the borrow with a clear message until V4.x ships with the fix.
+    if (isToken2022) {
+      throw new Error(
+        "TOKEN2022_EXIT_ARMING_TEMPORARILY_BLOCKED: Auto-sells on Token-2022 " +
+        "collateral (tokenized stocks, ETFs, metals) are temporarily paused " +
+        "while V4 is patched for in-vault repay handling. Two options: " +
+        "(a) borrow without an auto-sell attached, or " +
+        "(b) use a classic-SPL memecoin collateral if you need the exit feature. " +
+        "We'll re-enable Token-2022 exits the moment the V4 patch ships at a fresh " +
+        "program ID — existing loans won't be affected.",
       );
     }
     return PROGRAM_ID_V4;

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -150,36 +150,8 @@ export function isRwaCategory(category) {
  * Fail-safe for the no-exit path: when in doubt, return v1.
  */
 export function chooseProgramId(category, opts = {}) {
-  const { hasExitArming = false, isToken2022 = false } = opts;
+  const { hasExitArming = false } = opts;
   if (hasExitArming) {
-    // 2026-06-15: Token-2022 collateral (SPCX and other RWA tokenized
-    // stocks/ETFs/metals built on Token-2022) does NOT repay cleanly
-    // against the currently-deployed V4 program — simulation reverts
-    // with `incorrect program id for instruction` at the RepayLoan
-    // CPI when V4 initializes sol_proceeds_vault. Operator hit it on
-    // loan id=763 (SPCX, V4). Per the operator-mandated
-    // never-affect-existing-loans rule, V4 is NOT being redeployed.
-    //
-    // Stop the bleeding for NEW borrows: route Token-2022 + exit-armed
-    // borrows to V3, which has been repaying SPCX cleanly all along.
-    // V3 uses the legacy fire-and-close exit model (fire = repay loan
-    // + sell + send SOL to wallet) instead of V4's in-vault model —
-    // semantically different but functional. Better than silently
-    // failing at repay time.
-    //
-    // Classic SPL collateral (memecoins) with exit arming keeps the V4
-    // in-vault routing — no Token-2022 bug, no behavior change.
-    if (isToken2022) {
-      if (PROGRAM_ID_V3 && ROUTE_RWA_TO_V3) return PROGRAM_ID_V3;
-      // Defense-in-depth: if V3 isn't configured, refuse the borrow
-      // rather than fall through to V4 (which would silently fail
-      // at repay time).
-      throw new Error(
-        "EXIT_ARMING_REQUIRES_V3_FOR_TOKEN2022: Token-2022 collateral with " +
-        "exit arming requires PROGRAM_ID_V3 + ROUTE_RWA_TO_V3=true. " +
-        "Currently misconfigured.",
-      );
-    }
     if (!PROGRAM_ID_V4) {
       throw new Error(
         "EXIT_ARMING_REQUIRES_V4: exit-armed borrow requested but PROGRAM_ID_V4 is not configured. " +


### PR DESCRIPTION
V4 in-vault thesis is non-negotiable. V3 routing for Token-2022 violated the thesis (proceeds to user wallet on fire). Revert + block with clear user-facing message. V4 source found; patch path is V4.x at fresh program ID.