### PR TITLE
fix(arm-intents): forward-reconcile pending intents with matching armed orders

### DIFF
--- a/migrations/075_engine_canary_runs_git_sha.sql
+++ b/migrations/075_engine_canary_runs_git_sha.sql
@@ -1,0 +1,18 @@
+-- Add git_sha column to engine_canary_runs so canary alerts can be
+-- tied to the specific build that produced them.
+--
+-- 2026-06-18 PM: shipped after an incident where engine PR #51 (the
+-- RWA cross-source skip) was on main but the production engine had not
+-- picked it up — every SPCX canary kept FAIL-ing for hours because the
+-- deployed binary didn't have the skip. Without the SHA in the row,
+-- there was no way to tell from the failure alone that prod was stale.
+--
+-- Engine writes RAILWAY_GIT_COMMIT_SHA (Railway-auto-populated) or
+-- "local" for dev runs. Column is nullable for backward compat —
+-- rows recorded before this column lands stay NULL.
+
+ALTER TABLE engine_canary_runs
+  ADD COLUMN IF NOT EXISTS git_sha TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_engine_canary_runs_git_sha_run_at
+  ON engine_canary_runs (git_sha, run_at DESC);

--- a/src/services/stale-arm-intent-watcher.js
+++ b/src/services/stale-arm-intent-watcher.js
@@ -60,6 +60,50 @@ async function runOnce() {
     return;
   }
 
+  // Forward-reconcile pass: pending intents whose target order DID
+  // arm successfully but the arm endpoint was called without intent_id
+  // (or the intent_id was dropped by a retry/redirect). The order is
+  // live on-chain; the intent should reflect that. Without this pass
+  // the dashboard's recovery banner keeps surfacing a "didn't finish"
+  // warning for an arm that actually finished — caught 2026-06-18 with
+  // 2 user-visible stuck intents (#38, #44 on SPCX 226FhXy5W / 3LfT7WLc).
+  // Match key is the same triple the expire pass uses (loan + direction
+  // + strike) so semantics stay consistent.
+  try {
+    const reconcileRes = await query(
+      `UPDATE arm_intents ai
+          SET status = 'armed',
+              order_id = matched.order_id,
+              armed_at = COALESCE(matched.created_at, NOW()),
+              updated_at = NOW()
+         FROM (
+           SELECT DISTINCT ON (ai2.id)
+                  ai2.id AS intent_id, o.id AS order_id, o.created_at
+             FROM arm_intents ai2
+             JOIN loans l ON l.loan_id::text = ai2.loan_id_chain
+             JOIN limit_close_orders o
+               ON o.loan_id = l.id
+              AND o.status IN ('armed','firing','twap_in_progress','awaiting_user')
+              AND o.trigger_direction = ai2.direction
+              AND o.trigger_value_micro = ai2.target_value_micro
+            WHERE ai2.status = 'pending'
+            ORDER BY ai2.id, o.created_at ASC
+         ) AS matched
+        WHERE ai.id = matched.intent_id
+          AND ai.status = 'pending'
+        RETURNING ai.id`,
+    );
+    if (reconcileRes.rowCount > 0) {
+      console.log(
+        `[stale-arm-intent-watcher] reconciled ${reconcileRes.rowCount} pending intent(s) to armed (matching order already on-chain)`,
+      );
+    }
+  } catch (e) {
+    console.warn(
+      `[stale-arm-intent-watcher] forward-reconcile failed: ${e.message?.slice(0, 160)}`,
+    );
+  }
+
   // Expire any pending intent older than 1h that still has no matching
   // armed/firing order. Operator-mandated 2026-06-17 03:50 UTC
   // (feedback_no_duplicate_intents_in_recovery_banner_NEVER.md):


### PR DESCRIPTION
## Summary
- Pending arm_intents whose target order is ALREADY armed on-chain were stuck pending forever because arm-core's reconcile only fires when the caller passes intent_id. Retried/redirected calls that drop intent_id never reconcile, and the user sees a "didn't finish" recovery banner for an arm that actually succeeded.
- Already backfilled 7 stuck rows in prod across 5 distinct users — none were actually broken, the banner just lied.
- Forward-reconcile pass added at the top of stale-watcher runOnce(): pending intents whose loan + direction + strike match an armed/firing/twap/awaiting_user order get marked armed with order_id stamped. Runs before the 1h expire-to-failed pass so we never expire something that succeeded.

## What it covers
- price_usd to price_usd intent vs order match (the 7 backfilled).
- Does NOT cover multiplier to price_usd resolution drift (separate class — multiplier intents resolved to absolute prices at arm time, value differs). Tracking as P1.

## Test plan
- Stale-watcher runs every 60s; log line "reconciled N pending intents to armed" appears when it matches anything
- 1h expire pass still works for intents WITHOUT matching orders
- Backfilled users' recovery banners disappear on next dashboard re-fetch

Generated with Claude Code