### PR TITLE
fix(backfill): wallet-loan backfill must scan V4 — operator hit silent V4 SPCX loan loss

### DIFF
--- a/src/api/backfill-wallet-loans.js
+++ b/src/api/backfill-wallet-loans.js
@@ -23,6 +23,7 @@ import {
   PROGRAM_ID,
   PROGRAM_ID_V2,
   PROGRAM_ID_V3,
+  PROGRAM_ID_V4,
 } from "../solana/program.js";
 import { query } from "../db/pool.js";
 import { recordLoan } from "../services/loans.js";
@@ -147,7 +148,15 @@ export async function handleBackfillWalletLoans(req) {
   }
 
   // Scan every known program for loans by this borrower.
-  const programs = [PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3].filter(Boolean);
+  //
+  // V4 added 2026-06-18: a V4 SPCX loan landed on-chain for operator's
+  // user but never reached the DB; the dashboard couldn't see it and
+  // the arm-intent for the exit failed with loan_not_found_for_user.
+  // Root cause: this backfill safety net only scanned V1/V2/V3, so V4
+  // borrows that slipped past cosign-borrow's primary recordLoan call
+  // had no recovery path. Every future Vn MUST be added here at deploy
+  // time. See [[feedback_backfill_must_scan_every_program_version]].
+  const programs = [PROGRAM_ID, PROGRAM_ID_V2, PROGRAM_ID_V3, PROGRAM_ID_V4].filter(Boolean);
   const onChainLoans = [];
   for (const programId of programs) {
     const prog = getReadOnlyProgram(programId);


### PR DESCRIPTION
Operator opened V4 SPCX 70% LTV loan via wallet 3LfT7WLc tonight. Borrow tx landed on chain (loan_pda 3FkFJ91i...) but cosign-borrow's recordLoan didn't persist. Dashboard didn't show it. /stats missed it. $250 exit arm-intent failed with loan_not_found_for_user. Root cause: /api/v1/wallet/backfill-loans was scanning V1/V2/V3 only — V4 silently dropped. Same bug class as the cosign-allowlist drift rule. Fix adds PROGRAM_ID_V4 to import + scan list with a memory comment locking it in for future Vn. After deploy + a backfill call, the canonical recordLoan path heals the row with no admin DB writes.