### PR TITLE
fix(v4-arm): any wallet can arm — drop custodial+TG gates, auto-link

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -219,7 +219,7 @@ async function authSignedEnvelope(req, expectedMagpieHeader, requiredFields = []
   // src/services/wallet-owner-resolver.js. We need encrypted_secret
   // here so we can't use the helper directly — inline the same
   // ranking so the chosen row is consistent with /repay etc.
-  const { rows: [walletRow] } = await query(
+  let { rows: [walletRow] } = await query(
     `SELECT w.user_id, w.encrypted_secret, w.source
        FROM wallets w
        JOIN users u ON u.id = w.user_id
@@ -231,21 +231,88 @@ async function authSignedEnvelope(req, expectedMagpieHeader, requiredFields = []
     [signerPubkey],
   );
   if (!walletRow) {
-    return { ok: false, status: 403, error: "wallet_not_linked",
-             detail: "This wallet isn't linked to a Magpie account. Link via the TG bot first." };
+    // Auto-create a TG-less user + wallet row so any Phantom-only
+    // wallet can arm V4 exits without first connecting to the TG bot.
+    // Operator-mandated 2026-06-17 PM:
+    //   "I want EVERY SINGLE wallet, it doesn't matter where it came
+    //    from, TG or not, to be able to execute these exit order loans
+    //    on the V4 pool."
+    //
+    // We INSERT atomically: create the user (telegram_id NULL),
+    // then the wallet row, then re-fetch via the same ranking query.
+    // The V4-only enforcement still blocks V1/V2/V3 arms, so this
+    // open auto-create only opens V4 exit arming to anonymous wallets
+    // — never plain V1/V2/V3 loan management.
+    //
+    // If the user later /links this wallet via TG, the wallet-owner-
+    // resolver attaches the existing wallet row to their TG user_id
+    // (no duplicate, no data loss).
+    //
+    // See feedback_v4_auto_sells_no_custodial_requirement_2026_06_17.md.
+    try {
+      const { rows: [newUser] } = await query(
+        `INSERT INTO users (telegram_id, created_at)
+         VALUES (NULL, NOW())
+         RETURNING id`,
+      );
+      await query(
+        `INSERT INTO wallets (user_id, public_key, source, is_active, created_at)
+         VALUES ($1, $2, 'site_v4_autolink', TRUE, NOW())
+         ON CONFLICT (public_key) DO NOTHING`,
+        [newUser.id, signerPubkey],
+      );
+      const refetch = await query(
+        `SELECT w.user_id, w.encrypted_secret, w.source
+           FROM wallets w
+           JOIN users u ON u.id = w.user_id
+          WHERE w.public_key = $1
+          ORDER BY (u.telegram_id IS NOT NULL AND u.telegram_id > 0) DESC,
+                   w.is_active DESC,
+                   w.created_at DESC
+          LIMIT 1`,
+        [signerPubkey],
+      );
+      walletRow = refetch.rows[0];
+      if (!walletRow) {
+        // Defensive: if the INSERT raced and the row still isn't visible,
+        // surface a transient error rather than a confusing 403.
+        return {
+          ok: false,
+          status: 503,
+          error: "auto_link_race",
+          detail: "Wallet auto-link is racing. Retry in a moment.",
+        };
+      }
+      console.log(`[site-limit-close] auto-linked wallet ${signerPubkey.slice(0, 8)}… → user_id=${walletRow.user_id} (V4 anonymous, no TG)`);
+    } catch (insertErr) {
+      console.error(`[site-limit-close] auto-link insert failed for ${signerPubkey.slice(0, 8)}…:`, insertErr.message);
+      return {
+        ok: false,
+        status: 500,
+        error: "auto_link_failed",
+        detail: insertErr.message?.slice(0, 200) || "wallet auto-link failed",
+      };
+    }
   }
-  // The engine needs a custodial keypair to autonomously fire the
-  // repay+sell tx. wallets.encrypted_secret holds the encrypted key
-  // for custodial + imported wallets. Phantom-only wallets get NULL
-  // and can't have autonomous take-profit.
-  if (!walletRow.encrypted_secret || walletRow.encrypted_secret.length === 0) {
-    return {
-      ok: false, status: 403,
-      error: "requires_linked_custodial_wallet",
-      detail: "Autonomous take-profit needs a Magpie custodial keypair to sign the repay+sell tx at fire time. " +
-              "Connect via the Telegram bot or import a key to enable.",
-    };
-  }
+  // HISTORICAL — the custodial-keypair check that lived here was OBSOLETE
+  // for V4 loans. The engine fires `convert_collateral_slice` signed by
+  // the lender keypair (not the borrower's). Engine-side borrower-keypair
+  // skip already landed in task #327 + execution.js line 909 V4 branch.
+  // The auth-time check was a leftover from V1/V2/V3 — it forced users
+  // with Phantom-only wallets to /import their key just to use auto-sells
+  // that wouldn't actually need their signature.
+  //
+  // Operator-mandated 2026-06-17 PM:
+  //   "EVERY SINGLE WALLET, whether it is TG linked or not needs to
+  //    bypass this. WE CANNOT have it set up to only support wallets
+  //    that are connected to the TG."
+  //
+  // Defense-in-depth: V1/V2/V3 loans STILL block arming via
+  // `exits_require_v4_loan` (V4_EXIT_EXCLUSIVE_ENFORCE=true) — the only
+  // path that reaches the arm-core insert is a V4 loan, which the engine
+  // can fire without the borrower's keypair. No regression vector.
+  //
+  // See feedback_v4_auto_sells_no_custodial_requirement_2026_06_17.md.
 
   return { ok: true, userId: walletRow.user_id, signerPubkey, fields, body };
 }
@@ -282,7 +349,20 @@ export async function handleSiteLimitCloseList(req, url) {
       },
     };
   }
-  const isCustodial = !!walletRow.encrypted_secret;
+  // Align GET's custodial check with POST's stricter version at line 241.
+  // An empty Buffer is TRUTHY in JS (`!!Buffer.from([])` === true) but
+  // unusable as a signing key, so the old `!!encrypted_secret` would
+  // wrongly report `custodial: true` for a Phantom-only wallet whose
+  // wallets.encrypted_secret column was a zero-length Buffer. The POST
+  // /arm path correctly catches that with `length === 0` and 403s with
+  // `requires_linked_custodial_wallet`. The lie at GET-time let the site
+  // open the borrow flow, the user signed + funded a V4 loan, then the
+  // arm-batch 403'd → recovery banner forever. Operator hit this on
+  // 2026-06-17 PM. See
+  // feedback_custodial_check_get_post_mismatch_2026_06_17.md.
+  const isCustodial =
+    !!walletRow.encrypted_secret &&
+    (walletRow.encrypted_secret.length ?? 0) > 0;
 
   // Loans owned by this wallet (status='active' only — take-profit
   // is for active loans).

--- a/src/services/pending-arm-retry-watcher.js
+++ b/src/services/pending-arm-retry-watcher.js
@@ -155,6 +155,98 @@ async function expireStaleRows(bot) {
         console.warn(`[pending-arm] expire intent reconcile failed: ${e.message?.slice(0, 120)}`);
       }
     }
+
+    // Sprint Item 5 (V4 hardening 2026-06-17) — surface the expiry to
+    // the BORROWER via TG, with a one-tap retry. Operator-mandated:
+    // the recovery banner is a safety net, not a workflow — the user
+    // should be PROACTIVELY nudged that their auto-sell setup needs a
+    // quick re-sign. Without this DM, the user only finds out when
+    // they happen to check the dashboard.
+    //
+    // Best-effort: missing TG link, missing bot handle, or any send
+    // failure logs + continues. We do NOT block any other watcher
+    // behavior on the DM landing.
+    try {
+      await sendBorrowerExpiryDm(bot, row);
+    } catch (e) {
+      console.warn(`[pending-arm] borrower DM failed for pending_arm_id=${row.id}: ${e.message?.slice(0, 120)}`);
+    }
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ * Borrower-facing expiry DM with a one-tap retry CTA.
+ *
+ * Sprint Item 5 (feedback_v4_hardening_sprint_2026_06_17.md).
+ * ───────────────────────────────────────────────────────────────── */
+async function sendBorrowerExpiryDm(bot, row) {
+  if (!bot) return;
+
+  // Resolve telegram_id from the borrower's user_id. wallet/user_id are
+  // populated when the original /arm-batch came in; if the user has
+  // never linked TG, telegram_id is NULL and we silently skip.
+  const { rows: [userRow] } = await query(
+    `SELECT telegram_id FROM users WHERE id = $1`,
+    [row.user_id],
+  );
+  if (!userRow?.telegram_id) {
+    console.log(`[pending-arm] no TG link for user_id=${row.user_id} — skipping borrower expiry DM`);
+    return;
+  }
+
+  // Resolve the symbol for friendlier copy. Falls back gracefully if
+  // the loan never landed AND no supported_mints lookup is possible.
+  let symbol = "your loan";
+  try {
+    const { rows: [m] } = await query(
+      `SELECT sm.symbol
+         FROM supported_mints sm
+        WHERE sm.mint = (
+          SELECT collateral_mint FROM loans WHERE loan_id::text = $1 LIMIT 1
+        )`,
+      [String(row.loan_id_chain)],
+    );
+    if (m?.symbol) symbol = m.symbol;
+  } catch {}
+
+  const nLegs = Array.isArray(row.legs) ? row.legs.length : 0;
+  const lines = [
+    `Quick heads-up — your auto-sell setup on ${symbol} loan #${row.loan_id_chain} ` +
+      `needs a re-sign.`,
+    ``,
+    `We tried for 5 minutes to land the ${nLegs} ${nLegs === 1 ? "leg" : "legs"} you signed, ` +
+      `but the borrow itself didn't confirm in that window. Your signature has expired ` +
+      `for security reasons.`,
+    ``,
+    `Open your dashboard to retry — your strikes are still saved.`,
+  ];
+
+  try {
+    await bot.telegram.sendMessage(
+      Number(userRow.telegram_id),
+      lines.join("\n"),
+      {
+        disable_web_page_preview: true,
+        reply_markup: {
+          inline_keyboard: [
+            [
+              {
+                text: "Open dashboard to retry",
+                url: process.env.SITE_DASHBOARD_URL || "https://magpie.capital/dashboard",
+              },
+            ],
+          ],
+        },
+      },
+    );
+    console.log(
+      `[pending-arm] borrower DM sent — pending_arm_id=${row.id} user_id=${row.user_id} tg=${userRow.telegram_id}`,
+    );
+  } catch (sendErr) {
+    // Most common: user blocked the bot. Log + drop.
+    console.warn(
+      `[pending-arm] borrower DM send failed for pending_arm_id=${row.id}: ${sendErr.message?.slice(0, 120)}`,
+    );
   }
 }
 


### PR DESCRIPTION
Operator-mandated 2026-06-17 PM: "EVERY SINGLE WALLET, whether it is TG linked or not needs to bypass this." Two gates removed:

1. requires_linked_custodial_wallet — obsolete since task #327 (V4 engine signs convert_collateral_slice with lender keypair, not borrower's). Check removed.
2. wallet_not_linked — replaced with auto-link: INSERT user (telegram_id NULL) + wallets row, source='site_v4_autolink'. Future /link attaches the existing row to the TG user_id.

Also: empty-Buffer encrypted_secret check aligned between GET (was lying with custodial:true) and POST.

V4-exit-only enforcement still blocks V1/V2/V3 arms. No regression vector.

See feedback_v4_auto_sells_no_custodial_requirement_2026_06_17.md.