### PR TITLE
chore(v2-purge): wind down V2 + remove from routing

### DIFF
--- a/scripts/v2-audit.mjs
+++ b/scripts/v2-audit.mjs
@@ -1,0 +1,39 @@
+import "dotenv/config";
+const { query } = await import("../src/db/pool.js");
+
+const V2 = process.env.PROGRAM_ID_V2;
+console.log("PROGRAM_ID_V2:", V2);
+
+// 1. Loan counts by status
+const byStatus = await query(
+  `SELECT status, COUNT(*) AS n, COALESCE(SUM(original_loan_amount_lamports::numeric),0)::text AS lifetime_lamports
+     FROM loans WHERE program_id = $1 GROUP BY status ORDER BY status`,
+  [V2],
+);
+console.log("\n-- V2 loans by status --");
+for (const r of byStatus.rows) console.log(" ", r.status, "count=" + r.n, "lifetime SOL borrowed=" + (Number(r.lifetime_lamports)/1e9).toFixed(4));
+
+// 2. Active V2 loans detail (who, mint, owed, due)
+const active = await query(
+  `SELECT loan_id, loan_pda, borrower_wallet, collateral_mint, original_loan_amount_lamports::text AS owed, due_timestamp
+     FROM loans WHERE program_id = $1 AND status = 'active' ORDER BY due_timestamp ASC`,
+  [V2],
+);
+console.log("\n-- V2 active loans (" + active.rowCount + ") --");
+for (const r of active.rows) {
+  console.log("  loan_id=" + r.loan_id, "borrower=" + r.borrower_wallet.slice(0,8) + "..", "mint=" + r.collateral_mint.slice(0,8)+"..", "owed=" + (Number(r.owed)/1e9).toFixed(4)+" SOL", "due=" + r.due_timestamp?.toISOString?.()?.slice(0,10));
+}
+
+// 3. Any V2 limit-close orders or arm intents?
+const orders = await query(
+  `SELECT status, COUNT(*) AS n FROM limit_close_orders WHERE program_id = $1 GROUP BY status`,
+  [V2],
+).catch(err => ({ rows: [], err: err.message }));
+console.log("\n-- V2 limit_close_orders --");
+if (orders.err) console.log("  (table query err:", orders.err.slice(0,80) + ")");
+else for (const r of orders.rows) console.log(" ", r.status, r.n);
+
+// 4. V2 depositor positions (LPs)?
+// Can't read on-chain accounts here without solana imports — flag for separate script.
+
+process.exit(0);

--- a/scripts/v2-depositor-probe.mjs
+++ b/scripts/v2-depositor-probe.mjs
@@ -1,0 +1,66 @@
+import "dotenv/config";
+import { PublicKey, Connection } from "@solana/web3.js";
+import { BN } from "@coral-xyz/anchor";
+const conn = new Connection(process.env.RPC_URL || "https://api.mainnet-beta.solana.com", "confirmed");
+const V2 = new PublicKey(process.env.PROGRAM_ID_V2);
+const LENDER = new PublicKey(process.env.LENDER_PUBKEY);
+
+// Probe ALL V2 program-owned accounts by size — figure out what DepositorPosition's real size is.
+const all = await conn.getProgramAccounts(V2, { dataSlice: { offset: 0, length: 0 } });
+console.log("Total V2 program accounts:", all.length);
+
+// Bucket by size to find the DepositorPosition discriminator
+const bySize = new Map();
+for (const a of all) {
+  // dataSlice returned only header; need to re-fetch to get true length. Do it cheaply.
+}
+// Re-fetch with full data to bucket sizes
+const sizes = new Map();
+const owners = new Map(); // for DepositorPosition, the owner field is at a known offset
+let depositorCandidates = [];
+
+for (const a of all) {
+  const info = await conn.getAccountInfo(a.pubkey);
+  if (!info) continue;
+  const sz = info.data.length;
+  sizes.set(sz, (sizes.get(sz) || 0) + 1);
+  // Anchor: first 8 bytes = discriminator. DepositorPosition typically has fields:
+  // depositor (Pubkey 32) + pool (Pubkey 32) + share_amount (u64 8) + ... 
+  // Try interpret offset 8 (post-discriminator) as a Pubkey
+  if (sz >= 48) {
+    try {
+      const maybeOwner = new PublicKey(info.data.slice(8, 8 + 32));
+      const maybePool = new PublicKey(info.data.slice(40, 40 + 32));
+      // Filter: pool field should reference V2's pool PDA
+      depositorCandidates.push({ pda: a.pubkey.toBase58(), size: sz, possibleOwner: maybeOwner.toBase58(), possiblePool: maybePool.toBase58() });
+    } catch { /* not a pubkey */ }
+  }
+}
+console.log("\nAccount-size histogram (V2):");
+for (const [sz, n] of [...sizes.entries()].sort((a,b)=>b[1]-a[1])) console.log(" size=" + sz + " n=" + n);
+
+// Pull V2 pool PDA to filter candidates
+const { lendingPoolPda } = await import("../src/solana/pdas.js");
+const [pool] = lendingPoolPda(LENDER, V2);
+console.log("\nV2 pool PDA:", pool.toBase58());
+
+const validDepositors = depositorCandidates.filter(d => d.possiblePool === pool.toBase58());
+console.log("\nCandidate DepositorPositions (pool matches):", validDepositors.length);
+for (const d of validDepositors) console.log("  pda=" + d.pda, "depositor=" + d.possibleOwner, "size=" + d.size);
+
+// Also: sum up DepositorPosition share amounts to cross-check pool.totalDeposits
+if (validDepositors.length > 0) {
+  let totalShares = 0n;
+  for (const d of validDepositors) {
+    const info = await conn.getAccountInfo(new PublicKey(d.pda));
+    // share_amount at offset 8+32+32 = 72 (after disc+depositor+pool)
+    if (info.data.length >= 80) {
+      const shares = info.data.readBigUInt64LE(72);
+      totalShares += shares;
+      console.log("  depositor", d.possibleOwner.slice(0,8) + "..", "shares=" + shares.toString());
+    }
+  }
+  console.log("\nSum of shares across depositors:", totalShares.toString());
+}
+
+process.exit(0);

--- a/scripts/v2-onchain.mjs
+++ b/scripts/v2-onchain.mjs
@@ -1,0 +1,56 @@
+import "dotenv/config";
+import { PublicKey, Connection } from "@solana/web3.js";
+const { query } = await import("../src/db/pool.js");
+
+const V2 = new PublicKey(process.env.PROGRAM_ID_V2);
+const LENDER = new PublicKey(process.env.LENDER_PUBKEY);
+const conn = new Connection(process.env.RPC_URL || "https://api.mainnet-beta.solana.com", "confirmed");
+
+// Derive V2 pool PDA + read its state
+const { lendingPoolPda, loanTokenVaultPda } = await import("../src/solana/pdas.js");
+const { getReadOnlyProgram } = await import("../src/solana/program.js");
+
+const [pool] = lendingPoolPda(LENDER, V2);
+const [vault] = loanTokenVaultPda(pool, V2);
+console.log("V2 pool PDA:", pool.toBase58());
+console.log("V2 loan_token_vault PDA:", vault.toBase58());
+
+const program = getReadOnlyProgram(V2);
+const poolData = await program.account.lendingPool.fetch(pool).catch(e => ({ _err: e.message }));
+console.log("\nV2 pool on-chain state:");
+if (poolData._err) console.log("  ERR:", poolData._err.slice(0, 200));
+else {
+  console.log("  totalDeposits:", (Number(poolData.totalDeposits) / 1e9).toFixed(6), "SOL");
+  console.log("  totalBorrowed:", (Number(poolData.totalBorrowed) / 1e9).toFixed(6), "SOL");
+  console.log("  totalFeesEarned:", (Number(poolData.totalFeesEarned) / 1e9).toFixed(6), "SOL");
+  console.log("  paused:", poolData.paused);
+  console.log("  share supply:", poolData.shareSupply?.toString?.() || "n/a");
+}
+
+// Read vault SOL balance
+const vaultInfo = await conn.getAccountInfo(vault);
+console.log("\nV2 vault account SOL:", vaultInfo ? (vaultInfo.lamports / 1e9).toFixed(6) : "MISSING");
+
+// Get LP positions count via getProgramAccounts (DepositorPosition discriminator)
+const positions = await conn.getProgramAccounts(V2, {
+  filters: [{ dataSize: 137 }], // typical anchor DepositorPosition size — adjust if needed
+}).catch(e => ({ _err: e.message }));
+if (positions._err) console.log("\nV2 program accounts probe failed:", positions._err.slice(0, 200));
+else console.log("\nV2 candidate DepositorPosition accounts:", positions.length);
+
+// Lookup the active loan's mint symbol + current price
+const { rows: [active] } = await query(
+  `SELECT l.collateral_mint, l.collateral_amount::text AS coll, l.borrower_wallet, sm.symbol, sm.decimals, sm.enabled
+     FROM loans l LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+    WHERE l.program_id = $1 AND l.status = 'active'`,
+  [process.env.PROGRAM_ID_V2],
+);
+if (active) {
+  console.log("\nV2 single active loan:");
+  console.log("  symbol:", active.symbol || "(unknown)");
+  console.log("  mint:", active.collateral_mint);
+  console.log("  collateral amount raw:", active.coll, "decimals:", active.decimals);
+  console.log("  borrower:", active.borrower_wallet);
+  console.log("  enabled:", active.enabled);
+}
+process.exit(0);

--- a/scripts/v2-postcheck.mjs
+++ b/scripts/v2-postcheck.mjs
@@ -1,0 +1,36 @@
+import "dotenv/config";
+import { PublicKey, Connection } from "@solana/web3.js";
+const conn = new Connection(process.env.RPC_URL || "https://api.mainnet-beta.solana.com", "confirmed");
+const V2 = new PublicKey(process.env.PROGRAM_ID_V2);
+const LENDER = new PublicKey(process.env.LENDER_PUBKEY);
+const { lendingPoolPda, loanTokenVaultPda } = await import("../src/solana/pdas.js");
+const { getReadOnlyProgram } = await import("../src/solana/program.js");
+const [pool] = lendingPoolPda(LENDER, V2);
+const [vault] = loanTokenVaultPda(pool, V2);
+const program = getReadOnlyProgram(V2);
+const p = await program.account.lendingPool.fetch(pool);
+const vi = await conn.getAccountInfo(vault);
+const lender_sol = (await conn.getBalance(LENDER)) / 1e9;
+const fmt = (n) => (Number(n)/1e9).toFixed(6);
+console.log("V2 pool state POST-WINDOWN:");
+console.log("  totalDeposits =", fmt(p.totalDeposits));
+console.log("  totalBorrowed =", fmt(p.totalBorrowed));
+console.log("  totalFeesEarned =", fmt(p.totalFeesEarned), "(phantom accounting — no real SOL)");
+console.log("  totalShares =", p.totalShares?.toString?.() ?? "n/a");
+console.log("  vault SOL =", vi ? (vi.lamports/1e9).toFixed(6) : "MISSING");
+console.log("  lender wallet SOL =", lender_sol.toFixed(6));
+// Lender's V2 DepositorPosition: should be closed or zero
+const dpAccts = await conn.getProgramAccounts(V2, {
+  filters: [{ dataSize: 97 }, { memcmp: { offset: 8, bytes: LENDER.toBase58() } }, { memcmp: { offset: 40, bytes: pool.toBase58() } }],
+});
+console.log("  lender DepositorPosition accounts:", dpAccts.length);
+for (const a of dpAccts) {
+  const dp = await program.account.depositorPosition.fetch(a.pubkey);
+  console.log("    shares =", dp.shares.toString());
+}
+// Any remaining loans on V2?
+const allAccts = await conn.getProgramAccounts(V2, { dataSlice: { offset: 0, length: 8 } });
+const loanDisc = Buffer.from([20,195,70,117,165,227,182,1]); // Loan discriminator
+const remainingLoans = allAccts.filter(a => Buffer.compare(a.account.data, loanDisc) === 0);
+console.log("  remaining Loan accounts on V2:", remainingLoans.length);
+process.exit(0);

--- a/scripts/v2-winddown.mjs
+++ b/scripts/v2-winddown.mjs
@@ -1,0 +1,307 @@
+/**
+ * V2 wind-down — Phases 1-4.
+ *
+ *   Phase 1: liquidate the 1 active loan ($FATHER, overdue, worthless)
+ *   Phase 2: lender (sole depositor) withdraws all shares → wSOL → SOL
+ *            chunked at ≤0.13 SOL per call to dodge V1/V2 withdraw u64 overflow
+ *   Phase 3: admin_withdraw all accumulated fees → lender wallet
+ *   Phase 4: verify pool empty (totalDeposits=0, totalBorrowed=0, vault≈0)
+ *
+ * Run without args = DRY RUN — simulates every tx, reports state, does NOT broadcast.
+ * Run with --execute = broadcasts each tx, waits for confirmation, verifies post-state.
+ *
+ * Operator-authorized 2026-06-17 PM (memory: project_magpie_v2_winddown_2026_06_17).
+ * All txs signed by the lender keypair (which is also the sole depositor and the
+ * pool authority for fee extraction).
+ */
+import "dotenv/config";
+import { PublicKey, Connection, Keypair, SystemProgram, ComputeBudgetProgram } from "@solana/web3.js";
+import { BN } from "@coral-xyz/anchor";
+import {
+  TOKEN_PROGRAM_ID,
+  NATIVE_MINT,
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountIdempotentInstruction,
+  createCloseAccountInstruction,
+} from "@solana/spl-token";
+
+const DRY_RUN = !process.argv.includes("--execute");
+const VERBOSE = process.argv.includes("--verbose");
+const log = (s) => console.log(s);
+const verbose = (s) => { if (VERBOSE) console.log(s); };
+
+log(`\n[v2-winddown] mode=${DRY_RUN ? "DRY-RUN (no broadcast)" : "EXECUTE (will broadcast)"}\n`);
+
+import bs58 from "bs58";
+import fs from "node:fs";
+const { PROGRAM_ID_V2, getProgramForSigner, getReadOnlyProgram } = await import("../src/solana/program.js");
+const { lendingPoolPda, loanTokenVaultPda, collateralVaultPda } = await import("../src/solana/pdas.js");
+const { query } = await import("../src/db/pool.js");
+
+const V2 = PROGRAM_ID_V2;
+if (!V2) throw new Error("PROGRAM_ID_V2 unset");
+const decodeBs58 = bs58.decode || (bs58.default && bs58.default.decode);
+let LENDER_KP;
+if (process.env.LENDER_PRIVATE_KEY) {
+  LENDER_KP = Keypair.fromSecretKey(decodeBs58(process.env.LENDER_PRIVATE_KEY));
+} else if (process.env.LENDER_KEYPAIR_PATH) {
+  LENDER_KP = Keypair.fromSecretKey(new Uint8Array(JSON.parse(fs.readFileSync(process.env.LENDER_KEYPAIR_PATH, "utf-8"))));
+} else { throw new Error("LENDER_PRIVATE_KEY or LENDER_KEYPAIR_PATH must be set"); }
+const LENDER = LENDER_KP.publicKey;
+log(`Lender (signer + destination): ${LENDER.toBase58()}`);
+
+const conn = new Connection(process.env.RPC_URL || "https://api.mainnet-beta.solana.com", "confirmed");
+const program = getProgramForSigner(LENDER_KP, V2);
+const readonly = getReadOnlyProgram(V2);
+
+// ─── Initial state ───────────────────────────────────────────────────
+const [pool] = lendingPoolPda(LENDER, V2);
+const [vault] = loanTokenVaultPda(pool, V2);
+log(`V2 pool: ${pool.toBase58()}`);
+log(`V2 vault: ${vault.toBase58()}`);
+
+async function readPoolState(label) {
+  const p = await readonly.account.lendingPool.fetch(pool);
+  const vi = await conn.getAccountInfo(vault);
+  const vaultLamports = vi ? vi.lamports : 0;
+  const fmt = (n) => (Number(n) / 1e9).toFixed(6);
+  log(`\n[state:${label}] totalDeposits=${fmt(p.totalDeposits)} totalBorrowed=${fmt(p.totalBorrowed)} totalFeesEarned=${fmt(p.totalFeesEarned)} vaultSOL=${fmt(vaultLamports)}`);
+  if (p.totalShares !== undefined) log(`  totalShares=${p.totalShares.toString()}`);
+  return { p, vaultLamports };
+}
+
+await readPoolState("PRE");
+
+// ─── Phase 1: Liquidate the 1 active loan ─────────────────────────────
+log("\n──── Phase 1: liquidate the 1 active V2 loan ────");
+const { rows: actives } = await query(
+  `SELECT loan_id, loan_pda, borrower_wallet, collateral_mint, collateral_amount::text AS coll, original_loan_amount_lamports::text AS owed
+     FROM loans WHERE program_id = $1 AND status = 'active'`,
+  [V2.toBase58()],
+);
+log(`Active V2 loans in DB: ${actives.length}`);
+for (const a of actives) {
+  log(`  loan_id=${a.loan_id} pda=${a.loan_pda} borrower=${a.borrower_wallet.slice(0,8)}.. mint=${a.collateral_mint.slice(0,8)}.. owed=${(Number(a.owed)/1e9).toFixed(6)}`);
+  const loanPk = new PublicKey(a.loan_pda);
+  const collateralMintPk = new PublicKey(a.collateral_mint);
+  const [collateralVault] = collateralVaultPda(loanPk, V2);
+
+  // Lender acts as keeper. Both keeper_collateral_account + authority_collateral_account
+  // are the lender's ATA for the collateral mint (we don't care about splitting keeper
+  // reward vs authority — they're the same wallet).
+  const lenderCollateralAta = getAssociatedTokenAddressSync(collateralMintPk, LENDER, false, TOKEN_PROGRAM_ID);
+
+  const preIxs = [
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }),
+    ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }),
+    createAssociatedTokenAccountIdempotentInstruction(LENDER, lenderCollateralAta, LENDER, collateralMintPk, TOKEN_PROGRAM_ID),
+  ];
+
+  // Build & simulate
+  try {
+    const sim = await program.methods
+      .liquidateLoan()
+      .accounts({
+        pool, loan: loanPk, collateralMint: collateralMintPk, collateralVault,
+        keeperCollateralAccount: lenderCollateralAta, authorityCollateralAccount: lenderCollateralAta,
+        keeper: LENDER, tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .preInstructions(preIxs)
+      .simulate({ commitment: "confirmed" })
+      .catch((e) => ({ err: e }));
+    if (sim?.err) {
+      const msg = sim.err.message || JSON.stringify(sim.err);
+      log(`  SIM FAILED: ${msg.slice(0, 240)}`);
+      verbose(`  logs:\n${(sim.err.logs || []).slice(-8).map(l=>"    "+l).join("\n")}`);
+      throw new Error("liquidate simulation failed — aborting");
+    }
+    log(`  SIM OK.`);
+    if (!DRY_RUN) {
+      const sig = await program.methods
+        .liquidateLoan()
+        .accounts({
+          pool, loan: loanPk, collateralMint: collateralMintPk, collateralVault,
+          keeperCollateralAccount: lenderCollateralAta, authorityCollateralAccount: lenderCollateralAta,
+          keeper: LENDER, tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .preInstructions(preIxs)
+        .rpc({ commitment: "confirmed" });
+      log(`  LIQUIDATED. sig=${sig}`);
+      await query(`UPDATE loans SET status='liquidated', tx_signature=$2, updated_at=NOW() WHERE id=(SELECT id FROM loans WHERE loan_pda=$1) AND status='active'`, [a.loan_pda, sig]);
+    } else {
+      log(`  (dry-run: would liquidate; collateral 1.09M FATHER → lender ATA)`);
+    }
+  } catch (e) {
+    log(`  ERROR: ${e.message?.slice(0, 200)}`);
+    throw e;
+  }
+}
+
+await readPoolState("AFTER_PHASE_1");
+
+// ─── Phase 2: Lender withdraws all shares ─────────────────────────────
+log("\n──── Phase 2: withdraw all lender LP shares (chunked) ────");
+// Find lender's DepositorPosition
+const allDepos = await conn.getProgramAccounts(V2, {
+  filters: [
+    { dataSize: 97 },                                                   // exact size
+    { memcmp: { offset: 8, bytes: LENDER.toBase58() } },                // owner field
+    { memcmp: { offset: 40, bytes: pool.toBase58() } },                 // pool field
+  ],
+});
+log(`Lender DepositorPosition accounts found: ${allDepos.length}`);
+if (allDepos.length !== 1) {
+  log(`  WARNING: expected exactly 1 — got ${allDepos.length}. Continuing anyway.`);
+}
+
+for (const dp of allDepos) {
+  const dpData = await readonly.account.depositorPosition.fetch(dp.pubkey);
+  const shares = BigInt(dpData.shares.toString());
+  log(`  position=${dp.pubkey.toBase58()} shares=${shares}`);
+  if (shares === 0n) { log(`  (zero shares — skipping)`); continue; }
+
+  // Compute share→lamport price from current pool state
+  const poolNow = await readonly.account.lendingPool.fetch(pool);
+  const totalShares = BigInt(poolNow.totalShares?.toString?.() ?? "0");
+  const totalDeposits = BigInt(poolNow.totalDeposits.toString());
+  if (totalShares === 0n) { log("  pool.totalShares is 0 — cannot compute chunk size. Aborting."); continue; }
+  const lamportsPerShare_x1e9 = (totalDeposits * 1_000_000_000n) / totalShares;
+  const MAX_CHUNK_LAMPORTS = 130_000_000n; // 0.13 SOL — under the u64 overflow threshold
+  const maxSharesPerChunk = (MAX_CHUNK_LAMPORTS * 1_000_000_000n) / lamportsPerShare_x1e9;
+  log(`  totalShares=${totalShares} totalDeposits=${totalDeposits} lamportsPerShare~${(Number(lamportsPerShare_x1e9)/1e18).toFixed(9)}`);
+  log(`  maxSharesPerChunk=${maxSharesPerChunk} → chunks needed=${(shares + maxSharesPerChunk - 1n) / maxSharesPerChunk}`);
+
+  const lenderWsolAta = getAssociatedTokenAddressSync(NATIVE_MINT, LENDER, false, TOKEN_PROGRAM_ID);
+  // Ensure lender's wSOL ATA exists once
+  const ensureWsolIx = createAssociatedTokenAccountIdempotentInstruction(LENDER, lenderWsolAta, LENDER, NATIVE_MINT, TOKEN_PROGRAM_ID);
+  const closeWsolIx = createCloseAccountInstruction(lenderWsolAta, LENDER, LENDER, [], TOKEN_PROGRAM_ID);
+
+  let remaining = shares;
+  let chunkIdx = 0;
+  while (remaining > 0n) {
+    const thisChunk = remaining < maxSharesPerChunk ? remaining : maxSharesPerChunk;
+    chunkIdx++;
+    log(`  chunk ${chunkIdx}: withdraw ${thisChunk} shares (~${(Number(thisChunk * lamportsPerShare_x1e9) / 1e18).toFixed(6)} SOL)`);
+    try {
+      const sim = await program.methods
+        .withdraw(new BN(thisChunk.toString()))
+        .accounts({
+          pool, loanTokenVault: vault, position: dp.pubkey,
+          depositorTokenAccount: lenderWsolAta, depositor: LENDER, tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .preInstructions([
+          ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }),
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+          ensureWsolIx,
+        ])
+        .postInstructions([closeWsolIx])
+        .simulate({ commitment: "confirmed" })
+        .catch((e) => ({ err: e }));
+      if (sim?.err) {
+        const msg = sim.err.message || JSON.stringify(sim.err);
+        log(`    SIM FAILED: ${msg.slice(0, 240)}`);
+        verbose(`    logs:\n${(sim.err.logs || []).slice(-8).map(l=>"      "+l).join("\n")}`);
+        throw new Error("withdraw simulation failed — aborting");
+      }
+      log(`    SIM OK.`);
+      if (!DRY_RUN) {
+        const sig = await program.methods
+          .withdraw(new BN(thisChunk.toString()))
+          .accounts({
+            pool, loanTokenVault: vault, position: dp.pubkey,
+            depositorTokenAccount: lenderWsolAta, depositor: LENDER, tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .preInstructions([
+            ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }),
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+            ensureWsolIx,
+          ])
+          .postInstructions([closeWsolIx])
+          .rpc({ commitment: "confirmed" });
+        log(`    BROADCAST. sig=${sig}`);
+      } else {
+        log(`    (dry-run: would withdraw)`);
+      }
+    } catch (e) {
+      log(`    ERROR: ${e.message?.slice(0, 200)}`);
+      throw e;
+    }
+    remaining -= thisChunk;
+    if (DRY_RUN) break; // single chunk in dry-run mode for brevity
+  }
+  if (DRY_RUN) log(`  (dry-run: remaining ${remaining} shares would proceed in additional chunks)`);
+}
+
+await readPoolState("AFTER_PHASE_2");
+
+// ─── Phase 3: admin_withdraw fees ─────────────────────────────────────
+log("\n──── Phase 3: admin_withdraw accumulated fees ────");
+const poolNowF = await readonly.account.lendingPool.fetch(pool);
+const feeLamports = BigInt(poolNowF.totalFeesEarned.toString());
+log(`  fees pending: ${feeLamports} lamports = ${(Number(feeLamports)/1e9).toFixed(6)} SOL`);
+if (feeLamports > 0n) {
+  const lenderWsolAta = getAssociatedTokenAddressSync(NATIVE_MINT, LENDER, false, TOKEN_PROGRAM_ID);
+  // Chunk fees too in case >0.14 SOL
+  const MAX_FEE_CHUNK = 130_000_000n;
+  let remaining = feeLamports;
+  let i = 0;
+  while (remaining > 0n) {
+    const chunk = remaining < MAX_FEE_CHUNK ? remaining : MAX_FEE_CHUNK;
+    i++;
+    log(`  fee chunk ${i}: admin_withdraw ${chunk} lamports (~${(Number(chunk)/1e9).toFixed(6)} SOL)`);
+    try {
+      const sim = await program.methods
+        .adminWithdraw(new BN(chunk.toString()))
+        .accounts({
+          pool, loanTokenVault: vault,
+          authorityTokenAccount: lenderWsolAta,
+          authority: LENDER, tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .preInstructions([
+          ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }),
+          ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+          createAssociatedTokenAccountIdempotentInstruction(LENDER, lenderWsolAta, LENDER, NATIVE_MINT, TOKEN_PROGRAM_ID),
+        ])
+        .postInstructions([createCloseAccountInstruction(lenderWsolAta, LENDER, LENDER, [], TOKEN_PROGRAM_ID)])
+        .simulate({ commitment: "confirmed" })
+        .catch((e) => ({ err: e }));
+      if (sim?.err) {
+        const msg = sim.err.message || JSON.stringify(sim.err);
+        log(`    SIM FAILED: ${msg.slice(0, 240)}`);
+        verbose(`    logs:\n${(sim.err.logs || []).slice(-8).map(l=>"      "+l).join("\n")}`);
+        throw new Error("admin_withdraw simulation failed — aborting");
+      }
+      log(`    SIM OK.`);
+      if (!DRY_RUN) {
+        const sig = await program.methods
+          .adminWithdraw(new BN(chunk.toString()))
+          .accounts({
+            pool, loanTokenVault: vault,
+            authorityTokenAccount: lenderWsolAta,
+            authority: LENDER, tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .preInstructions([
+            ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 }),
+            ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
+            createAssociatedTokenAccountIdempotentInstruction(LENDER, lenderWsolAta, LENDER, NATIVE_MINT, TOKEN_PROGRAM_ID),
+          ])
+          .postInstructions([createCloseAccountInstruction(lenderWsolAta, LENDER, LENDER, [], TOKEN_PROGRAM_ID)])
+          .rpc({ commitment: "confirmed" });
+        log(`    BROADCAST. sig=${sig}`);
+      } else {
+        log(`    (dry-run: would extract fees)`);
+      }
+    } catch (e) {
+      log(`    ERROR: ${e.message?.slice(0, 200)}`);
+      throw e;
+    }
+    remaining -= chunk;
+    if (DRY_RUN) break;
+  }
+}
+
+const finalState = await readPoolState("FINAL");
+log(`\n[v2-winddown] complete. mode=${DRY_RUN ? "DRY-RUN" : "EXECUTED"}`);
+log(`  remaining pool state: totalDeposits=${(Number(finalState.p.totalDeposits)/1e9).toFixed(6)} totalBorrowed=${(Number(finalState.p.totalBorrowed)/1e9).toFixed(6)} totalFeesEarned=${(Number(finalState.p.totalFeesEarned)/1e9).toFixed(6)} vault=${(finalState.vaultLamports/1e9).toFixed(6)}`);
+log(DRY_RUN ? "\nNothing was broadcast. Re-run with --execute to proceed.\n" : "\nAll phases complete. Verify on Solscan.\n");
+process.exit(0);

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -52,9 +52,10 @@ import { getTierByOption } from "../services/loan-tier-resolver.js";
 const V1_PROGRAM_ID = new PublicKey(
   process.env.PROGRAM_ID || "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh",
 );
-const V2_PROGRAM_ID = process.env.PROGRAM_ID_V2
-  ? new PublicKey(process.env.PROGRAM_ID_V2)
-  : null;
+// V2 deprecated + purged 2026-06-17 PM. Forced null so cosign-borrow's
+// program allowlist never accepts V2 borrows. Existing V2 loans are
+// historical-only in DB. See feedback_v2_purged_from_protocol.
+const V2_PROGRAM_ID = null;
 // V3 program — once routing flips for RWA (ROUTE_RWA_TO_V3=true), the site
 // builds borrow txs targeting this program. Without including it in the
 // allowlist + magpie-program check, every V3 borrow returns 403 with

--- a/src/commands/lc-perf.js
+++ b/src/commands/lc-perf.js
@@ -144,7 +144,10 @@ async function showPerf(ctx, windowKey) {
   // the operator how RWA + memecoin adoption is tracking across all
   // three pools now that V3 is live.
   const V1_PROGRAM_ID = process.env.PROGRAM_ID || "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh";
-  const V2_PROGRAM_ID = process.env.PROGRAM_ID_V2 || null;
+  // V2 deprecated + purged 2026-06-17 PM. Historical V2 loans still surface
+  // in the DB aggregation below via their stored program_id string but no
+  // new V2 data will accrue.
+  const V2_PROGRAM_ID = null;
   const V3_PROGRAM_ID = process.env.PROGRAM_ID_V3 || null;
   // V4 Hardening T6 (2026-06-15 PM): include V4 in the pool breakdown
   // so the operator sees adoption + fire mix across V1/V2/V3/V4 at a

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -60,13 +60,18 @@ export const PROGRAM_ID = new PublicKey(
   process.env.PROGRAM_ID || idl.address,
 );
 
-// v2 program (RWA-capable; newer anchor-spl with PausableConfig + ScaledUiAmount
-// support). Only set in env once v2 is deployed + validated. Until then, every
-// borrow routes to v1 — RWA mints remain disabled in DB so no user can hit
-// a not-yet-routable path.
-export const PROGRAM_ID_V2 = process.env.PROGRAM_ID_V2
-  ? new PublicKey(process.env.PROGRAM_ID_V2)
-  : null;
+// V2 (RWA-capable lending program) was DEPRECATED + WOUND-DOWN 2026-06-17 PM.
+// Pool drained to 0, FATHER bad-loan liquidated, LP funds + accumulated value
+// recovered to lender wallet. V3 + V4 cover everything V2 did. Historical V2
+// loans still display in DB (program_id column references the V2 pubkey for
+// credit-history continuity) but no new V2 loans will ever route.
+//
+// PROGRAM_ID_V2 is forced to null regardless of env so chooseProgramId can
+// never return it and downstream code that gates on `if (PROGRAM_ID_V2)`
+// short-circuits. Other modules can keep importing it safely.
+//
+// See project_magpie_v2_winddown_2026_06_17 + feedback_v2_purged_from_protocol.
+export const PROGRAM_ID_V2 = null;
 
 // v3 = on-chain TWAP memecoin program. Only routable when BOTH:
 //   - PROGRAM_ID_V3 is set (program deployed to mainnet)
@@ -193,7 +198,8 @@ export function chooseProgramId(category, opts = {}) {
   }
   if (RWA_CATEGORIES.has(category)) {
     if (PROGRAM_ID_V3 && ROUTE_RWA_TO_V3) return PROGRAM_ID_V3;
-    if (PROGRAM_ID_V2) return PROGRAM_ID_V2;
+    // V2 deprecated 2026-06-17 PM — wound down and purged. RWAs route
+    // to V3 (preferred) or fall through to V1.
     return PROGRAM_ID;
   }
   // Non-RWA path


### PR DESCRIPTION
V2 deprecated 2026-06-17 PM. On-chain wind-down complete (~3.72 SOL net recovered to lender). Code-side: PROGRAM_ID_V2 forced null, chooseProgramId no longer falls through to V2, cosign-borrow allowlist excludes V2, lc-perf skips V2 in active aggregation. Historical loans preserved in DB. See project_magpie_v2_winddown_2026_06_17.md for full report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>