### PR TITLE
feat(tg): V4 in-vault verbiage on borrow + repay cards

### DIFF
--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -1001,6 +1001,19 @@ export function registerBorrowCallbacks(bot) {
     // "borrow failed" miscommunication for a borrow that actually
     // succeeded.
 
+    // V4 in-vault explainer (operator-mandated rule
+    // feedback_v4_in_vault_thesis_non_negotiable.md). When the loan is
+    // on V4 AND any auto-sell is involved (either armed-in-flow or
+    // pickable via the retry buttons), the borrow card MUST tell the
+    // user how V4 fires actually behave — proceeds accumulate in the
+    // per-loan vault, loan stays Active, /repay releases SOL. Without
+    // this, V4 borrowers who see a fire DM later might expect SOL in
+    // their wallet and panic.
+    const showV4Note = isV4Loan && (allLegsArmed || (canArmExits && !allLegsArmed));
+    const v4InVaultLine = showV4Note
+      ? "_V4 in-vault auto-sell: when a target hits, the engine sells that slice on-chain — SOL accumulates inside your loan's vault, loan stays Active. Run /repay anytime to release the SOL._"
+      : null;
+
     const markdownLines = [
       "✅ *Loan funded*",
       "",
@@ -1031,6 +1044,7 @@ export function registerBorrowCallbacks(bot) {
         : `\`/stoploss ${result.loanId} at 0.7x\` (sell if down 30%)`,
       allLegsArmed || !canArmExits ? null : "",
       allLegsArmed || !canArmExits ? null : "/positions to check status · /share to flex on the timeline",
+      v4InVaultLine,
     ].filter((l) => l != null);
 
     const plainTextLines = [

--- a/src/commands/repay.js
+++ b/src/commands/repay.js
@@ -249,12 +249,30 @@ export function registerRepayCallbacks(bot) {
         }
       } catch { /* non-critical */ }
 
+      // V4 vault-SOL release line — operator-mandated
+      // (feedback_v4_in_vault_thesis_non_negotiable.md). For V4 loans
+      // with any sol_proceeds_amount, the repay tx releases that SOL
+      // back to the user alongside the SPL collateral. Show it
+      // explicitly so V4 users see the V4 thesis play out end-to-end.
+      // The loan row was fetched BEFORE the repay so its
+      // sol_proceeds_amount is the exact balance just released.
+      const v4ProgramIdRepay = process.env.PROGRAM_ID_V4 || null;
+      const isV4Repay = !!v4ProgramIdRepay && loan.program_id === v4ProgramIdRepay;
+      const vaultLamportsReleased = isV4Repay
+        ? BigInt(loan.sol_proceeds_amount || 0)
+        : 0n;
+      const vaultReleasedLine =
+        vaultLamportsReleased > 0n
+          ? `_Plus ${fmtSol(vaultLamportsReleased)} SOL released from your V4 loan's vault._`
+          : null;
+
       await ctx.editMessageText(
         [
           "*Loan repaid*",
           "",
           `${loan.symbol ?? "?"} loan · ${fmtSol(owedNow)} SOL`,
           "Collateral returned to your wallet.",
+          vaultReleasedLine,
           milestoneLine,
           `[View tx](https://solscan.io/tx/${result.signature})`,
         ].filter(Boolean).join("\n"),


### PR DESCRIPTION
## Summary
Adds a single V4-in-vault explainer line to the /borrow funded-loan card when the loan lands on V4 and is exit-eligible. Closes the last TG-side V4 verbiage education gap.

> _V4 in-vault auto-sell: when a target hits, the engine sells that slice on-chain — SOL accumulates inside your loan's vault, loan stays Active. Run /repay anytime to release the SOL._

Only renders when isV4Loan AND (allLegsArmed || canArmExits). V1/V3 borrows are unchanged.

## Test plan
- [x] node --check clean
- [ ] /borrow on a V4-eligible mint with exit set → funded card shows the explainer line
- [ ] /borrow on a V4-eligible mint WITHOUT exit picker → funded card shows the explainer (since exits can be armed via inline buttons)
- [ ] /borrow on a V1 memecoin → funded card UNCHANGED

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>