### PR TITLE
feat(support): Pip pre-analysis on every ticket + drop bug_report skip

### DIFF
--- a/migrations/073_support_tickets_pip_pre_analysis.sql
+++ b/migrations/073_support_tickets_pip_pre_analysis.sql
@@ -1,0 +1,23 @@
+-- Pip pre-analysis on every support ticket
+--
+-- 2026-06-18 PM: ticket #60 sat in 'open' status for 12h+ because its
+-- escalation reason was `bug_report`, which the immediate auto-resolver
+-- skipped. The actual issue was a Pip wording misread, not a real bug —
+-- a second-pass with admin-context tools would have caught it in seconds.
+--
+-- Per operator directive (feedback_pip_must_proactively_resolve_every_ticket):
+-- Pip must take an active pass on EVERY ticket the moment it opens,
+-- including the categories where we don't auto-DM the user. The output
+-- is stored on the ticket so the operator sees Pip's read of the situation
+-- in /tickets <N> and can /reply in seconds.
+--
+-- pip_pre_analysis     — Pip's admin-facing read on the ticket (4-section
+--                        structure: what asked / current state / root
+--                        cause / recommended action). Up to 4000 chars.
+-- pip_pre_analyzed_at  — when pre-analysis last ran. Refreshed on
+--                        aging-tier alerts so the operator sees current
+--                        state, not stale.
+
+ALTER TABLE support_tickets
+  ADD COLUMN IF NOT EXISTS pip_pre_analysis TEXT,
+  ADD COLUMN IF NOT EXISTS pip_pre_analyzed_at TIMESTAMPTZ;

--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -887,6 +887,7 @@ export async function handleTicket(ctx) {
             s.admin_reply, s.admin_replied_at,
             s.auto_resolved_at, s.last_user_followup_at, s.followup_count,
             s.closed_at, s.created_at,
+            s.pip_pre_analysis, s.pip_pre_analyzed_at,
             u.telegram_id, u.telegram_username, u.current_streak, u.created_at AS user_created_at,
             (SELECT COUNT(*) FROM loans WHERE user_id = u.id)::int AS total_loans,
             (SELECT COUNT(*) FROM loans WHERE user_id = u.id AND status = 'active')::int AS active_loans
@@ -919,6 +920,20 @@ export async function handleTicket(ctx) {
 
   if (t.followup_count > 0) {
     lines.push("", `_${t.followup_count} follow-up(s) — see message above for full thread._`);
+  }
+
+  // Pip pre-analysis — what Pip looked at + what she thinks is going on.
+  // Surfaced prominently so the operator can /reply in seconds without
+  // having to repeat the investigation.
+  if (t.pip_pre_analysis) {
+    const ageMin = t.pip_pre_analyzed_at
+      ? Math.floor((Date.now() - new Date(t.pip_pre_analyzed_at).getTime()) / 60_000)
+      : null;
+    const ageLabel = ageMin == null
+      ? ""
+      : ageMin < 60 ? ` (${ageMin}m ago)` : ` (${Math.floor(ageMin / 60)}h ago)`;
+    lines.push("", `*Pip pre-analysis${ageLabel}:*`);
+    lines.push("```", t.pip_pre_analysis.slice(0, 2000), "```");
   }
 
   if (t.admin_reply) {

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -4169,15 +4169,56 @@ const TOOL_HANDLERS = {
     }
 
     if (scopedRows.length === 0) {
+      // The user has loans on the account, but none of them match the
+      // wallet they're currently signing with. Figure out WHERE the
+      // loans actually live so the agent can tell them which wallet to
+      // use — instead of vague "OTHER linked wallets" wording that
+      // makes a single-wallet account sound like it has multiple
+      // linked addresses (2026-06-18 PM, ticket #60 fix).
+      const otherWalletPubkeys = Array.from(new Set(
+        rows
+          .filter((r) => !scopedRows.includes(r))
+          .map((r) => r.borrower_wallet)
+          .filter(Boolean),
+      ));
+      // What wallets does the user have on their Magpie account?
+      let linkedWallets = [];
+      try {
+        const { rows: w } = await query(
+          `SELECT public_key, label, is_active FROM wallets WHERE user_id = $1 ORDER BY is_active DESC, created_at ASC`,
+          [userId],
+        );
+        linkedWallets = w;
+      } catch { /* best-effort */ }
+      const otherWalletsOnAccount = otherWalletPubkeys.filter(
+        (pk) => linkedWallets.some((lw) => lw.public_key === pk),
+      );
+      const otherWalletsOffAccount = otherWalletPubkeys.filter(
+        (pk) => !linkedWallets.some((lw) => lw.public_key === pk),
+      );
+      let note;
+      if (otherWalletCount === 0) {
+        note = "User has no loans on record. They may need to /borrow to take one out.";
+      } else if (otherWalletsOffAccount.length > 0) {
+        // The loans are on wallets the user took them from directly,
+        // not on Magpie-linked wallets. Most common pattern: site Pip
+        // with browser Phantom connected to a wallet other than the
+        // user's Magpie custodial.
+        note = `User has 0 loans on the wallet they're currently using (${scopedWallet}). Their ${otherWalletCount} loan(s) live on wallet(s) ${otherWalletsOffAccount.map((p) => p.slice(0, 8) + "…").join(", ")}. If the user only has ONE wallet on their Magpie account, they may have taken these loans by signing from a different wallet (e.g. their custodial Magpie wallet via TG /borrow). Tell them which wallet the loans live on, and that they need to use THAT wallet to see/manage them.`;
+      } else {
+        note = `User has 0 loans on the wallet they're currently using (${scopedWallet}). Their ${otherWalletCount} loan(s) live on another wallet they've linked to this Magpie account: ${otherWalletsOnAccount.map((p) => p.slice(0, 8) + "…").join(", ")}. Tell them to switch to that wallet (via TG /wallets or on the site) to see those loans.`;
+      }
       return {
         total: 0,
         active_count: 0,
         loans: [],
         scoped_to_wallet: scopedWallet,
         other_wallets_loan_count: otherWalletCount,
-        note: otherWalletCount > 0
-          ? `User has 0 loans on the currently-active wallet (${scopedWallet}). ${otherWalletCount} loan(s) live on OTHER linked wallets — tell them to switch wallets if they want those.`
-          : "User has no loans on record. They may need to /borrow to take one out.",
+        other_wallet_pubkeys: otherWalletPubkeys,
+        linked_wallets_on_account: linkedWallets.map((w) => ({
+          pubkey: w.public_key, label: w.label, is_active: w.is_active,
+        })),
+        note,
       };
     }
 
@@ -4937,35 +4978,76 @@ const TOOL_HANDLERS = {
       [userId, `[AI-escalated] ${detail}`],
     );
 
-    // Fire-and-forget: kick the auto-resolver IMMEDIATELY for this
-    // brand-new ticket. The user gets their "ticket opened" message
-    // first; the AI follow-up DM lands seconds later via the resolver's
-    // own send. Critical-reason tickets (security_incident, bug_report,
-    // refund_request) are SKIP_REASONS in the resolver so admin still
-    // gets primacy on those — for those we DM the operator directly
-    // since the resolver won't, and they explicitly need a human.
-    const SKIP_REASONS = ["security_incident", "bug_report", "refund_request"];
+    // Fire-and-forget — two parallel paths for every new ticket:
+    //
+    //   (1) ALWAYS: runPipPreAnalysis writes Pip's admin-facing read
+    //       of the ticket to support_tickets.pip_pre_analysis. Operator
+    //       sees it in /tickets <N> and can /reply in seconds knowing
+    //       exactly what Pip looked at. No user-facing DM here.
+    //
+    //   (2) FOR NON-SKIP REASONS: resolveTicketImmediate sends the
+    //       user-facing DM with Pip's answer (today's auto-resolve
+    //       behavior). This is what makes the user feel heard within
+    //       seconds of opening the ticket.
+    //
+    // bug_report was REMOVED from SKIP_REASONS 2026-06-18 PM after
+    // ticket #60 — most "bugs" are misreads of system state, and Pip's
+    // second-pass catches them. Operator directive
+    // (feedback_pip_must_proactively_resolve_every_ticket): every
+    // ticket gets a Pip pass. SKIP_REASONS now only covers categories
+    // where the AI must NOT speak to the user without operator review:
+    // security_incident (potential exploit / compromise reports) and
+    // refund_request (money movement disputes).
+    const SKIP_REASONS = ["security_incident", "refund_request"];
+
+    // Always: pre-analysis
+    if (botRef) {
+      import("./auto-ticket-resolver.js")
+        .then(({ runPipPreAnalysis }) => runPipPreAnalysis(t.id))
+        .then((r) => {
+          if (!r?.ok) console.warn(`[ai-support] pre-analysis #${t.id} failed: ${r?.reason}`);
+        })
+        .catch((err) => console.warn(`[ai-support] pre-analysis fire for #${t.id} failed:`, err.message));
+    }
+
+    // Non-SKIP: also send user-facing auto-DM
     if (botRef && !SKIP_REASONS.includes(escalation_reason)) {
       import("./auto-ticket-resolver.js")
         .then(({ resolveTicketImmediate }) => resolveTicketImmediate(botRef, t.id))
         .catch((err) => console.warn(`[ai-support] immediate-resolve fire for #${t.id} failed:`, err.message));
     } else if (SKIP_REASONS.includes(escalation_reason)) {
-      // Critical-reason escalation — DM operator directly. These
-      // categories explicitly bypass auto-resolution because they
-      // need human judgment (potential exploit reports, money
-      // movement disputes, bug reports affecting users). Without
-      // this DM the ticket would silently sit until /mytickets is
-      // checked.
+      // SKIP_REASONS — operator must read pre-analysis and reply themselves.
+      // DM the operator now so they know there's something to look at.
+      // The DM includes the pre-analysis if it lands within a short
+      // window; otherwise it goes out and the operator pulls the
+      // pre-analysis from /tickets <N>.
       import("./admin-notify.js")
-        .then(({ notifyAdmin }) =>
-          notifyAdmin(
+        .then(async ({ notifyAdmin }) => {
+          // Give the pre-analysis a couple seconds to land so it can
+          // be included inline. If it doesn't, we still DM — operator
+          // hits /tickets <N> for the full read.
+          let preAnalysis = null;
+          for (let i = 0; i < 6 && !preAnalysis; i++) {
+            await new Promise((res) => setTimeout(res, 2000));
+            try {
+              const { rows: r } = await query(
+                `SELECT pip_pre_analysis FROM support_tickets WHERE id = $1`,
+                [t.id],
+              );
+              if (r[0]?.pip_pre_analysis) preAnalysis = r[0].pip_pre_analysis;
+            } catch { /* keep looping */ }
+          }
+          await notifyAdmin(
             `🚨 CRITICAL ticket #${t.id} (${escalation_reason})\n\n` +
             `User: ${userId}\n` +
             `Summary: ${(summary || "").slice(0, 400)}\n` +
             (what_i_tried ? `AI tried: ${what_i_tried.slice(0, 400)}\n` : "") +
-            `\nReply via /mytickets or DM the user directly.`,
-          ),
-        )
+            (preAnalysis
+              ? `\n— Pip pre-analysis —\n${preAnalysis.slice(0, 2000)}\n`
+              : `\n(Pip pre-analysis still running — check /tickets ${t.id} in a moment.)\n`) +
+            `\nReply via /reply ${t.id} <text> · Close via /close ${t.id}`,
+          );
+        })
         .catch((err) => console.warn(`[ai-support] critical-ticket DM failed for #${t.id}:`, err.message));
     }
     return { ticket_id: t.id, status: "open", reason: escalation_reason };

--- a/src/services/auto-ticket-resolver.js
+++ b/src/services/auto-ticket-resolver.js
@@ -37,10 +37,20 @@ const FIRST_RUN_DELAY_MS = 60 * 1000;               // 60s after boot
 // rather than have the AI keep trying. The AI clearly isn't cracking it.
 const DEAD_LETTER_FOLLOWUP_COUNT = 3;
 
-// Reasons we do NOT auto-resolve — these genuinely need a human.
+// Reasons we do NOT auto-DM the user — these genuinely need a human
+// to read Pip's pre-analysis and decide on the actual reply. The
+// pre-analysis ITSELF still runs for every ticket (see runPipPreAnalysis
+// below) — only the user-facing auto-DM is gated.
+//
+// 2026-06-18 PM: bug_report was REMOVED from this list per operator
+// directive (feedback_pip_must_proactively_resolve_every_ticket). Most
+// "bug reports" are actually misreads of system state (e.g. ticket #60
+// where Pip's "other linked wallets" wording made a normal account look
+// anomalous). Pip's second-pass catches those before they ever reach the
+// operator. Genuine bugs still surface because Pip's analysis will say
+// "this is a real issue" in the pre-analysis, and aging tiers escalate.
 const SKIP_REASONS = [
   "security_incident",
-  "bug_report",
   "refund_request",
 ];
 
@@ -101,6 +111,92 @@ export async function resolveTicketImmediate(bot, ticketId) {
     return await resolveTicket(bot, t);
   } catch (err) {
     console.warn(`[auto-resolver] immediate fire for #${ticketId} failed:`, err.message);
+    return { ok: false, reason: err.message?.slice(0, 100) };
+  }
+}
+
+/**
+ * Run Pip's admin-facing pre-analysis on a ticket. Always runs on EVERY
+ * ticket — including SKIP_REASONS — so the operator sees Pip's read of
+ * the situation in /tickets <N> when deciding how to /reply.
+ *
+ * Writes the agent's output to support_tickets.pip_pre_analysis. Does
+ * NOT DM the user. Does NOT change ticket status. Safe to call any time
+ * — re-running it just refreshes the analysis with current state, which
+ * is what we want when the ticket-aging-watcher fires a tier alert.
+ *
+ * Operator-mandated 2026-06-18 PM
+ * (feedback_pip_must_proactively_resolve_every_ticket).
+ *
+ * @param {number} ticketId
+ * @returns {Promise<{ok: boolean, reason?: string, text?: string}>}
+ */
+export async function runPipPreAnalysis(ticketId) {
+  if (!isAiSupportEnabled()) {
+    return { ok: false, reason: "ai_disabled" };
+  }
+  try {
+    const { rows } = await query(
+      `SELECT t.id, t.user_id, t.message, u.telegram_username
+         FROM support_tickets t
+         JOIN users u ON u.id = t.user_id
+        WHERE t.id = $1`,
+      [ticketId],
+    );
+    const t = rows[0];
+    if (!t) return { ok: false, reason: "ticket_not_found" };
+
+    const cleanMessage = unwrapTicketMessage(t.message);
+    if (!cleanMessage) return { ok: false, reason: "empty_message" };
+
+    // Reset the user's conversation so the analysis runs on a clean
+    // slate — same pattern as resolveTicket below. Their old chat is
+    // gone but that's fine: a fresh ticket means a fresh problem and
+    // the agent shouldn't carry over yesterday's context.
+    try { await resetConversation(t.user_id); } catch { /* non-critical */ }
+
+    const prompt = [
+      "(SYSTEM — admin-only pre-analysis pass. Your output goes to the operator's /tickets dashboard, NOT to the user. Do not address the user, do not start with a greeting, do not include sign-offs.)",
+      "",
+      "A user has opened a support ticket. Use your diagnostic tools (list_my_loans, list_my_wallets, lookup_loan, get_my_wallet, check_my_token_balance, get_my_holder_stats, check_tx, etc.) to take a careful read of their actual account state. Then write four short sections for the operator:",
+      "",
+      "WHAT THE USER ASKED — one sentence summarizing the actual question or complaint.",
+      "",
+      "CURRENT STATE — what you found via tools. Loan IDs, wallet pubkeys, balances, recent tx sigs, anything load-bearing. Be specific.",
+      "",
+      "ROOT CAUSE — is this a real issue, a misunderstanding, a system bug, or an information gap? Be honest. If the user reported a 'bug' but tools show their account is fine, say so.",
+      "",
+      "RECOMMENDED ADMIN ACTION — what should the operator /reply, or is there a product issue to fix? If the user just needs to be told their account is fine, draft the exact reply text.",
+      "",
+      "User's ticket message:",
+      "",
+      cleanMessage,
+    ].join("\n");
+
+    let result;
+    try {
+      result = await chatWithAgent(t.user_id, prompt, {
+        username: t.telegram_username,
+      });
+    } catch (err) {
+      return { ok: false, reason: `agent_error: ${err.message?.slice(0, 100)}` };
+    }
+    if (!result || !result.text) return { ok: false, reason: "agent_no_response" };
+
+    // Reset conversation again so the user's NEXT chat (if any) starts
+    // fresh. The pre-analysis prompt above is admin-framed and we don't
+    // want it leaking into the user's view.
+    try { await resetConversation(t.user_id); } catch { /* non-critical */ }
+
+    await query(
+      `UPDATE support_tickets
+          SET pip_pre_analysis = $2,
+              pip_pre_analyzed_at = NOW()
+        WHERE id = $1`,
+      [ticketId, result.text.slice(0, 4000)],
+    );
+    return { ok: true, text: result.text };
+  } catch (err) {
     return { ok: false, reason: err.message?.slice(0, 100) };
   }
 }

--- a/src/services/ticket-aging-watcher.js
+++ b/src/services/ticket-aging-watcher.js
@@ -68,6 +68,31 @@ async function tick(bot) {
 
   if (newlyEscalated.length === 0) return;
 
+  // Refresh Pip's pre-analysis for every escalated ticket BEFORE we
+  // alert the operator. State drifts — a ticket opened 12h ago about a
+  // pending tx may have settled, or a stuck loan may have unstuck, or
+  // the user's situation may have changed entirely. The operator should
+  // see Pip's CURRENT read, not the one from when the ticket was filed.
+  // 2026-06-18 PM: feedback_pip_must_proactively_resolve_every_ticket.
+  let runPipPreAnalysis;
+  try {
+    ({ runPipPreAnalysis } = await import("./auto-ticket-resolver.js"));
+  } catch (err) {
+    console.warn("[ticket-age] could not load runPipPreAnalysis:", err.message);
+  }
+  if (runPipPreAnalysis) {
+    for (const e of newlyEscalated) {
+      try {
+        const r = await runPipPreAnalysis(e.id);
+        if (!r?.ok) console.warn(`[ticket-age] pre-analysis refresh #${e.id} skipped: ${r?.reason}`);
+      } catch (err) {
+        console.warn(`[ticket-age] pre-analysis refresh #${e.id} threw:`, err.message);
+      }
+      // small breathing room between agent invocations
+      await new Promise((res) => setTimeout(res, 1000));
+    }
+  }
+
   // Group by tier for a tidy summary
   const byTier = {};
   for (const e of newlyEscalated) {
@@ -90,7 +115,7 @@ async function tick(bot) {
         "",
         ...sections,
         "",
-        "Use `/tickets` for the full list with messages, `/reply <#> <text>` to respond, `/close <#>` to resolve.",
+        "Pip pre-analysis was refreshed on each. Open `/tickets <#>` to see her current read; reply via `/reply <#> <text>`.",
       ].join("\n"),
       { parse_mode: "Markdown" },
     );


### PR DESCRIPTION
## Summary

Operator-mandated 2026-06-18 PM after ticket #60 sat 12h+ stale due to its `bug_report` reason hitting the auto-resolver SKIP list. Most reported `bug_reports` are actually misreads of system state.

- migration 073: `pip_pre_analysis` + `pip_pre_analyzed_at` on support_tickets
- new exported `runPipPreAnalysis(ticketId)` writes admin-facing 4-section read on every ticket
- `bug_report` removed from SKIP_REASONS (security_incident + refund_request still skip user auto-DM)
- aging-watcher refreshes pre-analysis before each tier alert
- `/ticket <N>` shows pre-analysis above admin_reply
- `list_my_loans` wording fix (no more misleading `OTHER linked wallets`)

## Test plan

- migration auto-applies on next Railway boot
- open a non-SKIP ticket → user auto-DM + pre-analysis stamped
- open a SKIP ticket (security_incident) → no user DM; operator CRITICAL DM with pre-analysis inline; ticket stays open
- `/ticket <#>` shows pre-analysis block prominently

🤖 Generated with Claude Code