### PR TITLE
fix(credit-events): tighten healer cadence 6h→1h + drop alert crit threshold 10→3

### DIFF
--- a/src/services/credit-events-healer.js
+++ b/src/services/credit-events-healer.js
@@ -20,12 +20,14 @@
  *   - Operator-stated mandate: "make sure we have parameters in place
  *     for this to NEVER happen again." This is the parameter.
  *
- * Cadence: every 6 hours. Audit query is two LEFT JOINs over loans +
- * credit_events; both tables are indexed. Cheap.
+ * Cadence: every 1 hour (tightened from 6h on 2026-06-18 PM per
+ * operator request — once-a-shift was too slow when the self-monitor
+ * already surfaces the gap proactively, and the audit query is cheap
+ * enough to run hourly without measurable cost).
  *
- * Self-monitor probe (in self-monitor.js) reads the same query at every
- * 60s tick and DMs the operator if gap > 0, so the operator finds out
- * within a minute rather than waiting for the healer's 6h cadence.
+ * Self-monitor probe (in self-monitor.js) reads the same query every
+ * tick and DMs the operator if gap > 0, so the operator finds out
+ * within a minute rather than waiting for the healer's cadence.
  *
  * Security:
  *   - Read-only audit query + INSERT into credit_events + UPDATE on
@@ -36,7 +38,7 @@
  */
 import { query } from "../db/pool.js";
 
-const TICK_MS = 6 * 60 * 60_000; // 6h
+const TICK_MS = 60 * 60_000; // 1h (tightened 2026-06-18 PM)
 
 let _timer = null;
 

--- a/src/services/self-monitor.js
+++ b/src/services/self-monitor.js
@@ -459,8 +459,9 @@ async function probeCreditCoverage(bot) {
     if (audit.missing_repay > 0) parts.push(`${audit.missing_repay} repay`);
     if (audit.missing_liquidated > 0) parts.push(`${audit.missing_liquidated} liquidated`);
     await alertIfNew(bot, KIND,
-      `Credit-event coverage gap: ${audit.total} loan(s) missing canonical events (${parts.join(", ")}). Healer auto-backfills within 6h; investigate the WRITE path if this persists.`,
-      audit.total >= 10 ? "crit" : "warn",
+      `Credit-event coverage gap: ${audit.total} loan(s) missing canonical events (${parts.join(", ")}). Healer auto-backfills within 1h. ` +
+      `If the same loan persists across two self-monitor ticks, the live WRITE path dropped — investigate before the healer hides it.`,
+      audit.total >= 3 ? "crit" : "warn",
     );
   } else {
     await alertRecovery(bot, KIND, `Credit-event coverage clean (0 gaps).`);


### PR DESCRIPTION
## Summary
Operator green-lit SLA tighten 2026-06-18 PM after self-monitor flagged a transient 1-loan repay-event gap that the healer cleaned up. On the old 6h cadence the audit row could stay visible to the operator for up to 6 hours before being cleared, AND the crit threshold of 10 was too loose to escalate small-but-persistent write-path bugs.

## Changes
- credit-events-healer.js: TICK_MS 6h → 1h. Audit query is two cheap LEFT JOINs over loans + credit_events; both indexed. Hourly runs add negligible load.
- self-monitor.js: probe alert escalates to crit at >= 3 loans (was >= 10). Updated copy to reflect 1h healer cadence + a diagnostic hint that any same-loan repeat across two probe ticks points at a broken WRITE path.

## Behavior
- Transient race (loan repaid, credit_event INSERT lagged a few seconds): self-monitor still fires WARN once. Healer cleans within 1h. Self-monitor goes green on the next tick.
- Genuine write-path break: gap accumulates past 3 loans within an hour → crit. Operator gets paged immediately rather than waiting for the warn floor.

## Test plan
- Watch self-monitor next tick — should fire WARN if any loan is missing canonical events, with the new copy mentioning 1h cadence.
- Verify healer logs the new 1h sweep cadence on startup ("[credit-healer] armed — sweeping every 1h").

Generated with Claude Code