### PR TITLE
feat(reliability+security): V4 TWAP JIT warmer + lender-wallet drain monitor

### DIFF
--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -848,6 +848,40 @@ export function registerBorrowCallbacks(bot) {
     const feedAge = await getPriceFeedAgeSeconds(state.selected.mint, attestProgramId);
     const needsAttest = feedAge === null || feedAge > FRESH_THRESHOLD_SEC;
 
+    // V4 TWAP warming gate (operator-mandated 2026-06-18 PM, see
+    // [[feedback_twap_insufficient_history_never_again]]). If this borrow
+    // routes to V4, the on-chain TWAP check needs >= 8 samples in 300s;
+    // a single attest below doesn't get us there from a cold start. Loop
+    // until the PriceHistory PDA has the count it needs, or surface a
+    // clean "feed warming" prompt to the user with state preserved.
+    {
+      const { PROGRAM_ID_V4 } = await import("../solana/program.js");
+      const isV4Borrow = !!(PROGRAM_ID_V4 && attestProgramId && attestProgramId.equals(PROGRAM_ID_V4));
+      if (isV4Borrow) {
+        const { ensureV4TwapReady } = await import("../services/price-attestor.js");
+        const warm = await ensureV4TwapReady(state.selected.mint, state.selected.decimals);
+        if (!warm.ok) {
+          // Preserve state so the user just taps Retry — no need to
+          // re-pick collateral/tier/exits.
+          pending.set(ctx.chat.id, state);
+          const kb = new InlineKeyboard()
+            .text("Retry borrow", "borrow:retry_submit").row()
+            .text("Cancel", "borrow:cancel");
+          await say(
+            `*Price oracle is warming up for ${state.selected.symbol}.*\n\n` +
+            `V4 needs ${warm.inWindow}/8 samples within the rolling 5-min window. ` +
+            `It usually finishes in 30–45 seconds. Your collateral + tier + exits are saved — tap to retry.`,
+            { parse_mode: "Markdown", reply_markup: kb },
+          );
+          return;
+        }
+        // V4 path also writes a fresh sample as side effect of
+        // ensureV4TwapReady, so the freshness check below would no-op.
+        // Fall through anyway — the single-shot attest path stays
+        // available for V1/V3 callers and is cheap when feed is fresh.
+      }
+    }
+
     if (needsAttest) {
       try {
         await attestPrice(state.selected.mint, state.selected.decimals, undefined, attestProgramId);

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -119,6 +119,160 @@ export async function getPriceFeedAgeSeconds(mintStr, programIdOverride = null) 
 }
 
 /**
+ * Read the V4/V3 PriceHistory PDA and return how many samples sit within
+ * `windowSec` of `now`, plus diagnostic counters.
+ *
+ * Background: the V4 program's TWAP check requires
+ *   MIN_SAMPLES_FOR_TWAP=8 within MIN_HISTORY_SECONDS=300
+ * so a borrow that lands while the window is still warming hits
+ * `TwapInsufficientHistory` (Anchor error 6016 / 0x1780). Cosign-borrow
+ * uses this function to know if it needs to JIT-warm the feed BEFORE
+ * returning the cosigned tx to the user — see ensureV4TwapReady below.
+ *
+ * Returns null if the PDA doesn't exist OR isn't a PriceHistory layout
+ * (so callers can distinguish "needs init" from "needs warming").
+ *
+ * Layout reference (from priceFeedAgeSeconds above):
+ *   offset 104 → head_index (u8) — next-write slot
+ *   offset 105 → count (u8) — total samples ever written (0–32)
+ *   offset 112 → samples[32] × 16 bytes (price u64 + timestamp i64)
+ *
+ * IMPORTANT: `count` is the cumulative population, not the in-window
+ * population. Once the buffer fills (count=32) every fresh tick rolls
+ * the head and overwrites the oldest sample. So we ALWAYS iterate every
+ * populated slot and count by timestamp rather than trusting `count`.
+ */
+export async function getV4TwapSampleCount(mintStr, windowSec = 300) {
+  try {
+    const { PROGRAM_ID_V4 } = await import("../solana/program.js");
+    if (!PROGRAM_ID_V4) return null;
+    const mintPk = new PublicKey(mintStr);
+    const [pool] = lendingPoolPda(LENDER_PUBKEY, PROGRAM_ID_V4);
+    const [priceFeed] = priceFeedPda(mintPk, pool, PROGRAM_ID_V4);
+    const info = await connection.getAccountInfo(priceFeed);
+    if (!info || info.data.length < 120) return null;
+    const totalCount = info.data.readUInt8(105);
+    const SAMPLES_OFFSET = 112;
+    const STRIDE = 16; // price(8) + timestamp(8)
+    const SLOTS = 32;
+    const slotsPopulated = Math.min(totalCount, SLOTS);
+    const nowSec = Math.floor(Date.now() / 1000);
+    const cutoff = nowSec - windowSec;
+    let inWindow = 0;
+    let newestTs = -Infinity;
+    let oldestInWindowTs = Infinity;
+    for (let i = 0; i < slotsPopulated; i++) {
+      const tsStart = SAMPLES_OFFSET + i * STRIDE + 8;
+      const ts = Number(info.data.readBigInt64LE(tsStart));
+      if (ts > newestTs) newestTs = ts;
+      if (ts >= cutoff) {
+        inWindow++;
+        if (ts < oldestInWindowTs) oldestInWindowTs = ts;
+      }
+    }
+    return {
+      inWindow,
+      totalCount,
+      slotsPopulated,
+      newestTs: newestTs === -Infinity ? null : newestTs,
+      oldestInWindowTs: oldestInWindowTs === Infinity ? null : oldestInWindowTs,
+      windowSec,
+    };
+  } catch (err) {
+    console.warn(`[getV4TwapSampleCount] ${mintStr.slice(0, 8)}: ${err.message?.slice(0, 100)}`);
+    return null;
+  }
+}
+
+/**
+ * Synchronously warm the V4 PriceHistory PDA so a borrow lands without
+ * hitting `TwapInsufficientHistory`. Returns:
+ *   { ok: true,  inWindow, waitedMs, attests }   on success
+ *   { ok: false, inWindow, waitedMs, attests, reason } on timeout/error
+ *
+ * The caller (cosign-borrow.js, commands/borrow.js) MUST treat
+ * `ok === false` as a soft 503 — return a clean "feed warming, retry in
+ * N seconds" message to the user, NEVER let the chain reject.
+ *
+ * Operator-mandated 2026-06-18 PM after the
+ * `only_0_samples_in_window_need_8` borrow failure. See
+ * [[feedback_twap_insufficient_history_never_again]].
+ *
+ * Defaults are conservative — 45s max wait + 4s spacing → up to 11 attest
+ * attempts which is more than the 8 we need even if 2-3 confirmations lag.
+ * For non-V4 callers this is a no-op (returns ok:true immediately).
+ */
+export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
+  const REQUIRED_IN_WINDOW = 8;
+  const WINDOW_SEC = 300;
+  const MAX_WAIT_MS = Number(opts.maxWaitMs ?? process.env.V4_TWAP_WARM_MAX_MS ?? 45_000);
+  const SPACING_MS = Number(opts.spacingMs ?? process.env.V4_TWAP_WARM_SPACING_MS ?? 4_000);
+  const START = Date.now();
+  let attests = 0;
+  let lastErr = null;
+
+  const { PROGRAM_ID_V4 } = await import("../solana/program.js");
+  if (!PROGRAM_ID_V4) {
+    // V4 not configured — nothing to warm. Treat as ok so V1/V3 callers
+    // can call this unconditionally without branching.
+    return { ok: true, inWindow: null, waitedMs: 0, attests: 0, reason: "v4_not_configured" };
+  }
+
+  while (Date.now() - START < MAX_WAIT_MS) {
+    let status = await getV4TwapSampleCount(mintStr, WINDOW_SEC);
+    if (status === null) {
+      // Feed PDA not initialized yet. Init then continue — the next
+      // iteration will see the empty PriceHistory and start filling it.
+      try {
+        await initializePriceFeed(mintStr, PROGRAM_ID_V4);
+      } catch (e) {
+        lastErr = `init failed: ${e.message?.slice(0, 100)}`;
+        // Don't hard-fail — maybe a race with the background attestor
+        // initialized it; sleep + retry.
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+      continue;
+    }
+    if (status.inWindow >= REQUIRED_IN_WINDOW) {
+      return {
+        ok: true,
+        inWindow: status.inWindow,
+        waitedMs: Date.now() - START,
+        attests,
+      };
+    }
+    // Need more samples — fire one attest and wait briefly so the
+    // tx finalizes (confirmed) before the next iteration measures.
+    try {
+      await attestPrice(mintStr, decimals, undefined, PROGRAM_ID_V4);
+      attests++;
+    } catch (e) {
+      lastErr = e.message?.slice(0, 100);
+      // If this fails because the feed PDA wasn't actually initialized,
+      // re-init and try again. AccountNotInitialized → 3012/0xbc4.
+      if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(lastErr)) {
+        try {
+          await initializePriceFeed(mintStr, PROGRAM_ID_V4);
+        } catch (e2) {
+          lastErr = `init-then-attest failed: ${e2.message?.slice(0, 80)}`;
+        }
+      }
+    }
+    await new Promise((r) => setTimeout(r, SPACING_MS));
+  }
+
+  // Timed out — return current state so caller can surface a good message.
+  const final = await getV4TwapSampleCount(mintStr, WINDOW_SEC);
+  return {
+    ok: false,
+    inWindow: final?.inWindow ?? 0,
+    waitedMs: Date.now() - START,
+    attests,
+    reason: lastErr || "timeout",
+  };
+}
+
+/**
  * Initialize a price feed PDA for a given mint. Idempotent — returns
  * { alreadyExists: true } if the PDA is already on chain.
  *

--- a/src/services/self-monitor.js
+++ b/src/services/self-monitor.js
@@ -468,6 +468,198 @@ async function probeCreditCoverage(bot) {
   }
 }
 
+/**
+ * V4 TWAP sample-count health. Every enabled V4 mint must have
+ * >= 8 samples within the rolling 5-min window — otherwise a borrow
+ * lands on `TwapInsufficientHistory`. Background attestor SHOULD keep
+ * this satisfied at the 35s cadence shipped in PR #348, but this probe
+ * is the trip-wire if the attestor stalls (RPC blip, Jupiter outage,
+ * service restart) or a freshly-enabled mint hasn't warmed yet.
+ *
+ * Operator-mandated 2026-06-18 PM after a "0 samples in window" borrow
+ * rejection. See [[feedback_twap_insufficient_history_never_again]] for
+ * the full defense; this is Layer 3 (Layer 1 is the cosign-borrow JIT
+ * warmer that catches it before the user signs anything).
+ */
+async function probeV4TwapHealth(bot) {
+  const KIND = "v4_twap_health";
+  if (!process.env.PROGRAM_ID_V4) {
+    recordOutcome(KIND, false);
+    return;
+  }
+  try {
+    const { getV4TwapSampleCount } = await import("./price-attestor.js");
+    // Look at enabled mints — those are the ones users can borrow on.
+    // Skip non-V4 categories (e.g. tokens that route purely to V1/V3).
+    // We probe ALL enabled mints because exit-armed loans on memecoins
+    // also use V4 regardless of category.
+    const { rows } = await query(
+      `SELECT mint, symbol, decimals FROM supported_mints
+        WHERE enabled = TRUE
+        ORDER BY symbol`,
+    );
+    const REQUIRED = 8;
+    const GAP_TOLERANCE_SEC = 60; // freshly-enabled mints get 60s grace
+    const warming = [];
+    const cold = [];
+    for (const m of rows) {
+      const status = await getV4TwapSampleCount(m.mint, 300);
+      if (status === null) {
+        cold.push(`${m.symbol}(no feed)`);
+        continue;
+      }
+      if (status.inWindow >= REQUIRED) continue;
+      // Newest timestamp tells us if the attestor is moving on this
+      // mint at all. If newest is fresh (< 60s ago), it's warming —
+      // tolerable. If newest is stale, attestor is BROKEN for this mint.
+      const now = Math.floor(Date.now() / 1000);
+      const ageSec = status.newestTs ? now - status.newestTs : Infinity;
+      if (ageSec > GAP_TOLERANCE_SEC) {
+        cold.push(`${m.symbol}(${status.inWindow}/8, last attest ${Math.round(ageSec)}s ago)`);
+      } else {
+        warming.push(`${m.symbol}(${status.inWindow}/8)`);
+      }
+    }
+    const isBad = cold.length > 0;
+    recordOutcome(KIND, isBad);
+    if (isBad) {
+      await alertIfNew(bot, KIND,
+        `V4 TWAP health: ${cold.length} mint(s) cold (attestor stalled OR not running for them): ${cold.slice(0, 8).join(", ")}` +
+        (warming.length > 0 ? `. Warming but tolerable: ${warming.slice(0, 5).join(", ")}` : "") +
+        `. Cosign-borrow JIT warmer is Layer 1, but if it's tripping for users RIGHT NOW, investigate attestor logs.`,
+        cold.length >= 3 ? "crit" : "warn",
+      );
+    } else if (warming.length > 0) {
+      // Warming-only is not a fail — just log so /lc-perf can show it.
+      console.log(`[self-monitor] v4_twap warming: ${warming.join(", ")}`);
+    } else {
+      await alertRecovery(bot, KIND, `V4 TWAP health: all ${rows.length} enabled mint(s) have 8+ samples in window.`);
+    }
+  } catch (err) {
+    console.warn("[self-monitor] v4_twap_health probe threw:", err.message?.slice(0, 160));
+  }
+}
+
+/**
+ * Lender-wallet drain detector. Snapshots the lender wallet's SOL +
+ * every token balance (SPL + Token-2022) on each tick, compares to the
+ * previous snapshot, and CRIT-alerts on ANY decrease that isn't
+ * accounted for by an expected outflow.
+ *
+ * This is the Layer 4 defense for the 2026-06-18 cosign-borrow
+ * Token-2022 drain exploit (see
+ * [[feedback_cosign_borrow_token_drain_exploit_2026_06_18]]). Even if
+ * a future allowlisted program lets some new state-mutating
+ * instruction shape slip past the Gate 0b enumeration in
+ * cosign-borrow.js, this probe catches it within 60 seconds and pages
+ * the operator.
+ *
+ * Expected-outflow filter: legitimate decreases happen when
+ *   - treasury-sweeper moves SOL to the cold treasury vault
+ *   - the holder-rewards distributor pays $MAGPIE holders
+ *   - the lender voluntarily distributes liquidation proceeds
+ * For the MVP we DO NOT pre-filter these — over-alerting is FAR safer
+ * than missing a drain. Operator gets the tx signature in the alert
+ * and can mark expected ones as such. Follow-up will subtract a
+ * pre-registered allowlist of expected tx hashes.
+ */
+const lenderBalanceState = {
+  lastSolLamports: null,
+  lastTokenBalances: new Map(), // ata pubkey → { mint, owner, amount: bigint, decimals }
+  initialized: false,
+};
+async function probeLenderWalletBalance(bot) {
+  const KIND = "lender_wallet_balance_decrease";
+  let LENDER_PUBKEY;
+  try {
+    LENDER_PUBKEY = new PublicKey(process.env.LENDER_PUBKEY);
+  } catch {
+    return; // not configured
+  }
+  let solLamports;
+  let snapshot;
+  try {
+    solLamports = await connection.getBalance(LENDER_PUBKEY, "confirmed");
+    const [sslTokens, t22Tokens] = await Promise.all([
+      connection.getParsedTokenAccountsByOwner(
+        LENDER_PUBKEY,
+        { programId: new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA") },
+        "confirmed",
+      ),
+      connection.getParsedTokenAccountsByOwner(
+        LENDER_PUBKEY,
+        { programId: new PublicKey("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb") },
+        "confirmed",
+      ),
+    ]);
+    snapshot = new Map();
+    for (const accts of [sslTokens.value, t22Tokens.value]) {
+      for (const a of accts) {
+        const info = a.account.data.parsed.info;
+        const amt = BigInt(info.tokenAmount.amount);
+        if (amt === 0n) continue; // skip empty ATAs
+        snapshot.set(a.pubkey.toBase58(), {
+          mint: info.mint,
+          owner: info.owner,
+          amount: amt,
+          decimals: info.tokenAmount.decimals,
+        });
+      }
+    }
+  } catch (err) {
+    console.warn("[self-monitor] lender_wallet_balance probe RPC error:", err.message?.slice(0, 120));
+    return;
+  }
+
+  if (!lenderBalanceState.initialized) {
+    lenderBalanceState.lastSolLamports = solLamports;
+    lenderBalanceState.lastTokenBalances = snapshot;
+    lenderBalanceState.initialized = true;
+    return; // first run baselines, doesn't alert
+  }
+
+  const decreases = [];
+  // Threshold: ignore tiny SOL deltas that come from price-attestor tx
+  // fees (the lender pays ~5000 lamports per attest, ~70 per minute).
+  // 0.01 SOL is well above the per-hour fee budget but small enough to
+  // catch real drains.
+  const SOL_DECREASE_THRESHOLD_LAMPORTS = 10_000_000n; // 0.01 SOL
+  const solDelta = BigInt(lenderBalanceState.lastSolLamports) - BigInt(solLamports);
+  if (solDelta > SOL_DECREASE_THRESHOLD_LAMPORTS) {
+    decreases.push(`SOL: -${(Number(solDelta) / 1e9).toFixed(4)} SOL (was ${(lenderBalanceState.lastSolLamports / 1e9).toFixed(4)}, now ${(solLamports / 1e9).toFixed(4)})`);
+  }
+  for (const [ata, last] of lenderBalanceState.lastTokenBalances) {
+    const current = snapshot.get(ata);
+    if (!current) {
+      // ATA was closed — full balance vanished. Mint info from last snapshot.
+      decreases.push(`token ${last.mint.slice(0, 8)}… ATA ${ata.slice(0, 8)}… DRAINED+CLOSED (was ${Number(last.amount) / 10 ** last.decimals})`);
+      continue;
+    }
+    if (current.amount < last.amount) {
+      const delta = last.amount - current.amount;
+      decreases.push(
+        `token ${last.mint.slice(0, 8)}… ATA ${ata.slice(0, 8)}… -${Number(delta) / 10 ** last.decimals} (${Number(last.amount) / 10 ** last.decimals} → ${Number(current.amount) / 10 ** current.decimals})`,
+      );
+    }
+  }
+
+  const isBad = decreases.length > 0;
+  recordOutcome(KIND, isBad);
+  if (isBad) {
+    await alertIfNew(bot, KIND,
+      `LENDER WALLET BALANCE DECREASED — investigate immediately. Changes: ${decreases.join(" | ")}. ` +
+      `If you didn't initiate a sweep/distribution/sale in the last 60s, treat as a potential drain.`,
+      "crit",
+    );
+  } else {
+    await alertRecovery(bot, KIND, `Lender wallet balance stable across tick.`);
+  }
+
+  // Update baseline AFTER alerting so the next tick sees the new "stable" state.
+  lenderBalanceState.lastSolLamports = solLamports;
+  lenderBalanceState.lastTokenBalances = snapshot;
+}
+
 /* ─── Tick loop ──────────────────────────────────────────────── */
 
 let _timer = null;
@@ -484,6 +676,8 @@ async function tick(bot) {
       probeLoanProgramIdDrift(bot).catch((e) => console.warn("[self-monitor] program_drift probe threw:", e.message)),
       probeStaleSupport(bot).catch((e) => console.warn("[self-monitor] stale_support probe threw:", e.message)),
       probeCreditCoverage(bot).catch((e) => console.warn("[self-monitor] credit_coverage probe threw:", e.message)),
+      probeV4TwapHealth(bot).catch((e) => console.warn("[self-monitor] v4_twap_health probe threw:", e.message)),
+      probeLenderWalletBalance(bot).catch((e) => console.warn("[self-monitor] lender_wallet_balance probe threw:", e.message)),
     ]);
   } catch (err) {
     // Belt-and-suspenders catch — Promise.all shouldn't throw because


### PR DESCRIPTION
## Two defenses, one diff
Bundled because both touch self-monitor.js. Each is independent.

## Part 1 — V4 TwapInsufficientHistory: NEVER again
Operator-mandated 2026-06-18 PM after a custom-ladder borrow hit "only_0_samples_in_window_need_8". See feedback_twap_insufficient_history_never_again.md.

- **price-attestor.js**: new getV4TwapSampleCount + ensureV4TwapReady helpers. The ensure-helper loops attestPrice with 4s spacing until the V4 PriceHistory PDA has 8 fresh samples in the 300s window, or times out at 45s.
- **cosign-borrow.js**: V4 branch calls ensureV4TwapReady BEFORE partialSign. On timeout, returns 503 with oracle_warming=true.
- **commands/borrow.js**: same JIT call before the TG borrow tx is presented. State preserved on timeout.
- **self-monitor.js**: probeV4TwapHealth alerts crit if any enabled V4 mint has < 8 samples AND last-attest age > 60s.

## Part 2 — Lender-wallet drain detector (Layer 4 follow-up to PR #373)
Belt-and-suspenders for the cosign-borrow Token-2022 drain exploit patched in PR #373. Even if a future allowlisted program lets a new state-mutating instruction shape slip past Gate 0b, this probe catches the resulting balance decrease within 60 seconds.

- **self-monitor.js**: probeLenderWalletBalance snapshots SOL + every SPL/Token-2022 ATA balance on each tick. Compares to last snapshot. Crit-alerts on ANY decrease > 0.01 SOL or any token amount delta. First run baselines without alerting.

## Test plan
- Bot restarts cleanly with the new probes active
- probeV4TwapHealth logs warming-only state for any mint that has < 8 samples but a fresh last-attest (normal post-restart)
- probeLenderWalletBalance baselines silently on first tick, alerts on a manual sweep on tick 2

## Future
- Layer 2 (preflight balance-delta simulation) — separate PR
- Layer 5 (auto-sweep liquidation proceeds to SOL) — separate PR

Generated with Claude Code