### PR TITLE
V4 TG quality wave 2: /preview + failure DM retry + Pip + V4 verbiage + smart redirect

### DIFF
--- a/src/commands/fallback.js
+++ b/src/commands/fallback.js
@@ -54,6 +54,177 @@ const HANDLER_MAP = {
 // Solana base58 address pattern (32-44 chars of base58 alphabet)
 const SOLANA_ADDR = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 
+// Verbs users naturally reach for when they want to set an exit on a
+// loan. None of these were registered as bot.command() pre-2026-06-16.
+// Operator-mandated 2026-06-16 PM: ANY user expression of arm intent
+// must be RECOGNIZED, never silently ignored
+// (feedback_exit_strategy_must_always_be_recognized.md).
+//
+// Direction-implied verbs are routed without ambiguity. Neutral verbs
+// (sell, exit, target) defer to the parsed strike's impliedDirection
+// (multiplier >= 1 → TP, multiplier < 1 → SL; "-N%" → SL; "+N%" → TP).
+const ARM_INTENT_VERBS = {
+  // neutral — direction inferred from strike
+  sell: "neutral",
+  exit: "neutral",
+  target: "neutral",
+  goal: "neutral",
+  strike: "neutral",
+  trigger: "neutral",
+  closeat: "neutral",
+  // TP-implying
+  buy: "above",
+  sellat: "above",
+  sellabove: "above",
+  tpat: "above",
+  selltop: "above",
+  protectgains: "above",
+  // SL-implying
+  stop: "below",
+  stopat: "below",
+  stopabove: "below",
+  stopbelow: "below",
+  slat: "below",
+  floor: "below",
+  protect: "below",
+  protectfloor: "below",
+  downto: "below",
+  // bracket
+  tpsl: "bracket",
+  protectboth: "bracket",
+  bothlegs: "bracket",
+};
+
+/**
+ * If the unrecognized command is arm-intent-shaped, re-dispatch to the
+ * correct registered handler with the same arg shape and return true.
+ * Otherwise return false so the caller can render the generic "I
+ * don't recognize that command" reply.
+ */
+async function maybeRedirectArmIntent(ctx, text) {
+  // Extract the leading /command token.
+  const m = /^\/([a-z_]+)(?:@\w+)?\b/i.exec(text);
+  if (!m) return false;
+  const verb = m[1].toLowerCase();
+  const known = ARM_INTENT_VERBS[verb];
+  if (!known) return false;
+
+  // Strip the leading /<verb>; pass the rest as "/<canonical> <rest>"
+  // so the registered handler's parser sees the same args the user
+  // typed. Preserves loan_id + strike + slip= etc unchanged.
+  const rest = text.slice(m[0].length).trim();
+
+  // For unambiguous direction, route directly.
+  if (known === "above") {
+    return await dispatchAsCommand(ctx, "takeprofit", rest);
+  }
+  if (known === "below") {
+    return await dispatchAsCommand(ctx, "stoploss", rest);
+  }
+  if (known === "bracket") {
+    return await dispatchAsCommand(ctx, "bracket", rest);
+  }
+
+  // Neutral verb: infer direction from the strike. Use the parser to
+  // see what direction the strike implies. If parser fails, surface a
+  // helpful reply asking the user to clarify.
+  let parsed;
+  try {
+    const mod = await import("../lib/strike-price-parser.js");
+    // Heuristic: find the strike portion. Common shapes:
+    //   <loan_id> at <strike>
+    //   <loan_id> <strike>
+    //   <loan_id> at 1.3x slip=2%
+    // Grab the first non-loan token after "at" (or after loan_id).
+    const tokens = rest.split(/\s+/).filter(Boolean);
+    // skip first token (loan id) if it's a number
+    let idx = 0;
+    if (/^\d+$/.test(tokens[0] || "")) idx = 1;
+    // skip "at" / "sell" / "buy" filler
+    while (
+      tokens[idx] &&
+      ["at", "sell", "buy", "to", "around", "near"].includes(tokens[idx].toLowerCase())
+    )
+      idx += 1;
+    const strikeText = tokens.slice(idx).join(" ");
+    if (strikeText) {
+      parsed = mod.parseStrike(strikeText, {});
+    }
+  } catch (e) {
+    console.warn("[fallback-arm-redirect] parseStrike failed:", e.message?.slice(0, 100));
+  }
+
+  if (parsed?.ok && parsed.impliedDirection) {
+    const canonical = parsed.impliedDirection === "below" ? "stoploss" : "takeprofit";
+    return await dispatchAsCommand(ctx, canonical, rest);
+  }
+
+  // Strike ambiguous — ask the user explicitly. Inline buttons let them
+  // pick without re-typing the strike.
+  const safeRest = rest.replace(/[`*_]/g, "");
+  await ctx.reply(
+    [
+      `I recognize you wanted to set an exit, but I need to know which side.`,
+      ``,
+      `If you want to *sell ABOVE current price* (take-profit):`,
+      `  /takeprofit ${safeRest}`,
+      ``,
+      `If you want to *sell BELOW current price* (stop-loss):`,
+      `  /stoploss ${safeRest}`,
+      ``,
+      `Or send /preview ${safeRest} to dry-run without committing.`,
+    ].join("\n"),
+    { parse_mode: "Markdown" },
+  );
+  return true;
+}
+
+/**
+ * Re-dispatch an unrecognized arm-shaped command as if the user had
+ * typed the canonical command. Constructs a fresh ctx with
+ * ctx.message.text rewritten so the handler's parser sees what it
+ * expects, then invokes the handler directly.
+ */
+async function dispatchAsCommand(ctx, canonicalCmd, restArgs) {
+  const newText = `/${canonicalCmd}${restArgs ? " " + restArgs : ""}`;
+  // Shallow-clone the context's message so we don't mutate grammy
+  // internal state mid-update. The handlers only read ctx.message.text
+  // and ctx.from / ctx.chat for behavior, so a property override on
+  // the message is sufficient.
+  const origMessage = ctx.message;
+  const newMessage = { ...origMessage, text: newText };
+  Object.defineProperty(ctx, "message", {
+    value: newMessage,
+    configurable: true,
+    writable: true,
+  });
+
+  try {
+    const lc = await import("./limit-close.js");
+    if (canonicalCmd === "takeprofit") return await runAndOk(lc.handleLimitClose, ctx);
+    if (canonicalCmd === "stoploss") return await runAndOk(lc.handleStopLoss, ctx);
+    if (canonicalCmd === "bracket") return await runAndOk(lc.handleBracket, ctx);
+  } catch (e) {
+    console.warn(`[fallback-arm-redirect] dispatch ${canonicalCmd} failed: ${e.message?.slice(0, 200)}`);
+    return false;
+  } finally {
+    // Restore original message so any downstream middleware sees the
+    // original text. (No middleware runs after handleFallback today,
+    // but this keeps the contract clean.)
+    Object.defineProperty(ctx, "message", {
+      value: origMessage,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return false;
+}
+
+async function runAndOk(handler, ctx) {
+  await handler(ctx);
+  return true;
+}
+
 export async function handleFallback(ctx) {
   // Skip non-DM chats entirely — fallback is meant for 1:1 conversation
   // with the bot. In groups, the bot replying to every text message
@@ -74,8 +245,18 @@ export async function handleFallback(ctx) {
   // tweet URL doesn't trigger this.
   if (await maybeAutoCrosspostTweet(ctx, text)) return;
 
-  // Ignore messages that start with / (those are unrecognized commands)
+  // Smart redirect for arm-intent-shaped unknown commands
+  // (operator-mandated 2026-06-16 PM,
+  // feedback_exit_strategy_must_always_be_recognized.md). When the
+  // user types an unrecognized command that LOOKS like they're trying
+  // to set an exit ("/sell 810 at 1.3x", "/buy 810 at $0.005",
+  // "/target 810 at $150m"), parse the strike, infer direction from
+  // it, and re-dispatch to the correct registered handler with the
+  // bot.command argv shape. NEVER silently ignore an arm-shaped
+  // message.
   if (text.startsWith("/")) {
+    const armRedirect = await maybeRedirectArmIntent(ctx, text);
+    if (armRedirect) return;
     await ctx.reply(
       `I don't recognize that command. Try /help to see what I can do.`,
     );

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -310,7 +310,14 @@ function fmtTrigger(kind, value_micro) {
 
 /* ─── /limitclose ──────────────────────────────────────────────── */
 
-export async function handleLimitClose(ctx, direction = "above") {
+export async function handleLimitClose(ctx, direction = "above", opts = {}) {
+  // opts.dryRun (operator-mandated 2026-06-16 PM,
+  // feedback_tg_must_follow_v4_at_highest_level.md): run every
+  // validation, oracle quote, slice/ladder check, and arm-core gate
+  // — but skip the INSERT. Mirror of the x402 preflight endpoint;
+  // closes the "did this arm actually validate?" question on TG
+  // BEFORE the user gets a confusing failure DM.
+  const dryRun = opts.dryRun === true;
   const tgUser = ctx.from;
   if (!tgUser) return;
   const text = ctx.message?.text ?? "";
@@ -364,6 +371,7 @@ export async function handleLimitClose(ctx, direction = "above") {
     sellDestination: dest,
     expiresAt: expire_iso,
     slicePct: parseResult.parsed.slice_pct,
+    dryRun,
   });
 
   if (!armed.ok) {
@@ -463,6 +471,39 @@ export async function handleLimitClose(ctx, direction = "above") {
     return ctx.reply(m, { parse_mode: "Markdown" });
   }
 
+  // Dry-run preview — operator-mandated 2026-06-16 PM,
+  // feedback_tg_must_follow_v4_at_highest_level.md. armOrder with
+  // dryRun:true returned ok=true having validated every gate without
+  // persisting. Tell the user explicitly that nothing was armed, then
+  // show what WOULD have armed so they can choose to commit.
+  if (dryRun && armed.ok) {
+    const loanD = armed.loan;
+    const mintD = armed.mint;
+    const triggerLabelD = fmtTrigger(trigger_kind, trigger_value_micro);
+    const isSlD = direction === "below";
+    const symD = mintD?.symbol || "your collateral";
+    const owedSolD = loanD?.owed ? (Number(loanD.owed) / 1e9).toFixed(4) : "?";
+    const appliedD = armed.initialSlippageBpsApplied ?? slippage_bps;
+    const originalD = armed.initialSlippageBpsRequested ?? slippage_bps;
+    const bumpedD = appliedD !== originalD;
+    return ctx.reply(
+      [
+        `*Preview only — nothing armed.*`,
+        ``,
+        `Loan: #${loanD?.loan_id || loan_id} (${symD}) · owes ${owedSolD} SOL`,
+        `Direction: ${isSlD ? "stop-loss" : "take-profit"}`,
+        `Trigger: ${triggerLabelD}`,
+        multiplierContextLine ? `_${multiplierContextLine}_` : null,
+        `Slippage: ${(appliedD / 100).toFixed(2)}%${bumpedD ? ` _(would be bumped from ${(originalD / 100).toFixed(2)}%)_` : ""}`,
+        `Destination: ${dest.toUpperCase()}`,
+        ``,
+        `All gates passed at this moment. Run \`/${isSlD ? "stoploss" : "takeprofit"} ${loan_id} at ${multiplier ? `${multiplier}x` : triggerLabelD}\` (without "preview") to actually arm it.`,
+        `_Liquidity can shift between now and a real arm._`,
+      ].filter(Boolean).join("\n"),
+      { parse_mode: "Markdown" },
+    );
+  }
+
   // Success — render the confirmation. arm-core surfaces any liquidity
   // bump via initialSlippageBpsRequested vs initialSlippageBpsApplied
   // so we can show the bump line when relevant.
@@ -515,8 +556,24 @@ export async function handleLimitClose(ctx, direction = "above") {
 // Thin wrapper that delegates to handleLimitClose with direction='below'.
 // Shares every gate, fill-guarantee, and 1% fee — only the trigger
 // comparator flips at fire time (see magpie-limitclose isTriggerHit).
-export async function handleStopLoss(ctx) {
-  return handleLimitClose(ctx, "below");
+export async function handleStopLoss(ctx, opts = {}) {
+  return handleLimitClose(ctx, "below", opts);
+}
+
+/* ─── /preview ─────────────────────────────────────────────────── */
+// TG arm pre-flight (operator-mandated 2026-06-16 PM,
+// feedback_tg_must_follow_v4_at_highest_level.md). Mirror of the
+// site / x402 dry-run endpoints — runs the entire validation +
+// oracle + slice / cap stack against the user's loan and reports
+// whether an arm WOULD succeed right now, without persisting.
+// Lets the user catch "trigger would fire immediately" / "loan
+// below minimum size" / "ladder sum exceeds 100" before they
+// commit a slot.
+export async function handlePreviewTp(ctx) {
+  return handleLimitClose(ctx, "above", { dryRun: true });
+}
+export async function handlePreviewSl(ctx) {
+  return handleLimitClose(ctx, "below", { dryRun: true });
 }
 
 /* ─── /trailingstop ────────────────────────────────────────────── */

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -712,6 +712,16 @@ export async function handleTrailingStop(ctx) {
   }
 
   const fmt = (n) => n < 0.01 ? n.toFixed(8) : n < 1 ? n.toFixed(6) : n.toFixed(4);
+  // V4 in-vault verbiage — operator-mandated
+  // (feedback_v4_in_vault_thesis_non_negotiable.md). On V4 trail fire,
+  // proceeds accumulate in the per-loan sol_proceeds_vault and the
+  // loan STAYS active until borrower-signed repay. Legacy programs
+  // close the loan on fire.
+  const v4ProgramIdTrail = process.env.PROGRAM_ID_V4 || null;
+  const isV4Trail = !!v4ProgramIdTrail && armed.loan?.program_id === v4ProgramIdTrail;
+  const fireLine = isV4Trail
+    ? `Fires when price retraces ${(trailingDistanceBps / 100).toFixed(1)}% from peak — sells into SOL on-chain, proceeds accumulate inside your loan's vault. Run /repay when you want the SOL released.`
+    : `Fires when price retraces ${(trailingDistanceBps / 100).toFixed(1)}% from peak.`;
   return ctx.reply([
     `*Trailing stop armed* on loan #${loan_id}`,
     "",
@@ -720,7 +730,7 @@ export async function handleTrailingStop(ctx) {
     `Initial floor: $${fmt(r.targetUsd)} (-${(trailingDistanceBps / 100).toFixed(1)}%)`,
     `Slippage: ${(slippage_bps / 100).toFixed(2)}%`,
     "",
-    `Floor rises with each new high. Fires when price retraces ${(trailingDistanceBps / 100).toFixed(1)}% from peak.`,
+    `Floor rises with each new high. ${fireLine}`,
     `Order ID: \`${armed.orderId}\` — \`/limitorders\` to view, \`/cancellimitorder ${armed.orderId}\` to cancel.`,
   ].join("\n"), { parse_mode: "Markdown" });
 }
@@ -959,6 +969,16 @@ export async function handleBracket(ctx) {
     : sl.kind === "mc_usd"
       ? `MC $${(slResolved.resolvedMc / 1e6).toFixed(1)}M`
       : `$${fmt(slResolved.resolvedUsd)}`;
+  // V4 in-vault verbiage — operator-mandated
+  // (feedback_v4_in_vault_thesis_non_negotiable.md). On V4 the first
+  // leg to fire converts its slice into SOL inside the per-loan vault
+  // and sibling-cancels the other leg; the loan stays Active and the
+  // user releases the SOL via /repay. Legacy programs close the loan.
+  const v4ProgramIdBracket = process.env.PROGRAM_ID_V4 || null;
+  const isV4Bracket = !!v4ProgramIdBracket && tpArm.loan?.program_id === v4ProgramIdBracket;
+  const bracketFireLine = isV4Bracket
+    ? `First leg to fire converts that slice to SOL inside your loan's vault, auto-cancels the other leg, and leaves the loan Active. Run /repay when you want the SOL released.`
+    : `First leg to fire closes the loan and auto-cancels the other.`;
   return ctx.reply([
     `*Bracket armed* on loan #${loan_id}`,
     "",
@@ -967,7 +987,7 @@ export async function handleBracket(ctx) {
     `Slippage: ${(slippage_bps / 100).toFixed(2)}% · proceeds → ${sell_destination.toUpperCase()}`,
     expiresAtIso ? `Both legs expire: ${new Date(expiresAtIso).toISOString().slice(0, 10)}` : null,
     "",
-    `First leg to fire closes the loan and auto-cancels the other.`,
+    bracketFireLine,
     `\`/limitorders\` to view, \`/cancellimitorder <id>\` to cancel either leg.`,
   ].join("\n"), { parse_mode: "Markdown" });
 }

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -524,9 +524,23 @@ export async function handleLimitClose(ctx, direction = "above", opts = {}) {
     ? `*Stop-loss armed* — order #${orderId}${expiryLabel}`
     : `*Take-profit armed* — order #${orderId}${expiryLabel}`;
   const triggerVerb = isStopLoss ? "drops to" : "hits";
-  const purpose = isStopLoss
-    ? `If ${symbol} ${triggerVerb} your floor, I'll cut the position before liquidation: repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`
-    : `When ${symbol} ${triggerVerb} your target, I'll repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`;
+  // V4 in-vault behavior vs V1/V2/V3 fire-and-close behavior. The
+  // operator-mandated V4 thesis is non-negotiable
+  // (feedback_v4_in_vault_thesis_non_negotiable): on V4 fires, SOL
+  // accumulates inside the per-loan sol_proceeds_vault and the loan
+  // STAYS ACTIVE; the only path to the user's wallet is borrower-
+  // signed repay. Legacy programs sell + repay + close in one shot.
+  // The success DM must describe what will actually happen so users
+  // know to repay when they want their SOL.
+  const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
+  const isV4 = !!v4ProgramId && loan?.program_id === v4ProgramId;
+  const purpose = isV4
+    ? (isStopLoss
+        ? `If ${symbol} ${triggerVerb} your floor, I'll sell that slice into SOL on-chain — the proceeds accumulate inside your loan's vault (V4 in-vault auto-sell). The loan stays Active; run /repay when you want the SOL released to your wallet.`
+        : `When ${symbol} ${triggerVerb} your target, I'll sell that slice into SOL on-chain — the proceeds accumulate inside your loan's vault (V4 in-vault auto-sell). The loan stays Active; run /repay when you want the SOL released to your wallet.`)
+    : (isStopLoss
+        ? `If ${symbol} ${triggerVerb} your floor, I'll cut the position before liquidation: repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`
+        : `When ${symbol} ${triggerVerb} your target, I'll repay the ${owedSol} SOL loan + sell the collateral into ${dest.toUpperCase()}.`);
   const listCmd = isStopLoss ? "/stoplosses" : "/takeprofitorders";
 
   await ctx.reply(

--- a/src/index.js
+++ b/src/index.js
@@ -405,6 +405,13 @@ bot.command("crosspost", handleCommunityCrosspost);
   // strike (multiplier >= 1 → above/TP, < 1 → below/SL). Natural verb,
   // same arm-core path.
   bot.command("sell", lc.handleLimitClose);
+  // /preview, /previewsl — TG arm pre-flight (operator-mandated
+  // 2026-06-16 PM, feedback_tg_must_follow_v4_at_highest_level.md).
+  // Dry-run any /takeprofit or /stoploss without persisting. Mirror
+  // of x402's /agent/preflight + site's /arm-preflight so TG users
+  // get the same "would this work?" check before committing a slot.
+  bot.command(["preview", "checkarm", "preflight"], lc.handlePreviewTp);
+  bot.command(["previewsl", "checkarmsl"], lc.handlePreviewSl);
   // Stop-loss — same arm-core path, direction='below' flips the engine's
   // trigger comparator from >= to <=. 1% protocol fee applies in BOTH
   // directions (operator rule 2026-06-12). Cutting losses before the

--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -160,9 +160,19 @@ If a user asks "what pool am I on?" — they don't usually need to know. Plain b
 
 9. **T14 Token-2022 arm-side block removed.** SPCX / extended Token-2022 mints now arm cleanly. Jupiter routing failures at fire-time still surface as failed legs; arming itself never refuses on extension grounds.
 
-10. **/fixarm TG command (new).** TG users with V4 loans that have no armed orders can type /fixarm to see inline preset buttons (Sell at 2x / 3x / 0.7x / Bracket) and arm in one tap. Aliases: /armretry, /recoverarm.
+10. **/fixarm TG command.** TG users with V4 loans that have no armed orders can type /fixarm to see inline retry buttons. As of 2026-06-16 PM the buttons are **intent-aware** — they render the EXACT strike the user originally requested (e.g. "Sell at 1.3x") read from the server-side arm_intents ledger, not generic 2x/3x/0.7x defaults. Falls back to the preset buttons only when no pending intent exists for that loan. Aliases: /armretry, /recoverarm.
 
 11. **Cumulative slice cap honors existing armed legs.** Adding a leg to an already-laddered loan now correctly bounds the new leg's budget to (100% - already-armed slice%) before the user signs. No more "slice_overflow" rejections after a Phantom popup.
+
+12. **TG V4 arm path full hardening — shipped 2026-06-16 PM:**
+   - **/sell <loan_id> at <strike>** is now a registered command alias — natural verb for arming a TP without typing /takeprofit. Routes through the same arm-core. If a user types "/sell 810 at 1.3x" and asks why nothing happened in the past, that was the pre-fix UX gap.
+   - **Breadcrumb intents on every TG arm path** (/sell, /takeprofit, /stoploss, /bracket, /trailingstop, ladders). The server records the user's exact requested strike in the arm_intents ledger BEFORE armOrder runs. If anything downstream fails (Jupiter blip, parser issue, network glitch), the strike is preserved and /fixarm + dashboard banner + a proactive DM all show the user's actual ask, not a default.
+   - **/preview <loan_id> at <strike>** + **/previewsl** (and aliases /checkarm, /preflight, /checkarmsl) — dry-run any TP or SL through the full validation + oracle + slice math stack WITHOUT persisting. Mirror of the x402 /agent/preflight + site /arm-preflight. If a user asks "can I check whether this arm would succeed?" — recommend this.
+   - **Proactive stale-intent DM watcher.** A pending arm_intent on a V4 loan that hasn't resolved within 90s triggers a TG DM to the user with a one-tap retry button (same fixarm:intent callback). User never has to notice the issue themselves.
+   - **Failure DM one-tap retry.** When an armOrder call fails, the DM that goes to the user now has a "Retry now" inline button (when the intent was recorded). One tap re-runs the exact same arm.
+   - **Site recovery banner intent-aware.** Same as /fixarm — renders "Sell at 1.3x" with the actual strike pulled from arm_intents, not hardcoded defaults.
+
+If a user reports a TG arm "dropped" or "didn't go through" — explain the breadcrumb system: their intent is on file, /fixarm will show it as a one-tap retry button with their exact strike. They can also wait ~90s and a DM will arrive automatically.
 
 If a user asks about any of these by name or describes hitting an issue these fixed (e.g. "my ladder didn't fully arm", "exit said not set on V4 loan", "0.5 SOL too small for auto-sells"), explain the relevant fix and tell them it's live.
 

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -1716,6 +1716,13 @@ async function enqueueArmFailedDm(args, result) {
   // user_id, so we don't need to lookup here. Just enqueue.
   if (!args.userId) return;
 
+  // intent_id flows in from the breadcrumb writer (or from a site-side
+  // caller that passed args.intentId explicitly). Notification-sender
+  // attaches a one-tap retry button keyed by intent_id so the user can
+  // recover from a failure without leaving Telegram. Operator-mandated
+  // rule: one-tap recovery on every failure (feedback_tg_must_follow_
+  // v4_at_highest_level.md). When no intent_id is available the button
+  // falls back to a /fixarm prompt.
   const payload = {
     direction: args.triggerDirection || args.direction || "above",
     trigger_kind: args.triggerKind || null,
@@ -1726,6 +1733,7 @@ async function enqueueArmFailedDm(args, result) {
     ladder_group_id: args.ladderGroupId || null,
     source: args.source || null,
     loan_id_chain: args.loanIdChain != null ? String(args.loanIdChain) : null,
+    intent_id: args.intentId ?? null,
     error_code: safeTruncate(result?.error, 64),
     error_detail: safeTruncate(jsonStringifyError(result?.detail), 400),
   };

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -588,6 +588,27 @@ async function tick(bot) {
               const kb = new InlineKeyboard()
                 .text("Cancel this order", `lcret:cancel:${row.payload.order_id}`);
               extra = { reply_markup: kb };
+            } else if (row.kind === "limit_close_arm_failed") {
+              // One-tap retry on every failure (operator-mandated rule
+              // feedback_tg_must_follow_v4_at_highest_level.md). When the
+              // breadcrumb writer left an intent_id behind, route the
+              // retry through the same fixarm:intent handler the
+              // dashboard banner uses. Otherwise just point the user at
+              // /fixarm so they can pick from their pending intents.
+              const intentId = row.payload?.intent_id;
+              const loanIdChain = row.payload?.loan_id_chain;
+              if (
+                intentId != null &&
+                typeof loanIdChain === "string" &&
+                loanIdChain.length > 0
+              ) {
+                const cbData = `fixarm:intent:${loanIdChain}:${intentId}`;
+                if (cbData.length <= 64) {
+                  const { InlineKeyboard } = await import("grammy");
+                  const kb = new InlineKeyboard().text("Retry now", cbData);
+                  extra = { reply_markup: kb };
+                }
+              }
             } else if (row.kind === "limit_close_fired") {
               // Receipt-confirmation keyboard. Solscan links are already
               // inline in the body, but tap-once buttons are friendlier


### PR DESCRIPTION
## Summary
Closes the TG V4 quality gap on **arm preview**: x402 has /agent/preflight and the site has /arm-preflight, but TG users had to commit-or-fail. New commands:

- `/preview <loan_id> at 1.3x` — dry-run a TP
- `/previewsl <loan_id> at 0.7x` — dry-run an SL

Aliases: `/checkarm`, `/preflight`, `/checkarmsl`.

Runs the full validation stack (loan lookup, eligibility, oracle freshness, ladder math, immediate-fire guard, slippage floor) without writing to `limit_close_orders` or `arm_intents`. Reports back what WOULD have armed.

armOrder already supports `dryRun: true` (used by x402 today). This wires it through `handleLimitClose` + `handleStopLoss` and renders a distinct "Preview only — nothing armed" reply.

## Test plan
- [x] `node --check` clean
- [ ] `/preview <V4_loan_id> at 2x` on an eligible loan → preview reply, no row in `limit_close_orders`
- [ ] `/preview <V1_loan_id> at 2x` → reports `exits_require_v4_loan`
- [ ] `/previewsl <V4_loan_id> at 0.7x` → SL preview reply
- [ ] `/preview <V4_loan_id> at 0.5x` → rejected with "downside target use /stoploss"
- [ ] `/preview <V4_loan_id> at 2x slice=25%` → preview shows 25% slice
- [ ] Real `/takeprofit` after a successful preview commits as expected

Related: [[feedback_tg_must_follow_v4_at_highest_level]]

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>