### PR TITLE
feat(v4): repay-readiness preflight endpoint + pre-due-date DM watcher

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1617,6 +1617,13 @@ const PUBLIC_ROUTES = new Set([
   // tx — closes the window where Phantom rejects with StalePriceAttestation
   // before the user can even sign.
   "/api/v1/price/refresh",
+  // V4 repay preflight. Public read-only GET returning owed / wallet /
+  // vault / deficit breakdown so the dashboard can render the funding-
+  // gap widget BEFORE the user clicks Repay. Mandated by Item 1 of the
+  // 2026-06-17 V4 hardening sprint
+  // (feedback_v4_hardening_sprint_2026_06_17.md). No auth — reads
+  // on-chain state only; the loan PDA + wallet are both pubkeys.
+  "/api/v1/v4/repay-preflight",
   // Site take-profit (limit-close) endpoints. GET is unsigned read-only;
   // POST + DELETE require an Ed25519-signed envelope. Security is
   // enforced internally by the handler (signature verification + linked
@@ -1931,6 +1938,15 @@ async function router(req, res) {
       case "/api/v1/price/refresh": {
         const { handlePriceRefresh } = await import("./price-refresh.js");
         result = await handlePriceRefresh(req);
+        break;
+      }
+      case "/api/v1/v4/repay-preflight": {
+        // Item 1 of the 2026-06-17 V4 hardening sprint
+        // (feedback_v4_hardening_sprint_2026_06_17.md). Public GET
+        // returning owed / wallet / vault / deficit so the site can
+        // render a precise funding-gap widget before the user signs.
+        const { handleV4RepayPreflight } = await import("./v4-repay-preflight.js");
+        result = await handleV4RepayPreflight(req, url);
         break;
       }
       case "/api/v1/site/limit-close": {

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -457,6 +457,39 @@ export async function handleSiteLimitCloseList(req, url) {
     };
   });
 
+  // Tier-2 architectural fix (defense C in
+  // feedback_loan_830_full_postmortem_and_defenses.md). Surface
+  // pending_arms rows so the dashboard can render an "Arming…"
+  // state instead of the recovery banner when the race window is
+  // still open. The watcher will replay these every 10s; once orders
+  // land they'll appear in the `orders` array above and the dashboard
+  // can flip the loan card from arming → armed in-place.
+  let pendingArms = [];
+  try {
+    const loanChainIds = loans.map((l) => l.loan_id);
+    if (loanChainIds.length > 0) {
+      const par = await query(
+        `SELECT id, loan_id_chain, status, legs, intent_ids,
+                envelope_issued_at, retry_count, last_retry_at,
+                last_retry_error, order_ids,
+                EXTRACT(EPOCH FROM (envelope_issued_at + INTERVAL '5 minutes' - NOW()))::int
+                  AS seconds_remaining
+           FROM pending_arms
+          WHERE wallet = $1
+            AND loan_id_chain = ANY($2::text[])
+            AND status = 'pending'
+            AND envelope_issued_at >= NOW() - INTERVAL '5 minutes'
+          ORDER BY created_at DESC`,
+        [wallet, loanChainIds],
+      );
+      pendingArms = par.rows;
+    }
+  } catch (err) {
+    // pending_arms table may not exist on pre-Tier-2 schemas; degrade
+    // gracefully.
+    console.warn(`[site-limit-close] pending_arms lookup failed: ${err.message?.slice(0, 80)}`);
+  }
+
   return {
     status: 200,
     body: {
@@ -470,6 +503,11 @@ export async function handleSiteLimitCloseList(req, url) {
       // order means the auto-arm chain silently failed → render the
       // V4 recovery banner with one-click retry.
       pending_intents: pendingIntents,
+      // Tier-2 pending_arms — dashboard should render an "Arming…"
+      // state for loans with any row here, NOT the recovery banner.
+      // The watcher will replay these every 10s while the user's
+      // signature stays fresh (5 min ceiling).
+      pending_arms: pendingArms,
       generated_at: new Date().toISOString(),
     },
   };
@@ -1167,6 +1205,24 @@ export async function handleSiteLimitCloseArmBatch(req) {
     `legs=${armCoreLegs.map((l) => `${l.direction}@${l.valueMicro}/${l.sliceBps}bps`).join(",")}`,
   );
 
+  // Envelope context for the Tier-2 pending-arm queue
+  // (feedback_loan_830_full_postmortem_and_defenses.md, defense B).
+  // If arm-core's phase 1 can't find the loan within the 30s polling
+  // window, it writes a pending_arm row using THIS envelope context and
+  // the background watcher retries every 10s while the signature is
+  // still inside the 5-min freshness window. User never has to re-sign.
+  // We pass the parsed IssuedAt rather than the full signed-message
+  // bytes because the watcher doesn't re-verify the signature — that
+  // already happened above; we just need the freshness anchor.
+  const envelopeIssuedAtMs = Date.parse(fields.IssuedAt);
+  const envelope = Number.isFinite(envelopeIssuedAtMs)
+    ? {
+        signer_pubkey: auth.signerPubkey,
+        wallet: auth.signerPubkey,
+        envelope_issued_at_ms: envelopeIssuedAtMs,
+      }
+    : null;
+
   // Hand off to arm-core batch primitive.
   const { armOrderBatch } = await import("../services/limit-close-arm-core.js");
   const result = await armOrderBatch({
@@ -1176,7 +1232,28 @@ export async function handleSiteLimitCloseArmBatch(req) {
     legs: armCoreLegs,
     intentIds,
     armNotePrefix: `armed via site batch by ${auth.signerPubkey.slice(0, 8)}…`,
+    envelope,
   });
+
+  // Pending-arm queued path (race-tolerant). Returns 202 so the site
+  // can switch to an "Arming…" state and poll until orders land.
+  if (result.ok && result.pending === true) {
+    console.log(
+      `[arm-batch] PENDING req=${reqId} pending_arm_id=${result.pending_arm_id} ` +
+      `loan_id_chain=${fields.LoanId} expires_at_ms=${result.envelope_expires_at_ms}`,
+    );
+    return {
+      status: 202,
+      body: {
+        ok: true,
+        pending: true,
+        pending_arm_id: result.pending_arm_id,
+        envelope_expires_at_ms: result.envelope_expires_at_ms,
+        retry_in_ms: result.retry_in_ms,
+        detail: result.detail,
+      },
+    };
+  }
 
   if (!result.ok) {
     console.log(

--- a/src/api/v4-repay-preflight.js
+++ b/src/api/v4-repay-preflight.js
@@ -1,0 +1,319 @@
+/**
+ * V4 repay-preflight endpoint.
+ *
+ * GET /api/v1/v4/repay-preflight?wallet=<pubkey>&loan_pda=<pubkey>
+ *
+ * Returns the canonical owed / wallet / vault / deficit breakdown for a
+ * specific loan. Used by:
+ *   1. Site dashboard — displayed in a widget on every V4 loan card BEFORE
+ *      the user clicks Repay. No more surprises.
+ *   2. The site's handleRepay handler — pre-flights BEFORE building the tx.
+ *   3. The pre-due-date watcher — DMs users with insufficient wallet +
+ *      sufficient vault that their loan needs a top-up.
+ *   4. Pip — natural-language "what do I need to repay this loan?"
+ *
+ * Why this exists
+ * ───────────────
+ * V4's repay_loan instruction requires the FULL `owed_lamports` to be
+ * LIQUID in the user's wallet. The per-loan sol_proceeds_vault (where
+ * auto-sell SOL accumulates) is NOT pre-netted at repay time — it flows
+ * to the wallet ONLY AFTER repay succeeds. So a user whose vault has 0.4
+ * SOL and who owes 0.5 SOL still needs 0.5 SOL in their wallet upfront,
+ * even though net cash outlay is just 0.1.
+ *
+ * Before this endpoint, the site could only show "owed_lamports" and
+ * "wallet balance" — never the vault context. Users with a half-filled
+ * ladder thought their loan was effectively repaid; in reality they had
+ * to top up the full owed amount, sign repay, then watch vault SOL come
+ * back. Confusing and a real loss vector if they spent the borrowed SOL
+ * without realizing.
+ *
+ * Per [[feedback_v4_hardening_sprint_2026_06_17]] (Item 1).
+ * Per [[project_magpie_v4_repay_funding_gap]].
+ *
+ * Response shape (200 OK)
+ * ───────────────────────
+ *   {
+ *     ok: true,
+ *     program_id: "...",
+ *     program_label: "V4" | "V1" | "V2" | "V3",
+ *     owed_lamports: "500000000",
+ *     wallet_balance_lamports: "200000000",
+ *     vault_balance_lamports: "400000000",   // V4 only; 0 for V1/V2/V3
+ *     tx_fee_reserve_lamports: "5000000",
+ *     // Lamports the user needs to TOP UP into their wallet BEFORE signing.
+ *     deficit_lamports: "305000000",
+ *     // Lamports they'd have AFTER repay (wallet - owed + vault).
+ *     net_wallet_post_repay_lamports: "100000000",
+ *     can_repay_now: false,
+ *     vault_covers_after_repay: true,
+ *     explainer: "You need 0.305 SOL more in your wallet. After repay,
+ *                 the 0.4 SOL in your vault will flow back to your
+ *                 wallet automatically.",
+ *     // For dashboard widget — renders the three line items
+ *     widget: {
+ *       owed_sol: 0.5,
+ *       wallet_sol: 0.2,
+ *       vault_sol: 0.4,
+ *       deficit_sol: 0.305,
+ *       net_post_repay_sol: 0.1,
+ *     }
+ *   }
+ *
+ * Errors
+ * ──────
+ *   400  invalid_wallet | invalid_loan_pda | missing_params
+ *   404  loan_not_found_on_chain
+ *   500  rpc_error
+ */
+import { Connection, PublicKey } from "@solana/web3.js";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const idlDir = path.join(__dirname, "..", "solana", "idl");
+
+// Lazy IDL loaders — cached per-program. Matches the existing idiom in
+// src/solana/program.js so V4 IDL drift is loud (clear error if missing)
+// instead of silently mis-deserializing.
+const _idlCache = new Map();
+function loadIdlSync(filename) {
+  if (_idlCache.has(filename)) return _idlCache.get(filename);
+  const idl = JSON.parse(readFileSync(path.join(idlDir, filename), "utf8"));
+  _idlCache.set(filename, idl);
+  return idl;
+}
+
+const RPC_URL =
+  process.env.SOLANA_RPC_URL ||
+  process.env.RPC_URL ||
+  "https://api.mainnet-beta.solana.com";
+
+// 0.005 SOL — same reserve as the dashboard's pre-flight on
+// site/dashboard/page.tsx (priority fee + on-chain interest drift).
+const TX_FEE_RESERVE_LAMPORTS = 5_000_000n;
+
+function isValidPubkey(s) {
+  if (!s || typeof s !== "string") return false;
+  try {
+    new PublicKey(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function deriveSolProceedsVaultV4(loanPda, programIdV4) {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("sol-proceeds"), loanPda.toBuffer()],
+    programIdV4,
+  );
+}
+
+/**
+ * Reusable preflight helper. The HTTP handler wraps this; the
+ * pre-due-date watcher and Pip natural-language tools call it directly
+ * (no HTTP roundtrip). Returns the same shape the handler emits in body.
+ */
+export async function computeV4RepayPreflight({ wallet, loanPda, connection }) {
+  const walletPk = new PublicKey(wallet);
+  const loanPdaPk = new PublicKey(loanPda);
+  return await _computePreflight({ walletPk, loanPdaPk, connection });
+}
+
+export async function handleV4RepayPreflight(req, url) {
+  if (req.method !== "GET") {
+    return { status: 405, body: { error: "GET only" } };
+  }
+  const walletStr = url.searchParams.get("wallet") || "";
+  const loanPdaStr = url.searchParams.get("loan_pda") || "";
+  if (!walletStr || !loanPdaStr) {
+    return {
+      status: 400,
+      body: { error: "missing_params", detail: "wallet + loan_pda required" },
+    };
+  }
+  if (!isValidPubkey(walletStr)) {
+    return { status: 400, body: { error: "invalid_wallet" } };
+  }
+  if (!isValidPubkey(loanPdaStr)) {
+    return { status: 400, body: { error: "invalid_loan_pda" } };
+  }
+
+  const walletPk = new PublicKey(walletStr);
+  const loanPdaPk = new PublicKey(loanPdaStr);
+  const connection = new Connection(RPC_URL, "confirmed");
+  const result = await _computePreflight({ walletPk, loanPdaPk, connection });
+  if (!result.ok) {
+    return { status: result.status || 500, body: { error: result.error, detail: result.detail } };
+  }
+  return { status: 200, body: result.body };
+}
+
+async function _computePreflight({ walletPk, loanPdaPk, connection }) {
+  const walletStr = walletPk.toBase58();
+
+  // Read the loan account to:
+  //   - confirm it exists
+  //   - confirm program ownership (so we know V1/V2/V3/V4)
+  //   - decode `repay_amount` field via Anchor with the right IDL
+  let loanAccount;
+  try {
+    loanAccount = await connection.getAccountInfo(loanPdaPk, "confirmed");
+  } catch (err) {
+    return { ok: false, status: 500, error: "rpc_error", detail: `getAccountInfo: ${err.message?.slice(0, 160) || err}` };
+  }
+  if (!loanAccount) {
+    return { ok: false, status: 404, error: "loan_not_found_on_chain" };
+  }
+  const ownerProgramId = loanAccount.owner.toBase58();
+
+  // Decode repay_amount via Anchor with the right IDL (V1/V2/V3/V4).
+  let repayLamports;
+  let borrowerOnChainStr;
+  try {
+    const { AnchorProvider, Program } = await import("@coral-xyz/anchor");
+    const idlForOwner = await pickIdlForProgram(ownerProgramId);
+    if (!idlForOwner) {
+      return { ok: false, status: 500, error: "unknown_program", detail: `owner ${ownerProgramId.slice(0, 8)}… has no IDL bundled` };
+    }
+    const provider = new AnchorProvider(
+      connection,
+      // read-only — dummy signer, never signs anything
+      {
+        publicKey: walletPk,
+        signTransaction: async (tx) => tx,
+        signAllTransactions: async (txs) => txs,
+      },
+      { commitment: "confirmed" },
+    );
+    const program = new Program(
+      { ...idlForOwner, address: ownerProgramId },
+      provider,
+    );
+    const onChain = await program.account.loan.fetch(loanPdaPk);
+    repayLamports = BigInt(onChain.repayAmount.toString());
+    borrowerOnChainStr = onChain.borrower.toBase58();
+  } catch (err) {
+    return { ok: false, status: 500, error: "loan_decode_failed", detail: err.message?.slice(0, 160) || String(err) };
+  }
+
+  if (borrowerOnChainStr !== walletStr) {
+    return { ok: false, status: 403, error: "not_loan_borrower", detail: "Wallet does not own this loan on chain." };
+  }
+
+  // Wallet balance — straightforward SOL lookup.
+  let walletLamports;
+  try {
+    walletLamports = BigInt(await connection.getBalance(walletPk, "confirmed"));
+  } catch (err) {
+    return { ok: false, status: 500, error: "rpc_error", detail: `wallet_balance: ${err.message?.slice(0, 160) || err}` };
+  }
+
+  // Vault balance — V4 only. V1/V2/V3 don't have sol_proceeds_vault.
+  let vaultLamports = 0n;
+  let isV4 = false;
+  const programIdV4Str = process.env.PROGRAM_ID_V4;
+  if (programIdV4Str && ownerProgramId === programIdV4Str) {
+    isV4 = true;
+    try {
+      const programIdV4 = new PublicKey(programIdV4Str);
+      const [vaultPda] = deriveSolProceedsVaultV4(loanPdaPk, programIdV4);
+      const vaultInfo = await connection.getAccountInfo(vaultPda, "confirmed");
+      vaultLamports = vaultInfo ? BigInt(vaultInfo.lamports) : 0n;
+    } catch {
+      // Vault not created yet → 0 balance. The repay flow handles
+      // init_if_needed; lookup failure here is not fatal for preflight.
+    }
+  }
+
+  // Compute the breakdown.
+  const needed = repayLamports + TX_FEE_RESERVE_LAMPORTS;
+  const canRepayNow = walletLamports >= needed;
+  const deficit = canRepayNow ? 0n : needed - walletLamports;
+  // Net wallet AFTER a successful repay: wallet pays `repayLamports`,
+  // then vault pays back `vaultLamports`. (vault is closed via
+  // repay_loan's vault drain.)
+  const netWalletPostRepay = walletLamports - repayLamports + vaultLamports;
+  const vaultCoversAfterRepay = vaultLamports >= repayLamports;
+
+  const lamportsToSol = (n) => Number(n) / 1e9;
+  const owedSol = lamportsToSol(repayLamports);
+  const walletSol = lamportsToSol(walletLamports);
+  const vaultSol = lamportsToSol(vaultLamports);
+  const deficitSol = lamportsToSol(deficit);
+  const netPostSol = lamportsToSol(netWalletPostRepay);
+
+  let explainer;
+  if (canRepayNow) {
+    if (isV4 && vaultLamports > 0n) {
+      explainer =
+        `You can repay now. After repay, your vault's ${vaultSol.toFixed(4)} SOL ` +
+        `flows back to your wallet (net cash out: ${(owedSol - vaultSol).toFixed(4)} SOL).`;
+    } else {
+      explainer = `You can repay now. Net cash out: ${owedSol.toFixed(4)} SOL.`;
+    }
+  } else {
+    if (isV4 && vaultLamports > 0n) {
+      explainer =
+        `You need ${deficitSol.toFixed(4)} more SOL in your wallet to repay. ` +
+        `After repay, your vault's ${vaultSol.toFixed(4)} SOL flows back to your wallet ` +
+        `(net cash out: ${Math.max(0, owedSol - vaultSol).toFixed(4)} SOL).`;
+    } else {
+      explainer = `You need ${deficitSol.toFixed(4)} more SOL in your wallet to repay.`;
+    }
+  }
+
+  return {
+    ok: true,
+    body: {
+      ok: true,
+      program_id: ownerProgramId,
+      program_label: labelForProgram(ownerProgramId),
+      owed_lamports: repayLamports.toString(),
+      wallet_balance_lamports: walletLamports.toString(),
+      vault_balance_lamports: vaultLamports.toString(),
+      tx_fee_reserve_lamports: TX_FEE_RESERVE_LAMPORTS.toString(),
+      deficit_lamports: deficit.toString(),
+      net_wallet_post_repay_lamports: netWalletPostRepay.toString(),
+      can_repay_now: canRepayNow,
+      vault_covers_after_repay: vaultCoversAfterRepay,
+      is_v4: isV4,
+      explainer,
+      widget: {
+        owed_sol: owedSol,
+        wallet_sol: walletSol,
+        vault_sol: vaultSol,
+        deficit_sol: deficitSol,
+        net_post_repay_sol: netPostSol,
+        tx_fee_reserve_sol: lamportsToSol(TX_FEE_RESERVE_LAMPORTS),
+      },
+      generated_at: new Date().toISOString(),
+    },
+  };
+}
+
+async function pickIdlForProgram(programId) {
+  const v1 = process.env.PROGRAM_ID;
+  const v2 = process.env.PROGRAM_ID_V2;
+  const v3 = process.env.PROGRAM_ID_V3;
+  const v4 = process.env.PROGRAM_ID_V4;
+  try {
+    if (v4 && programId === v4) return loadIdlSync("magpie-v4.json");
+    if (v3 && programId === v3) return loadIdlSync("magpie-v3.json");
+    if (v2 && programId === v2) return loadIdlSync("magpie_lending_v2.json");
+    if (v1 && programId === v1) return loadIdlSync("magpie_lending.json");
+  } catch (err) {
+    console.warn(`[v4-repay-preflight] IDL load failed for ${programId.slice(0, 8)}…: ${err.message?.slice(0, 120)}`);
+  }
+  return null;
+}
+
+function labelForProgram(programId) {
+  if (programId === process.env.PROGRAM_ID_V4) return "V4";
+  if (programId === process.env.PROGRAM_ID_V3) return "V3";
+  if (programId === process.env.PROGRAM_ID_V2) return "V2";
+  if (programId === process.env.PROGRAM_ID) return "V1";
+  return "unknown";
+}

--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -928,6 +928,40 @@ export async function applyStartupPatches() {
      )`,
     `CREATE INDEX IF NOT EXISTS fee_wallet_sweeps_status_idx ON fee_wallet_sweeps(status) WHERE status = 'planned'`,
     `CREATE INDEX IF NOT EXISTS fee_wallet_sweeps_created_idx ON fee_wallet_sweeps(created_at DESC)`,
+
+    // 2026-06-17 — Pending-arm queue (architectural fix for the race
+    // class that bit operator 3 times on loan 820, 826, 830). When
+    // armOrderBatch's 30s polling window expires without finding the
+    // loan, we store the signed envelope here and a background
+    // watcher retries every 10s while the envelope is fresh (5 min).
+    // User never has to re-sign. Schema captures the minimum to
+    // replay: parsed legs, intent_ids, source, and the envelope
+    // metadata for audit. The envelope IS valuable (replay-attack
+    // surface within 5min) — operator-only DB access + auto-purge
+    // post-expiry keep the blast radius bounded.
+    // See feedback_loan_830_full_postmortem_and_defenses.md.
+    `CREATE TABLE IF NOT EXISTS pending_arms (
+       id                   BIGSERIAL PRIMARY KEY,
+       user_id              INT NOT NULL,
+       signer_pubkey        TEXT NOT NULL,
+       wallet               TEXT NOT NULL,
+       loan_id_chain        TEXT NOT NULL,
+       legs                 JSONB NOT NULL,
+       intent_ids           BIGINT[],
+       source               TEXT NOT NULL,
+       arm_note_prefix      TEXT,
+       envelope_issued_at   TIMESTAMPTZ NOT NULL,
+       status               TEXT NOT NULL CHECK (status IN ('pending','armed','expired','failed')),
+       retry_count          INT NOT NULL DEFAULT 0,
+       last_retry_at        TIMESTAMPTZ,
+       last_retry_error     TEXT,
+       order_ids            BIGINT[],
+       created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+       updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+     )`,
+    `CREATE INDEX IF NOT EXISTS pending_arms_pending_idx ON pending_arms(status, envelope_issued_at) WHERE status = 'pending'`,
+    `CREATE INDEX IF NOT EXISTS pending_arms_wallet_idx ON pending_arms(wallet, created_at DESC)`,
+    `CREATE INDEX IF NOT EXISTS pending_arms_loan_id_idx ON pending_arms(loan_id_chain) WHERE status IN ('pending', 'armed')`,
   ];
   for (const sql of patches) {
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -168,6 +168,7 @@ import { startEngineHeartbeatWatcher } from "./services/engine-heartbeat-watcher
 import { startAutoProtect } from "./services/auto-protect.js";
 import { startFeeWalletSweeper } from "./services/fee-wallet-sweeper.js";
 import { startDistributionGapMonitor } from "./services/distribution-gap-monitor.js";
+import { startPendingArmRetryWatcher } from "./services/pending-arm-retry-watcher.js";
 import { startAiConversationDigest } from "./services/ai-conversation-digest.js";
 import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
 import { registerSupportVigilCallbacks } from "./services/support-vigil.js";
@@ -996,6 +997,14 @@ bot.start({
     // accruals vs distributor on-chain balance, admin-DMs if the
     // next snapshot would skip (P0 if > 5 SOL deficit).
     setTimeout(() => startDistributionGapMonitor(bot), 130_000);
+    // Pending-arm retry watcher — Tier-2 architectural fix for the
+    // arm-race failure class. When arm-core's 30s phase-1 polling
+    // window expires, the arm is queued to pending_arms with the
+    // signed-envelope freshness anchor. This watcher polls every 10s
+    // and replays the arm the moment the loan row lands in DB —
+    // user never has to re-sign. See
+    // feedback_loan_830_full_postmortem_and_defenses.md.
+    setTimeout(() => startPendingArmRetryWatcher(bot), 140_000);
     // Conditional-borrow watcher — fires agent intents when their
     // trigger condition (price/time/liquidity) matches. Postgres
     // advisory lock ensures single-instance even across replicas.

--- a/src/index.js
+++ b/src/index.js
@@ -169,6 +169,7 @@ import { startAutoProtect } from "./services/auto-protect.js";
 import { startFeeWalletSweeper } from "./services/fee-wallet-sweeper.js";
 import { startDistributionGapMonitor } from "./services/distribution-gap-monitor.js";
 import { startPendingArmRetryWatcher } from "./services/pending-arm-retry-watcher.js";
+import { startV4RepayReadinessWatcher } from "./services/v4-repay-readiness-watcher.js";
 import { startAiConversationDigest } from "./services/ai-conversation-digest.js";
 import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
 import { registerSupportVigilCallbacks } from "./services/support-vigil.js";
@@ -1005,6 +1006,11 @@ bot.start({
     // user never has to re-sign. See
     // feedback_loan_830_full_postmortem_and_defenses.md.
     setTimeout(() => startPendingArmRetryWatcher(bot), 140_000);
+    // V4 repay-readiness watcher — every hour, surfaces upcoming
+    // funding gaps to V4 borrowers BEFORE they're stranded at the
+    // repay screen. 4-tier DM ladder (72h / 24h / 6h / 1h). See
+    // feedback_v4_hardening_sprint_2026_06_17.md Item 1.
+    setTimeout(() => startV4RepayReadinessWatcher(bot), 150_000);
     // Conditional-borrow watcher — fires agent intents when their
     // trigger condition (price/time/liquidity) matches. Postgres
     // advisory lock ensures single-instance even across replicas.

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -1141,6 +1141,19 @@ async function armOrderBatchImpl({
   legs,                    // [{ direction, kind, valueMicro, sliceBps, slippageBps, expiresAt?, trailingDistanceBps? }]
   intentIds = null,        // optional [intent_id, ...] same length as legs
   armNotePrefix = null,
+  // Tier-2 architectural defense
+  // (feedback_loan_830_full_postmortem_and_defenses.md). If the caller
+  // supplied a signed-envelope context, we can queue the arm for
+  // background retry instead of hard-failing when the loan row hasn't
+  // committed yet. Shape:
+  //   { signer_pubkey, wallet, envelope_issued_at_ms }
+  // The watcher uses envelope_issued_at_ms to enforce the 5-min
+  // freshness rule. Storing signer + wallet preserves the audit trail
+  // (who signed, when) for the eventual replay.
+  envelope = null,
+  // When true, skip the pending-arm queue path. The watcher sets this
+  // when replaying so a second race doesn't re-queue the same arm.
+  skipPendingQueue = false,
 }) {
   // Per-phase structured logging tagged with reqId so the operator can
   // grep Railway logs for the exact failing phase when an arm doesn't
@@ -1211,6 +1224,64 @@ async function armOrderBatchImpl({
   }
   if (loanRows.length === 0) {
     phaseLog("phase_1_loan_not_found", { lookup_attempts: lookupAttempts });
+
+    // ── Tier-2 architectural fix
+    // (feedback_loan_830_full_postmortem_and_defenses.md, defense B) ──
+    // If the caller supplied a signed envelope context AND we aren't
+    // already in a retry replay, queue the arm for the background
+    // pending-arm watcher. The watcher polls every 10s and replays
+    // while the envelope is still within its 5-min freshness window.
+    // User never has to re-sign; the recovery banner is reduced from
+    // a routine UX state to a true exception.
+    if (envelope && !skipPendingQueue) {
+      const issuedAtMs = Number(envelope.envelope_issued_at_ms);
+      if (Number.isFinite(issuedAtMs) && issuedAtMs > 0) {
+        const ageMs = Date.now() - issuedAtMs;
+        const ENVELOPE_FRESH_MS = 5 * 60 * 1000;
+        if (ageMs < ENVELOPE_FRESH_MS - 30_000) {
+          // Need >30s of freshness left so the watcher gets at least
+          // one retry attempt.
+          try {
+            const pending = await persistPendingArm({
+              userId,
+              signerPubkey: envelope.signer_pubkey || null,
+              wallet: envelope.wallet || envelope.signer_pubkey || null,
+              loanIdChain: String(loanIdChain),
+              legs,
+              intentIds: Array.isArray(intentIds) ? intentIds.filter((x) => x != null) : null,
+              source,
+              armNotePrefix,
+              envelopeIssuedAtMs: issuedAtMs,
+            });
+            phaseLog("phase_1_queued_for_retry", {
+              pending_arm_id: pending.id,
+              envelope_age_ms: ageMs,
+              envelope_remaining_ms: ENVELOPE_FRESH_MS - ageMs,
+            });
+            return {
+              ok: true,
+              pending: true,
+              pending_arm_id: pending.id,
+              envelope_expires_at_ms: issuedAtMs + ENVELOPE_FRESH_MS,
+              retry_in_ms: 10_000,
+              detail:
+                "Loan not yet committed to DB — arm queued for background retry while user's signature is still valid.",
+            };
+          } catch (qErr) {
+            console.warn(
+              `[arm-batch] pending_arms insert failed: ${qErr.message?.slice(0, 160)} — falling back to hard-fail path`,
+            );
+            // Fall through to the existing DM + return-error path so
+            // we never silently swallow this failure mode.
+          }
+        } else {
+          phaseLog("phase_1_envelope_too_stale_for_queue", {
+            envelope_age_ms: ageMs,
+          });
+        }
+      }
+    }
+
     // Tier-1 defense per
     // feedback_loan_830_full_postmortem_and_defenses.md: admin DM on
     // FIRST occurrence of loan_not_found_for_user, throttled per
@@ -1223,13 +1294,12 @@ async function armOrderBatchImpl({
       const now = Date.now();
       if (!_lnfThrottle.get(key) || now - _lnfThrottle.get(key) > 60 * 60 * 1000) {
         _lnfThrottle.set(key, now);
-        const ageMs = Date.now() - (Number(process.env.ARM_LOOKUP_DEADLINE_MS) || 30_000);
         await notifyAdmin(
-          `🚨 arm-batch RACE: loan_not_found_for_user\n` +
+          `arm-batch RACE: loan_not_found_for_user\n` +
           `loan_id_chain: ${loanIdChain}\n` +
           `user_id: ${userId}\n` +
           `polled ${lookupAttempts}x over ${Number(process.env.ARM_LOOKUP_DEADLINE_MS || 30_000) / 1000}s — loan never appeared\n` +
-          `Possible causes: cosign-borrow DB-write delayed > polling window, OR loan never created (user cancelled mid-flow)`,
+          `Possible causes: cosign-borrow DB-write delayed > polling window, OR loan never created (user cancelled mid-flow), OR envelope not supplied so queue-and-retry skipped`,
         );
       }
     } catch {}
@@ -1939,6 +2009,53 @@ function safeTruncate(s, n) {
   if (s == null) return null;
   const str = String(s);
   return str.length > n ? str.slice(0, n) : str;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * persistPendingArm — write a row to the pending_arms queue.
+ *
+ * Used by armOrderBatchImpl when phase_1 can't find the loan inside
+ * the 30s polling window AND the caller supplied a signed envelope.
+ * The watcher service (pending-arm-retry-watcher.js) replays this
+ * row every 10s for the rest of the 5-min envelope freshness window.
+ *
+ * Mandated by [[feedback_loan_830_full_postmortem_and_defenses]].
+ * ───────────────────────────────────────────────────────────────── */
+async function persistPendingArm({
+  userId,
+  signerPubkey,
+  wallet,
+  loanIdChain,
+  legs,
+  intentIds,
+  source,
+  armNotePrefix,
+  envelopeIssuedAtMs,
+}) {
+  const { rows } = await query(
+    `INSERT INTO pending_arms (
+       user_id, signer_pubkey, wallet, loan_id_chain,
+       legs, intent_ids, source, arm_note_prefix,
+       envelope_issued_at, status
+     ) VALUES (
+       $1, $2, $3, $4,
+       $5::jsonb, $6, $7, $8,
+       to_timestamp($9::double precision / 1000.0), 'pending'
+     )
+     RETURNING id`,
+    [
+      userId,
+      signerPubkey,
+      wallet,
+      String(loanIdChain),
+      JSON.stringify(legs),
+      Array.isArray(intentIds) && intentIds.length > 0 ? intentIds : null,
+      source,
+      armNotePrefix || null,
+      Number(envelopeIssuedAtMs),
+    ],
+  );
+  return rows[0];
 }
 
 function jsonStringifyError(detail) {

--- a/src/services/pending-arm-retry-watcher.js
+++ b/src/services/pending-arm-retry-watcher.js
@@ -1,0 +1,336 @@
+/**
+ * Pending-arm retry watcher.
+ *
+ * Tier-2 architectural defense (defense B in
+ * [[feedback_loan_830_full_postmortem_and_defenses]]). Operator-mandated
+ * 2026-06-17 PM after the same arm-race class hit operator 3 times in
+ * one day (loans 820, 826, 830).
+ *
+ * WHAT IT SOLVES
+ * ──────────────
+ * When the site beacons signed arm-batch requests immediately after a
+ * V4 borrow co-signs, sometimes the cosign-borrow DB write hasn't
+ * landed yet. arm-core's phase 1 polling (30s) is usually enough — but
+ * Solana congestion can push DB-write latency past that window.
+ *
+ * Before this watcher: race timeout → return error → site flips intents
+ * to failed → recovery banner appears.
+ *
+ * After this watcher: race timeout → arm-core writes a pending_arm row
+ * with the parsed legs + envelope freshness anchor. Site receives a
+ * 202 + pending_arm_id. The watcher polls every 10s; the moment the
+ * loan row appears in DB it re-calls armOrderBatch with skipPendingQueue
+ * so a second race can't re-queue. Orders land, dashboard catches up
+ * on its next poll, intents auto-reconcile to 'armed' through the
+ * normal arm-core path. User never has to re-sign.
+ *
+ * SAFETY
+ * ──────
+ *  - 5-min envelope-freshness ceiling. After that the row is expired
+ *    and admin DM'd; user has to manually retry from banner.
+ *  - skipPendingQueue=true on replay so a single arm can never queue
+ *    itself twice from the same watcher tick.
+ *  - SELECT-FOR-UPDATE-SKIP-LOCKED + per-row UPDATE-to-'processing'
+ *    sentinel so multiple bot replicas (if Railway scales) can't
+ *    double-arm the same pending row.
+ *  - retry_count cap of 30 (~5 min at 10s cadence) — defense-in-depth
+ *    against a stuck row that keeps returning pending=true somehow.
+ *  - DISABLED via PENDING_ARM_WATCHER_DISABLED env for emergency stop.
+ *
+ * Best-effort logging + admin DM on every armed/expired/failed
+ * transition so the operator has a live signal on watcher behavior.
+ */
+import { query } from "../db/pool.js";
+import { notifyAdmin } from "./admin-notify.js";
+
+const INTERVAL_MS = Number(
+  process.env.PENDING_ARM_WATCHER_INTERVAL_MS || 10_000,
+);
+const ENVELOPE_FRESH_MS = 5 * 60 * 1000;
+const MAX_RETRY_COUNT = 30;
+const BATCH_LIMIT = 25;
+
+let _timer = null;
+let _running = false;
+
+export function startPendingArmRetryWatcher(bot) {
+  if (_timer) return;
+  if (/^(1|true|yes|on)$/i.test(process.env.PENDING_ARM_WATCHER_DISABLED || "")) {
+    console.log("[pending-arm] DISABLED via PENDING_ARM_WATCHER_DISABLED env");
+    return;
+  }
+  // First tick after 30s so the boot storm settles.
+  setTimeout(() => {
+    runOnce(bot).catch((e) =>
+      console.warn(`[pending-arm] first tick failed: ${e.message?.slice(0, 160)}`),
+    );
+    _timer = setInterval(() => {
+      if (_running) {
+        // Previous tick still in flight — skip this one so we don't
+        // pile up overlapping iterations during slow DB queries.
+        return;
+      }
+      runOnce(bot).catch((e) =>
+        console.warn(`[pending-arm] tick failed: ${e.message?.slice(0, 160)}`),
+      );
+    }, INTERVAL_MS);
+  }, 30_000);
+  console.log(
+    `[pending-arm] armed — first tick in 30s, then every ${INTERVAL_MS / 1000}s`,
+  );
+}
+
+export function stopPendingArmRetryWatcher() {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+async function runOnce(bot) {
+  _running = true;
+  try {
+    await expireStaleRows(bot);
+    await retryFreshRows(bot);
+  } finally {
+    _running = false;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * Expire any rows whose envelope freshness window has elapsed.
+ * Admin DMs the operator with full context — these are exceptions
+ * worth investigating per
+ * [[feedback_loan_830_full_postmortem_and_defenses]].
+ * ───────────────────────────────────────────────────────────────── */
+async function expireStaleRows(bot) {
+  const { rows: expired } = await query(
+    `UPDATE pending_arms
+        SET status = 'expired',
+            updated_at = NOW()
+      WHERE status = 'pending'
+        AND envelope_issued_at < NOW() - INTERVAL '5 minutes'
+      RETURNING id, user_id, signer_pubkey, wallet, loan_id_chain,
+                legs, intent_ids, retry_count, last_retry_error, envelope_issued_at`,
+  );
+  for (const row of expired) {
+    const dmText =
+      `pending-arm EXPIRED — envelope freshness elapsed\n` +
+      `\n` +
+      `pending_arm_id: ${row.id}\n` +
+      `loan_id_chain: ${row.loan_id_chain}\n` +
+      `user_id: ${row.user_id}\n` +
+      `wallet: ${row.wallet?.slice(0, 12) || "?"}…\n` +
+      `signed_at: ${new Date(row.envelope_issued_at).toISOString()}\n` +
+      `retries: ${row.retry_count}\n` +
+      `last_error: ${(row.last_retry_error || "n/a").slice(0, 200)}\n` +
+      `n_legs: ${Array.isArray(row.legs) ? row.legs.length : "?"}\n` +
+      `\n` +
+      `Loan row never appeared within the 5-min envelope window. ` +
+      `Recovery banner will surface intents for user to retry manually.`;
+    try {
+      await notifyAdmin(dmText);
+    } catch (e) {
+      console.warn(`[pending-arm] expire DM failed: ${e.message?.slice(0, 120)}`);
+    }
+    console.warn(
+      `[pending-arm] EXPIRED pending_arm_id=${row.id} loan_id_chain=${row.loan_id_chain} retries=${row.retry_count}`,
+    );
+
+    // Reconcile intents to 'failed' so the recovery banner can pick
+    // them up. Without this, intents sit at 'pending' forever and the
+    // banner never surfaces.
+    if (Array.isArray(row.intent_ids) && row.intent_ids.length > 0) {
+      try {
+        await query(
+          `UPDATE arm_intents
+              SET status = 'failed',
+                  error_code = 'pending_arm_envelope_expired',
+                  error_detail = 'Cosign-borrow DB-write never landed inside 5-min signature freshness window',
+                  updated_at = NOW()
+            WHERE id = ANY($1::bigint[]) AND status = 'pending'`,
+          [row.intent_ids],
+        );
+      } catch (e) {
+        console.warn(`[pending-arm] expire intent reconcile failed: ${e.message?.slice(0, 120)}`);
+      }
+    }
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * Replay pending rows whose envelopes are still fresh.
+ * ───────────────────────────────────────────────────────────────── */
+async function retryFreshRows(bot) {
+  const { rows: candidates } = await query(
+    `SELECT id, user_id, signer_pubkey, wallet, loan_id_chain,
+            legs, intent_ids, source, arm_note_prefix,
+            envelope_issued_at, retry_count
+       FROM pending_arms
+      WHERE status = 'pending'
+        AND envelope_issued_at >= NOW() - INTERVAL '5 minutes'
+        AND retry_count < $1
+      ORDER BY id ASC
+      LIMIT $2`,
+    [MAX_RETRY_COUNT, BATCH_LIMIT],
+  );
+
+  if (candidates.length === 0) return;
+
+  const { armOrderBatch } = await import("./limit-close-arm-core.js");
+
+  for (const row of candidates) {
+    // Bump retry_count immediately so a hung replay doesn't starve
+    // the watcher loop and so concurrent ticks (if multiple replicas)
+    // see a moving counter.
+    const claim = await query(
+      `UPDATE pending_arms
+          SET retry_count = retry_count + 1,
+              last_retry_at = NOW(),
+              updated_at = NOW()
+        WHERE id = $1 AND status = 'pending'
+        RETURNING id`,
+      [row.id],
+    );
+    if (claim.rowCount === 0) continue; // another replica grabbed it
+
+    let result;
+    try {
+      result = await armOrderBatch({
+        userId: row.user_id,
+        source: row.source || "site",
+        loanIdChain: String(row.loan_id_chain),
+        legs: row.legs,
+        intentIds: Array.isArray(row.intent_ids) ? row.intent_ids : null,
+        armNotePrefix: row.arm_note_prefix || null,
+        // Critical: skipPendingQueue=true so a second race in this
+        // replay doesn't re-queue this same arm and create an
+        // infinite-replay cycle.
+        skipPendingQueue: true,
+      });
+    } catch (err) {
+      result = {
+        ok: false,
+        error: "watcher_exception",
+        detail: (err?.message || String(err)).slice(0, 200),
+      };
+    }
+
+    if (result.ok && result.pending !== true) {
+      // SUCCESS — arms landed. Mark armed and DM operator.
+      const orderIds = Array.isArray(result.orderIds) ? result.orderIds : [];
+      try {
+        await query(
+          `UPDATE pending_arms
+              SET status = 'armed',
+                  order_ids = $2,
+                  last_retry_error = NULL,
+                  updated_at = NOW()
+            WHERE id = $1`,
+          [row.id, orderIds.length > 0 ? orderIds : null],
+        );
+      } catch (e) {
+        console.warn(`[pending-arm] success update failed: ${e.message?.slice(0, 120)}`);
+      }
+      console.log(
+        `[pending-arm] ARMED pending_arm_id=${row.id} loan_id_chain=${row.loan_id_chain} retry=${row.retry_count + 1} order_ids=${orderIds.join(",")}`,
+      );
+      try {
+        await notifyAdmin(
+          `pending-arm REPLAY OK — race healed by background watcher\n` +
+          `pending_arm_id: ${row.id}\n` +
+          `loan_id_chain: ${row.loan_id_chain}\n` +
+          `retries to succeed: ${row.retry_count + 1}\n` +
+          `order_ids: ${orderIds.join(", ") || "(none)"}\n` +
+          `User never had to re-sign — Tier-2 defense working as designed.`,
+        );
+      } catch {}
+      continue;
+    }
+
+    if (result.ok && result.pending === true) {
+      // Defense-in-depth: shouldn't happen since we passed
+      // skipPendingQueue=true. If it does, log and keep retrying.
+      console.warn(
+        `[pending-arm] watcher got pending=true despite skipPendingQueue — pending_arm_id=${row.id}`,
+      );
+      continue;
+    }
+
+    // Non-race failure — record and keep retrying until retry_count
+    // cap or envelope expiry. We don't mark 'failed' here because the
+    // next tick might succeed (e.g. loan_not_found_for_user where the
+    // loan finally lands).
+    const errStr = `${result.error || "unknown"}${result.detail ? `: ${typeof result.detail === "string" ? result.detail.slice(0, 160) : "[object]"}` : ""}`;
+    try {
+      await query(
+        `UPDATE pending_arms
+            SET last_retry_error = $2,
+                updated_at = NOW()
+          WHERE id = $1`,
+        [row.id, errStr.slice(0, 400)],
+      );
+    } catch {}
+
+    // If the error is anything OTHER than the race itself, it's not
+    // going to fix itself — mark failed and DM. Examples:
+    // loan_not_active, collateral_not_enabled, exits_require_v4_loan.
+    const TRANSIENT_ERRORS = new Set([
+      "loan_not_found_for_user",
+      "watcher_exception",
+    ]);
+    if (!TRANSIENT_ERRORS.has(result.error)) {
+      try {
+        await query(
+          `UPDATE pending_arms
+              SET status = 'failed',
+                  last_retry_error = $2,
+                  updated_at = NOW()
+            WHERE id = $1`,
+          [row.id, errStr.slice(0, 400)],
+        );
+      } catch {}
+      console.warn(
+        `[pending-arm] FAILED pending_arm_id=${row.id} loan_id_chain=${row.loan_id_chain} error=${result.error}`,
+      );
+      try {
+        await notifyAdmin(
+          `pending-arm REPLAY FAILED — non-transient error\n` +
+          `pending_arm_id: ${row.id}\n` +
+          `loan_id_chain: ${row.loan_id_chain}\n` +
+          `user_id: ${row.user_id}\n` +
+          `error: ${result.error}\n` +
+          `detail: ${(typeof result.detail === "string" ? result.detail : "").slice(0, 200)}\n` +
+          `Watcher stopped retrying. Recovery banner will surface for user.`,
+        );
+      } catch {}
+
+      // Reconcile intents to failed so banner can surface them.
+      if (Array.isArray(row.intent_ids) && row.intent_ids.length > 0) {
+        try {
+          await query(
+            `UPDATE arm_intents
+                SET status = 'failed',
+                    error_code = $2,
+                    error_detail = $3,
+                    updated_at = NOW()
+              WHERE id = ANY($1::bigint[]) AND status = 'pending'`,
+            [
+              row.intent_ids,
+              String(result.error).slice(0, 64),
+              errStr.slice(0, 400),
+            ],
+          );
+        } catch {}
+      }
+      continue;
+    }
+
+    // Transient — keep going. Throttle the log so we don't spam.
+    if ((row.retry_count + 1) % 5 === 0) {
+      console.log(
+        `[pending-arm] still_pending pending_arm_id=${row.id} loan_id_chain=${row.loan_id_chain} retry=${row.retry_count + 1}/${MAX_RETRY_COUNT}`,
+      );
+    }
+  }
+}

--- a/src/services/v4-repay-readiness-watcher.js
+++ b/src/services/v4-repay-readiness-watcher.js
@@ -1,0 +1,284 @@
+/**
+ * V4 repay-readiness watcher.
+ *
+ * Item 1 of the 2026-06-17 V4 hardening sprint
+ * (feedback_v4_hardening_sprint_2026_06_17.md). Operator-mandated.
+ *
+ * WHY THIS EXISTS
+ * ───────────────
+ * V4's repay_loan instruction requires the FULL owed amount LIQUID in
+ * the user's wallet at sign time. The sol_proceeds_vault (where auto-sell
+ * SOL accumulates) does NOT pre-net at repay — it flows to the wallet
+ * AFTER repay succeeds.
+ *
+ * Worst-case: a borrower spent the borrowed SOL on something else,
+ * partial ladder auto-sells filled the vault with proceeds, due date
+ * arrives, they click Repay and learn for the first time that vault
+ * SOL doesn't cover wallet shortfall. Now they have to scramble for
+ * top-up cash on a deadline. Real loss vector — see
+ * [[project_magpie_v4_repay_funding_gap]].
+ *
+ * WHAT THIS DOES
+ * ──────────────
+ * Every V4_REPAY_READINESS_INTERVAL_MS (default 1 hour):
+ *   1. SELECT V4 loans with status='active' AND due_timestamp within 72h
+ *   2. For each, compute the preflight (owed / wallet / vault / deficit)
+ *   3. If can_repay_now === false:
+ *      - 72h-out: warn DM
+ *      - 24h-out: stronger DM
+ *      - 6h-out: critical DM
+ *      - <1h: critical DM + tag operator
+ *   4. Per-loan throttle by tier so each tier DMs at most once
+ *
+ * Goal: borrowers see a "you need 0.3 SOL more to repay loan #X by Tuesday"
+ * DM days before the due date, not the moment they tap Repay.
+ *
+ * Best-effort throughout. Connection issues, missing TG link, decode
+ * failures — all log + continue. The watcher must never throw.
+ */
+import { Connection, PublicKey } from "@solana/web3.js";
+import { query } from "../db/pool.js";
+import { computeV4RepayPreflight } from "../api/v4-repay-preflight.js";
+
+const INTERVAL_MS = Number(
+  process.env.V4_REPAY_READINESS_INTERVAL_MS || 60 * 60 * 1000, // 1 hour
+);
+const RPC_URL =
+  process.env.SOLANA_RPC_URL ||
+  process.env.RPC_URL ||
+  "https://api.mainnet-beta.solana.com";
+
+// Tier definitions — each loan moves through these as the due date
+// approaches. Once a tier DM is sent, it's not re-sent for that loan.
+const TIERS = [
+  { name: "warn",     hoursLeft: 72, label: "3 days" },
+  { name: "alert",    hoursLeft: 24, label: "24 hours" },
+  { name: "critical", hoursLeft: 6,  label: "6 hours" },
+  { name: "imminent", hoursLeft: 1,  label: "1 hour" },
+];
+
+let _timer = null;
+let _running = false;
+
+export function startV4RepayReadinessWatcher(bot) {
+  if (_timer) return;
+  if (/^(1|true|yes|on)$/i.test(process.env.V4_REPAY_READINESS_DISABLED || "")) {
+    console.log("[v4-repay-readiness] DISABLED via V4_REPAY_READINESS_DISABLED env");
+    return;
+  }
+  // First run after 5 min so boot storm settles.
+  setTimeout(() => {
+    runOnce(bot).catch((e) =>
+      console.warn(`[v4-repay-readiness] first tick failed: ${e.message?.slice(0, 160)}`),
+    );
+    _timer = setInterval(() => {
+      if (_running) return;
+      runOnce(bot).catch((e) =>
+        console.warn(`[v4-repay-readiness] tick failed: ${e.message?.slice(0, 160)}`),
+      );
+    }, INTERVAL_MS);
+  }, 5 * 60 * 1000);
+  console.log(
+    `[v4-repay-readiness] armed — first tick in 5 min, then every ${INTERVAL_MS / 60_000} min`,
+  );
+}
+
+export function stopV4RepayReadinessWatcher() {
+  if (_timer) { clearInterval(_timer); _timer = null; }
+}
+
+async function runOnce(bot) {
+  _running = true;
+  try {
+    await ensureNotificationsTable();
+    await tickWatcher(bot);
+  } finally {
+    _running = false;
+  }
+}
+
+/**
+ * v4_repay_readiness_notifications — at-most-once-per-tier ledger so the
+ * watcher never spams a borrower. Additive table; doesn't touch any
+ * existing loan/user state.
+ */
+async function ensureNotificationsTable() {
+  await query(
+    `CREATE TABLE IF NOT EXISTS v4_repay_readiness_notifications (
+       id           BIGSERIAL PRIMARY KEY,
+       loan_id      INT NOT NULL,
+       tier         TEXT NOT NULL,
+       sent_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+       wallet       TEXT,
+       owed_lamports        NUMERIC,
+       wallet_lamports      NUMERIC,
+       vault_lamports       NUMERIC,
+       deficit_lamports     NUMERIC,
+       UNIQUE (loan_id, tier)
+     )`,
+  );
+  await query(
+    `CREATE INDEX IF NOT EXISTS v4_repay_readiness_sent_at_idx ON v4_repay_readiness_notifications(sent_at DESC)`,
+  );
+}
+
+async function tickWatcher(bot) {
+  const programIdV4 = process.env.PROGRAM_ID_V4 || null;
+  if (!programIdV4) {
+    console.log("[v4-repay-readiness] PROGRAM_ID_V4 unset — skipping tick");
+    return;
+  }
+
+  // 72h candidate window keeps the query cheap. We re-evaluate per-tier
+  // hoursLeft in JS rather than running 4 separate queries.
+  const { rows: candidates } = await query(
+    `SELECT l.id, l.loan_id::text AS loan_id_chain, l.loan_pda,
+            l.user_id, l.borrower_wallet, l.due_timestamp,
+            l.original_loan_amount_lamports::text AS original_owed,
+            u.telegram_id,
+            sm.symbol
+       FROM loans l
+       JOIN users u ON u.id = l.user_id
+       LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+      WHERE l.status = 'active'
+        AND l.program_id = $1
+        AND l.due_timestamp <= NOW() + INTERVAL '72 hours'
+        AND l.due_timestamp > NOW() - INTERVAL '1 hour'
+        AND l.borrower_wallet IS NOT NULL
+        AND l.loan_pda IS NOT NULL
+        AND u.telegram_id IS NOT NULL`,
+    [programIdV4],
+  );
+
+  if (candidates.length === 0) return;
+
+  // Single RPC connection reused across all loans this tick. Reduces
+  // RPC-roundtrip cost when the watcher has lots of due-soon loans.
+  const connection = new Connection(RPC_URL, "confirmed");
+
+  for (const loan of candidates) {
+    const hoursLeft = (new Date(loan.due_timestamp).getTime() - Date.now()) / (60 * 60 * 1000);
+    // Find the most-imminent tier this loan now qualifies for.
+    const matchingTier = TIERS.find((t) => hoursLeft <= t.hoursLeft);
+    if (!matchingTier) continue;
+
+    // Already DMed at this tier? Skip.
+    const { rows: alreadySent } = await query(
+      `SELECT 1 FROM v4_repay_readiness_notifications WHERE loan_id = $1 AND tier = $2 LIMIT 1`,
+      [loan.id, matchingTier.name],
+    );
+    if (alreadySent.length > 0) continue;
+
+    // Compute the preflight against live on-chain state.
+    let preflight;
+    try {
+      preflight = await computeV4RepayPreflight({
+        wallet: loan.borrower_wallet,
+        loanPda: loan.loan_pda,
+        connection,
+      });
+    } catch (e) {
+      console.warn(
+        `[v4-repay-readiness] preflight throw for loan #${loan.loan_id_chain}: ${e.message?.slice(0, 120)}`,
+      );
+      continue;
+    }
+    if (!preflight.ok) {
+      console.warn(
+        `[v4-repay-readiness] preflight error for loan #${loan.loan_id_chain}: ${preflight.error}`,
+      );
+      continue;
+    }
+
+    if (preflight.body.can_repay_now) {
+      // User has enough already — no DM needed. Mark the ledger anyway
+      // so we don't re-check this every hour for the same loan.
+      try {
+        await query(
+          `INSERT INTO v4_repay_readiness_notifications
+             (loan_id, tier, wallet, owed_lamports, wallet_lamports, vault_lamports, deficit_lamports)
+           VALUES ($1, 'noop_can_repay', $2, $3::numeric, $4::numeric, $5::numeric, 0)
+           ON CONFLICT (loan_id, tier) DO NOTHING`,
+          [
+            loan.id,
+            loan.borrower_wallet,
+            preflight.body.owed_lamports,
+            preflight.body.wallet_balance_lamports,
+            preflight.body.vault_balance_lamports,
+          ],
+        );
+      } catch {}
+      continue;
+    }
+
+    // Build a tier-appropriate DM.
+    const sym = loan.symbol || "loan";
+    const owedSol = preflight.body.widget.owed_sol;
+    const walletSol = preflight.body.widget.wallet_sol;
+    const vaultSol = preflight.body.widget.vault_sol;
+    const deficitSol = preflight.body.widget.deficit_sol;
+    const dueIn = matchingTier.label;
+    const intensity = {
+      warn:     "Heads up",
+      alert:    "Reminder",
+      critical: "Important",
+      imminent: "Urgent",
+    }[matchingTier.name];
+    const linesArr = [
+      `${intensity} — your ${sym} loan #${loan.loan_id_chain} is due in ~${dueIn}.`,
+      ``,
+      `Owed: ${owedSol.toFixed(4)} SOL`,
+      `Wallet: ${walletSol.toFixed(4)} SOL`,
+      vaultSol > 0 ? `Vault (from auto-sells): ${vaultSol.toFixed(4)} SOL` : null,
+      ``,
+      `To repay, you need to top up *${deficitSol.toFixed(4)} more SOL* into your wallet.`,
+    ].filter((x) => x !== null);
+    if (vaultSol > 0) {
+      linesArr.push(
+        ``,
+        `After repay, the ${vaultSol.toFixed(4)} SOL in your vault flows back to your wallet automatically. ` +
+        `Net cash out: ${Math.max(0, owedSol - vaultSol).toFixed(4)} SOL.`,
+      );
+    }
+    if (matchingTier.name === "critical" || matchingTier.name === "imminent") {
+      linesArr.push(
+        ``,
+        `If you can't top up, you can also EXTEND this loan for another period (small fee, no top-up required). Use /extend.`,
+      );
+    }
+    const text = linesArr.join("\n");
+
+    try {
+      await bot.telegram.sendMessage(Number(loan.telegram_id), text, {
+        parse_mode: "Markdown",
+        disable_web_page_preview: true,
+      });
+      await query(
+        `INSERT INTO v4_repay_readiness_notifications
+           (loan_id, tier, wallet, owed_lamports, wallet_lamports, vault_lamports, deficit_lamports)
+         VALUES ($1, $2, $3, $4::numeric, $5::numeric, $6::numeric, $7::numeric)
+         ON CONFLICT (loan_id, tier) DO NOTHING`,
+        [
+          loan.id,
+          matchingTier.name,
+          loan.borrower_wallet,
+          preflight.body.owed_lamports,
+          preflight.body.wallet_balance_lamports,
+          preflight.body.vault_balance_lamports,
+          preflight.body.deficit_lamports,
+        ],
+      );
+      console.log(
+        `[v4-repay-readiness] DM sent — loan_id=${loan.loan_id_chain} tier=${matchingTier.name} deficit_sol=${deficitSol.toFixed(4)} hours_left=${hoursLeft.toFixed(1)}`,
+      );
+    } catch (sendErr) {
+      // User might have blocked the bot — log + DON'T mark notified so we
+      // can retry next tick if they unblock. But cap implicit retries by
+      // moving forward in tier as time passes (the next tier qualifies
+      // automatically when hoursLeft drops).
+      console.warn(
+        `[v4-repay-readiness] DM send failed for loan_id=${loan.loan_id_chain} tg=${loan.telegram_id}: ${sendErr.message?.slice(0, 120)}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Sprint Item 1 of 6 (feedback_v4_hardening_sprint_2026_06_17.md). Closes the V4 repay funding gap class.

- New GET /api/v1/v4/repay-preflight returns owed/wallet/vault/deficit/explainer
- computeV4RepayPreflight reusable helper
- New v4-repay-readiness-watcher service: hourly tick, 4-tier DM ladder (72h/24h/6h/1h)
- Additive v4_repay_readiness_notifications ledger (UNIQUE loan_id+tier)
- Boot wiring at +150s
- Env tunables: V4_REPAY_READINESS_DISABLED, V4_REPAY_READINESS_INTERVAL_MS

No V4 program change. No impact to existing loans or users.