### PR TITLE
docs(pip): audit status — "researching and vetting auditors"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -594,13 +594,11 @@ bot.catch(async (err) => {
       await ctx.api.sendMessage(
         ctx.chat.id,
         [
-          "⚠️ *Something unexpected happened*",
+          "*That didn't go through.*",
           "",
-          "We hit a snag handling that. The team has been logged.",
+          "Server-side hiccup — logged and routed to ops.",
           "",
-          "*What to do:*",
-          "• Try the command again",
-          "• Or /support → Chat with agent and describe what you were doing",
+          "Try the same command again. If it sticks, use /support to chat with a human.",
         ].join("\n"),
         { parse_mode: "Markdown" },
       );

--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -36,7 +36,7 @@ const ASK_PER_CHAT_HOURLY_MAX = Math.max(0, Number(process.env.PIP_ASK_PER_CHAT_
 const GROUP_SYSTEM_PROMPT = `You are *Pip* — Magpie Capital's AI agent — answering questions in the public @magpietalk community group on Telegram.
 
 # PERSONA
-You're warm, plainspoken, and a little nerdy about DeFi mechanics. You talk like a smart friend who knows the protocol inside-out, not like a corporate FAQ. You're proud of what Magpie does well (low historical liquidation rate verifiable at /stats, on-chain transparency, snappy UX) and honest about what it doesn't (no formal audit yet, custodial-by-design trade-offs). Real-talk over hype, every time.
+You're warm, plainspoken, and a little nerdy about DeFi mechanics. You talk like a smart friend who knows the protocol inside-out, not like a corporate FAQ. You're proud of what Magpie does well (low historical liquidation rate verifiable at /stats, on-chain transparency, snappy UX) and honest about what it doesn't (no formal audit shipped yet — team is researching and vetting auditors right now, see /audit for the current posture; custodial-by-design trade-offs). Real-talk over hype, every time.
 
 # SHAPE OF A GOOD ANSWER
 - 1–3 sentences for simple questions. Up to ~5 if the user is genuinely asking "how does X work" and needs the mechanics.
@@ -254,7 +254,7 @@ That's it. No further elaboration on the why is permitted (no examples, no speci
 
 **Exploit defenses (post 2026-06-07):** Borrows now run through a multi-layer gauntlet — $50k live pool-liquidity floor, off-chain TWAP (refuses borrows when spot is >15% above the trailing 30-min avg), cross-source price agreement (Jupiter ↔ DexScreener must be within 5%), per-token total exposure cap, imported-wallet cooldown (24h × 4 SOL), new-account cap, 60s rapid-fire cap, ban registry. If a user complains they were refused, the message they got tells them which gate; you can explain the gate's purpose in friendly terms. None of these are punitive — they exist to defeat pump-and-borrow oracle-manipulation attacks. A separate auto-detector watches every fresh loan and bans confirmed exploit patterns autonomously.
 
-**Audit status:** No formal third-party audit yet. Open-source compensates partially. Treat as you would any unaudited protocol.
+**Audit status:** No formal third-party audit shipped yet. The team is *actively researching and vetting auditors* — that's the current posture. No public timeline yet; the operator will announce when scope + firm are locked. Until then, what compensates is open source, short loan terms, low LTV caps, no admin override, and a verifiable sub-1% lifetime liquidation rate. Treat as you would any pre-audit protocol; full breakdown at /audit and /risk.
 
 # PUBLIC SLASH COMMANDS — point users at these whenever they map cleanly
 
@@ -277,10 +277,10 @@ If a question is suspicious (someone asking about giving up a seed phrase, sendi
 
 User: "wen audit"
 Bad: "Magpie has not yet undergone a formal audit at this time. The team is exploring options."
-Good: "No formal audit yet — being upfront about that. Run /audit for the honest version of what compensates in the meantime (open source, short terms, low LTV, low liquidation rate verifiable at /stats)."
+Good: "No formal audit shipped yet — team is *researching and vetting auditors* right now. No public timeline yet; operator will announce when scope + firm are locked. Run /audit for the current posture and what compensates in the meantime (open source, short terms, low LTV, sub-1% liquidation rate verifiable at /stats)."
 
 User: "is it safe to lend my SOL"
-Good: "Pretty solid track record — zero LP losses to date, fees flowing back to LPs at ~X% APR. But it's not zero-risk: in a flash crash liquidations can lag, and we're not formally audited yet. Run /risk for the full breakdown so you can size your deposit deliberately."
+Good: "Pretty solid track record — zero LP losses to date, fees flowing back to LPs at ~X% APR. But it's not zero-risk: in a flash crash liquidations can lag, and a formal audit hasn't shipped yet (team is researching and vetting auditors). Run /risk for the full breakdown so you can size your deposit deliberately."
 
 User: "how do I borrow"
 Good: "Hop into @magpie\\_capital\\_bot, run /borrow, pick your collateral + tier. Three tiers — see /tiers for the trade-offs. Whole flow takes ~30 seconds."

--- a/src/services/community-public-cmds.js
+++ b/src/services/community-public-cmds.js
@@ -776,9 +776,9 @@ export async function handleCommunityAudit(ctx) {
   // and the community will eventually find out. Instead: explain
   // what compensates for the missing audit + what's planned.
   const text = [
-    `🔍 *Audit status — honest answer*`,
+    `*Audit status — honest answer*`,
     ``,
-    `Magpie has *not* yet undergone a formal third-party audit. The community deserves transparency on this rather than a misleading "audited" claim.`,
+    `Magpie has *not* yet shipped a formal third-party audit. The team is *actively researching and vetting auditors* right now — that's the current posture. No public timeline yet; the operator will announce when scope + firm are locked.`,
     ``,
     `*What compensates in the meantime*`,
     `• *Open source* — both repos are public (github.com/magpiecapital). Every line is readable and forkable.`,
@@ -788,7 +788,7 @@ export async function handleCommunityAudit(ctx) {
     `• *No admin override* — there's no privileged key that can drain user collateral.`,
     `• *Bug bounty* — see /security to report findings.`,
     ``,
-    `Treat Magpie as you would any unaudited protocol: deposit only what you can afford to lose, and verify everything on-chain.`,
+    `Treat Magpie as you would any pre-audit protocol: deposit only what you can afford to lose, and verify everything on-chain.`,
   ].join("\n");
   await ctx.reply(text, {
     parse_mode: "Markdown",
@@ -819,7 +819,7 @@ export async function handleCommunityRisk(ctx) {
     `In a flash crash, a token can move faster than liquidators. The keeper network is designed for this, but in extreme markets LPs can see partial losses. Tier LTVs are set conservatively to bound this.`,
     ``,
     `*3. Smart-contract risk*`,
-    `Magpie is *not yet formally audited* (see /audit). Source is open. A bug anywhere in the program could result in loss of funds.`,
+    `A formal third-party audit hasn't shipped yet — team is *researching and vetting auditors* (see /audit for the current posture). Source is open. Until an audit lands, a bug anywhere in the program could result in loss of funds.`,
     ``,
     `*4. Custodial risk*`,
     `Your Magpie wallet IS the bot wallet — that's what enables one-click co-signing. Keys are AES-256-GCM encrypted, but a compromise of the infrastructure would expose them. /export your private key and self-custody if you'd prefer that trade-off.`,


### PR DESCRIPTION
## Summary
Operator-mandated update to how Pip + /audit + /risk discuss audit status. After a community user got "no formal audit exists today" (which sounds resigned and under-states the team's actual posture), the canonical line everywhere becomes:

> "No formal third-party audit shipped yet — team is *actively researching and vetting auditors* right now. No public timeline yet; operator will announce when scope + firm are locked."

## Changes
- `community-pip.js`: Pip identity line + Audit status block + "wen audit" tone example + "is it safe to lend" tone example
- `community-public-cmds.js`: /audit canned text + /risk smart-contract section
- `index.js`: global bot.catch fallback — drops banned warning emoji + tighter copy

## What stays as-is
- Site /security page is already framed as "Internal Security Audit" (accurate) — no change

## Test plan
- /audit in TG shows new wording
- /risk in TG shows new smart-contract section
- Pip replies in @magpietalk use new language
- Bot uncaught-error fallback no longer emits emoji

Generated with Claude Code