### PR TITLE
feat(stats): recovery_credits — count out-of-band SOL deposits as profitable defaults

### DIFF
--- a/migrations/078_recovery_credits.sql
+++ b/migrations/078_recovery_credits.sql
@@ -1,0 +1,58 @@
+-- Protocol recovery / contribution events.
+--
+-- Some events bring SOL into the rewards-distributor wallet OUTSIDE the
+-- normal "liquidation → sale → distribute" pipeline. The first instance:
+-- the 2026-06-18 cosign-borrow Token-2022 exploit recovery. The operator
+-- manually deposited 4 SOL to the rewards distributor (CHCAMWtn…) and
+-- wants it counted in the "profitable defaults" totals + flow through the
+-- same 80/10/10 (holder / LP-loyalty / protocol-reserve) split.
+--
+-- Rather than pollute liquidation_economics with synthetic NULL-loan_id
+-- rows, this table exists for these out-of-band credit events. The
+-- distribution-watcher picks up rows with distribution_status =
+-- 'awaiting_distribution' and credits the pool ledgers the same way it
+-- does for liquidation_economics rows. The /stats query UNIONs both
+-- tables for the public "profitable defaults" headline.
+--
+-- Future kinds: 'protocol_contribution', 'goodwill', 'audit_bounty',
+-- whatever editorial bucket fits.
+
+CREATE TABLE IF NOT EXISTS recovery_credits (
+  id BIGSERIAL PRIMARY KEY,
+  -- 'exploit_recovery' | 'protocol_contribution' | ...
+  kind TEXT NOT NULL,
+  -- Human-readable for /stats + audit-trail surfaces.
+  description TEXT NOT NULL,
+  -- On-chain deposit tx signature if known. UNIQUE so the migration is
+  -- idempotent and a re-run can't double-credit.
+  source_tx_sig TEXT UNIQUE,
+  -- The credit amount (SOL deposited that flows to users).
+  amount_lamports BIGINT NOT NULL CHECK (amount_lamports > 0),
+  -- Split fields — filled in by the distribution-watcher after the
+  -- 80/10/10 split is applied. Same shape as liquidation_economics.
+  holder_share_lamports BIGINT,
+  lp_loyalty_share_lamports BIGINT,
+  protocol_reserve_share_lamports BIGINT,
+  distribution_status TEXT NOT NULL DEFAULT 'awaiting_distribution'
+    CHECK (distribution_status IN ('awaiting_distribution', 'distributing', 'distributed')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  distributed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_recovery_credits_distribution_status
+  ON recovery_credits (distribution_status, created_at);
+
+-- Seed the 2026-06-18 cosign-borrow exploit recovery row.
+-- 4 SOL deposited by the operator to CHCAMWtn… (rewards distributor)
+-- as goodwill restitution after the Token-2022 drain ($528 loss).
+-- ON CONFLICT prevents double-insert if the migration ever re-runs.
+INSERT INTO recovery_credits (
+  kind, description, source_tx_sig, amount_lamports
+) VALUES (
+  'exploit_recovery',
+  'Operator-funded recovery after the 2026-06-18 cosign-borrow Token-2022 drain exploit. 4 SOL deposited to the rewards distributor wallet (CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac) and credited to the holder / LP-loyalty / protocol-reserve pools via the same 80/10/10 split that profitable defaults use.',
+  'OPERATOR_DEPOSIT_2026_06_18_EXPLOIT_RECOVERY_4_SOL',
+  4000000000
+)
+ON CONFLICT (source_tx_sig) DO NOTHING;

--- a/src/services/liquidation-distribution-watcher.js
+++ b/src/services/liquidation-distribution-watcher.js
@@ -344,11 +344,108 @@ async function distributeOne(row) {
   return { ok: true };
 }
 
+/**
+ * Distribute a recovery_credits row. Out-of-band SOL the operator (or a
+ * future buyback / contribution flow) deposited directly to the rewards
+ * distributor wallet. No on-chain transfer needed — the SOL is already
+ * there. Same 80/10/10 split as profitable defaults: holder + LP-loyalty
+ * + protocol-reserve. No referrer dimension (these aren't loans).
+ *
+ * Operator-mandated 2026-06-18 PM as part of the exploit-into-positive
+ * spin: 4 SOL deposited goes into the holder + LP + protocol-reserve
+ * pools the same way a profitable default would.
+ */
+async function distributeRecoveryCredit(row) {
+  const amount = BigInt(row.amount_lamports);
+  if (amount <= 0n) {
+    await query(
+      `UPDATE recovery_credits SET distribution_status = 'distributed', distributed_at = NOW(), updated_at = NOW() WHERE id = $1`,
+      [row.id],
+    );
+    return { ok: true, reason: "zero_amount_skip" };
+  }
+  // Same 80/10/10 split as profitable defaults with no-referrer fallback.
+  // Holder gets default 70% + the rolled 10% referrer share = 80%.
+  const HOLDER_BPS = 8_000n;
+  const LP_BPS = 1_000n;
+  const RESERVE_BPS = 1_000n;
+  const TOTAL_BPS = 10_000n;
+  const holderShare = (amount * HOLDER_BPS) / TOTAL_BPS;
+  const lpShare = (amount * LP_BPS) / TOTAL_BPS;
+  const reserveShare = amount - holderShare - lpShare; // sweep rounding
+
+  // Race-safe claim.
+  const claim = await query(
+    `UPDATE recovery_credits
+        SET distribution_status = 'distributing', updated_at = NOW()
+      WHERE id = $1 AND distribution_status = 'awaiting_distribution'
+      RETURNING id`,
+    [row.id],
+  );
+  if (claim.rowCount === 0) {
+    return { ok: false, reason: "claim_lost_race" };
+  }
+
+  const errors = [];
+  try {
+    const { creditHolderPoolDirect } = await import("./magpie-holder-rewards.js");
+    if (holderShare > 0n) await creditHolderPoolDirect(holderShare);
+  } catch (err) {
+    errors.push(`holder: ${err.message?.slice(0, 80)}`);
+  }
+  try {
+    const { creditLpLoyaltyPoolDirect } = await import("./lp-loyalty.js");
+    if (lpShare > 0n) await creditLpLoyaltyPoolDirect(lpShare);
+  } catch (err) {
+    errors.push(`lp: ${err.message?.slice(0, 80)}`);
+  }
+  try {
+    const { creditProtocolReserveDirect } = await import("./protocol-reserve.js");
+    if (reserveShare > 0n) {
+      await creditProtocolReserveDirect({
+        loanDbId: null,
+        amountLamports: reserveShare,
+        eventType: `recovery_${row.kind}`,
+      });
+    }
+  } catch (err) {
+    errors.push(`reserve: ${err.message?.slice(0, 80)}`);
+  }
+
+  await query(
+    `UPDATE recovery_credits
+        SET distribution_status = $2,
+            holder_share_lamports = $3,
+            lp_loyalty_share_lamports = $4,
+            protocol_reserve_share_lamports = $5,
+            distributed_at = CASE WHEN $2 = 'distributed' THEN NOW() ELSE NULL END,
+            updated_at = NOW()
+      WHERE id = $1`,
+    [
+      row.id,
+      errors.length === 0 ? "distributed" : "awaiting_distribution",
+      holderShare.toString(),
+      lpShare.toString(),
+      reserveShare.toString(),
+    ],
+  );
+  if (errors.length > 0) {
+    console.warn(`[liq-distribute] recovery_credit #${row.id} partial fail: ${errors.join("; ")}`);
+    return { ok: false, reason: errors.join("; ") };
+  }
+  console.log(
+    `[liq-distribute] recovery_credit #${row.id} (${row.kind}) distributed ${(Number(amount) / 1e9).toFixed(4)} SOL ` +
+      `(H ${(Number(holderShare) / 1e9).toFixed(4)} / L ${(Number(lpShare) / 1e9).toFixed(4)} / P ${(Number(reserveShare) / 1e9).toFixed(4)})`,
+  );
+  return { ok: true };
+}
+
 async function tick() {
   if (_ticking) return;
   if (DISABLED) return;
   _ticking = true;
   try {
+    // Pass 1 — liquidation_economics
     const { rows } = await query(
       `SELECT id, loan_id, collateral_mint, collateral_symbol,
               borrower_wallet, net_profit_lamports::text AS net_profit_lamports,
@@ -361,7 +458,6 @@ async function tick() {
         ORDER BY sale_detected_at ASC NULLS FIRST
         LIMIT 25`,
     );
-    if (rows.length === 0) return;
     let succeeded = 0;
     let failed = 0;
     for (const row of rows) {
@@ -371,7 +467,38 @@ async function tick() {
       }));
       if (r.ok) succeeded++; else failed++;
     }
-    console.log(`[liq-distribute] tick: distributed=${succeeded} failed=${failed}`);
+    if (rows.length > 0) {
+      console.log(`[liq-distribute] tick liq: distributed=${succeeded} failed=${failed}`);
+    }
+
+    // Pass 2 — recovery_credits (operator contributions, exploit recoveries, etc.)
+    try {
+      const { rows: rcRows } = await query(
+        `SELECT id, kind, amount_lamports::text AS amount_lamports
+           FROM recovery_credits
+          WHERE distribution_status = 'awaiting_distribution'
+          ORDER BY created_at ASC
+          LIMIT 25`,
+      );
+      let rcOk = 0;
+      let rcFail = 0;
+      for (const row of rcRows) {
+        const r = await distributeRecoveryCredit(row).catch((err) => ({
+          ok: false,
+          reason: `unexpected: ${err.message?.slice(0, 80)}`,
+        }));
+        if (r.ok) rcOk++; else rcFail++;
+      }
+      if (rcRows.length > 0) {
+        console.log(`[liq-distribute] tick recovery: distributed=${rcOk} failed=${rcFail}`);
+      }
+    } catch (err) {
+      // recovery_credits table may not exist yet on a fresh deploy
+      // before migration 078 applies — skip gracefully.
+      if (!/relation .* does not exist/i.test(err.message || "")) {
+        console.warn(`[liq-distribute] recovery_credits pass failed: ${err.message?.slice(0, 160)}`);
+      }
+    }
   } catch (err) {
     console.warn(`[liq-distribute] tick failed: ${err.message?.slice(0, 200)}`);
   } finally {

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -422,9 +422,12 @@ export function startPriceAttestor(intervalMs = 30_000) {
 
   const lastPrices = new Map();
   const lastAttestAt = new Map();
-  // V4-specific tracking. Without separate timing, a legacy attest
-  // would refresh `lastAttestAt` and the V4 pre-warm would think the
-  // V4 feed is fresh too — leaving the V4 PDA stale.
+  // V3 + V4 each have their own PriceHistory PDA with the price_v3
+  // layout + TWAP gate, so each needs independent last-attest tracking
+  // to ensure neither gets starved. Without these, the legacy attest
+  // would refresh `lastAttestAt` and the V3/V4 pre-warms would think
+  // their feeds were fresh too — leaving the V3/V4 PDAs stale.
+  const lastAttestAtV3 = new Map();
   const lastAttestAtV4 = new Map();
   // Force a fresh on-chain attestation at least every MAX_GAP_MS so the
   // feed timestamp never crosses the contract's 120s staleness limit AND


### PR DESCRIPTION
## Operator's spin-to-positive
After the 2026-06-18 cosign-borrow exploit lost \$528, the operator deposited 4 SOL to the rewards distributor (CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac) and wants it counted as a profitable default on /stats. The 4 SOL flows to users through the same 80/10/10 split that real profitable defaults use.

## Ships
- **migration 078**: new recovery_credits table + seed row for the exploit recovery
- **liquidation-distribution-watcher.js**: distributeRecoveryCredit() pass — credits the holder/LP/protocol-reserve pools the same way real defaults do (no on-chain transfer needed; SOL is already at CHCAMWtn…)
- **price-attestor.js**: incidental lastAttestAtV3 map setup (follow-up PR uses it for V3 pre-warm)

## Companion site PR
magpie-site#TBD — UNIONs recovery_credits into the /stats profitable-defaults metrics. After both ship, /stats shows 2 profitable defaults / 15.96 SOL (was 1 / 11.96 SOL).

## Memory
feedback_recovery_credits_pattern_2026_06_18.md documents the pattern for future use (canonical kinds: exploit_recovery, protocol_contribution, buyback_burn_residual, audit_bounty).

Generated with Claude Code