### PR TITLE
fix(v4-anon): auto-link anonymous wallets in cosign-borrow + sync-loan

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -877,8 +877,17 @@ export async function handleCosignBorrow(req) {
         // Same TG-preferring resolver as the proposed-loan-lamports gate
         // above. Both must agree or recordLoan attributes to a different
         // user than the gates validated.
-        const { resolveWalletOwner: resolveWalletOwnerForRecord } = await import("../services/wallet-owner-resolver.js");
-        const recordUserId = await resolveWalletOwnerForRecord(borrowerStr);
+        // 2026-06-17 PM — for V4 anonymous borrowers (Phantom-only
+        // wallets with no `wallets` row), auto-link instead of skipping
+        // recordLoan. Without this, the borrow succeeds on chain but
+        // the dashboard's Active Loans tab is empty — operator hit
+        // exactly that scenario on wallet 3J1Ut4tK1... See
+        // feedback_cosign_borrow_must_auto_link_anonymous_wallets.md.
+        const { resolveOrAutoLinkWalletOwner } = await import("../services/wallet-owner-resolver.js");
+        const recordUserId = await resolveOrAutoLinkWalletOwner(
+          borrowerStr,
+          "cosign_borrow_autolink",
+        );
         const walletRow = recordUserId ? { user_id: recordUserId } : null;
         if (walletRow) {
           await recordLoan({

--- a/src/api/sync-loan.js
+++ b/src/api/sync-loan.js
@@ -186,8 +186,17 @@ export async function handleSyncLoan(req) {
     // can have multiple rows in wallets (site_native + imported); we
     // want the user who'll actually run /repay etc. See
     // src/services/wallet-owner-resolver.js.
-    const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
-    const resolvedUserId = await resolveWalletOwner(borrowerStr);
+    // 2026-06-17 PM — auto-link anonymous wallets. Without this, a
+    // Phantom-only wallet's V4 borrow succeeds on chain but never
+    // reaches DB (cosign-borrow ALSO has the gate; both paths use the
+    // auto-link resolver now). Operator-mandated parity with the V4
+    // anon-wallet sprint. See
+    // feedback_cosign_borrow_must_auto_link_anonymous_wallets.md.
+    const { resolveOrAutoLinkWalletOwner } = await import("../services/wallet-owner-resolver.js");
+    const resolvedUserId = await resolveOrAutoLinkWalletOwner(
+      borrowerStr,
+      "sync_loan_autolink",
+    );
     const walletRow = resolvedUserId ? { user_id: resolvedUserId } : null;
     if (!walletRow) {
       // Borrower's wallet isn't linked to a Magpie account — likely an

--- a/src/services/wallet-owner-resolver.js
+++ b/src/services/wallet-owner-resolver.js
@@ -69,6 +69,59 @@ export async function resolveWalletOwner(publicKey) {
 }
 
 /**
+ * Resolve OR auto-create the user+wallet row for an anonymous wallet.
+ *
+ * Operator-mandated 2026-06-17 PM after a Phantom-only wallet borrowed
+ * on V4 successfully but the loan never landed in DB (cosign-borrow
+ * silently skipped recordLoan because the wallet had no `wallets` row).
+ * For V4 anonymous wallets, the borrow MUST persist; otherwise the
+ * dashboard's Active Loans tab shows nothing and the user can't manage
+ * the loan they just paid for.
+ *
+ * Behavior:
+ *   1. If a wallets row exists, return its user_id (same as resolveWalletOwner).
+ *   2. Otherwise INSERT a new user (telegram_id NULL) + wallets row
+ *      (source=source, is_active=true), then return the new user_id.
+ *
+ * Race-safe: the wallets table has `UNIQUE (public_key)` enforced by
+ * the schema, so a concurrent INSERT for the same wallet falls back
+ * to the existing row via ON CONFLICT DO NOTHING + re-fetch.
+ *
+ * Mandated by feedback_anonymous_wallets_full_feature_parity_v4.md.
+ */
+export async function resolveOrAutoLinkWalletOwner(publicKey, source = "anonymous_borrow") {
+  if (!publicKey || typeof publicKey !== "string") return null;
+  // Fast path: existing row.
+  const existing = await resolveWalletOwner(publicKey);
+  if (existing) return existing;
+
+  // Slow path: auto-create user + wallets row.
+  try {
+    const { rows: [newUser] } = await query(
+      `INSERT INTO users (telegram_id, created_at)
+       VALUES (NULL, NOW())
+       RETURNING id`,
+    );
+    await query(
+      `INSERT INTO wallets (user_id, public_key, source, is_active, created_at)
+       VALUES ($1, $2, $3, TRUE, NOW())
+       ON CONFLICT (public_key) DO NOTHING`,
+      [newUser.id, publicKey, source],
+    );
+    const retry = await resolveWalletOwner(publicKey);
+    if (retry) return retry;
+    // ON CONFLICT raced — return null and let the caller log/retry.
+    console.warn(`[wallet-resolver] auto-link race on ${publicKey.slice(0, 8)}…`);
+    return null;
+  } catch (err) {
+    console.error(
+      `[wallet-resolver] auto-link insert failed for ${publicKey.slice(0, 8)}…: ${err.message?.slice(0, 200)}`,
+    );
+    return null;
+  }
+}
+
+/**
  * Variant that returns the full wallet row (user_id + metadata) so
  * callers that need more than just the id (e.g. cosign-borrow checking
  * is_active) don't have to re-query.


### PR DESCRIPTION
OPERATOR URGENT 2026-06-17 PM. Operator V4-borrowed on Phantom-only wallet 3J1Ut4tK1...; on-chain tx succeeded, but loan never appeared in Active Loans tab. 6th gate I missed in today's V4 anon-wallet sprint. cosign-borrow.js silently skips recordLoan when wallet has no row in wallets table; sync-loan returns 404 same condition. Fix: new resolveOrAutoLinkWalletOwner helper that INSERTs user (telegram_id NULL) + wallets row when needed. Both paths use it now. See feedback_cosign_borrow_must_auto_link_anonymous_wallets.md.