### PR TITLE
fix(price-attestor): tighten cadence so V3/V4 TWAP fills 8 samples in 5min

### DIFF
--- a/scripts/diagnose-spcx-twap-lag.mjs
+++ b/scripts/diagnose-spcx-twap-lag.mjs
@@ -1,0 +1,179 @@
+/**
+ * Read-only diagnosis: why did SPCX V3 PriceHistory TWAP lag spot
+ * tonight (2026-06-17 PM)?
+ *
+ * V2: enumerate operator's RECENT SPCX loans (last 24h), find the actual
+ * mint + program_id the borrow targeted, derive the matching feed PDA,
+ * dump samples + gaps + TWAP vs spot.
+ */
+import "dotenv/config";
+import { Connection, PublicKey } from "@solana/web3.js";
+import { query } from "../src/db/pool.js";
+
+const PROGRAM_ID_V1 = new PublicKey("4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh");
+const PROGRAM_ID_V3 = new PublicKey("B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP");
+const PROGRAM_ID_V4 = new PublicKey("HA1hgvskN1goEsb33rNHFBcDXBaYyLyyqfGwGMgTUwNo");
+
+// Inline PDAs (V3/V4 use "price_v3" seed; pool seed "pool" everywhere).
+// Bypasses pdas.js which reads env at module-load and falls back to V1's
+// "price" seed when PROGRAM_ID_V3/V4 env vars aren't set.
+function lendingPoolPda(lender, programId) {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("pool"), lender.toBuffer()], programId,
+  );
+}
+function priceFeedPda(mint, pool, programId) {
+  const isV3OrV4 = programId.equals(PROGRAM_ID_V3) || programId.equals(PROGRAM_ID_V4);
+  const seed = isV3OrV4 ? "price_v3" : "price";
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from(seed), mint.toBuffer(), pool.toBuffer()], programId,
+  );
+}
+
+const RPC_URL = process.env.SOLANA_RPC_URL;
+const LENDER_PUBKEY = new PublicKey(process.env.LENDER_PUBKEY);
+const conn = new Connection(RPC_URL, "confirmed");
+
+const MIN_HISTORY_SECONDS = 300;
+const MIN_SAMPLES = 8;
+const MAX_PUMP_BPS = 1500;
+
+function decodePriceHistory(data) {
+  const headIndex = data.readUInt8(104);
+  const count = data.readUInt8(105);
+  const samplesOffset = 112;
+  const stride = 16;
+  const samples = [];
+  for (let i = 0; i < count; i++) {
+    const slotOff = samplesOffset + i * stride;
+    const priceLamports = data.readBigUInt64LE(slotOff);
+    const ts = data.readBigInt64LE(slotOff + 8);
+    samples.push({ slot: i, priceLamports, ts: Number(ts) });
+  }
+  samples.sort((a, b) => a.ts - b.ts);
+  return { headIndex, count, samples };
+}
+
+function programLabel(pidStr) {
+  if (pidStr === PROGRAM_ID_V1.toBase58()) return "V1";
+  if (pidStr === PROGRAM_ID_V3.toBase58()) return "V3";
+  if (pidStr === PROGRAM_ID_V4.toBase58()) return "V4";
+  return "?";
+}
+
+console.log("\n=== Recent SPCX loans (last 24h) for any operator wallet ===\n");
+
+const { rows: loanRows } = await query(
+  `SELECT l.id, l.user_id, l.borrower_wallet, l.collateral_mint, l.program_id,
+          l.start_timestamp, l.loan_amount_lamports, l.status, sm.symbol, sm.category
+     FROM loans l
+     LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
+    WHERE sm.symbol = 'SPCX'
+      AND l.start_timestamp > NOW() - INTERVAL '24 hours'
+    ORDER BY l.id DESC
+    LIMIT 10`,
+);
+if (loanRows.length === 0) {
+  console.log("(no SPCX loans in last 24h)");
+} else {
+  for (const l of loanRows) {
+    console.log(`  loan #${l.id}  ${programLabel(l.program_id)}  ${l.status}  ${l.start_timestamp.toISOString()}  ${(Number(l.loan_amount_lamports)/1e9).toFixed(4)} SOL  user=${l.user_id}  mint=${l.collateral_mint}  cat=${l.category}`);
+  }
+}
+
+// Distinct (mint, program_id) combos that need feed inspection
+const combos = new Map();
+for (const l of loanRows) {
+  const key = `${l.collateral_mint}|${l.program_id}`;
+  if (!combos.has(key)) combos.set(key, { mint: l.collateral_mint, programId: l.program_id, symbol: l.symbol });
+}
+// Always also check canonical SPCX on V3 + V4 even if no recent loans
+const { rows: spcxMints } = await query(
+  `SELECT mint, symbol, name, decimals, category, is_canonical FROM supported_mints
+    WHERE UPPER(symbol) = 'SPCX' AND enabled = TRUE ORDER BY is_canonical DESC`,
+);
+for (const m of spcxMints) {
+  for (const pid of [PROGRAM_ID_V3.toBase58(), PROGRAM_ID_V4.toBase58()]) {
+    const key = `${m.mint}|${pid}`;
+    if (!combos.has(key)) combos.set(key, { mint: m.mint, programId: pid, symbol: m.symbol });
+  }
+}
+
+const nowSec = Math.floor(Date.now() / 1000);
+console.log(`\n(now=${new Date().toISOString()} epoch=${nowSec})\n`);
+
+for (const { mint, programId, symbol } of combos.values()) {
+  const programPk = new PublicKey(programId);
+  const mintPk = new PublicKey(mint);
+  const [poolPda] = lendingPoolPda(LENDER_PUBKEY, programPk);
+  const [feedPda] = priceFeedPda(mintPk, poolPda, programPk);
+  const tag = programLabel(programId);
+  console.log(`\n--- ${symbol} on ${tag} (${programId.slice(0,8)}…)`);
+  console.log(`  mint=${mint}`);
+  console.log(`  pool=${poolPda.toBase58()}`);
+  console.log(`  feed=${feedPda.toBase58()}`);
+
+  const [poolInfo, feedInfo] = await Promise.all([
+    conn.getAccountInfo(poolPda),
+    conn.getAccountInfo(feedPda),
+  ]);
+  console.log(`  pool exists=${!!poolInfo} owner=${poolInfo?.owner.toBase58() ?? "n/a"}`);
+  if (!feedInfo) {
+    console.log(`  feed exists=NO — never attested for this (mint, pool) pair`);
+    continue;
+  }
+  console.log(`  feed bytes=${feedInfo.data.length}`);
+  if (feedInfo.data.length < 112) {
+    console.log(`  → too small to be V3/V4 PriceHistory`);
+    continue;
+  }
+  const { headIndex, count, samples } = decodePriceHistory(feedInfo.data);
+  console.log(`  head_index=${headIndex} count=${count}`);
+  if (samples.length === 0) {
+    console.log(`  → no samples`);
+    continue;
+  }
+  const oldest = samples[0];
+  const newest = samples[samples.length - 1];
+  const oldestAge = nowSec - oldest.ts;
+  const newestAge = nowSec - newest.ts;
+  console.log(`\n  All samples (oldest→newest):`);
+  let prevTs = null;
+  let gaps = [];
+  for (const s of samples) {
+    const age = nowSec - s.ts;
+    const gap = prevTs ? s.ts - prevTs : 0;
+    if (prevTs) gaps.push(gap);
+    const gapStr = prevTs ? `gap=+${String(gap).padStart(4," ")}s` : "gap=  ----";
+    const priceStr = String(s.priceLamports).padStart(15, " ");
+    console.log(`    age=${String(age).padStart(5," ")}s   ${gapStr}   price_lamports=${priceStr}`);
+    prevTs = s.ts;
+  }
+  const inWin = samples.filter(s => nowSec - s.ts <= MIN_HISTORY_SECONDS);
+  const twap = inWin.length > 0
+    ? inWin.reduce((a, s) => a + Number(s.priceLamports), 0) / inWin.length
+    : 0;
+  const latestPrice = Number(newest.priceLamports);
+  const ratio = twap > 0 ? latestPrice / twap : NaN;
+  const bps = twap > 0 ? Math.round((ratio - 1) * 10_000) : 0;
+  console.log(`\n  Window (last ${MIN_HISTORY_SECONDS}s):`);
+  console.log(`    samples_in_window=${inWin.length} (need >= ${MIN_SAMPLES})`);
+  console.log(`    oldest_in_window_age=${inWin[0] ? nowSec - inWin[0].ts : "n/a"}s (need >= ${MIN_HISTORY_SECONDS})`);
+  console.log(`    newest_age=${newestAge}s`);
+  console.log(`    twap=${twap.toFixed(0)}`);
+  console.log(`    latest=${latestPrice}`);
+  console.log(`    latest/twap = ${ratio.toFixed(4)} (+${bps} bps;   max=${MAX_PUMP_BPS})`);
+  if (bps > MAX_PUMP_BPS) console.log(`    ⚠️  CURRENTLY exceeds pump threshold`);
+  else                    console.log(`    ✓ within pump threshold currently`);
+  if (gaps.length) {
+    const maxGap = Math.max(...gaps);
+    const avg = Math.round(gaps.reduce((a,b)=>a+b,0)/gaps.length);
+    const over60 = gaps.filter(g => g > 60).length;
+    const over120 = gaps.filter(g => g > 120).length;
+    console.log(`\n  Gap stats: avg=${avg}s max=${maxGap}s gaps>60s=${over60}/${gaps.length} gaps>120s=${over120}/${gaps.length}`);
+    if (maxGap > 60) console.log(`    ⚠️  Attestor dropped samples — TWAP weighted on stale points`);
+    else             console.log(`    ✓ cadence healthy (max gap < 60s)`);
+  }
+}
+
+process.exit(0);

--- a/src/index.js
+++ b/src/index.js
@@ -838,10 +838,16 @@ bot.start({
     setTimeout(() => startExtendLoanWatcher(), 40_000);
     // Push fresh prices to on-chain price feeds. DB-driven: the attestor
     // queries supported_mints (enabled=TRUE) every tick, so newly approved
-    // tokens get attested without a restart. Drift-gated to keep cost low.
-    // 45s interval so refresh fires before the 60s force-attest gap.
-    // Keeps on-chain feed timestamp comfortably under 120s contract limit.
-    setTimeout(() => startPriceAttestor(45_000), 35_000);
+    // tokens get attested without a restart.
+    //
+    // 20s interval: V4's on-chain TWAP needs 8 samples in the rolling
+    // 5-minute window. At 20s ticks the V4 throttle (MAX_GAP_MS_V4=35s)
+    // writes every other tick → ~40s effective cadence → 7-8 samples in
+    // any 5-min window. Previous 45s interval gave ~90s effective cadence
+    // (only 3-4 samples in window), which caused SPCX V3 borrows to fail
+    // with PriceImpactPumpDetected when price moved during the long gap.
+    // Operator hit it 2026-06-17 PM. Forensic: scripts/diagnose-spcx-twap-lag.mjs
+    setTimeout(() => startPriceAttestor(20_000), 35_000);
     // RWA screener — discovers Backed Finance xStocks + similar via DexScreener
     // search every 4h. Auto-adds new mints meeting liquidity/volume thresholds.
     // Auto-disables enabled RWAs that degrade or get paused by the issuer.

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -262,8 +262,15 @@ export function startPriceAttestor(intervalMs = 30_000) {
   // V4 feed is fresh too — leaving the V4 PDA stale.
   const lastAttestAtV4 = new Map();
   // Force a fresh on-chain attestation at least every MAX_GAP_MS so the
-  // feed timestamp never crosses the contract's 120s staleness limit.
-  const MAX_GAP_MS = 60_000;
+  // feed timestamp never crosses the contract's 120s staleness limit AND
+  // so the V3 on-chain TWAP fills its 8-samples-in-5-minutes window even
+  // for low-volatility tokens (xStocks, BTC). Previous value (60s) plus
+  // the drift-skip (drift < 0.5%) meant stable RWA prices were attested
+  // only every 90-120s, leaving the TWAP window with 2-3 samples instead
+  // of 8 — which surfaced as PriceImpactPumpDetected the moment any spot
+  // movement landed against the stale TWAP. Operator hit this on SPCX
+  // 2026-06-17 PM. Diagnostic: scripts/diagnose-spcx-twap-lag.mjs
+  const MAX_GAP_MS = 30_000;
   // V4 needs a TIGHTER cadence than V1/V3 because the on-chain TWAP rule
   // requires 8 samples within a rolling 5-minute window. At 60s pushes a
   // 5-minute window only contains ~5 samples — so every freshly-enabled


### PR DESCRIPTION
## Summary
Operator hit \`PriceImpactPumpDetected\` on V3 SPCX 2026-06-17 PM despite stable price. Root cause was the off-chain attestor failing to fill the on-chain 5-min TWAP window:

- \`src/index.js\` tick interval = 45_000ms (not the 30_000 default)
- V3 driftSkip gate: skips writes when drift < 0.5% AND since < 60s
- V4 \`MAX_GAP_MS_V4 = 35_000ms\` can never be hit at a 45s tick rate

Effect: stable RWA prices get attested every 90–120s. The TWAP window holds 2–3 samples (need 8). Any spot move trips the 15% pump cap.

### Measured live on SPCX feeds (pre-fix)
| Feed | avg gap | max gap | gaps > 60s |
|---|---|---|---|
| V3 \`Az…hZhz\` | 105s | 251s | 28/31 |
| V4 \`B2…EtT3\` | 89s | 196s | 20/31 |

### Fix
- tick 45s → 20s
- \`MAX_GAP_MS\` 60_000 → 30_000
- V4 throttle (35s) unchanged; now achievable

Effective cadence after change: ~40s stable, ~20s movers → 7-8 samples in any 5-min window.

## Diagnostic
\`scripts/diagnose-spcx-twap-lag.mjs\` — reads V3+V4 PriceHistory PDAs for any SPCX loan from last 24h, dumps all 32 samples with inter-sample gaps and the current TWAP vs spot ratio. Re-runnable after deploy to confirm cadence tightened.

## Test plan
- [x] \`node --check\` passes on both files
- [ ] Watch SPCX V3 + V4 feeds after deploy — confirm avg gap drops to 40s
- [ ] No regression in Helius RPC cost / 429 rate
- [ ] Operator's next SPCX borrow lands first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)