### PR TITLE
feat(treasury): auto-sweep fees from lender wallet to cold treasury vault

### DIFF
--- a/migrations/074_treasury_sweeps.sql
+++ b/migrations/074_treasury_sweeps.sql
@@ -1,0 +1,35 @@
+-- Treasury sweep audit ledger
+--
+-- Every periodic sweep of fees off the lender wallet (4JSSSa…) toward the
+-- treasury vault (6foLvbG…) is recorded here regardless of outcome:
+-- success, skip (balance below reserve floor), simulate-rejected, send
+-- error. The ledger is the investor-grade audit trail for "where did the
+-- protocol's fees go and when."
+--
+-- Outcomes:
+--   success       — tx confirmed on-chain
+--   skip_below_min — net sweep amount below TREASURY_SWEEP_MIN_SOL; no tx sent
+--   skip_disabled — TREASURY_SWEEP_DISABLED env var is set
+--   skip_locked   — another sweeper instance was running; advisory lock skip
+--   sim_reject    — preflight simulate returned err; tx never broadcast
+--   send_error    — RPC sendRawTransaction or confirmation timed out / failed
+
+CREATE TABLE IF NOT EXISTS treasury_sweeps (
+  id                  BIGSERIAL PRIMARY KEY,
+  initiated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  outcome             TEXT        NOT NULL,
+  lender_balance_lamports_before BIGINT NOT NULL,
+  reserve_lamports    BIGINT      NOT NULL,
+  swept_lamports      BIGINT      NOT NULL DEFAULT 0,
+  destination_pubkey  TEXT        NOT NULL,
+  tx_signature        TEXT,
+  error_message       TEXT,
+  confirmed_at        TIMESTAMPTZ,
+  notes               TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_treasury_sweeps_initiated_at
+  ON treasury_sweeps (initiated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_treasury_sweeps_outcome_initiated
+  ON treasury_sweeps (outcome, initiated_at DESC);

--- a/src/commands/treasury-status.js
+++ b/src/commands/treasury-status.js
@@ -1,0 +1,79 @@
+/**
+ * /treasury-status — admin command. Reports live state of the
+ * treasury sweeper: env config, current balances on the lender wallet
+ * + treasury vault, last 10 sweep audit rows.
+ *
+ * Read-only. Safe to run any time.
+ */
+import { isAdmin } from "../services/admin.js";
+import { getTreasurySweeperStatus } from "../services/treasury-sweeper.js";
+
+function fmtSol(n) {
+  if (n == null) return "—";
+  return Number(n).toFixed(4);
+}
+
+function fmtAge(ms) {
+  if (ms == null) return "—";
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h ago`;
+  return `${Math.round(ms / 86_400_000)}d ago`;
+}
+
+export async function handleTreasuryStatus(ctx) {
+  if (!isAdmin(ctx.from?.id)) return ctx.reply("Not authorized.");
+
+  await ctx.reply("Reading treasury state…");
+
+  let s;
+  try {
+    s = await getTreasurySweeperStatus();
+  } catch (err) {
+    return ctx.reply(`Failed to read status: ${err.message?.slice(0, 200)}`);
+  }
+
+  const lines = [
+    `*Treasury sweeper status*`,
+    "",
+    `Disabled:           ${s.disabled ? "*YES* — kill switch active" : "no"}`,
+    `Interval:           ${s.interval_min} min`,
+    `Operational reserve: ${s.reserve_sol} SOL`,
+    `Min sweep size:      ${s.min_sol} SOL`,
+    `Consecutive fails:   ${s.consecutive_failures}`,
+    "",
+    `*Balances*`,
+    `Lender wallet:   ${fmtSol(s.lender_balance_sol)} SOL  (\`${s.lender_pubkey.slice(0, 8)}…\`)`,
+    `Treasury vault:  ${fmtSol(s.treasury_balance_sol)} SOL  (\`${s.treasury_vault_pubkey.slice(0, 8)}…\`)`,
+    "",
+    `*Recent sweep activity*`,
+  ];
+
+  if (!s.recent || s.recent.length === 0) {
+    lines.push("_No sweep activity recorded yet._");
+  } else {
+    for (const r of s.recent) {
+      const ageMs = Date.now() - new Date(r.initiated_at).getTime();
+      const sweptSol = Number(r.swept || 0) / 1e9;
+      const tag = {
+        success: "✓",
+        skip_below_min: "·",
+        skip_disabled: "·",
+        skip_locked: "·",
+        sim_reject: "✗",
+        send_error: "✗",
+      }[r.outcome] || "?";
+      const detail =
+        r.outcome === "success"
+          ? `${sweptSol.toFixed(4)} SOL → \`${(r.tx_signature || "").slice(0, 10)}…\``
+          : r.error_message
+            ? `_${r.error_message.slice(0, 100)}_`
+            : r.notes
+              ? `_${r.notes.slice(0, 100)}_`
+              : "";
+      lines.push(`${tag} ${fmtAge(ageMs).padEnd(10)} ${r.outcome.padEnd(15)} ${detail}`);
+    }
+  }
+
+  await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -193,6 +193,7 @@ import { startNeonSync } from "./services/neon-sync.js";
 import { registerTxErrorCallbacks } from "./services/tx-error-callbacks.js";
 import { startAiAgentHealth } from "./services/ai-agent-health.js";
 import { startAutoTicketResolver } from "./services/auto-ticket-resolver.js";
+import { startTreasurySweeper } from "./services/treasury-sweeper.js";
 import { startDormantReengagement, registerDormantCallbacks } from "./services/dormant-reengagement.js";
 import { startIdleSolNudge } from "./services/idle-sol-nudge.js";
 import { startWinbackAgent, registerWinbackCallbacks } from "./services/winback-agent.js";
@@ -293,6 +294,12 @@ bot.command(["admincmds", "adminlog"], handleAdminCmds);
   // tail + arm-attempt audit). Read-only diagnostic.
   const v4Status = await import("./commands/v4-status.js");
   bot.command(["v4-status", "v4status", "v4_status"], v4Status.handleV4Status);
+  // Treasury sweeper observability (operator-facing). Read-only.
+  const treasuryStatus = await import("./commands/treasury-status.js");
+  bot.command(
+    ["treasury-status", "treasurystatus", "treasury_status", "treasury"],
+    treasuryStatus.handleTreasuryStatus,
+  );
   const scanImp = await import("./commands/scan-impersonators.js");
   bot.command(
     ["scan-impersonators", "scanimpersonators", "scan_impersonators"],
@@ -1039,6 +1046,13 @@ bot.start({
     // autonomously instead of pinging admin. Critical-reason tickets
     // (security/bug) skipped — those go to admin as designed.
     setTimeout(() => startAutoTicketResolver(bot), 120_000);
+    // Treasury sweeper — periodically moves accumulated fees from the
+    // lender wallet to the hardware-key-controlled treasury vault so a
+    // compromise of the hot key bounds the lifetime-fee-drain loss to
+    // a single sweep window. Disabled until TREASURY_SWEEP_DISABLED
+    // is explicitly unset and an operational reserve is verified.
+    // See project_treasury_vault_2026_06_18.
+    setTimeout(() => startTreasurySweeper(bot), 130_000);
     // Dormant Re-Engagement — every 6h, nudges users who hold approved
     // collateral but have never borrowed. One DM per user per 30 days.
     setTimeout(() => startDormantReengagement(bot), 135_000);

--- a/src/services/treasury-sweeper.js
+++ b/src/services/treasury-sweeper.js
@@ -1,0 +1,440 @@
+/**
+ * Treasury sweeper.
+ *
+ * Periodically moves accumulated fees from the lender wallet (4JSSSa…)
+ * to the treasury vault (6foLvbG…) so a compromise of the hot lender
+ * key bounds the lifetime-fee-drain loss to one sweep window.
+ *
+ * Design constraints (operator-mandated 2026-06-18 PM):
+ *
+ *   1. World-class engineering standard — pre-flight simulate every tx
+ *      before broadcast. Refuse to send anything the RPC rejects in sim.
+ *
+ *   2. Never breakage to existing users — the lender wallet handles
+ *      cosign-borrow, attestations, admin instructions. We MUST leave a
+ *      generous operational reserve (default 5 SOL, env-tunable) so
+ *      none of those flows ever run dry.
+ *
+ *   3. Audit-trail everything — every tick writes a row to
+ *      treasury_sweeps. Outcomes covered: success, skip_below_min,
+ *      skip_disabled, skip_locked, sim_reject, send_error.
+ *
+ *   4. Operator kill switch — TREASURY_SWEEP_DISABLED=true halts the
+ *      sweeper instantly without a redeploy.
+ *
+ *   5. Idempotent / non-overlapping — at boot, hold an advisory lock
+ *      so multiple bot instances can't double-sweep. (Railway runs
+ *      single-instance today but defense in depth costs nothing.)
+ *
+ * Env knobs:
+ *
+ *   | Env                              | Default            | Notes |
+ *   |----------------------------------|--------------------|-------|
+ *   | TREASURY_SWEEP_DISABLED          | (unset, enabled)   | Kill switch |
+ *   | TREASURY_SWEEP_INTERVAL_MS       | 21600000 (6h)      | Tick cadence |
+ *   | TREASURY_SWEEP_FIRST_RUN_MS      | 300000 (5min)      | Delay after boot |
+ *   | TREASURY_SWEEP_RESERVE_SOL       | 5                  | Operational floor |
+ *   | TREASURY_SWEEP_MIN_SOL           | 0.1                | Min sweep size; skip below |
+ *   | TREASURY_SWEEP_DEST_PUBKEY       | 6foLvbG…           | Override only if you know why |
+ *   | TREASURY_SWEEP_CONSEC_FAIL_ALERT | 3                  | Alert operator after N failures |
+ *
+ * Refs:
+ *   - project_treasury_vault_2026_06_18 — the destination vault
+ *   - feedback_world_class_engineering_standard
+ *   - feedback_no_breakage_to_existing_users
+ */
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  Keypair,
+} from "@solana/web3.js";
+import fs from "node:fs";
+import path from "node:path";
+import { query } from "../db/pool.js";
+import { connection } from "../solana/connection.js";
+import { getAdminId } from "./admin-notify.js";
+
+// ─── Constants ────────────────────────────────────────────────────
+
+const TREASURY_VAULT_DEFAULT =
+  "6foLvbGkB3Joqrj9TZRhoFwEmkSW4AbyREoYWCaHqgVk";
+const LENDER_PUBKEY_DEFAULT =
+  "4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx";
+
+const LAMPORTS_PER_SOL = 1_000_000_000;
+
+const ADVISORY_LOCK_KEY = 73_002_606_180_618n; // arbitrary unique key
+
+// ─── Config ───────────────────────────────────────────────────────
+
+function envNumber(name, fallback) {
+  const v = process.env[name];
+  if (v == null || v === "") return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function isDisabled() {
+  // Default to DISABLED until operator explicitly enables. Ship-safe
+  // posture — the sweeper rolls out with the deploy but doesn't start
+  // moving funds until TREASURY_SWEEP_ENABLED is set to a truthy value.
+  // A defense-in-depth TREASURY_SWEEP_DISABLED still wins (kill switch
+  // even if ENABLED is also set).
+  const killV = (process.env.TREASURY_SWEEP_DISABLED || "").toLowerCase();
+  if (killV === "1" || killV === "true" || killV === "yes") return true;
+  const enableV = (process.env.TREASURY_SWEEP_ENABLED || "").toLowerCase();
+  const enabled = enableV === "1" || enableV === "true" || enableV === "yes";
+  return !enabled;
+}
+
+const INTERVAL_MS = envNumber("TREASURY_SWEEP_INTERVAL_MS", 6 * 60 * 60 * 1000);
+const FIRST_RUN_MS = envNumber("TREASURY_SWEEP_FIRST_RUN_MS", 5 * 60 * 1000);
+const RESERVE_SOL = envNumber("TREASURY_SWEEP_RESERVE_SOL", 5);
+const MIN_SOL = envNumber("TREASURY_SWEEP_MIN_SOL", 0.1);
+const CONSEC_FAIL_ALERT = envNumber("TREASURY_SWEEP_CONSEC_FAIL_ALERT", 3);
+
+let consecutiveFailures = 0;
+
+// ─── Lender keypair load ──────────────────────────────────────────
+
+let lenderKeypairCache = null;
+function loadLenderKeypair() {
+  if (lenderKeypairCache) return lenderKeypairCache;
+  // Prefer the env var pointing at the JSON file; fall back to local
+  // dev path. NEVER read the file path from a user-controlled source.
+  const candidatePaths = [
+    process.env.LENDER_KEYPAIR_PATH,
+    "lender-keypair.json",
+    "./lender-keypair.json",
+  ].filter(Boolean);
+  for (const p of candidatePaths) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(p, "utf8"));
+      const kp = Keypair.fromSecretKey(Uint8Array.from(raw));
+      lenderKeypairCache = kp;
+      return kp;
+    } catch { /* try next */ }
+  }
+  throw new Error(
+    "treasury-sweeper: lender keypair file not found. Set LENDER_KEYPAIR_PATH or place lender-keypair.json in cwd.",
+  );
+}
+
+// ─── DB helpers ───────────────────────────────────────────────────
+
+async function recordSweep(row) {
+  try {
+    await query(
+      `INSERT INTO treasury_sweeps
+         (outcome, lender_balance_lamports_before, reserve_lamports,
+          swept_lamports, destination_pubkey, tx_signature, error_message,
+          confirmed_at, notes)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+      [
+        row.outcome,
+        String(row.lender_balance_lamports_before ?? 0),
+        String(row.reserve_lamports ?? 0),
+        String(row.swept_lamports ?? 0),
+        row.destination_pubkey,
+        row.tx_signature || null,
+        row.error_message || null,
+        row.confirmed_at || null,
+        row.notes || null,
+      ],
+    );
+  } catch (err) {
+    // Don't crash the sweeper if the audit insert fails — log loudly
+    console.error("[treasury-sweeper] audit insert failed:", err.message);
+  }
+}
+
+async function tryAdvisoryLock() {
+  try {
+    const { rows } = await query(
+      `SELECT pg_try_advisory_lock($1::bigint) AS got`,
+      [String(ADVISORY_LOCK_KEY)],
+    );
+    return rows[0]?.got === true;
+  } catch (err) {
+    console.warn("[treasury-sweeper] advisory lock query failed:", err.message);
+    return false;
+  }
+}
+
+async function releaseAdvisoryLock() {
+  try {
+    await query(`SELECT pg_advisory_unlock($1::bigint)`, [
+      String(ADVISORY_LOCK_KEY),
+    ]);
+  } catch { /* best-effort */ }
+}
+
+// ─── Alert ────────────────────────────────────────────────────────
+
+async function alertOperator(bot, text) {
+  try {
+    const adminId = getAdminId();
+    if (!adminId || !bot) return;
+    await bot.api.sendMessage(adminId, text, { parse_mode: "Markdown" });
+  } catch (err) {
+    console.warn("[treasury-sweeper] alert send failed:", err.message);
+  }
+}
+
+// ─── Tick ─────────────────────────────────────────────────────────
+
+async function tick(bot) {
+  if (isDisabled()) {
+    await recordSweep({
+      outcome: "skip_disabled",
+      lender_balance_lamports_before: 0,
+      reserve_lamports: 0,
+      swept_lamports: 0,
+      destination_pubkey: process.env.TREASURY_SWEEP_DEST_PUBKEY || TREASURY_VAULT_DEFAULT,
+      notes: "TREASURY_SWEEP_DISABLED env var set",
+    });
+    return;
+  }
+
+  const gotLock = await tryAdvisoryLock();
+  if (!gotLock) {
+    await recordSweep({
+      outcome: "skip_locked",
+      lender_balance_lamports_before: 0,
+      reserve_lamports: 0,
+      swept_lamports: 0,
+      destination_pubkey: process.env.TREASURY_SWEEP_DEST_PUBKEY || TREASURY_VAULT_DEFAULT,
+      notes: "advisory lock held by another instance",
+    });
+    return;
+  }
+
+  try {
+    await tickInner(bot);
+  } finally {
+    await releaseAdvisoryLock();
+  }
+}
+
+async function tickInner(bot) {
+  const lenderPk = new PublicKey(LENDER_PUBKEY_DEFAULT);
+  const destPk = new PublicKey(
+    process.env.TREASURY_SWEEP_DEST_PUBKEY || TREASURY_VAULT_DEFAULT,
+  );
+
+  // 1. Read balance
+  const lenderBal = await connection.getBalance(lenderPk, "confirmed");
+  const reserveLamports = Math.round(RESERVE_SOL * LAMPORTS_PER_SOL);
+  const minLamports = Math.round(MIN_SOL * LAMPORTS_PER_SOL);
+  const sweepable = lenderBal - reserveLamports;
+
+  // 2. Skip if below threshold
+  if (sweepable < minLamports) {
+    await recordSweep({
+      outcome: "skip_below_min",
+      lender_balance_lamports_before: lenderBal,
+      reserve_lamports: reserveLamports,
+      swept_lamports: 0,
+      destination_pubkey: destPk.toBase58(),
+      notes: `sweepable=${(sweepable / LAMPORTS_PER_SOL).toFixed(4)} SOL < min=${MIN_SOL} SOL`,
+    });
+    consecutiveFailures = 0; // clean state, not a failure
+    return;
+  }
+
+  // 3. Build transfer instruction
+  // Reserve ~5000 lamports of headroom for the tx fee on top of the
+  // operational reserve — we don't want to leave the wallet with
+  // exactly RESERVE and then need a few thousand lamports to actually
+  // send this tx.
+  const TX_FEE_HEADROOM = 5000;
+  const sweepAmount = sweepable - TX_FEE_HEADROOM;
+  if (sweepAmount <= 0) {
+    await recordSweep({
+      outcome: "skip_below_min",
+      lender_balance_lamports_before: lenderBal,
+      reserve_lamports: reserveLamports,
+      swept_lamports: 0,
+      destination_pubkey: destPk.toBase58(),
+      notes: "sweepable after tx-fee headroom is <= 0",
+    });
+    return;
+  }
+
+  const lenderKp = loadLenderKeypair();
+  if (!lenderKp.publicKey.equals(lenderPk)) {
+    const msg = `lender keypair pubkey ${lenderKp.publicKey.toBase58()} does not match expected ${LENDER_PUBKEY_DEFAULT}`;
+    await recordSweep({
+      outcome: "sim_reject",
+      lender_balance_lamports_before: lenderBal,
+      reserve_lamports: reserveLamports,
+      swept_lamports: 0,
+      destination_pubkey: destPk.toBase58(),
+      error_message: msg,
+    });
+    consecutiveFailures++;
+    await maybeAlertConsecutive(bot, msg);
+    return;
+  }
+
+  const ix = SystemProgram.transfer({
+    fromPubkey: lenderPk,
+    toPubkey: destPk,
+    lamports: sweepAmount,
+  });
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  const tx = new Transaction({
+    feePayer: lenderPk,
+    blockhash,
+    lastValidBlockHeight,
+  });
+  tx.add(ix);
+  tx.sign(lenderKp);
+
+  // 4. Pre-flight simulate
+  const sim = await connection.simulateTransaction(tx);
+  if (sim.value.err) {
+    const errStr = JSON.stringify(sim.value.err);
+    await recordSweep({
+      outcome: "sim_reject",
+      lender_balance_lamports_before: lenderBal,
+      reserve_lamports: reserveLamports,
+      swept_lamports: 0,
+      destination_pubkey: destPk.toBase58(),
+      error_message: `simulate err: ${errStr}`,
+      notes: (sim.value.logs || []).slice(-5).join(" | ").slice(0, 500),
+    });
+    consecutiveFailures++;
+    await maybeAlertConsecutive(bot, `Sweep sim rejected: ${errStr}`);
+    return;
+  }
+
+  // 5. Broadcast
+  let sig;
+  try {
+    sig = await connection.sendRawTransaction(tx.serialize(), {
+      skipPreflight: false,
+      preflightCommitment: "confirmed",
+    });
+  } catch (err) {
+    await recordSweep({
+      outcome: "send_error",
+      lender_balance_lamports_before: lenderBal,
+      reserve_lamports: reserveLamports,
+      swept_lamports: 0,
+      destination_pubkey: destPk.toBase58(),
+      error_message: err.message?.slice(0, 200),
+    });
+    consecutiveFailures++;
+    await maybeAlertConsecutive(bot, `Sweep send failed: ${err.message?.slice(0, 120)}`);
+    return;
+  }
+
+  // 6. Confirm
+  try {
+    await connection.confirmTransaction(
+      { signature: sig, blockhash, lastValidBlockHeight },
+      "confirmed",
+    );
+  } catch (err) {
+    await recordSweep({
+      outcome: "send_error",
+      lender_balance_lamports_before: lenderBal,
+      reserve_lamports: reserveLamports,
+      swept_lamports: 0,
+      destination_pubkey: destPk.toBase58(),
+      tx_signature: sig,
+      error_message: `confirm timeout: ${err.message?.slice(0, 120)}`,
+    });
+    consecutiveFailures++;
+    await maybeAlertConsecutive(bot, `Sweep confirm timeout: ${sig}`);
+    return;
+  }
+
+  // 7. Success
+  consecutiveFailures = 0;
+  await recordSweep({
+    outcome: "success",
+    lender_balance_lamports_before: lenderBal,
+    reserve_lamports: reserveLamports,
+    swept_lamports: sweepAmount,
+    destination_pubkey: destPk.toBase58(),
+    tx_signature: sig,
+    confirmed_at: new Date(),
+  });
+  console.log(
+    `[treasury-sweeper] swept ${(sweepAmount / LAMPORTS_PER_SOL).toFixed(4)} SOL to ${destPk.toBase58()} (sig: ${sig.slice(0, 10)}…)`,
+  );
+}
+
+async function maybeAlertConsecutive(bot, errMsg) {
+  if (consecutiveFailures < CONSEC_FAIL_ALERT) return;
+  // Reset so we don't spam — operator gets one alert per threshold crossing.
+  consecutiveFailures = 0;
+  await alertOperator(
+    bot,
+    `*Treasury sweeper failing*\n\n` +
+      `Last error: \`${errMsg.slice(0, 200)}\`\n\n` +
+      `Set \`TREASURY_SWEEP_DISABLED=true\` on Railway to halt, or check the \`treasury_sweeps\` audit table for context.`,
+  );
+}
+
+// ─── Start ────────────────────────────────────────────────────────
+
+export function startTreasurySweeper(bot) {
+  if (isDisabled()) {
+    console.log("[treasury-sweeper] disabled via TREASURY_SWEEP_DISABLED — not starting");
+    return null;
+  }
+  console.log(
+    `[treasury-sweeper] starting (interval=${INTERVAL_MS / 60_000}min, first run in ${FIRST_RUN_MS / 60_000}min, reserve=${RESERVE_SOL} SOL, min=${MIN_SOL} SOL)`,
+  );
+  setTimeout(() => {
+    tick(bot).catch((err) => {
+      console.error("[treasury-sweeper] first tick threw:", err.message);
+    });
+  }, FIRST_RUN_MS);
+  return setInterval(() => {
+    tick(bot).catch((err) => {
+      console.error("[treasury-sweeper] tick threw:", err.message);
+    });
+  }, INTERVAL_MS);
+}
+
+// ─── Status helpers (for admin commands) ──────────────────────────
+
+export async function getTreasurySweeperStatus() {
+  const lenderPk = new PublicKey(LENDER_PUBKEY_DEFAULT);
+  const destPk = new PublicKey(
+    process.env.TREASURY_SWEEP_DEST_PUBKEY || TREASURY_VAULT_DEFAULT,
+  );
+  const [lenderBal, treasuryBal, recent] = await Promise.all([
+    connection.getBalance(lenderPk, "confirmed").catch(() => null),
+    connection.getBalance(destPk, "confirmed").catch(() => null),
+    query(
+      `SELECT id, outcome, initiated_at,
+              lender_balance_lamports_before::text AS bal_before,
+              swept_lamports::text AS swept,
+              tx_signature, error_message, notes
+         FROM treasury_sweeps
+        ORDER BY initiated_at DESC LIMIT 10`,
+    ).catch(() => ({ rows: [] })),
+  ]);
+  return {
+    disabled: isDisabled(),
+    interval_min: INTERVAL_MS / 60_000,
+    reserve_sol: RESERVE_SOL,
+    min_sol: MIN_SOL,
+    lender_pubkey: lenderPk.toBase58(),
+    lender_balance_sol:
+      lenderBal == null ? null : lenderBal / LAMPORTS_PER_SOL,
+    treasury_vault_pubkey: destPk.toBase58(),
+    treasury_balance_sol:
+      treasuryBal == null ? null : treasuryBal / LAMPORTS_PER_SOL,
+    consecutive_failures: consecutiveFailures,
+    recent: recent.rows,
+  };
+}

--- a/src/services/treasury-sweeper.js
+++ b/src/services/treasury-sweeper.js
@@ -51,7 +51,7 @@ import {
   Keypair,
 } from "@solana/web3.js";
 import fs from "node:fs";
-import path from "node:path";
+import bs58 from "bs58";
 import { query } from "../db/pool.js";
 import { connection } from "../solana/connection.js";
 import { getAdminId } from "./admin-notify.js";
@@ -102,24 +102,27 @@ let consecutiveFailures = 0;
 let lenderKeypairCache = null;
 function loadLenderKeypair() {
   if (lenderKeypairCache) return lenderKeypairCache;
-  // Prefer the env var pointing at the JSON file; fall back to local
-  // dev path. NEVER read the file path from a user-controlled source.
-  const candidatePaths = [
-    process.env.LENDER_KEYPAIR_PATH,
-    "lender-keypair.json",
-    "./lender-keypair.json",
-  ].filter(Boolean);
-  for (const p of candidatePaths) {
-    try {
-      const raw = JSON.parse(fs.readFileSync(p, "utf8"));
-      const kp = Keypair.fromSecretKey(Uint8Array.from(raw));
-      lenderKeypairCache = kp;
-      return kp;
-    } catch { /* try next */ }
+  // Match the loader pattern used by src/services/price-attestor.js:
+  // prefer the env-var-encoded private key (production / Railway has
+  // no on-disk keypair file), fall back to LENDER_KEYPAIR_PATH for
+  // local dev. EXPLICITLY refuses the CWD-relative fallback so an
+  // attacker who can plant a file in cwd can't trick the sweeper into
+  // using it.
+  const b58 = process.env.LENDER_PRIVATE_KEY;
+  if (b58) {
+    const decode = bs58.decode || (bs58.default && bs58.default.decode);
+    lenderKeypairCache = Keypair.fromSecretKey(decode(b58));
+    return lenderKeypairCache;
   }
-  throw new Error(
-    "treasury-sweeper: lender keypair file not found. Set LENDER_KEYPAIR_PATH or place lender-keypair.json in cwd.",
-  );
+  const kpPath = process.env.LENDER_KEYPAIR_PATH;
+  if (!kpPath) {
+    throw new Error(
+      "treasury-sweeper: LENDER_PRIVATE_KEY or LENDER_KEYPAIR_PATH must be set — refusing the CWD-relative fallback. Set the env var.",
+    );
+  }
+  const raw = JSON.parse(fs.readFileSync(kpPath, "utf-8"));
+  lenderKeypairCache = Keypair.fromSecretKey(new Uint8Array(raw));
+  return lenderKeypairCache;
 }
 
 // ─── DB helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Operator-mandated 2026-06-18 PM after the upgrade-authority migration. Bounds the lifetime-fee-drain blast radius on `4JSSSa…` to a single sweep window.

**SHIP-SAFE DEFAULT: DISABLED.** Operator must set `TREASURY_SWEEP_ENABLED=true` on Railway to start moving funds.

What ships:
- migration `074_treasury_sweeps` — audit ledger
- `src/services/treasury-sweeper.js` — sweeper service with pre-flight sim, advisory-lock dedupe, op alert on consec failures
- `src/commands/treasury-status.js` — admin `/treasury-status`
- `src/index.js` — boot wire-in (130s delay)

Flow per tick (default 6h):
1. Read lender balance
2. Compute sweepable = balance − RESERVE_SOL − tx-fee headroom
3. If sweepable < MIN_SOL → log `skip_below_min`, exit
4. Build transfer ix to `6foLvbG…` (treasury vault)
5. Pre-flight simulate; if err → log `sim_reject`, alert if consec ≥ 3
6. Broadcast; if RPC error → log `send_error`, alert
7. Confirm; if timeout → log `send_error` with sig, alert
8. Success → log `success` with sig + swept amount

Env knobs all default to safe values; see commit message for full table.

## Test plan

- Boot the bot with `TREASURY_SWEEP_ENABLED` unset → log line should say `disabled via TREASURY_SWEEP_DISABLED — not starting`; no migration issues; `/treasury-status` shows `Disabled: YES`
- Set `TREASURY_SWEEP_ENABLED=true` on Railway → next deploy, sweeper ticks every 6h; `/treasury-status` shows recent attempts
- Verify the lender wallet retains ≥ `TREASURY_SWEEP_RESERVE_SOL` (5 SOL default) at all times
- Verify a successful sweep tx lands on Solscan and the SOL appears at the treasury vault
- Verify audit table is populated

🤖 Generated with Claude Code