### PR TITLE
fix(twap): generalize JIT warmer to V3+V4 — SPCX V3 borrows were exposed

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -1035,25 +1035,33 @@ export async function handleCosignBorrow(req) {
         // PDA was never initialized — bot's category routing never
         // reaches V4.
         const borrowProgramId = magpieIxForAttest.programId;
-        const isV4Borrow =
-          process.env.PROGRAM_ID_V4 &&
-          borrowProgramId.toBase58() === process.env.PROGRAM_ID_V4;
+        // V3 AND V4 both use the price_v3 PriceHistory layout with the
+        // same TWAP gate (>= 8 samples in 300s). Originally I only
+        // JIT-warmed V4, which left SPCX (RWA, defaults to V3 borrow
+        // routing) exposed. Operator hit TwapInsufficientHistory on an
+        // SPCX V3 borrow 2026-06-18 PM — see
+        // [[feedback_twap_insufficient_history_never_again]] for the
+        // mandate that this MUST cover every program with TWAP.
+        const usesTwapGate =
+          (process.env.PROGRAM_ID_V4 &&
+            borrowProgramId.toBase58() === process.env.PROGRAM_ID_V4) ||
+          (process.env.PROGRAM_ID_V3 &&
+            borrowProgramId.toBase58() === process.env.PROGRAM_ID_V3);
 
-        if (isV4Borrow) {
-          // V4 path: program's TWAP gate needs >= 8 samples within 300s
-          // OR `TwapInsufficientHistory` (Anchor 6016 / 0x1780) rejects
+        if (usesTwapGate) {
+          // Program's TWAP gate needs >= 8 samples within 300s OR
+          // `TwapInsufficientHistory` (Anchor 6016 / 0x1780) rejects
           // the borrow. The single-shot freshness attest below is
           // necessary but not sufficient — we MUST loop until the
-          // PriceHistory PDA has the count it needs. Operator-mandated
-          // 2026-06-18 PM, see
-          // [[feedback_twap_insufficient_history_never_again]].
+          // PriceHistory PDA has the count it needs.
           const warm = await ensureV4TwapReady(
             mintStr,
             Number(mintRow.decimals),
+            { programIdOverride: borrowProgramId },
           );
           if (!warm.ok) {
             console.warn(
-              `[cosign-borrow] V4 TWAP warming TIMED OUT mint=${mintStr.slice(0, 8)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests} reason=${warm.reason}`,
+              `[cosign-borrow] TWAP warming TIMED OUT prog=${borrowProgramId.toBase58().slice(0, 8)}… mint=${mintStr.slice(0, 8)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests} reason=${warm.reason}`,
             );
             return {
               status: 503,
@@ -1068,7 +1076,7 @@ export async function handleCosignBorrow(req) {
             };
           }
           console.log(
-            `[cosign-borrow] V4 TWAP ready mint=${mintStr.slice(0, 8)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests}`,
+            `[cosign-borrow] TWAP ready prog=${borrowProgramId.toBase58().slice(0, 8)}… mint=${mintStr.slice(0, 8)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests}`,
           );
         } else {
           // V1/V3 path: single-shot freshness check (PR was already

--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -848,18 +848,26 @@ export function registerBorrowCallbacks(bot) {
     const feedAge = await getPriceFeedAgeSeconds(state.selected.mint, attestProgramId);
     const needsAttest = feedAge === null || feedAge > FRESH_THRESHOLD_SEC;
 
-    // V4 TWAP warming gate (operator-mandated 2026-06-18 PM, see
-    // [[feedback_twap_insufficient_history_never_again]]). If this borrow
-    // routes to V4, the on-chain TWAP check needs >= 8 samples in 300s;
-    // a single attest below doesn't get us there from a cold start. Loop
-    // until the PriceHistory PDA has the count it needs, or surface a
-    // clean "feed warming" prompt to the user with state preserved.
+    // TWAP warming gate. V3 + V4 both use the price_v3 PriceHistory
+    // layout with a >=8-samples-in-300s rule. A single attest below
+    // doesn't get us there from a cold start — loop until the PDA has
+    // the count it needs, or surface a clean "feed warming" prompt
+    // with state preserved. Operator-mandated 2026-06-18 PM after the
+    // SPCX V3 TwapInsufficientHistory recurrence; the original V4-only
+    // implementation left V3 RWA borrows exposed. See
+    // [[feedback_twap_insufficient_history_never_again]].
     {
-      const { PROGRAM_ID_V4 } = await import("../solana/program.js");
-      const isV4Borrow = !!(PROGRAM_ID_V4 && attestProgramId && attestProgramId.equals(PROGRAM_ID_V4));
-      if (isV4Borrow) {
+      const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
+      const usesTwapGate = !!(
+        attestProgramId &&
+        ((PROGRAM_ID_V4 && attestProgramId.equals(PROGRAM_ID_V4)) ||
+          (PROGRAM_ID_V3 && attestProgramId.equals(PROGRAM_ID_V3)))
+      );
+      if (usesTwapGate) {
         const { ensureV4TwapReady } = await import("../services/price-attestor.js");
-        const warm = await ensureV4TwapReady(state.selected.mint, state.selected.decimals);
+        const warm = await ensureV4TwapReady(state.selected.mint, state.selected.decimals, {
+          programIdOverride: attestProgramId,
+        });
         if (!warm.ok) {
           // Preserve state so the user just taps Retry — no need to
           // re-pick collateral/tier/exits.
@@ -869,16 +877,15 @@ export function registerBorrowCallbacks(bot) {
             .text("Cancel", "borrow:cancel");
           await say(
             `*Price oracle is warming up for ${state.selected.symbol}.*\n\n` +
-            `V4 needs ${warm.inWindow}/8 samples within the rolling 5-min window. ` +
+            `We need ${warm.inWindow}/8 samples within the rolling 5-min window. ` +
             `It usually finishes in 30–45 seconds. Your collateral + tier + exits are saved — tap to retry.`,
             { parse_mode: "Markdown", reply_markup: kb },
           );
           return;
         }
-        // V4 path also writes a fresh sample as side effect of
-        // ensureV4TwapReady, so the freshness check below would no-op.
-        // Fall through anyway — the single-shot attest path stays
-        // available for V1/V3 callers and is cheap when feed is fresh.
+        // The TWAP-warm path also writes a fresh sample as side effect,
+        // so the freshness check below would no-op. Fall through anyway
+        // — the single-shot attest path stays cheap when feed is fresh.
       }
     }
 

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -142,13 +142,16 @@ export async function getPriceFeedAgeSeconds(mintStr, programIdOverride = null) 
  * the head and overwrites the oldest sample. So we ALWAYS iterate every
  * populated slot and count by timestamp rather than trusting `count`.
  */
-export async function getV4TwapSampleCount(mintStr, windowSec = 300) {
+export async function getV4TwapSampleCount(mintStr, windowSec = 300, programIdOverride = null) {
   try {
-    const { PROGRAM_ID_V4 } = await import("../solana/program.js");
-    if (!PROGRAM_ID_V4) return null;
+    const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
+    // Default to V4 for backward compatibility, but accept V3 too — both
+    // use the price_v3 PriceHistory layout with the same TWAP semantics.
+    const programId = programIdOverride || PROGRAM_ID_V4 || PROGRAM_ID_V3;
+    if (!programId) return null;
     const mintPk = new PublicKey(mintStr);
-    const [pool] = lendingPoolPda(LENDER_PUBKEY, PROGRAM_ID_V4);
-    const [priceFeed] = priceFeedPda(mintPk, pool, PROGRAM_ID_V4);
+    const [pool] = lendingPoolPda(LENDER_PUBKEY, programId);
+    const [priceFeed] = priceFeedPda(mintPk, pool, programId);
     const info = await connection.getAccountInfo(priceFeed);
     if (!info || info.data.length < 120) return null;
     const totalCount = info.data.readUInt8(105);
@@ -211,20 +214,27 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
   let attests = 0;
   let lastErr = null;
 
-  const { PROGRAM_ID_V4 } = await import("../solana/program.js");
-  if (!PROGRAM_ID_V4) {
-    // V4 not configured — nothing to warm. Treat as ok so V1/V3 callers
-    // can call this unconditionally without branching.
-    return { ok: true, inWindow: null, waitedMs: 0, attests: 0, reason: "v4_not_configured" };
+  const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
+  // Generalized to V3 + V4 (operator hit TwapInsufficientHistory on an
+  // SPCX V3 borrow 2026-06-18 PM — the V4-only JIT warmer didn't catch
+  // it). Both programs use the price_v3 PriceHistory layout. Caller can
+  // pin a specific program via opts.programIdOverride; otherwise we
+  // prefer the program the caller specified via opts.programIdOverride,
+  // falling back to V4 then V3. See
+  // [[feedback_twap_insufficient_history_never_again]].
+  const programId =
+    opts.programIdOverride || PROGRAM_ID_V4 || PROGRAM_ID_V3;
+  if (!programId) {
+    return { ok: true, inWindow: null, waitedMs: 0, attests: 0, reason: "no_program_configured" };
   }
 
   while (Date.now() - START < MAX_WAIT_MS) {
-    let status = await getV4TwapSampleCount(mintStr, WINDOW_SEC);
+    let status = await getV4TwapSampleCount(mintStr, WINDOW_SEC, programId);
     if (status === null) {
       // Feed PDA not initialized yet. Init then continue — the next
       // iteration will see the empty PriceHistory and start filling it.
       try {
-        await initializePriceFeed(mintStr, PROGRAM_ID_V4);
+        await initializePriceFeed(mintStr, programId);
       } catch (e) {
         lastErr = `init failed: ${e.message?.slice(0, 100)}`;
         // Don't hard-fail — maybe a race with the background attestor
@@ -239,12 +249,13 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
         inWindow: status.inWindow,
         waitedMs: Date.now() - START,
         attests,
+        programId: programId.toBase58().slice(0, 8),
       };
     }
     // Need more samples — fire one attest and wait briefly so the
     // tx finalizes (confirmed) before the next iteration measures.
     try {
-      await attestPrice(mintStr, decimals, undefined, PROGRAM_ID_V4);
+      await attestPrice(mintStr, decimals, undefined, programId);
       attests++;
     } catch (e) {
       lastErr = e.message?.slice(0, 100);
@@ -252,7 +263,7 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
       // re-init and try again. AccountNotInitialized → 3012/0xbc4.
       if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(lastErr)) {
         try {
-          await initializePriceFeed(mintStr, PROGRAM_ID_V4);
+          await initializePriceFeed(mintStr, programId);
         } catch (e2) {
           lastErr = `init-then-attest failed: ${e2.message?.slice(0, 80)}`;
         }
@@ -262,7 +273,7 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
   }
 
   // Timed out — return current state so caller can surface a good message.
-  const final = await getV4TwapSampleCount(mintStr, WINDOW_SEC);
+  const final = await getV4TwapSampleCount(mintStr, WINDOW_SEC, programId);
   return {
     ok: false,
     inWindow: final?.inWindow ?? 0,

--- a/src/services/self-monitor.js
+++ b/src/services/self-monitor.js
@@ -483,41 +483,45 @@ async function probeCreditCoverage(bot) {
  */
 async function probeV4TwapHealth(bot) {
   const KIND = "v4_twap_health";
-  if (!process.env.PROGRAM_ID_V4) {
+  if (!process.env.PROGRAM_ID_V4 && !process.env.PROGRAM_ID_V3) {
     recordOutcome(KIND, false);
     return;
   }
   try {
     const { getV4TwapSampleCount } = await import("./price-attestor.js");
-    // Look at enabled mints — those are the ones users can borrow on.
-    // Skip non-V4 categories (e.g. tokens that route purely to V1/V3).
-    // We probe ALL enabled mints because exit-armed loans on memecoins
-    // also use V4 regardless of category.
+    const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
+    // Probe V3 + V4 — both use the price_v3 PriceHistory layout with
+    // the same >=8-samples-in-300s TWAP rule. The V4-only probe missed
+    // SPCX V3 borrows (RWA defaults to V3) — operator hit
+    // TwapInsufficientHistory on SPCX 2026-06-18 PM.
+    const programsToProbe = [];
+    if (PROGRAM_ID_V4) programsToProbe.push({ id: PROGRAM_ID_V4, label: "V4" });
+    if (PROGRAM_ID_V3) programsToProbe.push({ id: PROGRAM_ID_V3, label: "V3" });
+
     const { rows } = await query(
       `SELECT mint, symbol, decimals FROM supported_mints
         WHERE enabled = TRUE
         ORDER BY symbol`,
     );
     const REQUIRED = 8;
-    const GAP_TOLERANCE_SEC = 60; // freshly-enabled mints get 60s grace
+    const GAP_TOLERANCE_SEC = 60;
     const warming = [];
     const cold = [];
     for (const m of rows) {
-      const status = await getV4TwapSampleCount(m.mint, 300);
-      if (status === null) {
-        cold.push(`${m.symbol}(no feed)`);
-        continue;
-      }
-      if (status.inWindow >= REQUIRED) continue;
-      // Newest timestamp tells us if the attestor is moving on this
-      // mint at all. If newest is fresh (< 60s ago), it's warming —
-      // tolerable. If newest is stale, attestor is BROKEN for this mint.
-      const now = Math.floor(Date.now() / 1000);
-      const ageSec = status.newestTs ? now - status.newestTs : Infinity;
-      if (ageSec > GAP_TOLERANCE_SEC) {
-        cold.push(`${m.symbol}(${status.inWindow}/8, last attest ${Math.round(ageSec)}s ago)`);
-      } else {
-        warming.push(`${m.symbol}(${status.inWindow}/8)`);
+      for (const prog of programsToProbe) {
+        const status = await getV4TwapSampleCount(m.mint, 300, prog.id);
+        if (status === null) {
+          cold.push(`${m.symbol}(${prog.label} no feed)`);
+          continue;
+        }
+        if (status.inWindow >= REQUIRED) continue;
+        const now = Math.floor(Date.now() / 1000);
+        const ageSec = status.newestTs ? now - status.newestTs : Infinity;
+        if (ageSec > GAP_TOLERANCE_SEC) {
+          cold.push(`${m.symbol}(${prog.label} ${status.inWindow}/8, last attest ${Math.round(ageSec)}s ago)`);
+        } else {
+          warming.push(`${m.symbol}(${prog.label} ${status.inWindow}/8)`);
+        }
       }
     }
     const isBad = cold.length > 0;


### PR DESCRIPTION
## P0 — TwapInsufficientHistory recurrence on SPCX
Operator hit TwapInsufficientHistory AGAIN on SPCX 2026-06-18 PM. My earlier "never again" fix only JIT-warmed V4. SPCX is RWA (category=stock) and defaults to V3 borrow routing — V3 also uses the price_v3 PriceHistory layout with the same >=8-samples-in-300s gate.

## Unified rule
Any program with the price_v3 layout (V3 + V4 today, plus any future Vn that reuses the seed name) MUST be JIT-warmed by every borrow path.

## Changes
- **price-attestor.js**: getV4TwapSampleCount + ensureV4TwapReady accept programIdOverride
- **cosign-borrow.js**: usesTwapGate = (V3 || V4); passes borrowProgramId as override
- **commands/borrow.js (TG)**: same generalization
- **self-monitor.probeV4TwapHealth**: iterates BOTH V3 and V4 per enabled mint

## Memory
feedback_twap_insufficient_history_never_again.md now states the unified V3+V4 rule + records this recurrence as the canonical case. Future Vn programs inherit automatically.

## Manual pre-warm
Once deployed, the next borrow that hits an uninitialized PDA triggers init + 8 attests. For impatient users, I'll also kick off a manual pre-warm of SPCX V3+V4 in parallel so they don't have to wait.

Generated with Claude Code