### PR TITLE
site-limit-close: surface current_collateral_amount + sol_proceeds (remainder watcher)

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -289,6 +289,13 @@ export async function handleSiteLimitCloseList(req, url) {
   const { rows: loans } = await query(
     `SELECT l.id, l.loan_id::text AS loan_id, l.loan_pda,
             l.collateral_mint, l.collateral_amount::text AS collateral_amount,
+            -- Remainder watcher columns (migration 066, engine maintains
+            -- them per fire). NULL on pre-066 rows → site falls back to
+            -- collateral_amount cleanly.
+            COALESCE(l.current_collateral_amount, l.collateral_amount)::text
+              AS current_collateral_amount,
+            COALESCE(l.sol_proceeds_amount, 0)::text AS sol_proceeds_amount,
+            COALESCE(l.auto_sells_fired, 0) AS auto_sells_fired,
             l.original_loan_amount_lamports::text AS owed_lamports,
             l.start_timestamp, l.due_timestamp,
             l.program_id,


### PR DESCRIPTION
Returns the V4 remainder-watcher columns added in migration 066 so site + TG can render 'X SOL in vault + Y TOKEN remaining' on partial-fire V4 loans. COALESCE falls back to collateral_amount / 0 / 0 on pre-066 rows.\n\nEngine PR magpiecapital/magpie-limitclose#42 keeps the columns fresh post-fire. Site PR consumes them in ExitStatusBanner.