### PR TITLE
fix(arm-core): breadcrumb arm_intent on TG / Pip / x402 paths

### DIFF
--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -1391,23 +1391,88 @@ export async function handleFixArm(ctx) {
   // don't pay the import on warm paths.
   const { InlineKeyboard } = await import("grammy");
 
+  // Intent-aware retry (operator-mandated 2026-06-16 PM,
+  // feedback_tg_v4_must_match_site_quality.md). For each candidate
+  // loan, look up pending arm_intents and surface the EXACT requested
+  // strike as the primary retry button — not generic 2x/3x/0.7x
+  // defaults. The hardcoded presets render only as a SECONDARY tier
+  // when no intent exists for the loan.
+  const loanChainIds = loans.map((l) => l.loan_id_chain);
+  const intentsByLoanChain = new Map();
+  if (loanChainIds.length > 0) {
+    try {
+      const { rows: intents } = await query(
+        `SELECT id, loan_id_chain, direction, target_kind,
+                target_value_micro::text AS target_value_micro,
+                slice_pct_bps
+           FROM arm_intents
+          WHERE wallet IN (
+            SELECT public_key FROM wallets WHERE user_id = $1
+          )
+            AND status = 'pending'
+            AND loan_id_chain = ANY($2::text[])
+            AND created_at > NOW() - INTERVAL '24 hour'
+          ORDER BY created_at DESC`,
+        [user.id, loanChainIds],
+      );
+      for (const r of intents) {
+        const arr = intentsByLoanChain.get(r.loan_id_chain) || [];
+        arr.push(r);
+        intentsByLoanChain.set(r.loan_id_chain, arr);
+      }
+    } catch (e) {
+      console.warn(`[fixarm] intent lookup failed (continuing with defaults): ${e.message?.slice(0, 100)}`);
+    }
+  }
+
   for (const ln of loans) {
     const sym = ln.symbol || ln.collateral_mint.slice(0, 4) + "…";
-    const kb = new InlineKeyboard()
-      .text("Sell at 2x", `fixarm:tp:${ln.loan_id_chain}:2`)
-      .text("Sell at 3x", `fixarm:tp:${ln.loan_id_chain}:3`)
-      .row()
-      .text("Sell at 0.7x", `fixarm:sl:${ln.loan_id_chain}:0.7`)
-      .text("Bracket 2x / 0.7x", `fixarm:br:${ln.loan_id_chain}`)
-      .row()
-      .text("Skip this loan", `fixarm:skip:${ln.loan_id_chain}`);
+    const intents = intentsByLoanChain.get(ln.loan_id_chain) || [];
 
-    await ctx.reply(
-      `*V4 loan on ${sym}* — no armed exit found.\n\n` +
-        `This loan landed on V4 because you set up an auto-sell, but the arming step didn't complete. ` +
-        `Pick a preset to retry now — single Telegram tap:`,
-      { parse_mode: "Markdown", reply_markup: kb },
-    );
+    const kb = new InlineKeyboard();
+    let intentButtonsRendered = 0;
+    for (const intent of intents) {
+      const v = Number(intent.target_value_micro) / 1e6;
+      const sliceBps = intent.slice_pct_bps ?? 10000;
+      let label;
+      // Callback shape: fixarm:intent:<loan_id_chain>:<intent_id> —
+      // handler reads the intent row to drive the arm. Stays under
+      // Telegram's 64-byte callback_data limit.
+      if (intent.target_kind === "multiplier") {
+        const verb = intent.direction === "above" ? "Sell at" : "Stop at";
+        label = `${verb} ${v}x`;
+        if (sliceBps < 10000) label += ` (${(sliceBps / 100).toFixed(0)}%)`;
+      } else if (intent.target_kind === "price_usd") {
+        const usd =
+          v >= 1 ? `$${v.toFixed(2)}` : v >= 0.01 ? `$${v.toFixed(4)}` : `$${v.toFixed(8)}`;
+        label = `${intent.direction === "above" ? "Sell at" : "Stop at"} ${usd}`;
+      } else if (intent.target_kind === "mc_usd") {
+        const mc =
+          v >= 1e9 ? `$${(v / 1e9).toFixed(2)}B mc` : `$${(v / 1e6).toFixed(2)}M mc`;
+        label = `${intent.direction === "above" ? "Sell at" : "Stop at"} ${mc}`;
+      } else {
+        label = `Retry ${intent.target_kind} ${v}`;
+      }
+      kb.text(label, `fixarm:intent:${ln.loan_id_chain}:${intent.id}`).row();
+      intentButtonsRendered += 1;
+    }
+
+    if (intentButtonsRendered === 0) {
+      kb.text("Sell at 2x", `fixarm:tp:${ln.loan_id_chain}:2`)
+        .text("Sell at 3x", `fixarm:tp:${ln.loan_id_chain}:3`)
+        .row()
+        .text("Sell at 0.7x", `fixarm:sl:${ln.loan_id_chain}:0.7`)
+        .text("Bracket 2x / 0.7x", `fixarm:br:${ln.loan_id_chain}`)
+        .row();
+    }
+    kb.text("Skip this loan", `fixarm:skip:${ln.loan_id_chain}`);
+
+    const headline =
+      intentButtonsRendered > 0
+        ? `*V4 loan on ${sym}* — your auto-sell didn't finish arming.\n\nWe have your exact strike on file. One tap retries it without losing the original target.`
+        : `*V4 loan on ${sym}* — no armed exit found.\n\nThis loan landed on V4 because you set up an auto-sell, but the arming step didn't complete. Pick a preset to retry now — single Telegram tap:`;
+
+    await ctx.reply(headline, { parse_mode: "Markdown", reply_markup: kb });
   }
 }
 
@@ -1474,6 +1539,118 @@ export function registerFixArmCallbacks(bot) {
     await ctx.editMessageText(
       `✓ ${sideLabel} armed at *${multiplier}x* — fires at $${fmt(r.targetUsd)}.\n\n` +
         `Order #${armed.orderId}. Manage via /limitorders.`,
+      { parse_mode: "Markdown" },
+    );
+  });
+
+  // Intent-aware retry handler (operator-mandated 2026-06-16 PM,
+  // feedback_tg_v4_must_match_site_quality.md). Loads the pending
+  // arm_intent row, resolves to a concrete trigger, calls armOrder
+  // with intentId so the existing reconcile path marks the intent
+  // 'armed' on success and the banner auto-hides.
+  bot.callbackQuery(/^fixarm:intent:(\d+):(\d+)$/, async (ctx) => {
+    const [, loanIdChain, intentIdStr] = ctx.match;
+    const intentId = Number(intentIdStr);
+    if (!Number.isInteger(intentId) || intentId <= 0) {
+      await ctx.answerCallbackQuery("Invalid intent.");
+      return;
+    }
+    await ctx.answerCallbackQuery("Arming…");
+
+    const tgUser = ctx.from;
+    const user = await upsertUser(tgUser.id, tgUser.username);
+
+    const { rows: [intent] } = await query(
+      `SELECT ai.id, ai.loan_id_chain, ai.direction, ai.target_kind,
+              ai.target_value_micro::text AS target_value_micro,
+              ai.slice_pct_bps
+         FROM arm_intents ai
+         JOIN wallets w ON w.public_key = ai.wallet AND w.user_id = $1
+        WHERE ai.id = $2
+          AND ai.loan_id_chain = $3
+          AND ai.status = 'pending'
+        LIMIT 1`,
+      [user.id, intentId, loanIdChain],
+    );
+    if (!intent) {
+      await ctx.editMessageText(
+        `That intent isn't pending anymore — it may have already armed. /limitorders to inspect.`,
+      );
+      return;
+    }
+
+    const { rows: [loan] } = await query(
+      `SELECT collateral_mint FROM loans WHERE user_id = $1 AND loan_id::text = $2 LIMIT 1`,
+      [user.id, loanIdChain],
+    );
+    if (!loan) {
+      await ctx.editMessageText(`Loan #${loanIdChain} not found in your account.`);
+      return;
+    }
+
+    let triggerKind;
+    let triggerValueMicro;
+    let labelForUser;
+    const targetVal = Number(intent.target_value_micro) / 1e6;
+    if (intent.target_kind === "multiplier") {
+      const r = await resolveMultiplierToPrice(loan.collateral_mint, targetVal, {
+        allowBelowOne: intent.direction === "below",
+      });
+      if (!r.ok) {
+        await ctx.editMessageText(
+          `Couldn't resolve ${targetVal}x target: ${r.detail || r.error}\n\nTry again in a few seconds.`,
+        );
+        return;
+      }
+      triggerKind = "price_usd";
+      triggerValueMicro = r.triggerValueMicro.toString();
+      labelForUser = `${targetVal}x`;
+    } else if (
+      intent.target_kind === "price_usd" ||
+      intent.target_kind === "mc_usd" ||
+      intent.target_kind === "price_sol"
+    ) {
+      triggerKind = intent.target_kind;
+      triggerValueMicro = intent.target_value_micro;
+      if (intent.target_kind === "mc_usd") {
+        labelForUser =
+          targetVal >= 1e9 ? `$${(targetVal / 1e9).toFixed(2)}B mc` : `$${(targetVal / 1e6).toFixed(2)}M mc`;
+      } else if (intent.target_kind === "price_usd") {
+        labelForUser =
+          targetVal >= 1 ? `$${targetVal.toFixed(2)}` : targetVal >= 0.01 ? `$${targetVal.toFixed(4)}` : `$${targetVal.toFixed(8)}`;
+      } else {
+        labelForUser = `${targetVal.toFixed(6)} SOL`;
+      }
+    } else {
+      await ctx.editMessageText(`Intent kind \`${intent.target_kind}\` not retryable here yet. Use /limitclose ${loanIdChain} ${targetVal} manually.`);
+      return;
+    }
+
+    const sliceBps = intent.slice_pct_bps && intent.slice_pct_bps < 10000 ? intent.slice_pct_bps : 10000;
+
+    const armed = await armOrder({
+      userId: user.id,
+      source: "tg",
+      loanIdChain,
+      triggerKind,
+      triggerValueMicro,
+      triggerDirection: intent.direction,
+      slicePct: sliceBps,
+      slippageBps: intent.direction === "below" ? 300 : 200,
+      sellDestination: "sol",
+      intentId,
+    });
+
+    if (!armed.ok) {
+      await ctx.editMessageText(
+        `Arm failed (${armed.error}). ${armed.detail || ""}\n\nUse /limitclose ${loanIdChain} ${targetVal}${intent.target_kind === "multiplier" ? "x" : ""} to retry manually.`,
+      );
+      return;
+    }
+
+    const verb = intent.direction === "above" ? "Take-profit" : "Stop-loss";
+    await ctx.editMessageText(
+      `✓ ${verb} armed at *${labelForUser}* — exact strike you asked for.\n\nOrder #${armed.orderId}. Manage via /limitorders.`,
       { parse_mode: "Markdown" },
     );
   });

--- a/src/index.js
+++ b/src/index.js
@@ -398,6 +398,12 @@ bot.command("crosspost", handleCommunityCrosspost);
   bot.command("takeprofit", lc.handleLimitClose);
   bot.command("tp", lc.handleLimitClose);
   bot.command("lo", lc.handleLimitClose);
+  // /sell — operator-mandated 2026-06-16 PM after PUMP loan 810: users
+  // reach for "sell at 1.3x" before they reach for "takeprofit at 1.3x".
+  // Routes to handleLimitClose which infers direction from the parsed
+  // strike (multiplier >= 1 → above/TP, < 1 → below/SL). Natural verb,
+  // same arm-core path.
+  bot.command("sell", lc.handleLimitClose);
   // Stop-loss — same arm-core path, direction='below' flips the engine's
   // trigger comparator from >= to <=. 1% protocol fee applies in BOTH
   // directions (operator rule 2026-06-12). Cutting losses before the

--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,7 @@ import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
 import { registerSupportVigilCallbacks } from "./services/support-vigil.js";
 import { startInfraHealth } from "./services/infra-health.js";
 import { startLimitCloseStalenessWatcher } from "./services/limit-close-staleness-watcher.js";
+import { startStaleArmIntentWatcher } from "./services/stale-arm-intent-watcher.js";
 import { startLimitCloseNearTriggerWatcher } from "./services/limit-close-near-trigger-watcher.js";
 import { registerLcStalenessCallbacks } from "./handlers/lc-staleness-callbacks.js";
 import { registerLcRetryingCallbacks } from "./handlers/lc-retrying-callbacks.js";
@@ -895,6 +896,14 @@ bot.start({
     // orders are old AND trigger far from current price. One-time
     // nudge per order. See feedback_tg_changes_careful.
     setTimeout(() => startLimitCloseStalenessWatcher(), 90_000);
+    // Stale-arm-intent watcher — every 60s DMs users whose V4 arm
+    // intents (recorded by site / TG / Pip / x402) haven't resolved
+    // to an armed order within 90s. Proactive recovery for silent
+    // arm drops; reactive surfaces (/fixarm + site recovery banner)
+    // still work without this, but the watcher catches users who
+    // never look. Operator-mandated 2026-06-16 PM after PUMP loan
+    // 810. See [[feedback_tg_v4_must_match_site_quality]].
+    setTimeout(() => startStaleArmIntentWatcher(), 30_000);
     // Near-trigger nudge — every 5 min DMs users whose armed orders
     // are within ~10% of firing. One-time per arm; reset on modify so
     // a re-tuned trigger gets a fresh nudge if it lands in the band.

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -225,6 +225,27 @@ const MAX_INITIAL_SLIPPAGE_BPS = MAX_PROTOCOL_SLIPPAGE_BPS; // 25% — allow agg
  * mask a real arm result.
  */
 export async function armOrder(args) {
+  // Breadcrumb intent (operator-mandated 2026-06-16 PM,
+  // feedback_tg_v4_must_match_site_quality.md). Every arm path — TG
+  // /sell, /takeprofit, /stoploss, /bracket, /trailingstop, ladders,
+  // Pip-driven arms, agent x402 — MUST leave an arm_intent row in
+  // 'pending' state BEFORE the armOrderImpl gates so the dashboard's
+  // V4 silent-arm recovery banner can render the user's exact strike
+  // if anything below fails. Site flow passes args.intentId because
+  // it already wrote one via /api/v1/site/limit-close/intent; in that
+  // case we don't write again. Best-effort: a write failure here does
+  // NOT abort the arm.
+  if (args.intentId == null && args.source !== "site") {
+    try {
+      const intentId = await writeBreadcrumbIntent(args);
+      if (intentId != null) args.intentId = intentId;
+    } catch (e) {
+      console.warn(
+        `[arm-core] breadcrumb intent write failed (continuing): ${e.message?.slice(0, 160)}`,
+      );
+    }
+  }
+
   let result;
   try {
     result = await armOrderImpl(args);
@@ -1714,4 +1735,123 @@ async function enqueueArmFailedDm(args, result) {
        VALUES ($1, 'tg', 'limit_close_arm_failed', $2::jsonb, 'pending')`,
     [args.userId, JSON.stringify(payload)],
   );
+}
+
+/* ────────────────────────────────────────────────────────────────
+ * Breadcrumb arm intent (operator-mandated 2026-06-16 PM,
+ * feedback_tg_v4_must_match_site_quality.md).
+ *
+ * Writes an arm_intent row in 'pending' state for any arm path that
+ * didn't already record one (TG /sell, /takeprofit, /stoploss,
+ * /bracket, /trailingstop, /ladder, Pip arms, agent x402). The
+ * intent acts as a durable record of the user's exact requested
+ * strike so:
+ *   - If armOrderImpl rejects (gate failure, ineligibility, etc.),
+ *     the dashboard V4 silent-arm-recovery banner can render the
+ *     exact strike as the retry CTA — not generic 2x/3x/0.7x.
+ *   - If armOrderImpl succeeds, the existing reconciliation path
+ *     marks the intent 'armed' and the dashboard hides the banner.
+ *
+ * Returns the new intent_id or null on any failure. Best-effort:
+ * a write failure must NEVER block the arm. Wallet lookup is
+ * derived from loans.borrower_wallet via the chain loan id — this
+ * is the wallet the user actually borrowed with, which is what
+ * arm_intents.wallet must contain for the dashboard's
+ * loan_id_chain filter to surface this intent.
+ * ──────────────────────────────────────────────────────────────── */
+async function writeBreadcrumbIntent(args) {
+  // Skip if we don't have what we need to write a useful breadcrumb.
+  if (!args.loanIdChain || !args.triggerKind || args.triggerValueMicro == null) {
+    return null;
+  }
+  // Skip dry-run paths — those are questions, not commitments.
+  if (args.dryRun) return null;
+
+  // Lookup borrower_wallet from loans by chain id. Defensive: only
+  // act when we get exactly one row to avoid cross-program ambiguity.
+  let walletPk;
+  let userId = args.userId || null;
+  try {
+    const { rows } = await query(
+      `SELECT borrower_wallet, user_id
+         FROM loans
+        WHERE loan_id::text = $1
+        ORDER BY id DESC
+        LIMIT 1`,
+      [String(args.loanIdChain)],
+    );
+    if (rows.length === 0) return null;
+    walletPk = rows[0].borrower_wallet;
+    if (!userId && rows[0].user_id) userId = rows[0].user_id;
+  } catch (e) {
+    console.warn(`[arm-core] breadcrumb loan lookup failed: ${e.message?.slice(0, 120)}`);
+    return null;
+  }
+
+  if (!walletPk || typeof walletPk !== "string" || walletPk.length < 32 || walletPk.length > 44) {
+    return null;
+  }
+
+  const targetKind = String(args.triggerKind);
+  const validKinds = new Set(["multiplier", "price_usd", "mc_usd", "price_sol", "trailing"]);
+  if (!validKinds.has(targetKind)) return null;
+
+  const tvm =
+    typeof args.triggerValueMicro === "bigint"
+      ? args.triggerValueMicro.toString()
+      : String(args.triggerValueMicro);
+  if (!/^\d+$/.test(tvm)) return null;
+
+  const direction =
+    args.triggerDirection === "below" || args.direction === "below" ? "below" : "above";
+
+  const sliceBpsRaw = args.slicePct;
+  const sliceBps =
+    sliceBpsRaw == null || sliceBpsRaw === 10000
+      ? null
+      : Number.isInteger(sliceBpsRaw) && sliceBpsRaw > 0 && sliceBpsRaw < 10000
+        ? sliceBpsRaw
+        : null;
+
+  // De-dupe: if an identical pending intent already exists for the
+  // same loan+direction+strike+slice in the last 5 min, reuse its id
+  // instead of writing a duplicate. Prevents UI noise from repeated
+  // /sell attempts at the same strike.
+  try {
+    const dedup = await query(
+      `SELECT id FROM arm_intents
+        WHERE wallet = $1
+          AND loan_id_chain = $2
+          AND direction = $3
+          AND target_kind = $4
+          AND target_value_micro = $5::numeric
+          AND COALESCE(slice_pct_bps, 0) = COALESCE($6::int, 0)
+          AND status = 'pending'
+          AND created_at > NOW() - INTERVAL '5 minutes'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [walletPk, String(args.loanIdChain), direction, targetKind, tvm, sliceBps],
+    );
+    if (dedup.rows.length > 0) return dedup.rows[0].id;
+  } catch (e) {
+    // Fall through to insert; dedupe is best-effort.
+    console.warn(`[arm-core] breadcrumb dedupe lookup failed: ${e.message?.slice(0, 120)}`);
+  }
+
+  const src = String(args.source || "unknown").slice(0, 32);
+
+  try {
+    const { rows } = await query(
+      `INSERT INTO arm_intents
+         (user_id, wallet, loan_id_chain, direction, target_kind, target_value_micro,
+          slice_pct_bps, source, status)
+       VALUES ($1, $2, $3, $4, $5, $6::numeric, $7, $8, 'pending')
+       RETURNING id`,
+      [userId, walletPk, String(args.loanIdChain), direction, targetKind, tvm, sliceBps, src],
+    );
+    return rows[0]?.id ?? null;
+  } catch (e) {
+    console.warn(`[arm-core] breadcrumb intent INSERT failed: ${e.message?.slice(0, 200)}`);
+    return null;
+  }
 }

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -1792,12 +1792,21 @@ async function writeBreadcrumbIntent(args) {
     return null;
   }
 
-  const targetKind = String(args.triggerKind);
+  // Trailing-stop arms pass triggerKind=price_usd + trailingDistanceBps;
+  // for the intent ledger they're 'trailing' with target_value_micro =
+  // the trailing distance in bps. arm_intents schema: target_kind
+  // CHECK ('multiplier','price_usd','mc_usd','price_sol','trailing').
+  const isTrailing =
+    args.trailingDistanceBps != null &&
+    Number.isInteger(args.trailingDistanceBps) &&
+    args.trailingDistanceBps > 0;
+  const targetKind = isTrailing ? "trailing" : String(args.triggerKind);
   const validKinds = new Set(["multiplier", "price_usd", "mc_usd", "price_sol", "trailing"]);
   if (!validKinds.has(targetKind)) return null;
 
-  const tvm =
-    typeof args.triggerValueMicro === "bigint"
+  const tvm = isTrailing
+    ? String(args.trailingDistanceBps)
+    : typeof args.triggerValueMicro === "bigint"
       ? args.triggerValueMicro.toString()
       : String(args.triggerValueMicro);
   if (!/^\d+$/.test(tvm)) return null;

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -1838,7 +1838,16 @@ async function writeBreadcrumbIntent(args) {
     console.warn(`[arm-core] breadcrumb dedupe lookup failed: ${e.message?.slice(0, 120)}`);
   }
 
-  const src = String(args.source || "unknown").slice(0, 32);
+  // arm_intents.source has a CHECK constraint: 'site' | 'tg' |
+  // 'agent_x402' | 'post_borrow_picker'. Map any caller-supplied
+  // source to the closest allowed value, default 'tg' (covers TG
+  // commands + Pip + anything else without an explicit source).
+  const rawSrc = String(args.source || "").toLowerCase();
+  let src;
+  if (rawSrc === "site") src = "site";
+  else if (rawSrc === "agent_x402" || rawSrc === "x402") src = "agent_x402";
+  else if (rawSrc === "post_borrow_picker") src = "post_borrow_picker";
+  else src = "tg";
 
   try {
     const { rows } = await query(

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -390,6 +390,23 @@ function renderPipUpsideAlert(p) {
   return p?.text || "";
 }
 
+function renderArmIntentStale(p) {
+  // p contains: intent_id, loan_id_chain, collateral_symbol,
+  // target_kind, target_value_micro, slice_pct_bps, direction,
+  // strike_label, recovery_command, recovery_callback, message_text
+  // The watcher pre-renders message_text so we just need to expose it.
+  if (typeof p.message_text === "string" && p.message_text.length > 0) {
+    return p.message_text;
+  }
+  const sym = p.collateral_symbol || "your loan";
+  const verb = p.direction === "above" ? "auto-sell" : "stop-loss";
+  return [
+    `Your ${verb} on ${sym} (loan #${p.loan_id_chain}) didn't finish arming — strike was *${p.strike_label || "the level you set"}*.`,
+    "",
+    `Tap to retry now or use /fixarm.`,
+  ].join("\n");
+}
+
 function renderLimitCloseStalenessNudge(p) {
   const dirLabel = p.trigger_direction === "below" ? "stop-loss" : "take-profit";
   return [
@@ -455,6 +472,7 @@ function renderEnginePreflightFailed(p) {
 const RENDERERS = {
   limit_close_armed:        renderLimitCloseArmed,
   limit_close_arm_failed:   renderLimitCloseArmFailed,
+  arm_intent_stale:         renderArmIntentStale,
   limit_close_fired:           renderLimitCloseFired,
   limit_close_v4_fired:        renderLimitCloseV4Fired,
   limit_close_failed:          renderLimitCloseFailed,
@@ -548,6 +566,19 @@ async function tick(bot) {
                 .text("Keep active", `lcstale:keep:${row.payload.order_id}`)
                 .text("Cancel order", `lcstale:cancel:${row.payload.order_id}`);
               extra = { reply_markup: kb };
+            } else if (row.kind === "arm_intent_stale") {
+              // One-tap retry: routes to the existing fixarm:intent
+              // callback in src/commands/limit-close.js so the same
+              // arm-via-intent path the dashboard uses lands here too.
+              const cbData = row.payload?.recovery_callback;
+              if (typeof cbData === "string" && cbData.length > 0 && cbData.length <= 64) {
+                const { InlineKeyboard } = await import("grammy");
+                const kb = new InlineKeyboard().text(
+                  `Retry ${row.payload.strike_label || "now"}`,
+                  cbData,
+                );
+                extra = { reply_markup: kb };
+              }
             } else if (row.kind === "limit_close_retrying") {
               // Lets the user bail mid-retry if they no longer want the
               // engine to keep escalating. Cancel is hard-cancel — order

--- a/src/services/stale-arm-intent-watcher.js
+++ b/src/services/stale-arm-intent-watcher.js
@@ -1,0 +1,188 @@
+/**
+ * Stale arm-intent DM watcher — proactive recovery for silent arm
+ * drops on V4 loans.
+ *
+ * Mandated by [[feedback_tg_v4_must_match_site_quality]] +
+ * [[feedback_arms_must_execute_without_babysitting]]. The site
+ * recovery banner + /fixarm command are REACTIVE: they only help if
+ * the user happens to look. This watcher is PROACTIVE: every minute
+ * it scans for arm_intents that have been pending > 90s with no
+ * matching armed/firing order, and DMs the user a one-tap-retry
+ * recovery prompt before they have to notice the problem themselves.
+ *
+ * Operates on V4 loans only — V1/V2/V3 loans can't take new exits
+ * (exits_require_v4_loan), so DM'ing the user would just confuse.
+ *
+ * Idempotency: when a DM is enqueued, the intent's updated_at is
+ * stamped. Only intents where updated_at = created_at are eligible.
+ * That makes the DM-once invariant robust across restarts without
+ * needing a new column.
+ */
+import { query } from "../db/pool.js";
+
+const TICK_INTERVAL_MS = Number(process.env.STALE_INTENT_TICK_MS || 60_000); // 60s
+const MIN_AGE_SECONDS = Number(process.env.STALE_INTENT_MIN_AGE_S || 90); // 1.5 min before nudging
+const MAX_AGE_HOURS = Number(process.env.STALE_INTENT_MAX_AGE_H || 24); // skip after 24h
+const NUDGE_BATCH_LIMIT = 25; // soft cap per tick
+
+let _timer = null;
+
+export function startStaleArmIntentWatcher() {
+  if (_timer) return;
+  // First run after 90s so the boot reconciler can clear any pre-existing
+  // stuck intents first.
+  setTimeout(() => {
+    runOnce().catch((e) =>
+      console.warn(`[stale-arm-intent-watcher] first run failed: ${e.message?.slice(0, 160)}`),
+    );
+    _timer = setInterval(() => {
+      runOnce().catch((e) =>
+        console.warn(`[stale-arm-intent-watcher] tick failed: ${e.message?.slice(0, 160)}`),
+      );
+    }, TICK_INTERVAL_MS);
+  }, 90_000);
+  console.log(
+    `[stale-arm-intent-watcher] armed — first run in 90s, then every ${Math.round(TICK_INTERVAL_MS / 1000)}s`,
+  );
+}
+
+export function stopStaleArmIntentWatcher() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+async function runOnce() {
+  const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
+  if (!v4ProgramId) {
+    // Without V4 there are no exit-only loans to recover; bail.
+    return;
+  }
+
+  // Pull pending intents that:
+  //   1) sit > MIN_AGE_SECONDS old
+  //   2) are no older than MAX_AGE_HOURS (don't nudge ancient ones)
+  //   3) have NEVER been nudged (updated_at = created_at — tolerance of 1s)
+  //   4) sit on a V4 loan
+  //   5) have no matching armed/firing order on the same loan+direction+strike
+  const { rows: stale } = await query(
+    `SELECT ai.id, ai.user_id, ai.wallet, ai.loan_id_chain,
+            ai.direction, ai.target_kind,
+            ai.target_value_micro::text AS target_value_micro,
+            ai.slice_pct_bps,
+            l.id AS loan_db_id,
+            sm.symbol AS collateral_symbol
+       FROM arm_intents ai
+       JOIN loans l ON l.loan_id::text = ai.loan_id_chain
+       LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+      WHERE ai.status = 'pending'
+        AND l.program_id = $1
+        AND l.status = 'active'
+        AND ai.created_at < NOW() - make_interval(secs => $2)
+        AND ai.created_at > NOW() - make_interval(hours => $3)
+        AND ai.updated_at <= ai.created_at + INTERVAL '1 second'
+        AND NOT EXISTS (
+          SELECT 1 FROM limit_close_orders o
+           WHERE o.loan_id = l.id
+             AND o.status IN ('armed','firing','twap_in_progress','awaiting_user')
+             AND o.trigger_direction = ai.direction
+             AND o.trigger_value_micro = ai.target_value_micro
+        )
+      ORDER BY ai.created_at ASC
+      LIMIT $4`,
+    [v4ProgramId, MIN_AGE_SECONDS, MAX_AGE_HOURS, NUDGE_BATCH_LIMIT],
+  );
+
+  if (stale.length === 0) return;
+
+  for (const row of stale) {
+    // Skip if user_id missing (can't DM without it) — best-effort backfill.
+    let userId = row.user_id;
+    if (!userId) {
+      try {
+        const w = await query(
+          `SELECT user_id FROM wallets WHERE public_key = $1 LIMIT 1`,
+          [row.wallet],
+        );
+        if (w.rows[0]?.user_id) userId = w.rows[0].user_id;
+      } catch {
+        /* fall through */
+      }
+    }
+    if (!userId) continue;
+
+    const v = Number(row.target_value_micro) / 1e6;
+    const sliceBps = row.slice_pct_bps ?? 10000;
+    let label;
+    if (row.target_kind === "multiplier") {
+      label = `${v}x`;
+      if (sliceBps < 10000) label += ` (${(sliceBps / 100).toFixed(0)}% slice)`;
+    } else if (row.target_kind === "price_usd") {
+      label = v >= 1 ? `$${v.toFixed(2)}` : v >= 0.01 ? `$${v.toFixed(4)}` : `$${v.toFixed(8)}`;
+    } else if (row.target_kind === "mc_usd") {
+      label =
+        v >= 1e9 ? `$${(v / 1e9).toFixed(2)}B mc` : `$${(v / 1e6).toFixed(2)}M mc`;
+    } else if (row.target_kind === "price_sol") {
+      label = `${v.toFixed(6)} SOL`;
+    } else {
+      label = `${row.target_kind} ${v}`;
+    }
+
+    const sym = row.collateral_symbol || "your loan";
+    const verb = row.direction === "above" ? "auto-sell" : "stop-loss";
+
+    // Stamp updated_at FIRST so a duplicate tick on a slow run can't
+    // re-enqueue the same DM. If the enqueue fails after, the intent
+    // is still marked as nudged — that's the right tradeoff (no spam).
+    try {
+      await query(
+        `UPDATE arm_intents SET updated_at = NOW() WHERE id = $1 AND updated_at <= created_at + INTERVAL '1 second'`,
+        [row.id],
+      );
+    } catch (e) {
+      console.warn(`[stale-arm-intent-watcher] mark-nudged failed for intent ${row.id}: ${e.message?.slice(0, 100)}`);
+      continue;
+    }
+
+    const payload = {
+      intent_id: row.id,
+      loan_id_chain: row.loan_id_chain,
+      collateral_symbol: row.collateral_symbol,
+      target_kind: row.target_kind,
+      target_value_micro: row.target_value_micro,
+      slice_pct_bps: row.slice_pct_bps,
+      direction: row.direction,
+      strike_label: label,
+      // Notification sender constructs the inline keyboard from these
+      // fields; the recovery action routes through fixarm:intent:.. so
+      // it lands on the same handler the dashboard banner uses.
+      recovery_command: "/fixarm",
+      recovery_callback: `fixarm:intent:${row.loan_id_chain}:${row.id}`,
+      message_text:
+        `Your ${verb} on ${sym} (loan #${row.loan_id_chain}) didn't finish arming — strike was *${label}*. ` +
+        `Tap to retry now or use /fixarm.`,
+    };
+
+    try {
+      await query(
+        `INSERT INTO pending_notifications (user_id, channel, kind, payload, status)
+           VALUES ($1, 'tg', 'arm_intent_stale', $2::jsonb, 'pending')`,
+        [userId, JSON.stringify(payload)],
+      );
+    } catch (e) {
+      console.warn(`[stale-arm-intent-watcher] DM enqueue failed for intent ${row.id}: ${e.message?.slice(0, 120)}`);
+      // Roll back the updated_at bump so a future tick will re-try.
+      try {
+        await query(
+          `UPDATE arm_intents SET updated_at = created_at WHERE id = $1`,
+          [row.id],
+        );
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+
+  console.log(`[stale-arm-intent-watcher] nudged ${stale.length} stale intent(s)`);
+}


### PR DESCRIPTION
## Summary
- TG `/sell`, `/takeprofit`, `/stoploss`, `/bracket`, `/trailingstop`, `/ladder`, Pip arms, and agent x402 arms now write an `arm_intent` row to `pending` BEFORE the armOrderImpl gates run. Companion to the site dashboard intent-aware recovery banner — operator caught a 1.3x request displayed as "Sell at 2x" on PUMP loan 810 because the banner had no breadcrumb to read.
- Site path unchanged: it passes `args.intentId` from its own /intent call, so we skip the duplicate write.
- De-dupe via `(wallet, loan, direction, strike, slice)` 5-min window prevents duplicate intents from repeated retry attempts.
- Best-effort end-to-end: intent-write failure NEVER blocks the arm.

## Test plan
- [x] `node --check src/services/limit-close-arm-core.js` clean
- [ ] TG `/sell <loan_id> at 1.3x` on V4 loan → `arm_intents` row appears with target_value_micro=1300000, source=tg
- [ ] Same loan: dashboard recovery banner renders "Sell at 1.3x", not "Sell at 2x"
- [ ] Site arms still write only ONE intent (not duplicate)
- [ ] Repeated /sell at same strike de-dupes inside 5-min window
- [ ] /sell on V1/V2/V3 loan: intent written, armOrder rejects, banner does NOT render (loan isn't V4)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>