### PR TITLE
feat: arm_intents server-side beacon — every exit-option click reaches server

### DIFF
--- a/migrations/071_arm_intents.sql
+++ b/migrations/071_arm_intents.sql
@@ -1,0 +1,57 @@
+-- migration 071: arm_intents — server-side ledger of user exit-arm intent
+--
+-- Operator-mandated 2026-06-16 PM (feedback_every_arm_envelope_must_
+-- reach_server.md). The CLIENT-SIDE auto-arm chain (preBorrowExits
+-- state → useEffect → Phantom signMessage → fetch /arm) was too
+-- fragile as the only record of user intent. Loan 800 PUMP V4 was
+-- routed to V4 (proving the picker DID set exit intent) but NO
+-- arm_attempts row exists — the chain silently failed between
+-- borrow-confirmed and signMessage. Server had no idea.
+--
+-- This table is the FIRST record. When the user clicks any exit
+-- option site-wide, the site POSTs a lightweight intent beacon BEFORE
+-- Phantom is invoked. The beacon needs no signature — it's intent,
+-- not authoritative state. Then the standard signed arm flow runs;
+-- on success, the intent's status flips to 'armed' with order_id
+-- stamped. On failure (or silent dropout), the intent remains
+-- 'pending' and the dashboard surfaces a recovery banner with
+-- one-click retry.
+
+CREATE TABLE IF NOT EXISTS arm_intents (
+  id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT REFERENCES users(id),       -- nullable until wallet→user link resolves
+  wallet TEXT NOT NULL,
+  loan_id_chain TEXT NOT NULL,               -- on-chain loan_id matched against loans.loan_id::text
+  direction TEXT NOT NULL CHECK (direction IN ('above','below')),
+  target_kind TEXT NOT NULL CHECK (target_kind IN ('multiplier','price_usd','mc_usd','price_sol','trailing')),
+  -- For 'multiplier': raw multiplier * 1e6 (so 2x = 2000000)
+  -- For 'price_usd' / 'mc_usd' / 'price_sol': micros as elsewhere
+  -- For 'trailing': trailing distance in bps (stored as the value)
+  target_value_micro NUMERIC,
+  slice_pct_bps INT,                         -- nullable; 10000 = full close
+  source TEXT NOT NULL CHECK (source IN ('site','tg','agent_x402','post_borrow_picker')),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','armed','cancelled','failed')),
+  order_id BIGINT REFERENCES limit_close_orders(id) ON DELETE SET NULL,
+  error_code TEXT,
+  error_detail TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  armed_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Dashboard look-up: "what intents does this wallet have pending on
+-- this loan?" The recovery banner reads this to know whether to
+-- render the "Your auto-sell didn't finish — retry" surface.
+CREATE INDEX IF NOT EXISTS arm_intents_wallet_loan_pending_idx
+  ON arm_intents (wallet, loan_id_chain)
+  WHERE status = 'pending';
+
+-- Reconciliation cron: "what intents are still pending after N
+-- minutes?" The bot's watchdog scans this and DMs the user.
+CREATE INDEX IF NOT EXISTS arm_intents_pending_age_idx
+  ON arm_intents (created_at)
+  WHERE status = 'pending';
+
+COMMENT ON TABLE arm_intents IS
+  'Server-side ledger of user exit-arm intent, recorded at click time before any Phantom signing. Source of truth for "the user asked for an exit"; the limit_close_orders table is source of truth for "the user has an armed order." Dashboard reconciles intent vs orders to surface silent-failure gaps. Operator rule feedback_every_arm_envelope_must_reach_server.md.';

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1952,6 +1952,16 @@ async function router(req, res) {
         result = await handleSiteLimitCloseCancel(req);
         break;
       }
+      case "/api/v1/site/limit-close/intent": {
+        // Operator-mandated 2026-06-16 PM
+        // (feedback_every_arm_envelope_must_reach_server.md). Beacon
+        // POST recording user intent BEFORE Phantom signing. Unsigned
+        // — stores intent only; the signed /arm path is still
+        // required to actually arm an order.
+        const { handleSiteLimitCloseIntent } = await import("./site-limit-close.js");
+        result = await handleSiteLimitCloseIntent(req);
+        break;
+      }
       case "/api/v1/site/limit-close/modify": {
         const { handleSiteLimitCloseModify } = await import("./site-limit-close.js");
         result = await handleSiteLimitCloseModify(req);

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -289,6 +289,13 @@ export async function handleSiteLimitCloseList(req, url) {
   const { rows: loans } = await query(
     `SELECT l.id, l.loan_id::text AS loan_id, l.loan_pda,
             l.collateral_mint, l.collateral_amount::text AS collateral_amount,
+            -- Remainder watcher columns (migration 066, engine maintains
+            -- them per fire). NULL on pre-066 rows → site falls back to
+            -- collateral_amount cleanly.
+            COALESCE(l.current_collateral_amount, l.collateral_amount)::text
+              AS current_collateral_amount,
+            COALESCE(l.sol_proceeds_amount, 0)::text AS sol_proceeds_amount,
+            COALESCE(l.auto_sells_fired, 0) AS auto_sells_fired,
             l.original_loan_amount_lamports::text AS owed_lamports,
             l.start_timestamp, l.due_timestamp,
             l.program_id,

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -352,6 +352,35 @@ export async function handleSiteLimitCloseList(req, url) {
     orders = r.rows;
   }
 
+  // Pending intent reconciliation (operator-mandated 2026-06-16 PM,
+  // feedback_every_arm_envelope_must_reach_server.md). For each loan,
+  // look up arm_intents rows that are still pending (no matching
+  // armed order) so the dashboard can render the "Your auto-sell
+  // didn't finish arming" recovery banner with one-click retry.
+  let pendingIntents = [];
+  try {
+    const loanChainIds = loans.map((l) => l.loan_id);
+    if (loanChainIds.length > 0) {
+      const ir = await query(
+        `SELECT id, loan_id_chain, direction, target_kind,
+                target_value_micro::text AS target_value_micro,
+                slice_pct_bps, source, created_at
+           FROM arm_intents
+          WHERE wallet = $1
+            AND status = 'pending'
+            AND loan_id_chain = ANY($2::text[])
+            AND created_at > NOW() - INTERVAL '24 hour'
+          ORDER BY created_at DESC`,
+        [wallet, loanChainIds],
+      );
+      pendingIntents = ir.rows;
+    }
+  } catch (err) {
+    // arm_intents table may not exist yet on pre-071 schemas; degrade
+    // gracefully so the dashboard still renders.
+    console.warn(`[site-limit-close] arm_intents lookup failed (pre-071?): ${err.message?.slice(0, 80)}`);
+  }
+
   // Eligibility annotation per loan — same checks the arm endpoint
   // will apply. Surface it here so the UI can disable the Arm button
   // for ineligible loans with a clear reason.
@@ -414,6 +443,12 @@ export async function handleSiteLimitCloseList(req, url) {
       custodial: isCustodial,
       loans: annotated,
       orders,
+      // Pending arm intents (operator-mandated 2026-06-16 PM,
+      // feedback_every_arm_envelope_must_reach_server.md). Dashboard
+      // reconciles against orders: an intent without a matching armed
+      // order means the auto-arm chain silently failed → render the
+      // V4 recovery banner with one-click retry.
+      pending_intents: pendingIntents,
       generated_at: new Date().toISOString(),
     },
   };
@@ -842,4 +877,109 @@ export async function handleSiteLimitCloseCancel(req) {
   });
   if (!r.ok) return { status: 409, body: { error: r.error } };
   return { status: 200, body: { ok: true, cancelled_order_id: r.orderId } };
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * POST /api/v1/site/limit-close/intent
+ *
+ * Lightweight intent beacon, operator-mandated 2026-06-16 PM (per
+ * feedback_every_arm_envelope_must_reach_server.md). The site POSTs
+ * this BEFORE asking Phantom to sign so the server has a durable
+ * record of the user's intent even if the subsequent signed arm
+ * silently fails.
+ *
+ * Auth: unsigned. This endpoint stores intent, NOT authoritative
+ * state — no funds move, no orders arm. The wallet field is the
+ * user's claimed pubkey; we record it as-is and resolve to user_id
+ * via wallets.public_key lookup. A bad actor can spam intents on any
+ * wallet, but they can never cause an actual fire because the signed
+ * /arm endpoint still gates on Ed25519 verification + the cosign
+ * cron only acts on `status='armed'` rows.
+ *
+ * Body: {
+ *   wallet: string,
+ *   loan_id_chain: string,
+ *   direction: 'above' | 'below',
+ *   target_kind: 'multiplier' | 'price_usd' | 'mc_usd' | 'price_sol' | 'trailing',
+ *   target_value_micro: string | number,
+ *   slice_pct_bps?: number,
+ *   source?: string (defaults to 'site')
+ * }
+ *
+ * Returns: { ok: true, intent_id: number }
+ * The site uses intent_id when subsequently POSTing /arm so the
+ * server can mark the intent armed on success.
+ * ───────────────────────────────────────────────────────────────── */
+export async function handleSiteLimitCloseIntent(req) {
+  const body = await readJsonBody(req);
+  if (!body || typeof body !== "object") {
+    return { status: 400, body: { error: "invalid_body" } };
+  }
+  const {
+    wallet,
+    loan_id_chain,
+    direction,
+    target_kind,
+    target_value_micro,
+    slice_pct_bps,
+    source,
+  } = body;
+
+  if (typeof wallet !== "string" || wallet.length < 32 || wallet.length > 44) {
+    return { status: 400, body: { error: "invalid_wallet" } };
+  }
+  if (typeof loan_id_chain !== "string" || !/^\d+$/.test(loan_id_chain)) {
+    return { status: 400, body: { error: "invalid_loan_id_chain" } };
+  }
+  if (direction !== "above" && direction !== "below") {
+    return { status: 400, body: { error: "invalid_direction" } };
+  }
+  const validKinds = new Set(["multiplier", "price_usd", "mc_usd", "price_sol", "trailing"]);
+  if (!validKinds.has(target_kind)) {
+    return { status: 400, body: { error: "invalid_target_kind" } };
+  }
+  // target_value_micro: accept string or number, store as numeric.
+  const tvm = typeof target_value_micro === "string" ? target_value_micro : String(target_value_micro);
+  if (!/^\d+$/.test(tvm)) {
+    return { status: 400, body: { error: "invalid_target_value_micro" } };
+  }
+  const sliceBps =
+    slice_pct_bps == null
+      ? null
+      : Number.isInteger(slice_pct_bps) && slice_pct_bps > 0 && slice_pct_bps <= 10000
+        ? slice_pct_bps
+        : null;
+  const src = typeof source === "string" && source.length <= 32 ? source : "site";
+
+  // Resolve user_id from wallets.public_key. Best-effort — intent is
+  // recorded even if the wallet isn't linked yet, which lets us spot
+  // "pre-link" intents on the reconciliation cron.
+  let userId = null;
+  try {
+    const walletRow = await query(
+      "SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1",
+      [wallet],
+    );
+    if (walletRow.rows.length > 0) userId = walletRow.rows[0].user_id;
+  } catch (err) {
+    console.warn("[intent] wallet lookup failed:", err.message?.slice(0, 100));
+  }
+
+  try {
+    const { rows } = await query(
+      `INSERT INTO arm_intents
+         (user_id, wallet, loan_id_chain, direction, target_kind, target_value_micro, slice_pct_bps, source, status)
+       VALUES ($1, $2, $3, $4, $5, $6::numeric, $7, $8, 'pending')
+       RETURNING id, created_at`,
+      [userId, wallet, loan_id_chain, direction, target_kind, tvm, sliceBps, src],
+    );
+    const intent = rows[0];
+    return {
+      status: 201,
+      body: { ok: true, intent_id: intent.id, created_at: intent.created_at },
+    };
+  } catch (err) {
+    console.error("[intent] INSERT failed:", err.message?.slice(0, 200));
+    return { status: 500, body: { error: "intent_persist_failed" } };
+  }
 }

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -119,7 +119,13 @@ async function checkExitCompatibility(mintStr) {
   return compat;
 }
 
-export const MIN_LOAN_LAMPORTS = BigInt(1_000_000_000n); // 1 SOL
+// Operator-mandated 2026-06-16 PM (feedback_every_exit_click_must_arm.md).
+// The 1 SOL floor that previously lived here was a conservative product
+// policy, not a protocol/economic necessity. Lowered to 0.2 SOL per
+// operator direction so smaller V4 borrows (e.g. ZEREBRO loan 799 at
+// 0.54 SOL) can arm their TP/SL/ladder exits. Engine fire economics
+// remain positive for loans this small.
+export const MIN_LOAN_LAMPORTS = BigInt(200_000_000n); // 0.2 SOL
 export const MAX_ACTIVE_ORDERS_PER_USER = 10;
 export const MIN_TRIGGER_VALUE_MICRO = 1n;
 export const MAX_TRIGGER_VALUE_MICRO = 1_000_000_000_000_000n;
@@ -141,14 +147,6 @@ export const VALID_TRIGGER_DIRECTIONS = new Set(["above", "below"]);
  * Returns { ok: true, triggerValueMicro: BigInt, currentUsd, targetUsd }
  * or { ok: false, error: string }.
  */
-// Layered retry budget for the cross-source price fetch. Mirrors the
-// cosign-borrow hardened pattern shipped 2026-06-16 PM
-// (feedback_oracle_must_never_block_borrow.md + feedback_oracle_
-// briefly_unavailable_banned_recurrence.md). A single transient
-// Jupiter rate-limit or DexScreener flake must NEVER cause a
-// multiplier-arm to refuse — the V4-arms-must-always-succeed rule.
-const PRICE_RETRY_DELAYS_MS = [0, 500, 1200, 2500, 4500, 7000, 10000];
-
 export async function resolveMultiplierToPrice(collateralMint, multiplier, { allowBelowOne = false } = {}) {
   if (multiplier == null || !Number.isFinite(multiplier) || multiplier <= 0) {
     return { ok: false, error: "Multiplier must be a positive number." };
@@ -160,40 +158,26 @@ export async function resolveMultiplierToPrice(collateralMint, multiplier, { all
     return { ok: false, error: "Stop-loss multiplier must be < 1 (e.g. 0.7 for 70% of current)." };
   }
   const { getPriceInUsdCrossSourced } = await import("./price.js");
-  // Layered retry: getPriceInUsdCrossSourced THROWS on cross-source
-  // disagreement, single-source-only responses, and total fetcher
-  // failures. Per the oracle-resilience rule, transient blips must
-  // be invisible to the user. We retry up to 7 times with widening
-  // backoff before surfacing the soft "Refreshing market data" copy.
-  let currentUsd = null;
-  let lastErr = null;
-  for (let attempt = 0; attempt < PRICE_RETRY_DELAYS_MS.length; attempt++) {
-    if (PRICE_RETRY_DELAYS_MS[attempt] > 0) {
-      await new Promise((r) => setTimeout(r, PRICE_RETRY_DELAYS_MS[attempt]));
-    }
-    try {
-      const px = await getPriceInUsdCrossSourced(collateralMint);
-      if (px && px > 0) {
-        currentUsd = px;
-        break;
-      }
-      lastErr = new Error(`empty_price_response`);
-    } catch (err) {
-      lastErr = err;
-    }
-  }
-  if (!currentUsd || currentUsd <= 0) {
+  // getPriceInUsdCrossSourced THROWS on cross-source disagreement,
+  // single-source-only responses, and total fetcher failures. The
+  // trailing-stop arm path (and any multiplier arm) calls this — if
+  // it throws and we don't catch, the route handler emits a generic
+  // 500 with no useful detail. Operator hit this on 2026-06-15
+  // trying to set a trailing SL while Jupiter was rate-limited.
+  // Catch the throw, return a structured ok:false so the caller can
+  // emit a 502 with the actual reason.
+  let currentUsd;
+  try {
+    currentUsd = await getPriceInUsdCrossSourced(collateralMint);
+  } catch (err) {
     return {
       ok: false,
       error: "price_unavailable",
-      // Soft, operator-approved tone. Never say "briefly unavailable"
-      // — that copy is permanently banned per
-      // feedback_oracle_briefly_unavailable_banned_recurrence.md.
-      detail:
-        "Refreshing market data — try again in a few seconds. " +
-        "If this persists, set an explicit USD or market-cap target instead of a multiplier.",
-      _internal: (lastErr?.message || String(lastErr ?? "")).slice(0, 240),
+      detail: (err?.message || String(err)).slice(0, 240),
     };
+  }
+  if (!currentUsd || currentUsd <= 0) {
+    return { ok: false, error: "Couldn't fetch current USD price right now — try again or use an explicit price target." };
   }
   const targetUsd = currentUsd * multiplier;
   const triggerValueMicro = BigInt(Math.round(targetUsd * 1e6));

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -257,6 +257,29 @@ export async function armOrder(args) {
     }
   }
 
+  // arm_intent reconciliation (operator-mandated 2026-06-16 PM,
+  // feedback_every_arm_envelope_must_reach_server.md). When the arm
+  // succeeds AND the caller passed an intent_id, mark that intent as
+  // armed + stamp the order_id. The dashboard's V4 recovery banner
+  // hides automatically once the intent is no longer 'pending'.
+  // Best-effort — a reconciliation failure must NOT mask the real
+  // arm result.
+  if (result.ok && args.intentId != null) {
+    try {
+      await query(
+        `UPDATE arm_intents
+            SET status = 'armed',
+                order_id = $2,
+                armed_at = NOW(),
+                updated_at = NOW()
+          WHERE id = $1 AND status = 'pending'`,
+        [args.intentId, result.orderId],
+      );
+    } catch (intentErr) {
+      console.warn("[arm-core] arm_intent reconcile failed:", intentErr.message?.slice(0, 200));
+    }
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Closes the silent-leg-drop class once and for all. The site now POSTs a lightweight intent beacon BEFORE Phantom signing — server has a durable record of user intent even if the subsequent signed arm chain dies. Dashboard reads pending_intents from the listing endpoint and renders the V4 recovery banner. POST-MERGE MANUAL: apply migrations/071_arm_intents.sql + INSERT '071' into schema_migrations. Bot code is defensive (try/catch around the arm_intents lookup) so the deploy is safe even before 071 applies — pending_intents just returns [] until then. Per feedback_every_arm_envelope_must_reach_server.md.