### PR TITLE
fix(stats): TG 'Liquidated' uses DB count, not on-chain pool counter

### DIFF
--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -286,7 +286,15 @@ export async function handleStats(ctx) {
       row("Active loans", String(r.active)),
       row("Issued lifetime", totalLoansIssued.toString()),
       row("Repaid", String(r.repaid)),
-      row("Liquidated", totalLiquidations.toString()),
+      // "Liquidated" uses the DB count (loans.status='liquidated'),
+      // not the on-chain pool counter. The on-chain pool counter
+      // (totalLiquidations) is a lifetime accumulator that includes
+      // pre-DB-tracking program events, devnet test invocations, and
+      // historical liquidations whose loans rows were never created.
+      // Operator reported TG=44 vs site=11 — 11 is the truthful number
+      // (real user loans that got liquidated). DB count matches the
+      // site's transparency endpoint exactly. 2026-06-17 04:25 UTC.
+      row("Liquidated", String(r.liquidated)),
       ``,
       `POOL${(v2 || v3 || v4) ? ` (${["V1", v2 ? "V2" : null, v3 ? "V3" : null, v4 ? "V4" : null].filter(Boolean).join("+")})` : ""}`,
       row("LP deposited", `${totalDepositsSol} SOL`),


### PR DESCRIPTION
Operator reported TG /stats showed 44 liquidations while the site showed 11. Site is the truthful number.

Root cause: TG was using the on-chain lending pool's lifetime totalLiquidations accumulator (summed across V1+V2+V3+V4 pool accounts), which includes pre-DB-tracking program events, devnet test invocations during early dev, and historical liquidations whose loans rows were never created.

The DB count (loans WHERE status='liquidated') is what the site uses + every other surface that tells the user about 'loans that got liquidated.'

One-line swap: use r.liquidated (already in the SELECT) instead of totalLiquidations.