### PR TITLE
P0 fix(arm-race): bump loan-lookup polling window 6s → 30s

### DIFF
--- a/src/api/internal-agent-limitclose.js
+++ b/src/api/internal-agent-limitclose.js
@@ -224,7 +224,7 @@ export async function handleAgentLimitCloseArm(req) {
   // Race-tolerant: agents acting on autonomous policies can fire within
   // seconds of a borrow tx confirming. Same 6s/400ms poll the other
   // arm paths use so /sync-loan has a chance to commit the loans row.
-  const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 6_000;
+  const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 30_000;
   const LOAN_LOOKUP_INTERVAL_MS = 400;
   let walletGuard = null;
   for (;;) {
@@ -550,7 +550,7 @@ export async function handleAgentLimitClosePreflight(req) {
   }
 
   // Wallet binding + loan owed lookup (same as /arm) — race-tolerant.
-  const PREFLIGHT_LOOKUP_DEADLINE_MS = Date.now() + 6_000;
+  const PREFLIGHT_LOOKUP_DEADLINE_MS = Date.now() + 30_000;
   const PREFLIGHT_LOOKUP_INTERVAL_MS = 400;
   let walletGuard = null;
   for (;;) {

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -655,7 +655,7 @@ export async function handleSiteLimitCloseArm(req) {
   // borrow tx may have confirmed but /sync-loan hasn't committed the
   // loans row yet when a multiplier-arm fires immediately after.
   if (multiplierUsed != null) {
-    const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 6_000;
+    const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 30_000;
     const LOAN_LOOKUP_INTERVAL_MS = 400;
     let loanLite = null;
     for (;;) {

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -464,7 +464,7 @@ async function armOrderImpl({
   // Same envelope, same nonce, no extra wallet prompts. The loan
   // reliably lands within 1-3s in practice; the longer window covers
   // RPC blips.
-  const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 6_000;
+  const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 30_000;
   const LOAN_LOOKUP_INTERVAL_MS = 400;
   let loan = null;
   for (;;) {
@@ -1152,9 +1152,13 @@ async function armOrderBatchImpl({
   // flip to status='failed' (recovery banner then has to do the work
   // of re-prompting for retry). Triggered 2026-06-17 on operator's
   // SPCX loan 820: intents 15/16 failed at 05:28:46, loan row landed
-  // at 05:28:51 — 5s late. Poll up to 6s/400ms, same envelope/sig.
+  // at 05:28:51 — 5s late. Initial fix was 6s/400ms; bumped to 30s/400ms
+  // on 2026-06-17 PM after operator's loan 830 took 9s to commit (the
+  // 6s window timed out before the loan landed). 30s is 3x worst-case
+  // so future Solana congestion doesn't re-trip this. Same envelope/sig.
+  // See feedback_arm_lookup_window_must_outlast_cosign_borrow.md.
   phaseLog("phase_1_loan_lookup_start");
-  const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 6_000;
+  const LOAN_LOOKUP_DEADLINE_MS = Date.now() + 30_000;
   const LOAN_LOOKUP_INTERVAL_MS = 400;
   let loanRows;
   let lookupAttempts = 0;


### PR DESCRIPTION
Third V4 ladder failure today for operator on loan 830. Intent beacon at 14:02:03, loan row landed at 14:02:12 — 9-second commit gap. PR #330 window was 6s. Bumping all 5 polling sites to 30s (3x worst-case headroom). Pure DB cost. Memory rule: feedback_arm_lookup_window_must_outlast_cosign_borrow.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)