### PR TITLE
fix(arm-core): batch reconciles intents to 'failed' on hard failure

### DIFF
--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -993,7 +993,55 @@ async function armOrderImpl({
  * audit trail) happens OUTSIDE the transaction so a failure there
  * doesn't undo the armed state.
  * ───────────────────────────────────────────────────────────────── */
-export async function armOrderBatch({
+export async function armOrderBatch(args) {
+  // Thin wrapper around the existing implementation that ALSO
+  // reconciles the supplied intent_ids on FAILURE (not just success).
+  // Without this, a failed batch arm leaves the intents stuck at
+  // status='pending' — the recovery banner keeps surfacing them
+  // forever even though the arm hard-failed. Operator-mandated
+  // (feedback_no_duplicate_intents_in_recovery_banner_NEVER.md):
+  // status must match reality; pending means "in flight or unresolved",
+  // not "we tried and gave up."
+  let result;
+  try {
+    result = await armOrderBatchImpl(args);
+  } catch (err) {
+    console.error("[arm-core:batch] unexpected throw:", err?.stack || err?.message || err);
+    result = {
+      ok: false,
+      error: "exception",
+      detail: (err?.message || String(err)).slice(0, 240),
+    };
+  }
+  if (!result.ok && Array.isArray(args.intentIds) && args.intentIds.length > 0) {
+    const ids = args.intentIds.filter((x) => x != null);
+    if (ids.length > 0) {
+      try {
+        await query(
+          `UPDATE arm_intents
+              SET status = 'failed',
+                  error_code = $2,
+                  error_detail = $3,
+                  updated_at = NOW()
+            WHERE id = ANY($1::bigint[]) AND status = 'pending'`,
+          [
+            ids,
+            safeTruncate(result.error, 64),
+            safeTruncate(jsonStringifyError(result.detail), 400),
+          ],
+        );
+      } catch (rcErr) {
+        console.warn(
+          "[arm-core:batch] failure-intent reconcile failed:",
+          rcErr.message?.slice(0, 120),
+        );
+      }
+    }
+  }
+  return result;
+}
+
+async function armOrderBatchImpl({
   userId,
   source = "site",
   sourceAgentPubkey = null,


### PR DESCRIPTION
## Summary
Closes the *deeper* bug behind SPCX loan #816's recovery-banner duplicates: failed arm-batch calls left intents stuck at `status='pending'` forever, so the recovery banner kept rendering retry buttons for arms that hard-failed.

After this PR, the wrapper:
- catches any throw and converts to ok:false
- on ok:false AND intentIds supplied, marks those rows as `status='failed'` with error_code + error_detail
- the recovery banner (already filters status='pending') auto-hides those rows

The pending state now means EXACTLY what the user thinks: 'in-flight or unresolved.'

## Test plan
- [x] node --check clean
- [ ] Submit an arm-batch that hits a known failure (e.g. ladder_sum_exceeds_100) with intent_ids — confirm intents flip to 'failed' with error_code recorded
- [ ] Recovery banner no longer renders those failed intents
- [ ] Successful arm-batch still reconciles intents to 'armed' (existing path unchanged)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>