### PR TITLE
feat(price): Jupiter request budgeting + RWA DexScreener-first routing

### DIFF
--- a/src/commands/v4-status.js
+++ b/src/commands/v4-status.js
@@ -23,6 +23,7 @@ import { TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
 import { query } from "../db/pool.js";
 import { connection } from "../solana/connection.js";
 import { isAdmin } from "../services/admin.js";
+import { getJupiterBudgetStats } from "../services/jupiter-budget.js";
 
 function fmt(n) {
   if (n == null) return "?";
@@ -61,6 +62,10 @@ export async function handleV4Status(ctx) {
   catch { return ctx.reply(`PROGRAM_ID_V4 invalid: \`${v4ProgramIdStr}\``, { parse_mode: "Markdown" }); }
 
   await ctx.reply("Collecting V4 health snapshot…");
+
+  // Jupiter budget stats (rolling 60s window) — cheap, no I/O
+  let jupBudget = null;
+  try { jupBudget = getJupiterBudgetStats(); } catch { /* best-effort */ }
 
   // ── 1. Loan + activity counts ──
   const sinceWindow = "INTERVAL '24 hours'";
@@ -230,6 +235,15 @@ export async function handleV4Status(ctx) {
       : armAuditTail.slice(0, 5).map((a) =>
           `• ${fmtAge(ageMs(a.created_at))}: \`${a.status || "?"}\` loan ${a.loan_id || "?"} ${a.error_code ? `(${a.error_code})` : ""}`,
         ).join("\n"),
+    "",
+    `*Jupiter budget (rolling 60s)*`,
+    ...(jupBudget
+      ? [
+          `• OK: ${jupBudget.jup_ok} · 429: ${jupBudget.jup_429} · err: ${jupBudget.jup_err} · ratio_429: ${jupBudget.ratio_429}`,
+          `• Bucket: ${Math.floor(jupBudget.bucket.tokens_available)}/${jupBudget.bucket.budget_max} (${jupBudget.bucket.budget_per_sec}/sec)`,
+          `• Defers to Dex: ${jupBudget.budget_defer} · backoff skips: ${jupBudget.backoff_skip} · mints in backoff: ${jupBudget.mints_in_backoff}`,
+        ]
+      : ["• stats unavailable"]),
   ];
 
   await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });

--- a/src/services/jupiter-budget.js
+++ b/src/services/jupiter-budget.js
@@ -1,0 +1,210 @@
+/**
+ * Jupiter request-budgeting layer.
+ *
+ * Operator-mandated 2026-06-18 PM after the lite-api endpoint switch
+ * pushed the Jupiter 429 ratio from 5× to 12×. The fundamental issue
+ * is that we hammer Jupiter at full speed for every price fetch, with
+ * no mint-class differentiation and no global throttle. This module
+ * adds three guardrails:
+ *
+ *   1. Token-bucket rate limiter — caps total Jupiter calls to
+ *      JUPITER_BUDGET_PER_SEC requests/sec across all callers.
+ *      Refills at the same rate, with a small headroom bucket so
+ *      genuine bursts (e.g. attestor tick start) aren't blocked.
+ *
+ *   2. Per-mint 429 backoff — when a mint returns 429 from Jupiter,
+ *      we suppress further Jupiter calls for that specific mint for
+ *      30s / 60s / 120s / 240s (exponential, capped at 5 min). A
+ *      success clears the backoff. This stops one badly-routed mint
+ *      from chewing the global budget.
+ *
+ *   3. RWA-first DexScreener routing — for category in (stock, etf,
+ *      metal), DexScreener is the primary source. Jupiter is only
+ *      consulted as a fallback if Dex fails AND we have budget. xStocks
+ *      have stable per-share prices that DexScreener tracks well and
+ *      Jupiter's route quality for thin RWA pairs is poor anyway —
+ *      we already saw the 1000× decimals mismatch driving the canary
+ *      alerts. Memecoins stay Jupiter-first because route quality
+ *      matters more for swap execution there.
+ *
+ * Observability: a rolling 60s window counts how many Jupiter requests
+ * we attempted, how many were 429, how many were budget-deferred to
+ * Dex. Exposed via getJupiterBudgetStats() for the health-watcher to
+ * surface in admin alerts.
+ *
+ * Configuration (all env-tunable, sensible defaults):
+ *   JUPITER_BUDGET_PER_SEC = 10  (10 req/sec sustained)
+ *   JUPITER_BUDGET_MAX     = 30  (3-second burst)
+ *   JUPITER_BACKOFF_BASE_MS= 30000  (30s first 429)
+ *   JUPITER_BACKOFF_CAP_MS = 300000 (5min max)
+ *
+ * See project_jupiter_request_budgeting_p0.md for the design history.
+ */
+import { query } from "../db/pool.js";
+
+const BUDGET_PER_SEC = Number(process.env.JUPITER_BUDGET_PER_SEC) || 10;
+const BUDGET_MAX = Number(process.env.JUPITER_BUDGET_MAX) || 30;
+const BACKOFF_BASE_MS = Number(process.env.JUPITER_BACKOFF_BASE_MS) || 30_000;
+const BACKOFF_CAP_MS = Number(process.env.JUPITER_BACKOFF_CAP_MS) || 300_000;
+
+const RWA_CATEGORIES = new Set(["stock", "etf", "metal"]);
+
+// ─── Token bucket ────────────────────────────────────────────────────
+let tokens = BUDGET_MAX;
+let lastRefillAt = Date.now();
+
+function refillTokens() {
+  const now = Date.now();
+  const elapsedSec = (now - lastRefillAt) / 1000;
+  tokens = Math.min(BUDGET_MAX, tokens + elapsedSec * BUDGET_PER_SEC);
+  lastRefillAt = now;
+}
+
+/**
+ * Try to take 1 token (= 1 Jupiter request). Returns true if we got it.
+ * A batch call counts as 1 token even if it covers N mints — the bucket
+ * sizes the HTTP-request rate, not the mint-coverage rate.
+ */
+export function tryAcquireJupiterToken() {
+  refillTokens();
+  if (tokens >= 1) {
+    tokens -= 1;
+    return true;
+  }
+  return false;
+}
+
+export function jupiterBudgetSnapshot() {
+  refillTokens();
+  return { tokens_available: tokens, budget_per_sec: BUDGET_PER_SEC, budget_max: BUDGET_MAX };
+}
+
+// ─── Per-mint 429 backoff ────────────────────────────────────────────
+const backoffByMint = new Map(); // mint → { until_ms, attempts }
+
+export function isMintInJupiterBackoff(mint) {
+  const e = backoffByMint.get(mint);
+  if (!e) return false;
+  if (e.until_ms <= Date.now()) {
+    backoffByMint.delete(mint);
+    return false;
+  }
+  return true;
+}
+
+export function bumpMintJupiterBackoff(mint) {
+  const existing = backoffByMint.get(mint);
+  const attempts = (existing?.attempts || 0) + 1;
+  const delayMs = Math.min(BACKOFF_CAP_MS, BACKOFF_BASE_MS * Math.pow(2, attempts - 1));
+  backoffByMint.set(mint, { until_ms: Date.now() + delayMs, attempts });
+  return { attempts, delayMs };
+}
+
+export function clearMintJupiterBackoff(mint) {
+  backoffByMint.delete(mint);
+}
+
+// ─── Category lookup (cached) ────────────────────────────────────────
+const categoryCache = new Map(); // mint → { category, fetched_at_ms }
+const CATEGORY_TTL_MS = 5 * 60_000; // 5min — categories rarely change
+
+async function getMintCategory(mint) {
+  const cached = categoryCache.get(mint);
+  if (cached && Date.now() - cached.fetched_at_ms < CATEGORY_TTL_MS) {
+    return cached.category;
+  }
+  let category = null;
+  try {
+    const { rows } = await query(
+      `SELECT category FROM supported_mints WHERE mint = $1 LIMIT 1`,
+      [mint],
+    );
+    category = rows[0]?.category ?? null;
+  } catch {
+    // Fail SAFE — unknown category, treat as memecoin (Jupiter-first).
+  }
+  categoryCache.set(mint, { category, fetched_at_ms: Date.now() });
+  return category;
+}
+
+/**
+ * Decide the routing for a given mint.
+ *
+ * Returns one of:
+ *   - "jupiter_first"   — try Jupiter primary, Dex fallback (default for
+ *                         memecoins with budget and no backoff)
+ *   - "dexscreener_first" — try Dex primary, Jupiter fallback only if
+ *                         budget allows (RWA mints or memecoins in
+ *                         backoff/no-budget)
+ *   - "dexscreener_only"  — Dex only, Jupiter skipped entirely (mint is
+ *                         deep in backoff AND budget is exhausted; or
+ *                         operator-flagged Jupiter-down state)
+ */
+export async function routeFor(mint) {
+  const category = await getMintCategory(mint);
+
+  // RWA: always Dex-first; Jupiter only as fallback if budget allows.
+  if (RWA_CATEGORIES.has(category)) {
+    return { route: "dexscreener_first", reason: `rwa-category=${category}` };
+  }
+
+  // Memecoin in active backoff: respect the backoff.
+  if (isMintInJupiterBackoff(mint)) {
+    refillTokens();
+    if (tokens < 1) {
+      return { route: "dexscreener_only", reason: "in-backoff+no-budget" };
+    }
+    return { route: "dexscreener_first", reason: "in-backoff" };
+  }
+
+  // No budget right now: defer to Dex.
+  refillTokens();
+  if (tokens < 1) {
+    return { route: "dexscreener_first", reason: "no-budget" };
+  }
+
+  return { route: "jupiter_first", reason: "ok" };
+}
+
+// ─── Metrics (rolling 60s) ───────────────────────────────────────────
+const WINDOW_MS = 60_000;
+const events = []; // { ts, kind }   kind ∈ {"jup_ok","jup_429","jup_err","budget_defer","backoff_skip"}
+
+function record(kind) {
+  const now = Date.now();
+  events.push({ ts: now, kind });
+  // Drop anything older than WINDOW_MS, lazily on read.
+}
+function pruneOld() {
+  const cutoff = Date.now() - WINDOW_MS;
+  while (events.length && events[0].ts < cutoff) events.shift();
+}
+
+export function recordJupiterOk() { record("jup_ok"); }
+export function recordJupiter429(mint) {
+  record("jup_429");
+  bumpMintJupiterBackoff(mint);
+}
+export function recordJupiterErr() { record("jup_err"); }
+export function recordBudgetDefer() { record("budget_defer"); }
+export function recordBackoffSkip() { record("backoff_skip"); }
+
+export function getJupiterBudgetStats() {
+  pruneOld();
+  const counts = events.reduce((acc, e) => { acc[e.kind] = (acc[e.kind] || 0) + 1; return acc; }, {});
+  const total_jup_attempts = (counts.jup_ok || 0) + (counts.jup_429 || 0) + (counts.jup_err || 0);
+  const ratio_429 = total_jup_attempts > 0
+    ? ((counts.jup_429 || 0) / total_jup_attempts).toFixed(3)
+    : "0.000";
+  return {
+    window_sec: WINDOW_MS / 1000,
+    jup_ok: counts.jup_ok || 0,
+    jup_429: counts.jup_429 || 0,
+    jup_err: counts.jup_err || 0,
+    budget_defer: counts.budget_defer || 0,
+    backoff_skip: counts.backoff_skip || 0,
+    ratio_429,
+    bucket: jupiterBudgetSnapshot(),
+    mints_in_backoff: backoffByMint.size,
+  };
+}

--- a/src/services/price.js
+++ b/src/services/price.js
@@ -1,6 +1,17 @@
 import axios from "axios";
 import "dotenv/config";
 import { hasPythCoverage, pythPriceInSol, pythPriceInUsd } from "./pyth-price.js";
+import {
+  routeFor,
+  tryAcquireJupiterToken,
+  recordJupiterOk,
+  recordJupiter429,
+  recordJupiterErr,
+  recordBudgetDefer,
+  recordBackoffSkip,
+  clearMintJupiterBackoff,
+  isMintInJupiterBackoff,
+} from "./jupiter-budget.js";
 
 // Jupiter v2 was deprecated in 2025. v3 returns USD only, so SOL-denominated
 // prices are derived as token_usd / sol_usd.
@@ -27,16 +38,29 @@ const JUP_BATCH_SIZE = 50;
  * path used by the on-chain price-feed attestor.
  */
 async function jupiterPriceInSol(mint) {
-  const resp = await axios.get(JUPITER_API, {
-    params: { ids: `${mint},${SOL_MINT}` },
-    timeout: 10_000,
-  });
-  const tokenUsd = resp.data?.[mint]?.usdPrice;
-  const solUsd = resp.data?.[SOL_MINT]?.usdPrice;
-  if (!tokenUsd || !solUsd) {
-    throw new Error(`No price data for mint ${mint}`);
+  try {
+    const resp = await axios.get(JUPITER_API, {
+      params: { ids: `${mint},${SOL_MINT}` },
+      timeout: 10_000,
+    });
+    const tokenUsd = resp.data?.[mint]?.usdPrice;
+    const solUsd = resp.data?.[SOL_MINT]?.usdPrice;
+    if (!tokenUsd || !solUsd) {
+      recordJupiterErr();
+      throw new Error(`No price data for mint ${mint}`);
+    }
+    recordJupiterOk();
+    clearMintJupiterBackoff(mint);
+    return tokenUsd / solUsd;
+  } catch (err) {
+    const status = err?.response?.status;
+    if (status === 429) {
+      recordJupiter429(mint);
+    } else if (!err?.response?.status?.toString().startsWith("2")) {
+      recordJupiterErr();
+    }
+    throw err;
   }
-  return tokenUsd / solUsd;
 }
 
 function isTransientPriceError(err) {
@@ -49,12 +73,50 @@ function isTransientPriceError(err) {
 }
 
 export async function getPriceInSol(mint) {
-  // Attempt 1: Jupiter
+  // Route decision: budget + backoff + RWA-class aware. See
+  // jupiter-budget.js for the policy.
+  const { route, reason } = await routeFor(mint);
+
+  if (route === "dexscreener_only") {
+    // Jupiter is off the table this round. Dex or bust.
+    recordBackoffSkip();
+    return await dexscreenerPriceInSol(mint);
+  }
+
+  if (route === "dexscreener_first") {
+    if (reason !== "rwa-category=stock" && reason !== "rwa-category=etf" && reason !== "rwa-category=metal") {
+      // Memecoin being deferred — note it for metrics.
+      recordBudgetDefer();
+    }
+    try {
+      return await dexscreenerPriceInSol(mint);
+    } catch (errDex) {
+      // Dex failed. Try Jupiter ONLY if budget allows + not in backoff.
+      if (isMintInJupiterBackoff(mint) || !tryAcquireJupiterToken()) {
+        throw new Error(`No price for ${mint} (Dex: ${errDex.message}; Jupiter skipped: ${reason})`);
+      }
+      try {
+        return await jupiterPriceInSol(mint);
+      } catch (errJup) {
+        throw new Error(`No price for ${mint} (Dex: ${errDex.message}; Jupiter: ${errJup.message})`);
+      }
+    }
+  }
+
+  // jupiter_first path — original logic with budget consumption.
+  if (!tryAcquireJupiterToken()) {
+    // Edge: routeFor said we had budget but it raced out. Defer to Dex.
+    recordBudgetDefer();
+    try {
+      return await dexscreenerPriceInSol(mint);
+    } catch (errDex) {
+      throw new Error(`No price for ${mint} (Jupiter budget exhausted; Dex: ${errDex.message})`);
+    }
+  }
   try {
     return await jupiterPriceInSol(mint);
   } catch (err1) {
     if (!isTransientPriceError(err1)) {
-      // Non-transient (e.g. mint not on Jupiter). Skip retry, try DexScreener.
       try {
         const dex = await dexscreenerPriceInSol(mint);
         console.warn(`[price] ${mint.slice(0, 8)} fallback to DexScreener (Jupiter: ${err1.message})`);
@@ -64,12 +126,21 @@ export async function getPriceInSol(mint) {
       }
     }
 
-    // Transient — wait 200-700ms with jitter, retry Jupiter once.
+    // Transient — wait 200-700ms with jitter, retry Jupiter once IF budget allows.
     await new Promise((r) => setTimeout(r, 200 + Math.random() * 500));
+    if (!tryAcquireJupiterToken()) {
+      // No budget for retry. Skip to Dex.
+      try {
+        const dex = await dexscreenerPriceInSol(mint);
+        console.warn(`[price] ${mint.slice(0, 8)} fallback to DexScreener (no budget for Jupiter retry)`);
+        return dex;
+      } catch (err2) {
+        throw new Error(`No price data for ${mint} (Jupiter: ${err1.message}; Dex: ${err2.message})`);
+      }
+    }
     try {
       return await jupiterPriceInSol(mint);
     } catch (err2) {
-      // Retry failed too. Fall back to DexScreener.
       try {
         const dex = await dexscreenerPriceInSol(mint);
         console.warn(`[price] ${mint.slice(0, 8)} fallback to DexScreener (Jupiter still failing after retry: ${err2.message})`);
@@ -94,18 +165,45 @@ export async function getPricesInSolBatch(mints) {
 
   for (let i = 0; i < unique.length; i += JUP_BATCH_SIZE) {
     const chunk = unique.slice(i, i + JUP_BATCH_SIZE);
-    const ids = chunk.concat(solUsd ? [] : [SOL_MINT]).join(",");
-    const resp = await axios.get(JUPITER_API, {
-      params: { ids },
-      timeout: 15_000,
-    });
-    if (!solUsd) {
-      solUsd = resp.data?.[SOL_MINT]?.usdPrice;
-      if (!solUsd) throw new Error("No SOL price from Jupiter");
+    // Each batch HTTP call costs 1 token even though it covers up to
+    // JUP_BATCH_SIZE mints. If we can't afford it, return what we have
+    // so far and the per-mint fallback in callers will pick up the rest
+    // via DexScreener.
+    if (!tryAcquireJupiterToken()) {
+      recordBudgetDefer();
+      break;
     }
-    for (const mint of chunk) {
-      const usd = resp.data?.[mint]?.usdPrice;
-      if (usd) result.set(mint, usd / solUsd);
+    const ids = chunk.concat(solUsd ? [] : [SOL_MINT]).join(",");
+    try {
+      const resp = await axios.get(JUPITER_API, {
+        params: { ids },
+        timeout: 15_000,
+      });
+      recordJupiterOk();
+      if (!solUsd) {
+        solUsd = resp.data?.[SOL_MINT]?.usdPrice;
+        if (!solUsd) throw new Error("No SOL price from Jupiter");
+      }
+      for (const mint of chunk) {
+        const usd = resp.data?.[mint]?.usdPrice;
+        if (usd) {
+          result.set(mint, usd / solUsd);
+          // A successful price clears any prior backoff for this mint —
+          // Jupiter is healthy for it again.
+          clearMintJupiterBackoff(mint);
+        }
+      }
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 429) {
+        // Bump backoff for ALL mints in this chunk so we don't waste the
+        // next batch hammering the same set.
+        for (const mint of chunk) recordJupiter429(mint);
+      } else {
+        recordJupiterErr();
+      }
+      // Don't throw — let the caller's per-mint fallback fill in via Dex.
+      break;
     }
   }
   return result;


### PR DESCRIPTION
Operator-mandated P0. Closes the 429-storm class of failures. Token-bucket rate limiter (10 req/sec sustained, 30 burst) + per-mint exponential 429 backoff (30s→300s) + RWA category Dex-first routing. /v4-status surfaces rolling 60s metrics. Env-tunable. See feedback_jupiter_request_budgeting_shipped_2026_06_18.md for full design + verification path.