### PR TITLE
fix(borrow-reliability): V4 attestor 35s cadence + /reborrow retry button

### DIFF
--- a/src/commands/reborrow.js
+++ b/src/commands/reborrow.js
@@ -92,8 +92,21 @@ export async function handleReborrow(ctx) {
   let valueLamports;
   try {
     valueLamports = await collateralValueLamports(match.mint, useRaw, match.decimals);
-  } catch {
-    return ctx.reply("⚠️ Couldn't fetch price right now. Try /borrow instead.");
+  } catch (err) {
+    // The cross-source cache (PR #347) means most transient failures here
+    // already serve a cached agreed price. If we still failed, it's a real
+    // multi-source outage — one re-tap of /reborrow almost always succeeds.
+    // Don't push the user to a different command; just tell them to retry.
+    console.error(`[reborrow] price fetch error for ${match.symbol}:`, err.message);
+    const kb = new InlineKeyboard().text("🔁 Retry /reborrow", "reborrow:retry");
+    return ctx.reply(
+      [
+        "⚠️ *Couldn't fetch the price right now*",
+        "",
+        `_Both Jupiter and DexScreener are slow on ${match.symbol} for a moment. Usually clears within 30s — tap to retry._`,
+      ].join("\n"),
+      { parse_mode: "Markdown", reply_markup: kb },
+    );
   }
 
   const loanAmountPreFee = Math.floor((valueLamports * tier.ltv) / 100);
@@ -124,6 +137,14 @@ export function registerReborrowCallbacks(bot) {
   bot.callbackQuery("reborrow:cancel", async (ctx) => {
     await ctx.answerCallbackQuery("Cancelled");
     await ctx.editMessageText("❌ Re-borrow cancelled.");
+  });
+
+  // One-tap retry on a transient price-fetch failure. /reborrow is
+  // stateless (everything derives from the last loan on this wallet),
+  // so the retry is literally re-running the handler.
+  bot.callbackQuery("reborrow:retry", async (ctx) => {
+    await ctx.answerCallbackQuery("Retrying…");
+    await handleReborrow(ctx);
   });
 
   bot.callbackQuery(/^reborrow:confirm:(.+):(\d+):(\d+):(\d+)$/, async (ctx) => {

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -264,6 +264,16 @@ export function startPriceAttestor(intervalMs = 30_000) {
   // Force a fresh on-chain attestation at least every MAX_GAP_MS so the
   // feed timestamp never crosses the contract's 120s staleness limit.
   const MAX_GAP_MS = 60_000;
+  // V4 needs a TIGHTER cadence than V1/V3 because the on-chain TWAP rule
+  // requires 8 samples within a rolling 5-minute window. At 60s pushes a
+  // 5-minute window only contains ~5 samples — so every freshly-enabled
+  // V4 token hits TwapInsufficientHistory on its first borrow (operator
+  // hit this on $BP 2026-06-17 PM, see feedback_tg_borrow_must_be_reliable).
+  // 35s pushes land 8+ samples in any 5-min window → TWAP ready ~5 min
+  // after a token first gets attested. Configurable so a future tightening
+  // of the on-chain rule (or a desire to widen for SOL spend) is one env
+  // bump away.
+  const MAX_GAP_MS_V4 = Number(process.env.V4_ATTEST_MAX_GAP_MS) || 35_000;
   // Cap on-chain inits per tick — drip-feed backfill of missing feeds to
   // avoid bursting Helius RPC and triggering 429 rate limits.
   const MAX_INITS_PER_TICK = 5;
@@ -361,7 +371,7 @@ export function startPriceAttestor(intervalMs = 30_000) {
           const { PROGRAM_ID_V4 } = await import("../solana/program.js");
           if (PROGRAM_ID_V4) {
             const sinceV4 = Date.now() - (lastAttestAtV4.get(mint) || 0);
-            if (sinceV4 >= MAX_GAP_MS) {
+            if (sinceV4 >= MAX_GAP_MS_V4) {
               try {
                 await attestPrice(mint, decimals, priceSol, PROGRAM_ID_V4);
                 lastAttestAtV4.set(mint, Date.now());


### PR DESCRIPTION
Follow-ups from feedback_tg_borrow_must_be_reliable.md:

1) V4 attestor MAX_GAP_MS_V4=35s so TWAP fills in 5 min flat (env V4_ATTEST_MAX_GAP_MS). Operator hit TwapInsufficientHistory on $BP today; this prevents recurrence for every future enabled token.
2) /reborrow shows a Retry button instead of dropping users to /borrow. Stateless retry just re-fires handleReborrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>