### PR TITLE
feat(distributions): unified investor-grade distribution ledger

### DIFF
--- a/scripts/backfill-distribution-events.mjs
+++ b/scripts/backfill-distribution-events.mjs
@@ -1,0 +1,199 @@
+/**
+ * Backfill distribution_events for every historical distribution we
+ * can reconstruct from existing per-kind detail tables.
+ *
+ * Sources scanned:
+ *   1. governance_distributions          — one row per (proposal_id) event
+ *   2. magpie_holder_distributions       — one row per snapshot
+ *   3. lp_loyalty_distributions          — one row per snapshot
+ *   4. (yield_distributions schema TBD; add when defined)
+ *   5. (loan_remediation_payouts schema TBD; add when defined)
+ *
+ * Idempotent: re-running upserts on (kind, external_ref). Safe to run
+ * repeatedly during development + after each new distribution.
+ *
+ *   node scripts/backfill-distribution-events.mjs [--dry]
+ */
+import "dotenv/config";
+import { query } from "../src/db/pool.js";
+import { upsertDistributionEvent } from "../src/services/distribution-events.js";
+
+const DRY = process.argv.includes("--dry");
+
+function median(sortedNums) {
+  if (!sortedNums.length) return null;
+  const mid = Math.floor(sortedNums.length / 2);
+  return sortedNums.length % 2 === 0
+    ? (BigInt(sortedNums[mid - 1]) + BigInt(sortedNums[mid])) / 2n
+    : BigInt(sortedNums[mid]);
+}
+
+async function backfillGovernance() {
+  console.log("\n== governance_distributions → kind=governance ==");
+  const props = await query(
+    `SELECT proposal_id,
+            COUNT(*)::int                                            AS eligible_count,
+            COUNT(*) FILTER (WHERE status='sent')::int               AS paid_count,
+            COUNT(*) FILTER (WHERE status<>'sent')::int              AS unpayable_count,
+            COALESCE(SUM(allocated_lamports) FILTER (WHERE status='sent'),0)::text  AS paid_lamports,
+            COALESCE(SUM(allocated_lamports) FILTER (WHERE status<>'sent'),0)::text AS unpaid_lamports,
+            COALESCE(SUM(weight_raw),0)::text                        AS total_weight,
+            MIN(sent_at) FILTER (WHERE status='sent')                AS paid_first_at,
+            MAX(sent_at) FILTER (WHERE status='sent')                AS paid_last_at,
+            MIN(created_at)                                          AS snapshot_at,
+            MAX(plan_hash)                                           AS plan_hash,
+            MAX(snapshot_hash)                                       AS snapshot_hash
+       FROM governance_distributions
+      GROUP BY proposal_id
+      ORDER BY MIN(created_at)`,
+  );
+  for (const p of props.rows) {
+    const amts = await query(
+      `SELECT allocated_lamports::text AS a
+         FROM governance_distributions
+        WHERE proposal_id = $1 AND status = 'sent'
+        ORDER BY allocated_lamports ASC`,
+      [p.proposal_id],
+    );
+    const sortedAmounts = amts.rows.map((r) => r.a);
+    const minA = sortedAmounts[0] ?? null;
+    const maxA = sortedAmounts[sortedAmounts.length - 1] ?? null;
+    const medA = median(sortedAmounts);
+    const sigSample = await query(
+      `SELECT DISTINCT tx_signature
+         FROM governance_distributions
+        WHERE proposal_id = $1 AND status='sent' AND tx_signature IS NOT NULL
+        LIMIT 5`,
+      [p.proposal_id],
+    );
+
+    const eventDef = {
+      kind: "governance",
+      external_ref: p.proposal_id,
+      snapshot_at: p.snapshot_at,
+      paid_first_at: p.paid_first_at,
+      paid_last_at: p.paid_last_at,
+      pool_lamports: p.paid_lamports,
+      distributed_lamports: p.paid_lamports,
+      unpaid_lamports: p.unpaid_lamports,
+      eligible_wallet_count: p.eligible_count,
+      paid_wallet_count: p.paid_count,
+      unpayable_wallet_count: p.unpayable_count,
+      denominator_kind: "weight_raw",
+      denominator_value: p.total_weight,
+      min_payout_lamports: minA,
+      max_payout_lamports: maxA,
+      median_payout_lamports: medA?.toString(),
+      source_other_lamports: p.paid_lamports, // governance ratification doesn't fit borrow/liquidation source buckets
+      plan_hash: p.plan_hash,
+      snapshot_hash: p.snapshot_hash,
+      sample_tx_signatures: sigSample.rows.map((r) => r.tx_signature),
+      notes: `Governance ratification distribution for proposal ${p.proposal_id}. ${p.paid_count} paid, ${p.unpayable_count} skipped (allocation below rent-exempt minimum).`,
+      status: p.unpayable_count > 0 ? "partial" : "complete",
+      metadata: { proposal_id: p.proposal_id },
+    };
+    console.log(
+      `  ${p.proposal_id}: paid=${p.paid_count}/${p.eligible_count} wallets, ${(Number(p.paid_lamports) / 1e9).toFixed(4)} SOL`,
+    );
+    if (!DRY) {
+      const id = await upsertDistributionEvent(eventDef);
+      console.log(`    → distribution_events #${id}`);
+    }
+  }
+}
+
+async function backfillHolderRewards() {
+  console.log("\n== magpie_holder_distributions → kind=holder_reward ==");
+  const snaps = await query(
+    `SELECT id, snapshot_at, pool_lamports::text AS pool_lamports,
+            total_balance::text AS total_balance,
+            holder_count, eligible_count
+       FROM magpie_holder_distributions ORDER BY snapshot_at`,
+  );
+  if (snaps.rows.length === 0) {
+    console.log("  (no rows — first distribution hasn't run)");
+    return;
+  }
+  for (const s of snaps.rows) {
+    const r = await query(
+      `SELECT COUNT(*)::int AS eligible_count,
+              COUNT(*) FILTER (WHERE status='paid')::int AS paid_count,
+              COALESCE(SUM(reward_lamports) FILTER (WHERE status='paid'),0)::text AS paid_lamports
+         FROM magpie_holder_rewards WHERE distribution_id = $1`,
+      [s.id],
+    );
+    const det = r.rows[0];
+    const eventDef = {
+      kind: "holder_reward",
+      external_ref: `holder-${s.id}`,
+      snapshot_at: s.snapshot_at,
+      pool_lamports: s.pool_lamports,
+      distributed_lamports: det.paid_lamports,
+      eligible_wallet_count: det.eligible_count,
+      paid_wallet_count: det.paid_count,
+      denominator_kind: "magpie_balance",
+      denominator_value: s.total_balance,
+      notes: `$MAGPIE holder distribution snapshot id=${s.id}.`,
+      status: "complete",
+    };
+    console.log(`  snapshot #${s.id}: ${(Number(det.paid_lamports) / 1e9).toFixed(4)} SOL`);
+    if (!DRY) await upsertDistributionEvent(eventDef);
+  }
+}
+
+async function backfillLpLoyalty() {
+  console.log("\n== lp_loyalty_distributions → kind=lp_loyalty ==");
+  const snaps = await query(
+    `SELECT id, snapshot_at, pool_lamports::text AS pool_lamports,
+            total_weight::text AS total_weight, eligible_count
+       FROM lp_loyalty_distributions ORDER BY snapshot_at`,
+  );
+  if (snaps.rows.length === 0) {
+    console.log("  (no rows)");
+    return;
+  }
+  for (const s of snaps.rows) {
+    const r = await query(
+      `SELECT COUNT(*)::int AS paid_count,
+              COALESCE(SUM(reward_lamports),0)::text AS paid_lamports
+         FROM lp_loyalty_rewards WHERE distribution_id = $1`,
+      [s.id],
+    );
+    const det = r.rows[0];
+    const eventDef = {
+      kind: "lp_loyalty",
+      external_ref: `lp-${s.id}`,
+      snapshot_at: s.snapshot_at,
+      pool_lamports: s.pool_lamports,
+      distributed_lamports: det.paid_lamports,
+      eligible_wallet_count: s.eligible_count,
+      paid_wallet_count: det.paid_count,
+      denominator_kind: "share_seconds",
+      denominator_value: s.total_weight,
+      notes: `LP loyalty distribution snapshot id=${s.id}.`,
+      status: "complete",
+    };
+    console.log(`  snapshot #${s.id}: ${(Number(det.paid_lamports) / 1e9).toFixed(4)} SOL`);
+    if (!DRY) await upsertDistributionEvent(eventDef);
+  }
+}
+
+console.log(`distribution_events backfill ${DRY ? "(dry run)" : "(writing)"}`);
+await backfillGovernance();
+await backfillHolderRewards();
+await backfillLpLoyalty();
+
+console.log("\n== current distribution_events ==");
+const all = await query(
+  `SELECT kind, external_ref, status,
+          (distributed_lamports::numeric / 1e9)::numeric(20,4) AS sol_distributed,
+          eligible_wallet_count, paid_wallet_count, unpayable_wallet_count,
+          snapshot_at
+     FROM distribution_events ORDER BY snapshot_at DESC`,
+);
+for (const r of all.rows) {
+  console.log(
+    `  ${r.kind.padEnd(18)} ${r.external_ref.padEnd(20)} ${r.status.padEnd(10)} ${String(r.sol_distributed).padStart(12)} SOL  ${r.paid_wallet_count}/${r.eligible_wallet_count} paid (${r.unpayable_wallet_count} unpayable)  ${r.snapshot_at.toISOString().slice(0,19)}`,
+  );
+}
+process.exit(0);

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1622,6 +1622,7 @@ const PUBLIC_ROUTES = new Set([
   // short-forms only, pure aggregates on protocol-pulse.
   "/api/v1/public/activity",
   "/api/v1/public/protocol-pulse",
+  "/api/v1/public/distributions",
   // Live x402 revenue + adoption — pure aggregates over the
   // x402_paid_calls log. No payer pubkeys surfaced, only counts +
   // SOL totals + per-endpoint breakdown.
@@ -1923,6 +1924,15 @@ async function router(req, res) {
       case "/api/v1/public/x402-metrics": {
         const { handleX402Metrics } = await import("./x402-metrics.js");
         result = await handleX402Metrics();
+        break;
+      }
+      case "/api/v1/public/distributions": {
+        // Unified investor-facing distribution roll-up.
+        // See feedback_unified_distribution_accounting.md.
+        const { listDistributionEventsPublic } = await import("../services/distribution-events.js");
+        const limit = url.searchParams.get("limit");
+        const { events, totals } = await listDistributionEventsPublic({ limit });
+        result = { status: 200, body: { ok: true, events, totals } };
         break;
       }
       case "/api/v1/internal/x402/record": {

--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -962,6 +962,63 @@ export async function applyStartupPatches() {
     `CREATE INDEX IF NOT EXISTS pending_arms_pending_idx ON pending_arms(status, envelope_issued_at) WHERE status = 'pending'`,
     `CREATE INDEX IF NOT EXISTS pending_arms_wallet_idx ON pending_arms(wallet, created_at DESC)`,
     `CREATE INDEX IF NOT EXISTS pending_arms_loan_id_idx ON pending_arms(loan_id_chain) WHERE status IN ('pending', 'armed')`,
+
+    // ─────────── UNIFIED DISTRIBUTION ACCOUNTING (2026-06-18) ───────────
+    // Operator-mandated 2026-06-18: every SOL distribution Magpie makes
+    // to stakeholders — holder rewards, governance ratifications, LP
+    // loyalty, yield, loan remediation — gets one row here. This is the
+    // canonical investor-facing roll-up sitting OVER the per-kind detail
+    // tables (which remain the source of truth for per-wallet payouts).
+    //
+    // Why a new table instead of extending magpie_holder_distributions:
+    // that table has a 6-field schema tightly coupled to holder-reward
+    // mechanics. A unified table needs to cover governance (weight-based
+    // denominator), LP-loyalty (share-seconds), yield (LP pro-rata), etc.
+    // Cleaner to ship a new layer than to retrofit.
+    //
+    // The per-kind tables stay as the source of truth for per-wallet
+    // detail (governance_distributions, lp_loyalty_rewards,
+    // magpie_holder_rewards, etc.). This table is the joinable summary.
+    //
+    // See feedback_unified_distribution_accounting.md.
+    `CREATE TABLE IF NOT EXISTS distribution_events (
+       id                              BIGSERIAL PRIMARY KEY,
+       kind                            TEXT NOT NULL CHECK (kind IN (
+                                         'holder_reward','governance','lp_loyalty','yield','loan_remediation'
+                                       )),
+       external_ref                    TEXT NOT NULL,
+       snapshot_at                     TIMESTAMPTZ NOT NULL,
+       paid_first_at                   TIMESTAMPTZ,
+       paid_last_at                    TIMESTAMPTZ,
+       pool_lamports                   NUMERIC(30,0),
+       distributed_lamports            NUMERIC(30,0) NOT NULL DEFAULT 0,
+       unpaid_lamports                 NUMERIC(30,0) NOT NULL DEFAULT 0,
+       eligible_wallet_count           INTEGER       NOT NULL DEFAULT 0,
+       paid_wallet_count               INTEGER       NOT NULL DEFAULT 0,
+       unpayable_wallet_count          INTEGER       NOT NULL DEFAULT 0,
+       denominator_kind                TEXT,
+       denominator_value               NUMERIC(40,0),
+       min_payout_lamports             NUMERIC(30,0),
+       max_payout_lamports             NUMERIC(30,0),
+       median_payout_lamports          NUMERIC(30,0),
+       source_borrow_fees_lamports     NUMERIC(30,0) NOT NULL DEFAULT 0,
+       source_liquidation_lamports     NUMERIC(30,0) NOT NULL DEFAULT 0,
+       source_other_lamports           NUMERIC(30,0) NOT NULL DEFAULT 0,
+       plan_hash                       TEXT,
+       snapshot_hash                   TEXT,
+       sample_tx_signatures            TEXT[],
+       notes                           TEXT,
+       status                          TEXT NOT NULL DEFAULT 'planned'
+                                         CHECK (status IN ('planned','partial','complete','verified')),
+       metadata                        JSONB,
+       created_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+       updated_at                      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+       UNIQUE (kind, external_ref)
+     )`,
+    `CREATE INDEX IF NOT EXISTS distribution_events_kind_at_idx
+       ON distribution_events(kind, snapshot_at DESC)`,
+    `CREATE INDEX IF NOT EXISTS distribution_events_at_idx
+       ON distribution_events(snapshot_at DESC)`,
   ];
   for (const sql of patches) {
     try {

--- a/src/services/distribution-events.js
+++ b/src/services/distribution-events.js
@@ -1,0 +1,178 @@
+/**
+ * Distribution events — the unified investor-facing accounting layer.
+ *
+ * One row per distribution event regardless of kind. Per-kind detail
+ * tables stay as source of truth for per-wallet payouts; this rolls them
+ * up into a single canonical stream for the public /distributions page
+ * and for any future investor-grade reporting.
+ *
+ * Kinds:
+ *   - holder_reward     — $MAGPIE pro-rata distributions
+ *   - governance        — MGP-NNN ratification payouts
+ *   - lp_loyalty        — LP share-seconds distributions
+ *   - yield             — generic LP-yield distributions
+ *   - loan_remediation  — refunds / remediation payments
+ *
+ * See feedback_unified_distribution_accounting.md for the rule.
+ */
+import { query } from "../db/pool.js";
+
+/**
+ * Upsert a distribution_events row.
+ *
+ * Idempotent on (kind, external_ref) — re-running with the same
+ * external_ref updates the existing row rather than inserting a
+ * duplicate. Use this from every distribution writer.
+ *
+ * @param {Object} ev
+ * @param {string} ev.kind                     - one of the CHECK kinds
+ * @param {string} ev.external_ref             - e.g. "MGP-001", "holder-2026-06-19"
+ * @param {Date|string} ev.snapshot_at         - when the eligible set was captured
+ * @param {Date|string} [ev.paid_first_at]
+ * @param {Date|string} [ev.paid_last_at]
+ * @param {bigint|string} [ev.pool_lamports]
+ * @param {bigint|string} [ev.distributed_lamports]
+ * @param {bigint|string} [ev.unpaid_lamports]
+ * @param {number} [ev.eligible_wallet_count]
+ * @param {number} [ev.paid_wallet_count]
+ * @param {number} [ev.unpayable_wallet_count]
+ * @param {string} [ev.denominator_kind]
+ * @param {bigint|string} [ev.denominator_value]
+ * @param {bigint|string} [ev.min_payout_lamports]
+ * @param {bigint|string} [ev.max_payout_lamports]
+ * @param {bigint|string} [ev.median_payout_lamports]
+ * @param {bigint|string} [ev.source_borrow_fees_lamports]
+ * @param {bigint|string} [ev.source_liquidation_lamports]
+ * @param {bigint|string} [ev.source_other_lamports]
+ * @param {string} [ev.plan_hash]
+ * @param {string} [ev.snapshot_hash]
+ * @param {string[]} [ev.sample_tx_signatures]
+ * @param {string} [ev.notes]
+ * @param {string} [ev.status]
+ * @param {Object} [ev.metadata]
+ */
+export async function upsertDistributionEvent(ev) {
+  if (!ev?.kind || !ev?.external_ref) {
+    throw new Error("upsertDistributionEvent requires kind + external_ref");
+  }
+  const sql = `
+    INSERT INTO distribution_events (
+      kind, external_ref, snapshot_at,
+      paid_first_at, paid_last_at,
+      pool_lamports, distributed_lamports, unpaid_lamports,
+      eligible_wallet_count, paid_wallet_count, unpayable_wallet_count,
+      denominator_kind, denominator_value,
+      min_payout_lamports, max_payout_lamports, median_payout_lamports,
+      source_borrow_fees_lamports, source_liquidation_lamports, source_other_lamports,
+      plan_hash, snapshot_hash, sample_tx_signatures, notes, status, metadata
+    ) VALUES (
+      $1, $2, $3,
+      $4, $5,
+      $6, $7, $8,
+      $9, $10, $11,
+      $12, $13,
+      $14, $15, $16,
+      $17, $18, $19,
+      $20, $21, $22, $23, $24, $25
+    )
+    ON CONFLICT (kind, external_ref) DO UPDATE SET
+      snapshot_at                    = EXCLUDED.snapshot_at,
+      paid_first_at                  = COALESCE(EXCLUDED.paid_first_at, distribution_events.paid_first_at),
+      paid_last_at                   = COALESCE(EXCLUDED.paid_last_at, distribution_events.paid_last_at),
+      pool_lamports                  = COALESCE(EXCLUDED.pool_lamports, distribution_events.pool_lamports),
+      distributed_lamports           = EXCLUDED.distributed_lamports,
+      unpaid_lamports                = EXCLUDED.unpaid_lamports,
+      eligible_wallet_count          = EXCLUDED.eligible_wallet_count,
+      paid_wallet_count              = EXCLUDED.paid_wallet_count,
+      unpayable_wallet_count         = EXCLUDED.unpayable_wallet_count,
+      denominator_kind               = COALESCE(EXCLUDED.denominator_kind, distribution_events.denominator_kind),
+      denominator_value              = COALESCE(EXCLUDED.denominator_value, distribution_events.denominator_value),
+      min_payout_lamports            = EXCLUDED.min_payout_lamports,
+      max_payout_lamports            = EXCLUDED.max_payout_lamports,
+      median_payout_lamports         = EXCLUDED.median_payout_lamports,
+      source_borrow_fees_lamports    = EXCLUDED.source_borrow_fees_lamports,
+      source_liquidation_lamports    = EXCLUDED.source_liquidation_lamports,
+      source_other_lamports          = EXCLUDED.source_other_lamports,
+      plan_hash                      = COALESCE(EXCLUDED.plan_hash, distribution_events.plan_hash),
+      snapshot_hash                  = COALESCE(EXCLUDED.snapshot_hash, distribution_events.snapshot_hash),
+      sample_tx_signatures           = COALESCE(EXCLUDED.sample_tx_signatures, distribution_events.sample_tx_signatures),
+      notes                          = COALESCE(EXCLUDED.notes, distribution_events.notes),
+      status                         = EXCLUDED.status,
+      metadata                       = COALESCE(EXCLUDED.metadata, distribution_events.metadata),
+      updated_at                     = NOW()
+    RETURNING id
+  `;
+  const params = [
+    ev.kind,
+    ev.external_ref,
+    ev.snapshot_at,
+    ev.paid_first_at ?? null,
+    ev.paid_last_at ?? null,
+    ev.pool_lamports != null ? String(ev.pool_lamports) : null,
+    ev.distributed_lamports != null ? String(ev.distributed_lamports) : "0",
+    ev.unpaid_lamports != null ? String(ev.unpaid_lamports) : "0",
+    ev.eligible_wallet_count ?? 0,
+    ev.paid_wallet_count ?? 0,
+    ev.unpayable_wallet_count ?? 0,
+    ev.denominator_kind ?? null,
+    ev.denominator_value != null ? String(ev.denominator_value) : null,
+    ev.min_payout_lamports != null ? String(ev.min_payout_lamports) : null,
+    ev.max_payout_lamports != null ? String(ev.max_payout_lamports) : null,
+    ev.median_payout_lamports != null ? String(ev.median_payout_lamports) : null,
+    ev.source_borrow_fees_lamports != null ? String(ev.source_borrow_fees_lamports) : "0",
+    ev.source_liquidation_lamports != null ? String(ev.source_liquidation_lamports) : "0",
+    ev.source_other_lamports != null ? String(ev.source_other_lamports) : "0",
+    ev.plan_hash ?? null,
+    ev.snapshot_hash ?? null,
+    ev.sample_tx_signatures ?? null,
+    ev.notes ?? null,
+    ev.status ?? "planned",
+    ev.metadata != null ? JSON.stringify(ev.metadata) : null,
+  ];
+  const { rows } = await query(sql, params);
+  return rows[0]?.id;
+}
+
+/**
+ * Return the public-facing list of distribution events.
+ * Excludes nothing — all kinds together, newest first, with lifetime
+ * aggregates included so a single API call powers the whole /distributions page.
+ */
+export async function listDistributionEventsPublic({ limit = 50 } = {}) {
+  const lim = Math.max(1, Math.min(200, Number(limit) | 0));
+  const events = await query(
+    `SELECT id, kind, external_ref, snapshot_at,
+            paid_first_at, paid_last_at,
+            distributed_lamports::text                  AS distributed_lamports,
+            unpaid_lamports::text                       AS unpaid_lamports,
+            eligible_wallet_count, paid_wallet_count, unpayable_wallet_count,
+            denominator_kind,
+            denominator_value::text                     AS denominator_value,
+            min_payout_lamports::text                   AS min_payout_lamports,
+            max_payout_lamports::text                   AS max_payout_lamports,
+            median_payout_lamports::text                AS median_payout_lamports,
+            source_borrow_fees_lamports::text           AS source_borrow_fees_lamports,
+            source_liquidation_lamports::text           AS source_liquidation_lamports,
+            source_other_lamports::text                 AS source_other_lamports,
+            sample_tx_signatures,
+            notes, status, metadata
+       FROM distribution_events
+      ORDER BY snapshot_at DESC
+      LIMIT $1`,
+    [lim],
+  );
+  const totals = await query(
+    `SELECT COUNT(*)::int                                                AS event_count,
+            COALESCE(SUM(distributed_lamports), 0)::text                 AS lifetime_distributed_lamports,
+            COALESCE(SUM(paid_wallet_count), 0)::int                     AS lifetime_payout_count,
+            MIN(snapshot_at)                                             AS first_event_at,
+            MAX(COALESCE(paid_last_at, snapshot_at))                     AS most_recent_event_at,
+            COUNT(*) FILTER (WHERE kind = 'holder_reward')::int          AS holder_reward_count,
+            COUNT(*) FILTER (WHERE kind = 'governance')::int             AS governance_count,
+            COUNT(*) FILTER (WHERE kind = 'lp_loyalty')::int             AS lp_loyalty_count,
+            COUNT(*) FILTER (WHERE kind = 'yield')::int                  AS yield_count,
+            COUNT(*) FILTER (WHERE kind = 'loan_remediation')::int       AS loan_remediation_count
+       FROM distribution_events`,
+  );
+  return { events: events.rows, totals: totals.rows[0] };
+}


### PR DESCRIPTION
Operator-mandated 2026-06-18: all distributions get one investor-grade ledger. Adds distribution_events table (governance/holder_reward/lp_loyalty/yield/loan_remediation kinds), upsert helper, public REST endpoint, and backfill that pulls MGP-001 (21.49 SOL to 1,558 wallets) from governance_distributions. Site /distributions page ships in parallel PR on magpie-site.