### PR TITLE
feat: arm-batch — 1 signature for N legs (closes silent-drop class)

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1623,6 +1623,7 @@ const PUBLIC_ROUTES = new Set([
   // wallet check), so the API-key gate is bypassed.
   "/api/v1/site/limit-close",
   "/api/v1/site/limit-close/arm",
+  "/api/v1/site/limit-close/arm-batch",
   "/api/v1/site/limit-close/arm-preflight",
   "/api/v1/site/limit-close/modify",
   "/api/v1/site/limit-close/cancel",
@@ -1940,6 +1941,15 @@ async function router(req, res) {
       case "/api/v1/site/limit-close/arm": {
         const { handleSiteLimitCloseArm } = await import("./site-limit-close.js");
         result = await handleSiteLimitCloseArm(req);
+        break;
+      }
+      case "/api/v1/site/limit-close/arm-batch": {
+        // Operator-mandated 2026-06-16 PM. One Phantom signature arms
+        // all legs of a ladder atomically. Replaces the N-popups-for-N-
+        // legs pattern that caused silent-leg-drop UX on loans 798/802.
+        // Per feedback_one_signature_for_n_legs_always.md.
+        const { handleSiteLimitCloseArmBatch } = await import("./site-limit-close.js");
+        result = await handleSiteLimitCloseArmBatch(req);
         break;
       }
       case "/api/v1/site/limit-close/arm-preflight": {

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -247,7 +247,7 @@ async function authSignedEnvelope(req, expectedMagpieHeader, requiredFields = []
     };
   }
 
-  return { ok: true, userId: walletRow.user_id, signerPubkey, fields };
+  return { ok: true, userId: walletRow.user_id, signerPubkey, fields, body };
 }
 
 /* ─────────────────────────────────────────────────────────────────
@@ -982,4 +982,176 @@ export async function handleSiteLimitCloseIntent(req) {
     console.error("[intent] INSERT failed:", err.message?.slice(0, 200));
     return { status: 500, body: { error: "intent_persist_failed" } };
   }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * POST /api/v1/site/limit-close/arm-batch
+ *
+ * Operator-mandated 2026-06-16 PM
+ * (feedback_one_signature_for_n_legs_always.md). ONE Phantom signature
+ * arms ALL legs of a ladder atomically. Replaces the N-popups-for-N-
+ * legs pattern that caused silent-leg-drop UX disasters on loans 798
+ * and 802 when Phantom sessions died between sequential signs.
+ *
+ * Signed envelope shape:
+ *   magpie: limit-close-arm-batch/v1
+ *   From:   <signer_wallet>
+ *   LoanId: <chain_loan_id>
+ *   Legs:   <json-array>
+ *   Nonce / Timestamp via signed_message envelope
+ *
+ * Where Legs is a JSON-stringified array:
+ *   [
+ *     {"d":"above","k":"price_usd","v":"212000000","s":5000,"slip":200},
+ *     {"d":"above","k":"price_usd","v":"230000000","s":5000,"slip":200}
+ *   ]
+ *   - d: 'above' (TP) | 'below' (SL)
+ *   - k: 'price_usd' | 'mc_usd' | 'price_sol'
+ *   - v: trigger_value_micro as string
+ *   - s: slice_bps (1..10000)
+ *   - slip: slippage_bps initial (10..MAX_PROTOCOL_SLIPPAGE_BPS)
+ *   - intent_id (optional): pending arm_intents row id to mark armed
+ *
+ * Body may ALSO include `intent_ids: [int, ...]` at the top level so
+ * the server reconciles each leg's intent without it being in the
+ * signed payload. Either path works; signed payload takes precedence.
+ *
+ * Returns:
+ *   201 + { ok: true, order_ids: [...], ladder_group_ids: { above?, below? } }
+ * or
+ *   409 + { ok: false, error, failed_leg_index, detail }
+ * ───────────────────────────────────────────────────────────────── */
+export async function handleSiteLimitCloseArmBatch(req) {
+  const auth = await authSignedEnvelope(req, "limit-close-arm-batch/v1", [
+    "LoanId",
+    "Legs",
+  ]);
+  if (!auth.ok) {
+    return {
+      status: auth.status,
+      body: {
+        error: auth.error,
+        ...(auth.detail ? { detail: auth.detail } : {}),
+        ...(auth.expected ? { expected: auth.expected } : {}),
+        ...(auth.retry_after_seconds ? { retry_after_seconds: auth.retry_after_seconds } : {}),
+      },
+    };
+  }
+  const { userId, fields, body: rawBody } = auth;
+  const reqId = (Math.random() * 1e9 | 0).toString(36);
+
+  // Parse Legs (signed payload — tamper-proof from middlemen).
+  let legs;
+  try {
+    legs = JSON.parse(String(fields.Legs));
+  } catch (e) {
+    return { status: 400, body: { error: "legs_json_parse_failed", detail: e.message?.slice(0, 120) } };
+  }
+  if (!Array.isArray(legs)) {
+    return { status: 400, body: { error: "legs_not_an_array" } };
+  }
+  if (legs.length === 0) {
+    return { status: 400, body: { error: "no_legs_supplied" } };
+  }
+  if (legs.length > 8) {
+    return { status: 400, body: { error: "too_many_legs", detail: "max 8 per batch" } };
+  }
+
+  // Translate the compact wire shape (d/k/v/s/slip) to armOrderBatch's
+  // friendlier internal shape.
+  const armCoreLegs = [];
+  for (let i = 0; i < legs.length; i++) {
+    const l = legs[i];
+    if (!l || typeof l !== "object") {
+      return { status: 400, body: { error: "leg_not_object", failed_leg_index: i } };
+    }
+    armCoreLegs.push({
+      direction: l.d,
+      kind: l.k,
+      valueMicro: l.v,
+      sliceBps: Number.isInteger(l.s) ? l.s : 10000,
+      slippageBps: Number.isInteger(l.slip) ? l.slip : (l.d === "below" ? 300 : 200),
+      expiresAt: l.exp || null,
+    });
+  }
+
+  // intent_ids may travel on the body (cheaper than padding the
+  // signed envelope). Site populates them from the postArmIntent
+  // calls that happen leg-by-leg in the picker.
+  const intentIds = Array.isArray(rawBody?.intent_ids) ? rawBody.intent_ids : null;
+
+  console.log(
+    `[arm-batch] AUTH-OK req=${reqId} user_id=${userId} signer=${auth.signerPubkey.slice(0, 8)}… ` +
+    `loan_id_chain=${fields.LoanId} n_legs=${armCoreLegs.length} ` +
+    `legs=${armCoreLegs.map((l) => `${l.direction}@${l.valueMicro}/${l.sliceBps}bps`).join(",")}`,
+  );
+
+  // Hand off to arm-core batch primitive.
+  const { armOrderBatch } = await import("../services/limit-close-arm-core.js");
+  const result = await armOrderBatch({
+    userId,
+    source: "site",
+    loanIdChain: String(fields.LoanId),
+    legs: armCoreLegs,
+    intentIds,
+    armNotePrefix: `armed via site batch by ${auth.signerPubkey.slice(0, 8)}…`,
+  });
+
+  if (!result.ok) {
+    console.log(
+      `[arm-batch] FAIL req=${reqId} error=${result.error} failed_leg=${result.failedLegIndex ?? "n/a"} detail=${result.detail?.slice?.(0, 200) || ""}`,
+    );
+    return {
+      status: 409,
+      body: {
+        ok: false,
+        error: result.error,
+        ...(result.failedLegIndex != null ? { failed_leg_index: result.failedLegIndex } : {}),
+        ...(result.detail ? { detail: result.detail } : {}),
+      },
+    };
+  }
+
+  console.log(
+    `[arm-batch] SUCCESS req=${reqId} order_ids=${result.orderIds.join(",")} ` +
+    `ladder_above=${result.ladderGroupIds.above?.slice(0, 8) || "-"} ` +
+    `ladder_below=${result.ladderGroupIds.below?.slice(0, 8) || "-"}`,
+  );
+
+  // Best-effort single combined DM. The site already shows immediate
+  // optimistic UI on the dashboard, so this is the operator-visible
+  // record for the borrower. Failure here does NOT undo the arm.
+  try {
+    const { enqueueNotification } = await import("../services/notification-sender.js");
+    await enqueueNotification({
+      userId,
+      kind: "limit_close_armed_batch",
+      payload: {
+        loan_id_chain: result.loanIdChain,
+        collateral_symbol: result.collateralSymbol,
+        n_legs: result.orderIds.length,
+        order_ids: result.orderIds,
+        legs: result.legs.map((l) => ({
+          order_id: l.orderId,
+          direction: l.direction,
+          trigger_kind: l.triggerKind,
+          trigger_value_micro: l.triggerValueMicro,
+          slice_pct_bps: l.slicePctBps,
+        })),
+        source: "site",
+      },
+    });
+  } catch (dmErr) {
+    console.warn(`[arm-batch] DM enqueue failed (non-fatal): ${dmErr.message?.slice(0, 120)}`);
+  }
+
+  return {
+    status: 201,
+    body: {
+      ok: true,
+      order_ids: result.orderIds,
+      ladder_group_ids: result.ladderGroupIds,
+      legs: result.legs,
+    },
+  };
 }

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -1065,14 +1065,24 @@ export async function handleSiteLimitCloseArmBatch(req) {
     if (!l || typeof l !== "object") {
       return { status: 400, body: { error: "leg_not_object", failed_leg_index: i } };
     }
-    armCoreLegs.push({
+    // Multiplier kind needs to forward the raw multiplier to arm-core's
+    // batch oracle-resolve phase. l.multiplier OR l.v (which carries
+    // the multiplier as a stringified number when k==="multiplier").
+    const armLeg = {
       direction: l.d,
       kind: l.k,
       valueMicro: l.v,
       sliceBps: Number.isInteger(l.s) ? l.s : 10000,
       slippageBps: Number.isInteger(l.slip) ? l.slip : (l.d === "below" ? 300 : 200),
       expiresAt: l.exp || null,
-    });
+    };
+    if (l.k === "multiplier" || typeof l.multiplier === "number") {
+      armLeg.multiplier =
+        typeof l.multiplier === "number" && l.multiplier > 0
+          ? l.multiplier
+          : Number(l.v);
+    }
+    armCoreLegs.push(armLeg);
   }
 
   // intent_ids may travel on the body (cheaper than padding the

--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -64,6 +64,26 @@ export async function query(text, params) {
 }
 
 /**
+ * Connect-out a client for a transactional sequence (BEGIN…COMMIT).
+ * Use for atomic multi-row writes where partial state is unacceptable
+ * — e.g. armOrderBatch's all-or-nothing N-leg insert
+ * (feedback_one_signature_for_n_legs_always.md). Always release the
+ * client in a finally block.
+ *
+ * Pins to the primary pool — we intentionally do NOT fail over to the
+ * secondary on connection-class errors here, because if a transaction
+ * is on a different DB than the rest of the request's writes the user
+ * would see "phantom" partial state. Better to surface a hard fail
+ * and let the caller decide.
+ */
+export async function getClient() {
+  if (!pool) {
+    throw new Error("No primary database connection available for transactional client");
+  }
+  return await pool.connect();
+}
+
+/**
  * One-shot schema patches run on bot startup. Each statement must be
  * idempotent — safe to re-run on every boot. Use sparingly; prefer
  * proper migration files for non-urgent changes.

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -917,6 +917,315 @@ async function armOrderImpl({
   };
 }
 
+/* ─────────────────────────────────────────────────────────────────
+ * armOrderBatch — atomic multi-leg arming.
+ *
+ * Operator-mandated 2026-06-16 PM
+ * (feedback_one_signature_for_n_legs_always.md). Triggering incident:
+ * SPCX loans 798 + 802 both had silent leg-drops when the site looped
+ * N signMessage calls (Phantom session died between the first two).
+ * Now multi-leg ladders sign exactly ONCE → POST batch envelope →
+ * server validates every leg → inserts ALL or NONE inside a single
+ * DB transaction.
+ *
+ * Validation runs in two phases:
+ *   1. Shared validation (loan exists, owner match, V4 routing,
+ *      collateral enabled, loan size floor, mint not blocked)
+ *   2. Per-leg sanity (direction, kind, value range, slice 1..10000,
+ *      slippage cap, optional trailing)
+ *   3. Cumulative slice check across (existing armed legs + batch
+ *      legs) per direction
+ *
+ * Insert phase opens a DB transaction, INSERTs N rows sharing one
+ * ladder_group_id per direction (computed up-front), commits.
+ * Rollback on any per-row failure.
+ *
+ * Returns:
+ *   { ok: true,
+ *     orderIds: [int, int, ...],
+ *     ladderGroupIds: { above?: uuid, below?: uuid },
+ *     legs: [{ orderId, direction, triggerValueMicro, slicePctBps }] }
+ * or
+ *   { ok: false, error, failedLegIndex?, detail }
+ *
+ * Best-effort post-commit work (intent reconcile, single combined DM,
+ * audit trail) happens OUTSIDE the transaction so a failure there
+ * doesn't undo the armed state.
+ * ───────────────────────────────────────────────────────────────── */
+export async function armOrderBatch({
+  userId,
+  source = "site",
+  sourceAgentPubkey = null,
+  loanIdChain,
+  legs,                    // [{ direction, kind, valueMicro, sliceBps, slippageBps, expiresAt?, trailingDistanceBps? }]
+  intentIds = null,        // optional [intent_id, ...] same length as legs
+  armNotePrefix = null,
+}) {
+  if (!Array.isArray(legs) || legs.length === 0) {
+    return { ok: false, error: "no_legs_supplied" };
+  }
+  if (legs.length > 8) {
+    return { ok: false, error: "too_many_legs", detail: "max 8 legs per batch" };
+  }
+
+  // Phase 1 — Shared loan + eligibility load (single round trip).
+  const { rows: loanRows } = await query(
+    `SELECT l.id, l.loan_id::text AS loan_id_chain, l.user_id, l.collateral_mint,
+            l.collateral_amount::text AS coll_raw,
+            l.original_loan_amount_lamports::text AS owed,
+            l.program_id, l.status,
+            sm.symbol, sm.decimals, sm.category, sm.enabled
+       FROM loans l
+       LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+      WHERE l.loan_id::text = $1 AND l.user_id = $2
+      LIMIT 1`,
+    [String(loanIdChain), userId],
+  );
+  if (loanRows.length === 0) {
+    return { ok: false, error: "loan_not_found_for_user" };
+  }
+  const loan = loanRows[0];
+  if (loan.status !== "active") {
+    return { ok: false, error: "loan_not_active", detail: loan.status };
+  }
+  if (BigInt(loan.owed) < MIN_LOAN_LAMPORTS) {
+    return {
+      ok: false,
+      error: "loan_below_minimum_size",
+      detail: `Loan is below the ${Number(MIN_LOAN_LAMPORTS) / 1e9} SOL minimum for limit-close orders.`,
+    };
+  }
+  if (loan.enabled === false) {
+    return { ok: false, error: "collateral_not_enabled" };
+  }
+  const v4Pid = process.env.PROGRAM_ID_V4 ?? null;
+  const v4EnforceOn = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
+  if (v4EnforceOn && v4Pid && loan.program_id && loan.program_id !== v4Pid) {
+    return { ok: false, error: "exits_require_v4_loan" };
+  }
+
+  // Phase 2 — Per-leg parse + validation. No DB writes yet.
+  const parsed = [];
+  for (let i = 0; i < legs.length; i++) {
+    const leg = legs[i];
+    const dir = (leg.direction || "above").toLowerCase();
+    if (dir !== "above" && dir !== "below") {
+      return { ok: false, error: "invalid_direction", failedLegIndex: i };
+    }
+    const kind = leg.kind;
+    if (!VALID_TRIGGER_KINDS.has(kind)) {
+      return { ok: false, error: "invalid_trigger_kind", failedLegIndex: i };
+    }
+    let tvBI;
+    try {
+      tvBI = BigInt(String(leg.valueMicro));
+    } catch {
+      return { ok: false, error: "invalid_trigger_value", failedLegIndex: i };
+    }
+    if (tvBI < MIN_TRIGGER_VALUE_MICRO || tvBI > MAX_TRIGGER_VALUE_MICRO) {
+      return { ok: false, error: "trigger_value_out_of_range", failedLegIndex: i };
+    }
+    const slice = Number.isInteger(leg.sliceBps) ? leg.sliceBps : 10000;
+    if (slice < 1 || slice > 10000) {
+      return { ok: false, error: "invalid_slice_pct", failedLegIndex: i };
+    }
+    const slip = Number.isInteger(leg.slippageBps)
+      ? leg.slippageBps
+      : (dir === "below" ? 300 : 200);
+    if (slip < 10 || slip > MAX_PROTOCOL_SLIPPAGE_BPS) {
+      return { ok: false, error: "invalid_slippage_bps", failedLegIndex: i };
+    }
+    parsed.push({
+      idx: i,
+      direction: dir,
+      kind,
+      valueMicro: tvBI,
+      sliceBps: slice,
+      slippageBps: slip,
+      maxSlippageCapBps: Math.min(MAX_PROTOCOL_SLIPPAGE_BPS, Math.max(slip, 2500)),
+      expiresAt: leg.expiresAt || null,
+      trailingDistanceBps: Number.isInteger(leg.trailingDistanceBps) ? leg.trailingDistanceBps : null,
+    });
+  }
+
+  // Phase 3 — Cumulative slice cap per direction (existing armed +
+  // this batch). Mirrors the DB trigger from migration 064 / 065.
+  const existingSliceByDir = { above: 0, below: 0 };
+  const { rows: existingArmed } = await query(
+    `SELECT COALESCE(trigger_direction, 'above') AS dir, COALESCE(slice_pct, 10000) AS sp
+       FROM limit_close_orders
+      WHERE loan_id = $1 AND status = 'armed'`,
+    [loan.id],
+  );
+  for (const r of existingArmed) {
+    existingSliceByDir[r.dir] = (existingSliceByDir[r.dir] || 0) + Number(r.sp);
+  }
+  const batchSliceByDir = { above: 0, below: 0 };
+  for (const leg of parsed) batchSliceByDir[leg.direction] += leg.sliceBps;
+  for (const dir of ["above", "below"]) {
+    const total = (existingSliceByDir[dir] || 0) + (batchSliceByDir[dir] || 0);
+    if (total > 10000) {
+      return {
+        ok: false,
+        error: "ladder_sum_exceeds_100",
+        detail: `${dir === "above" ? "Take-profit" : "Stop-loss"} ladder would total ${(total / 100).toFixed(0)}% (existing ${(existingSliceByDir[dir] / 100).toFixed(0)}% + this batch ${(batchSliceByDir[dir] / 100).toFixed(0)}%).`,
+      };
+    }
+  }
+
+  // Phase 4 — Resolve ladder_group_id per direction. If an existing
+  // ladder group already covers that direction, reuse its id +
+  // original collateral snapshot. Else generate fresh ones.
+  const ladderGroupIds = {};
+  const originalCollateralByDir = {};
+  for (const dir of ["above", "below"]) {
+    const legsInDir = parsed.filter((l) => l.direction === dir);
+    if (legsInDir.length === 0) continue;
+    const { rows: existingGroupRows } = await query(
+      `SELECT ladder_group_id, original_collateral_amount::text AS oca
+         FROM limit_close_orders
+        WHERE loan_id = $1
+          AND COALESCE(trigger_direction, 'above') = $2
+          AND status = 'armed'
+          AND ladder_group_id IS NOT NULL
+        LIMIT 1`,
+      [loan.id, dir],
+    );
+    if (existingGroupRows.length > 0) {
+      ladderGroupIds[dir] = existingGroupRows[0].ladder_group_id;
+      originalCollateralByDir[dir] = existingGroupRows[0].oca;
+    } else if (legsInDir.length > 1 || (existingSliceByDir[dir] || 0) > 0) {
+      // Need a ladder_group_id when batch has multiple legs in this
+      // direction, OR when extending a single existing leg into a
+      // ladder. Single-direction single-leg with no existing legs
+      // stays group-less (cheaper writes for the simplest TP).
+      const { randomUUID } = await import("node:crypto");
+      ladderGroupIds[dir] = randomUUID();
+      originalCollateralByDir[dir] = loan.coll_raw;
+    } else {
+      ladderGroupIds[dir] = null;
+      originalCollateralByDir[dir] = null;
+    }
+  }
+
+  // Phase 5 — Atomic INSERT inside a DB transaction. Either every leg
+  // lands OR none do. No partial-arm state ever surfaces.
+  const { getClient } = await import("../db/pool.js");
+  const client = await getClient();
+  const insertedOrderIds = [];
+  try {
+    await client.query("BEGIN");
+    for (const leg of parsed) {
+      const lgid = ladderGroupIds[leg.direction];
+      const oca = originalCollateralByDir[leg.direction];
+      const noteBase = `armed via ${source} (batch ${parsed.length} legs)`;
+      const r = await client.query(
+        `INSERT INTO limit_close_orders
+           (user_id, loan_id, trigger_kind, trigger_value_micro,
+            trigger_direction,
+            slippage_bps, sell_destination, expires_at,
+            source, source_agent_pubkey, status, armed_at,
+            auto_escalate_slippage, max_slippage_bps_cap, initial_slippage_bps,
+            engine_program_id,
+            trailing_distance_bps, peak_price_micros,
+            slice_pct,
+            ladder_group_id,
+            original_collateral_amount,
+            notes)
+         VALUES ($1, $2, $3, $4,
+                 $5,
+                 $6, 'sol', $7,
+                 $8, $9, 'armed', NOW(),
+                 true, $10, $6,
+                 $11,
+                 $12, NULL,
+                 $13,
+                 $14,
+                 $15,
+                 $16)
+         RETURNING id`,
+        [
+          userId,
+          loan.id,
+          leg.kind,
+          leg.valueMicro.toString(),
+          leg.direction,
+          leg.slippageBps,
+          leg.expiresAt,
+          source,
+          sourceAgentPubkey,
+          leg.maxSlippageCapBps,
+          loan.program_id || null,
+          leg.trailingDistanceBps,
+          leg.sliceBps,
+          lgid,
+          oca,
+          armNotePrefix ? `${armNotePrefix}; ${noteBase}` : noteBase,
+        ],
+      );
+      insertedOrderIds.push(r.rows[0].id);
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_) {}
+    if (/TP\/SL ladder exceeds 100/i.test(err.message || "")) {
+      return { ok: false, error: "ladder_sum_exceeds_100", detail: err.message?.slice(0, 240) };
+    }
+    if (/duplicate key value violates unique constraint/i.test(err.message || "")) {
+      return { ok: false, error: "loan_already_has_active_order_in_direction" };
+    }
+    console.error("[arm-core:batch] insert failed:", err.message);
+    return { ok: false, error: "insert_failed", detail: err.message?.slice(0, 200) };
+  } finally {
+    client.release();
+  }
+
+  // Phase 6 — Post-commit best-effort work. Failures here do NOT undo
+  // the armed state. Each block guarded independently.
+
+  // Reconcile intents.
+  if (Array.isArray(intentIds) && intentIds.length === parsed.length) {
+    for (let i = 0; i < parsed.length; i++) {
+      const iid = intentIds[i];
+      const oid = insertedOrderIds[i];
+      if (iid == null) continue;
+      try {
+        await query(
+          `UPDATE arm_intents
+              SET status = 'armed', order_id = $2, armed_at = NOW(), updated_at = NOW()
+            WHERE id = $1 AND status = 'pending'`,
+          [iid, oid],
+        );
+      } catch (e) {
+        console.warn("[arm-core:batch] intent reconcile failed:", e.message?.slice(0, 80));
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    orderIds: insertedOrderIds,
+    ladderGroupIds: {
+      above: ladderGroupIds.above ?? null,
+      below: ladderGroupIds.below ?? null,
+    },
+    legs: parsed.map((leg, i) => ({
+      orderId: insertedOrderIds[i],
+      direction: leg.direction,
+      triggerKind: leg.kind,
+      triggerValueMicro: leg.valueMicro.toString(),
+      slicePctBps: leg.sliceBps,
+      slippageBps: leg.slippageBps,
+    })),
+    loanDbId: loan.id,
+    loanIdChain: loan.loan_id_chain,
+    collateralMint: loan.collateral_mint,
+    collateralSymbol: loan.symbol,
+  };
+}
+
 /**
  * Modify an armed order in place — change trigger value, slippage,
  * sell destination, or expires_at without canceling first.

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -1005,6 +1005,35 @@ export async function armOrderBatch({
   }
 
   // Phase 2 — Per-leg parse + validation. No DB writes yet.
+  // Multiplier kinds are resolved through the cross-source oracle in
+  // ONE batched fetch (single getPriceInUsdCrossSourced call for the
+  // mint, then each multiplier-kind leg = currentUsd * multiplier).
+  // This keeps the batch path consistent with single-arm pricing and
+  // covers preset ladders (which specify legs as e.g. 1.5x/2x/3x).
+  let currentUsdForMultiplier = null;
+  const hasMultiplierLeg = legs.some(
+    (l) => l && (l.kind === "multiplier" || (typeof l.multiplier === "number" && l.multiplier > 0)),
+  );
+  if (hasMultiplierLeg) {
+    try {
+      const { getPriceInUsdCrossSourced } = await import("./price.js");
+      currentUsdForMultiplier = await getPriceInUsdCrossSourced(loan.collateral_mint);
+    } catch (priceErr) {
+      return {
+        ok: false,
+        error: "price_unavailable",
+        detail: `Couldn't resolve multiplier legs (cross-source oracle): ${priceErr.message?.slice(0, 120) || String(priceErr).slice(0, 120)}`,
+      };
+    }
+    if (!currentUsdForMultiplier || currentUsdForMultiplier <= 0) {
+      return {
+        ok: false,
+        error: "price_unavailable",
+        detail: "Oracle returned empty price — try again in a few seconds.",
+      };
+    }
+  }
+
   const parsed = [];
   for (let i = 0; i < legs.length; i++) {
     const leg = legs[i];
@@ -1012,15 +1041,36 @@ export async function armOrderBatch({
     if (dir !== "above" && dir !== "below") {
       return { ok: false, error: "invalid_direction", failedLegIndex: i };
     }
-    const kind = leg.kind;
-    if (!VALID_TRIGGER_KINDS.has(kind)) {
-      return { ok: false, error: "invalid_trigger_kind", failedLegIndex: i };
-    }
+
+    // Resolve multiplier → price_usd here so downstream INSERT only
+    // ever stores concrete price/mc/sol triggers.
+    let kind = leg.kind;
     let tvBI;
-    try {
-      tvBI = BigInt(String(leg.valueMicro));
-    } catch {
-      return { ok: false, error: "invalid_trigger_value", failedLegIndex: i };
+    if (kind === "multiplier" || (typeof leg.multiplier === "number" && leg.multiplier > 0)) {
+      const m = leg.multiplier ?? Number(leg.valueMicro) / 1e6;
+      if (!Number.isFinite(m) || m <= 0) {
+        return { ok: false, error: "invalid_multiplier", failedLegIndex: i };
+      }
+      // For TP (above), multiplier MUST be > 1; for SL (below), MUST
+      // be < 1. Otherwise the order would fire instantly at arm time.
+      if (dir === "above" && m <= 1) {
+        return { ok: false, error: "tp_multiplier_must_exceed_1", failedLegIndex: i };
+      }
+      if (dir === "below" && m >= 1) {
+        return { ok: false, error: "sl_multiplier_must_be_below_1", failedLegIndex: i };
+      }
+      const targetUsd = currentUsdForMultiplier * m;
+      tvBI = BigInt(Math.round(targetUsd * 1e6));
+      kind = "price_usd";
+    } else {
+      if (!VALID_TRIGGER_KINDS.has(kind)) {
+        return { ok: false, error: "invalid_trigger_kind", failedLegIndex: i };
+      }
+      try {
+        tvBI = BigInt(String(leg.valueMicro));
+      } catch {
+        return { ok: false, error: "invalid_trigger_value", failedLegIndex: i };
+      }
     }
     if (tvBI < MIN_TRIGGER_VALUE_MICRO || tvBI > MAX_TRIGGER_VALUE_MICRO) {
       return { ok: false, error: "trigger_value_out_of_range", failedLegIndex: i };


### PR DESCRIPTION
Architectural fix per operator-mandated rule. One signed envelope lists all N legs; server atomically inserts all-or-none inside a DB transaction. Closes the silent-leg-drop class permanently. Companion site PR wires LadderPanel + post-borrow custom-ladder loop to the new batch endpoint.