### PR TITLE
chore(scripts): pip-post-tg.sh — Pip-post-to-TG wrapper via Railway

### DIFF
--- a/scripts/pip-post-tg.sh
+++ b/scripts/pip-post-tg.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Post a @MagpieLoans tweet (or arbitrary text) to @magpietalk via the
+# prod bot. The local .env's TELEGRAM_BOT_TOKEN is a dev/test bot that
+# is NOT in the prod community chat, so a local `node scripts/*.js`
+# invocation fails with "Unauthorized". This wrapper runs the script
+# under `railway run --service magpie-bot` so it picks up the prod
+# bot token + DB + dedup table.
+#
+# Usage:
+#   scripts/pip-post-tg.sh tweet  <x-url>
+#   scripts/pip-post-tg.sh text   <file-or-->
+#
+# tweet:  X URL must match https://x.com/MagpieLoans/status/<id> — the
+#         existing /crosspost allowlist + dedup + engagement-line
+#         rotation applies.
+# text:   reads stdin (-) or a file, posts verbatim to every enabled
+#         community chat. No engagement footer. Caller owns the tone.
+set -euo pipefail
+
+mode="${1:-}"
+if [[ "$mode" != "tweet" && "$mode" != "text" ]]; then
+  echo "Usage: $0 tweet <x-url>   |   $0 text <file-or-->" >&2
+  exit 2
+fi
+shift
+
+case "$mode" in
+  tweet)
+    [[ $# -eq 1 ]] || { echo "tweet mode needs exactly 1 url" >&2; exit 2; }
+    railway run --service magpie-bot node scripts/crosspost-tweet.js "$1"
+    ;;
+  text)
+    [[ $# -eq 1 ]] || { echo "text mode needs exactly 1 file/-" >&2; exit 2; }
+    railway run --service magpie-bot node scripts/community-broadcast.js "$1"
+    ;;
+esac


### PR DESCRIPTION
## Summary
Operator: "if I ask you to have Pip post something in TG, then you DO IT."

The local \`.env\`'s \`TELEGRAM_BOT_TOKEN\` is a dev bot not in @magpietalk, so \`node scripts/crosspost-tweet.js\` fails with Unauthorized when run from this shell. This wrapper runs the existing scripts under \`railway run --service magpie-bot\`, picking up the prod bot token + DB + dedup table.

Usage:
\`\`\`
scripts/pip-post-tg.sh tweet <x-url>     # @MagpieLoans crosspost (allowlisted)
scripts/pip-post-tg.sh text  <file-or->  # arbitrary text via community-broadcast
\`\`\`

Both modes hit every enabled chat in \`community_chats\`.

## Test plan
- [x] Verified via Railway shell: tweet 2067380434355302465 posted to @magpietalk (1/1)
- [ ] Future "have Pip post X" requests run via this wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)