### PR TITLE
feat(security): universal privileged-sign guard + destination allowlist + audit log

### DIFF
--- a/migrations/077_privileged_sign_audit.sql
+++ b/migrations/077_privileged_sign_audit.sql
@@ -1,0 +1,56 @@
+-- Privileged-keypair signing audit log.
+--
+-- Every service that signs a tx with a protocol-privileged keypair
+-- (LENDER_PRIVATE_KEY, ENGINE_AUTHORITY_V4_PRIVATE_KEY, etc.) writes a
+-- row here BEFORE broadcast and updates it AFTER confirmation. The row
+-- captures what the service expected to happen so a self-monitor probe
+-- can later sum-of-expected vs actual-on-chain and crit-alert on drift.
+--
+-- If a tx ever lands on-chain WITHOUT a matching audit row, that's the
+-- smoking gun for code injection or a leaked keypair — something signed
+-- outside our code paths.
+--
+-- Shipped 2026-06-18 PM as part of the post-cosign-borrow-exploit
+-- hardening pass. See
+-- feedback_cosign_borrow_token_drain_exploit_2026_06_18.md.
+
+CREATE TABLE IF NOT EXISTS privileged_sign_audit (
+  id BIGSERIAL PRIMARY KEY,
+  -- The bot-internal service that requested the sign
+  service TEXT NOT NULL,
+  -- The privileged keypair's public key (so a reader can scope to
+  -- "all lender activity" or "all engine-authority activity")
+  signer_pubkey TEXT NOT NULL,
+  -- Pre-state snapshot of the accounts the service expected to touch.
+  -- Keyed by pubkey string, value is { lamports, token?: { mint, amount } }.
+  pre_balances JSONB,
+  -- The service's declaration of which accounts may change and by how
+  -- much. Format: [{ pubkey, max_lamports_decrease?, max_token_decrease? }]
+  expected_deltas JSONB,
+  -- Filled in after simulation/broadcast/confirmation.
+  actual_deltas JSONB,
+  -- After successful broadcast, the tx signature.
+  tx_sig TEXT,
+  -- Lifecycle:
+  --   'pending'        — row created, sim not yet run
+  --   'sim_passed'     — sim cleared, about to broadcast
+  --   'sim_rejected'   — sim caught a balance-delta violation, refused to broadcast
+  --   'broadcast'      — sent to network, awaiting confirmation
+  --   'confirmed'      — confirmed on-chain
+  --   'failed'         — broadcast or confirmation errored
+  status TEXT NOT NULL DEFAULT 'pending',
+  error_text TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  broadcast_at TIMESTAMPTZ,
+  confirmed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_privileged_sign_audit_service_created
+  ON privileged_sign_audit (service, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_privileged_sign_audit_signer_created
+  ON privileged_sign_audit (signer_pubkey, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_privileged_sign_audit_tx_sig
+  ON privileged_sign_audit (tx_sig)
+  WHERE tx_sig IS NOT NULL;

--- a/src/services/privileged-destinations.js
+++ b/src/services/privileged-destinations.js
@@ -1,0 +1,114 @@
+/**
+ * Privileged-keypair destination allowlists.
+ *
+ * Every service that signs with a protocol-privileged keypair AND moves
+ * funds to a configurable destination MUST validate the destination
+ * against the allowlist below. The allowlist is hardcoded at the source
+ * level — an attacker who flips an env var on Railway can still only
+ * redirect to a pre-approved destination.
+ *
+ * Env var override is allowed only for testnet/dev scoped builds. In
+ * production, the env var value MUST be one of the source-level
+ * allowlist entries.
+ *
+ * To add a new destination:
+ *   1. Add the pubkey to the appropriate Set below
+ *   2. Document who controls the destination + why it's in the allowlist
+ *   3. Reference the project memory or PR that approved it
+ *
+ * Operator-mandated 2026-06-18 PM as part of the post-cosign-borrow-
+ * exploit hardening pass. See
+ * feedback_cosign_borrow_token_drain_exploit_2026_06_18.md.
+ */
+import { PublicKey } from "@solana/web3.js";
+
+// ─────────────────────────────────────────────────────────────────
+// treasury-sweeper
+//
+// The treasury-sweeper moves accumulated fees from the hot lender
+// wallet (4JSSSa…) to a cold-storage vault to bound the lifetime
+// drain a hot-key compromise could cause.
+//
+// Allowed destinations:
+//   6foLvbG… — Squads-controlled cold treasury vault deployed
+//                2026-06-18 PM. Multi-sig with the operator's hardware
+//                wallet + a 48h timelock + immutable config.
+//                Documented in project_treasury_vault_2026_06_18.
+// ─────────────────────────────────────────────────────────────────
+const TREASURY_SWEEPER_ALLOWED = new Set([
+  "6foLvbGkB3Joqrj9TZRhoFwEmkSW4AbyREoYWCaHqgVk",
+]);
+
+// ─────────────────────────────────────────────────────────────────
+// fee-wallet-sweeper
+//
+// The fee-wallet-sweeper drains the V4 program's protocol_fee_wallet
+// PDA into the rewards-distributor wallet so the holder/LP/protocol
+// share lands somewhere the snapshot distributors can read.
+//
+// Allowed destinations:
+//   CHCAMWtn… — REWARDS_DISTRIBUTOR_PUBKEY. The hot wallet the
+//                holder-rewards / LP-loyalty / referral payout services
+//                draw from at snapshot time. Documented in
+//                project_magpie.
+// ─────────────────────────────────────────────────────────────────
+const FEE_WALLET_SWEEPER_ALLOWED = new Set([
+  "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac",
+]);
+
+// ─────────────────────────────────────────────────────────────────
+// liquidation-distribution-watcher
+//
+// Moves distributed liquidation proceeds from the lender wallet to
+// the rewards-distributor wallet so the per-distribution shares are
+// available at snapshot time.
+//
+// Allowed destinations:
+//   CHCAMWtn… — same REWARDS_DISTRIBUTOR_PUBKEY as fee-wallet-sweeper.
+// ─────────────────────────────────────────────────────────────────
+const LIQUIDATION_DISTRIBUTION_ALLOWED = new Set([
+  "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac",
+]);
+
+const ALLOWLISTS = {
+  "treasury-sweeper": TREASURY_SWEEPER_ALLOWED,
+  "fee-wallet-sweeper": FEE_WALLET_SWEEPER_ALLOWED,
+  "liquidation-distribution-watcher": LIQUIDATION_DISTRIBUTION_ALLOWED,
+};
+
+/**
+ * Throws if `destinationPubkey` isn't on the allowlist for `service`.
+ * Call this BEFORE building the tx — fail fast.
+ *
+ * @param {string} service
+ * @param {PublicKey|string} destinationPubkey
+ */
+export function assertAllowedDestination(service, destinationPubkey) {
+  const list = ALLOWLISTS[service];
+  if (!list) {
+    throw new Error(
+      `[privileged-destinations] no allowlist configured for service '${service}'. Add one to privileged-destinations.js before signing.`,
+    );
+  }
+  const dest =
+    destinationPubkey instanceof PublicKey
+      ? destinationPubkey.toBase58()
+      : String(destinationPubkey);
+  if (!list.has(dest)) {
+    throw new Error(
+      `[privileged-destinations] destination ${dest} is NOT on the allowlist for service '${service}'. Allowed: ${Array.from(list).join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Returns the canonical (first) destination for a service. Useful when
+ * a service needs a default without env-var overriding.
+ */
+export function canonicalDestinationFor(service) {
+  const list = ALLOWLISTS[service];
+  if (!list || list.size === 0) {
+    throw new Error(`[privileged-destinations] no canonical destination for '${service}'`);
+  }
+  return new PublicKey([...list][0]);
+}

--- a/src/services/privileged-sign-guard.js
+++ b/src/services/privileged-sign-guard.js
@@ -1,0 +1,321 @@
+/**
+ * Privileged-keypair signing guard.
+ *
+ * The single shared utility every service must call before broadcasting
+ * a tx signed with a protocol-privileged keypair (LENDER_PRIVATE_KEY,
+ * ENGINE_AUTHORITY_V4_PRIVATE_KEY, etc.). Centralising this means:
+ *
+ *   1. Every signing path inherits the same Layer-2-style balance-delta
+ *      simulation that closed the 2026-06-18 cosign-borrow exploit class
+ *   2. Every privileged sign emits an audit row, so a self-monitor probe
+ *      can later sum-of-expected vs actual-on-chain and crit-alert on
+ *      drift (the smoking gun for a leaked keypair: a tx lands on-chain
+ *      without a matching audit row)
+ *   3. Sweepers can enforce destination allowlists at one consistent
+ *      seam instead of bespoke per-service code
+ *
+ * The shape every caller follows:
+ *
+ *   1. Build the tx
+ *   2. Call `runPrivilegedSign({ ... })` which:
+ *      a) writes an audit row in status='pending'
+ *      b) snapshots pre-state of the accounts you said you'd touch
+ *      c) signs the tx with the privileged keypair(s)
+ *      d) simulates and verifies no decrease beyond declared maxima
+ *      e) on success: marks the row sim_passed and returns the signed tx
+ *         (caller broadcasts via its own confirmation handling)
+ *      f) on sim violation: marks the row sim_rejected and throws
+ *   3. After broadcast, caller calls `recordPrivilegedSignResult({...})`
+ *      with the tx_sig and final status.
+ *
+ * Operator-mandated 2026-06-18 PM ("think of any other potential similar
+ * exploits and put together the same safeguards"). See
+ * feedback_cosign_borrow_token_drain_exploit_2026_06_18.md.
+ */
+import { PublicKey } from "@solana/web3.js";
+import { connection } from "../solana/connection.js";
+import { query } from "../db/pool.js";
+
+const TOKENKEG = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+const TOKEN2022 = new PublicKey("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+
+/**
+ * Run a privileged sign + simulate + audit-log cycle.
+ *
+ * @param {Object} args
+ * @param {string} args.service              — service name, e.g. "treasury-sweeper"
+ * @param {import('@solana/web3.js').Transaction|import('@solana/web3.js').VersionedTransaction} args.tx
+ * @param {Array<import('@solana/web3.js').Keypair>} args.signers  — privileged keypair(s)
+ * @param {Array<Object>} args.allowedDeltas — [{ pubkey, kind: 'sol'|'token',
+ *                                                 mint?, maxDecrease: bigint|number }]
+ *   - Any account whose balance decreases beyond `maxDecrease` causes
+ *     sim rejection.
+ *   - Accounts NOT in this list are checked too: if any of them is owned
+ *     by a signer (i.e., a privileged account) AND its balance would
+ *     decrease, that's also a rejection. This catches the cosign-borrow
+ *     exploit shape (untracked lender ATA drained as a side effect).
+ *
+ * @returns {Promise<{ auditId: number, signedTx, preBalances, simResult }>}
+ *
+ * @throws Error if the sim detects an unauthorized balance decrease, or
+ *               if any precondition check fails. The audit row is updated
+ *               to sim_rejected before throwing.
+ */
+export async function runPrivilegedSign({ service, tx, signers, allowedDeltas }) {
+  if (!service || typeof service !== "string") {
+    throw new Error("runPrivilegedSign: service name required");
+  }
+  if (!Array.isArray(signers) || signers.length === 0) {
+    throw new Error("runPrivilegedSign: at least one signer required");
+  }
+  const signerPubkeys = signers.map((s) => s.publicKey);
+  const signerPubkeyStrs = new Set(signerPubkeys.map((p) => p.toBase58()));
+
+  // 1. Audit row — pending. Stamp early so we have a paper trail even
+  //    if every subsequent step throws.
+  const expectedDeltasJson = JSON.stringify(
+    (allowedDeltas || []).map((d) => ({
+      pubkey: d.pubkey.toBase58 ? d.pubkey.toBase58() : String(d.pubkey),
+      kind: d.kind,
+      mint: d.mint ? (d.mint.toBase58 ? d.mint.toBase58() : String(d.mint)) : null,
+      max_decrease: typeof d.maxDecrease === "bigint"
+        ? d.maxDecrease.toString()
+        : String(d.maxDecrease ?? 0),
+    })),
+  );
+  const { rows: [auditRow] } = await query(
+    `INSERT INTO privileged_sign_audit (service, signer_pubkey, expected_deltas, status)
+     VALUES ($1, $2, $3::jsonb, 'pending')
+     RETURNING id`,
+    [service, signerPubkeys[0].toBase58(), expectedDeltasJson],
+  );
+  const auditId = auditRow.id;
+
+  // 2. Enumerate every account in the tx (legacy + versioned)
+  const accountKeys =
+    typeof tx.compileMessage === "function"
+      ? tx.compileMessage().accountKeys
+      : tx.message.staticAccountKeys;
+
+  // 3. Snapshot pre-state of every account in the tx — we need it to
+  //    detect unexpected decreases on accounts the caller didn't declare.
+  let preInfos;
+  try {
+    preInfos = await connection.getMultipleAccountsInfo(accountKeys, "confirmed");
+  } catch (err) {
+    await markAuditRejected(auditId, `pre-state read failed: ${err.message?.slice(0, 100)}`);
+    throw new Error(`privileged-sign-guard: pre-state read failed: ${err.message}`);
+  }
+  // Build pre-balance snapshot keyed by account index
+  const preBalanceSnapshot = [];
+  for (let i = 0; i < accountKeys.length; i++) {
+    const info = preInfos[i];
+    if (!info) { preBalanceSnapshot.push(null); continue; }
+    const isToken = info.owner.equals(TOKENKEG) || info.owner.equals(TOKEN2022);
+    if (isToken && info.data.length >= 72) {
+      preBalanceSnapshot.push({
+        kind: "token",
+        mint: new PublicKey(info.data.subarray(0, 32)).toBase58(),
+        owner: new PublicKey(info.data.subarray(32, 64)).toBase58(),
+        amount: info.data.readBigUInt64LE(64),
+      });
+    } else {
+      preBalanceSnapshot.push({
+        kind: "sol",
+        lamports: BigInt(info.lamports),
+        owner: info.owner.toBase58(),
+      });
+    }
+  }
+  // Persist for forensics
+  await query(
+    `UPDATE privileged_sign_audit SET pre_balances = $2::jsonb WHERE id = $1`,
+    [
+      auditId,
+      JSON.stringify(
+        accountKeys.map((k, i) => ({
+          pubkey: k.toBase58(),
+          ...(preBalanceSnapshot[i]
+            ? {
+                ...preBalanceSnapshot[i],
+                lamports: preBalanceSnapshot[i].lamports?.toString(),
+                amount: preBalanceSnapshot[i].amount?.toString(),
+              }
+            : { kind: "missing" }),
+        })),
+      ),
+    ],
+  );
+
+  // 4. Sign with privileged keypair(s)
+  try {
+    if (typeof tx.sign === "function" && tx.message) {
+      // VersionedTransaction
+      tx.sign(signers);
+    } else {
+      // legacy Transaction
+      for (const kp of signers) tx.partialSign(kp);
+    }
+  } catch (err) {
+    await markAuditRejected(auditId, `sign failed: ${err.message?.slice(0, 100)}`);
+    throw err;
+  }
+
+  // 5. Simulate, requesting post-state of ALL accounts so we can verify
+  //    no privileged-account decrease was hidden in an undeclared spot.
+  let sim;
+  try {
+    sim = await connection.simulateTransaction(tx, {
+      sigVerify: false,
+      commitment: "confirmed",
+      accounts: {
+        encoding: "base64",
+        addresses: accountKeys.map((k) => k.toBase58()),
+      },
+    });
+  } catch (err) {
+    await markAuditRejected(auditId, `simulate failed: ${err.message?.slice(0, 100)}`);
+    throw new Error(`privileged-sign-guard: simulate failed: ${err.message}`);
+  }
+  if (sim.value.err) {
+    const detail = `sim err=${JSON.stringify(sim.value.err).slice(0, 100)} logs=${(sim.value.logs || []).slice(-3).join(" | ").slice(0, 200)}`;
+    await markAuditRejected(auditId, detail);
+    throw new Error(`privileged-sign-guard: simulate rejected — ${detail}`);
+  }
+
+  // 6. Compare pre vs post for every account. Two failure modes:
+  //    (a) An UNDECLARED account owned by a privileged signer decreased
+  //        → exploit-class drain attempt, hard reject
+  //    (b) A DECLARED account decreased MORE than its maxDecrease
+  //        → caller's accounting is off, reject
+  const postAccounts = sim.value.accounts || [];
+  const declaredByPubkey = new Map();
+  for (const d of allowedDeltas || []) {
+    declaredByPubkey.set(
+      d.pubkey.toBase58 ? d.pubkey.toBase58() : String(d.pubkey),
+      d,
+    );
+  }
+
+  for (let i = 0; i < accountKeys.length; i++) {
+    const pre = preBalanceSnapshot[i];
+    const post = postAccounts[i];
+    if (!pre || !post) continue;
+    const pubkey = accountKeys[i].toBase58();
+
+    // SOL delta
+    const preLamports = pre.lamports ?? 0n;
+    const postLamports = BigInt(post.lamports ?? 0);
+    if (postLamports < preLamports) {
+      const decrease = preLamports - postLamports;
+      const declared = declaredByPubkey.get(pubkey);
+      // privileged-signer SOL account: must be declared and within max
+      if (signerPubkeyStrs.has(pubkey)) {
+        if (!declared || declared.kind !== "sol") {
+          await markAuditRejected(
+            auditId,
+            `unauthorized SOL drain on signer ${pubkey.slice(0, 8)}…: -${decrease} lamports`,
+          );
+          throw new Error(
+            `privileged-sign-guard: signer ${pubkey.slice(0, 8)}… would lose ${decrease} lamports but no allowedDelta declared`,
+          );
+        }
+        const maxAllowed = BigInt(declared.maxDecrease);
+        if (decrease > maxAllowed) {
+          await markAuditRejected(
+            auditId,
+            `signer SOL decrease ${decrease} > allowed ${maxAllowed}`,
+          );
+          throw new Error(
+            `privileged-sign-guard: signer would lose ${decrease} lamports > maxDecrease ${maxAllowed}`,
+          );
+        }
+      }
+    }
+
+    // Token delta — pre.kind === 'token'
+    if (pre.kind === "token") {
+      const postBytes = Buffer.from(post.data[0], "base64");
+      if (postBytes.length < 72) continue;
+      const postAmount = postBytes.readBigUInt64LE(64);
+      if (postAmount < pre.amount) {
+        const decrease = pre.amount - postAmount;
+        // privileged-signer-owned ATA: must be declared and within max
+        if (signerPubkeyStrs.has(pre.owner)) {
+          const declared = declaredByPubkey.get(pubkey);
+          if (!declared || declared.kind !== "token") {
+            await markAuditRejected(
+              auditId,
+              `unauthorized token drain on signer-owned ATA ${pubkey.slice(0, 8)}…: -${decrease} (mint ${pre.mint.slice(0, 8)}…)`,
+            );
+            throw new Error(
+              `privileged-sign-guard: signer-owned ATA ${pubkey.slice(0, 8)}… (mint ${pre.mint.slice(0, 8)}…) would lose ${decrease} but no allowedDelta declared`,
+            );
+          }
+          const maxAllowed = BigInt(declared.maxDecrease);
+          if (decrease > maxAllowed) {
+            await markAuditRejected(
+              auditId,
+              `signer-owned token ATA decrease ${decrease} > allowed ${maxAllowed}`,
+            );
+            throw new Error(
+              `privileged-sign-guard: token decrease ${decrease} > maxDecrease ${maxAllowed}`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // 7. All checks passed — stamp sim_passed and return the signed tx.
+  await query(
+    `UPDATE privileged_sign_audit
+        SET status = 'sim_passed'
+      WHERE id = $1 AND status = 'pending'`,
+    [auditId],
+  );
+
+  return { auditId, signedTx: tx, preBalances: preBalanceSnapshot, simResult: sim.value };
+}
+
+/**
+ * Record the outcome of a broadcast attempt against an earlier
+ * runPrivilegedSign call.
+ *
+ * @param {Object} args
+ * @param {number} args.auditId
+ * @param {string} args.status — 'broadcast' | 'confirmed' | 'failed'
+ * @param {string} [args.txSig]
+ * @param {string} [args.error]
+ */
+export async function recordPrivilegedSignResult({ auditId, status, txSig, error }) {
+  const statusCol =
+    status === "broadcast"
+      ? "broadcast_at"
+      : status === "confirmed"
+        ? "confirmed_at"
+        : null;
+  await query(
+    `UPDATE privileged_sign_audit
+        SET status = $2,
+            tx_sig = COALESCE($3, tx_sig),
+            error_text = COALESCE($4, error_text)
+            ${statusCol ? `, ${statusCol} = NOW()` : ""}
+      WHERE id = $1`,
+    [auditId, status, txSig ?? null, error ?? null],
+  );
+}
+
+async function markAuditRejected(auditId, detail) {
+  try {
+    await query(
+      `UPDATE privileged_sign_audit
+          SET status = 'sim_rejected',
+              error_text = $2
+        WHERE id = $1`,
+      [auditId, detail?.slice(0, 500)],
+    );
+  } catch {
+    /* best-effort */
+  }
+}

--- a/src/services/treasury-sweeper.js
+++ b/src/services/treasury-sweeper.js
@@ -55,6 +55,11 @@ import bs58 from "bs58";
 import { query } from "../db/pool.js";
 import { connection } from "../solana/connection.js";
 import { getAdminId } from "./admin-notify.js";
+import { assertAllowedDestination } from "./privileged-destinations.js";
+import {
+  runPrivilegedSign,
+  recordPrivilegedSignResult,
+} from "./privileged-sign-guard.js";
 
 // ─── Constants ────────────────────────────────────────────────────
 
@@ -282,6 +287,27 @@ async function tickInner(bot) {
     return;
   }
 
+  // Hard allowlist check — the destination MUST be on the source-
+  // level allowlist for this service. An attacker who flips
+  // TREASURY_SWEEP_DEST_PUBKEY on Railway can only redirect to a
+  // pre-approved cold-storage vault.
+  try {
+    assertAllowedDestination("treasury-sweeper", destPk);
+  } catch (allowlistErr) {
+    await recordSweep({
+      outcome: "sim_reject",
+      lender_balance_lamports_before: lenderBal,
+      reserve_lamports: reserveLamports,
+      swept_lamports: 0,
+      destination_pubkey: destPk.toBase58(),
+      error_message: allowlistErr.message?.slice(0, 200),
+      notes: "destination not on source-level allowlist — refusing to build tx",
+    });
+    consecutiveFailures++;
+    await maybeAlertConsecutive(bot, allowlistErr.message?.slice(0, 200));
+    return;
+  }
+
   const ix = SystemProgram.transfer({
     fromPubkey: lenderPk,
     toPubkey: destPk,
@@ -295,25 +321,44 @@ async function tickInner(bot) {
     lastValidBlockHeight,
   });
   tx.add(ix);
-  tx.sign(lenderKp);
 
-  // 4. Pre-flight simulate
-  const sim = await connection.simulateTransaction(tx);
-  if (sim.value.err) {
-    const errStr = JSON.stringify(sim.value.err);
+  // Sign + simulate + audit-log through the centralised guard. The
+  // guard verifies the lender's SOL balance decreases by <= the swept
+  // amount + a tx-fee budget, and rejects on any other balance change
+  // (e.g. an undeclared token decrease on a lender ATA).
+  // Operator-mandated 2026-06-18 PM — see
+  // feedback_cosign_borrow_token_drain_exploit_2026_06_18.
+  let guard;
+  try {
+    guard = await runPrivilegedSign({
+      service: "treasury-sweeper",
+      tx,
+      signers: [lenderKp],
+      allowedDeltas: [
+        {
+          pubkey: lenderPk,
+          kind: "sol",
+          // Allow up to sweepAmount + tx-fee headroom + 5000 lamports of
+          // priority-fee slack. Any deviation is suspicious.
+          maxDecrease: BigInt(sweepAmount + TX_FEE_HEADROOM + 5_000),
+        },
+      ],
+    });
+  } catch (guardErr) {
+    const errStr = guardErr.message?.slice(0, 200) || "guard rejected";
     await recordSweep({
       outcome: "sim_reject",
       lender_balance_lamports_before: lenderBal,
       reserve_lamports: reserveLamports,
       swept_lamports: 0,
       destination_pubkey: destPk.toBase58(),
-      error_message: `simulate err: ${errStr}`,
-      notes: (sim.value.logs || []).slice(-5).join(" | ").slice(0, 500),
+      error_message: errStr,
     });
     consecutiveFailures++;
-    await maybeAlertConsecutive(bot, `Sweep sim rejected: ${errStr}`);
+    await maybeAlertConsecutive(bot, `Sweep guard rejected: ${errStr}`);
     return;
   }
+  const auditId = guard.auditId;
 
   // 5. Broadcast
   let sig;
@@ -331,10 +376,16 @@ async function tickInner(bot) {
       destination_pubkey: destPk.toBase58(),
       error_message: err.message?.slice(0, 200),
     });
+    await recordPrivilegedSignResult({
+      auditId,
+      status: "failed",
+      error: `broadcast: ${err.message?.slice(0, 200)}`,
+    });
     consecutiveFailures++;
     await maybeAlertConsecutive(bot, `Sweep send failed: ${err.message?.slice(0, 120)}`);
     return;
   }
+  await recordPrivilegedSignResult({ auditId, status: "broadcast", txSig: sig });
 
   // 6. Confirm
   try {
@@ -352,10 +403,16 @@ async function tickInner(bot) {
       tx_signature: sig,
       error_message: `confirm timeout: ${err.message?.slice(0, 120)}`,
     });
+    await recordPrivilegedSignResult({
+      auditId,
+      status: "failed",
+      error: `confirm: ${err.message?.slice(0, 200)}`,
+    });
     consecutiveFailures++;
     await maybeAlertConsecutive(bot, `Sweep confirm timeout: ${sig}`);
     return;
   }
+  await recordPrivilegedSignResult({ auditId, status: "confirmed", txSig: sig });
 
   // 7. Success
   consecutiveFailures = 0;


### PR DESCRIPTION
## Second-round hardening
Triggered by the 2026-06-18 cosign-borrow exploit and the operator's directive ("think of any other potential similar exploits and put together the same safeguards"). Extracts the Layer 2 balance-delta defense from cosign-borrow into a shared utility every privileged signing path can call.

## Three things shipping together

### A. Universal sign guard (privileged-sign-guard.js)
runPrivilegedSign signs + simulates + verifies no unauthorized balance change on any signer-owned account. Same shape that closed the cosign-borrow exploit now applies to every signing path that adopts the utility.

### B. Destination allowlist (privileged-destinations.js)
Hardcoded source-level allowlists. An attacker who flips an env var on Railway can only redirect to a pre-approved destination.

### C. Audit log (migration 077)
Every privileged sign emits a row. Future self-monitor probe will sum-of-expected vs actual-on-chain to catch txs that landed without an audit row (smoking gun for leaked keypair).

## Wired into treasury-sweeper as canonical example
- assertAllowedDestination BEFORE tx build
- runPrivilegedSign replaces bespoke sign+simulate
- recordPrivilegedSignResult after broadcast/confirm/fail

## Follow-up PR
Propagate the same pattern to:
- fee-wallet-sweeper
- liquidation-distribution-watcher
- liquidation-collateral-sweeper (replace bespoke sim with guard)
- magpie-holder-rewards / lp-loyalty / referral-rewards distributors

## Test plan
- Migration 077 auto-applies on next deploy
- treasury-sweeper next tick uses the new guard; row appears in privileged_sign_audit
- An intentionally-misconfigured TREASURY_SWEEP_DEST_PUBKEY (set to a random pubkey) gets rejected by the allowlist at sweep time

Generated with Claude Code