### PR TITLE
fix(recovery-credits): stop holder-pool over-credit loop

### DIFF
--- a/src/services/liquidation-distribution-watcher.js
+++ b/src/services/liquidation-distribution-watcher.js
@@ -386,6 +386,13 @@ async function distributeRecoveryCredit(row) {
     return { ok: false, reason: "claim_lost_race" };
   }
 
+  // Holder + LP direct-credit are pure UPDATEs with no event-ledger
+  // (no ON CONFLICT, no idempotency key). If we ever retry a row whose
+  // holder credit already succeeded, the pool will double-credit.
+  // Therefore: the recovery_credits row is the SINGLE idempotency
+  // anchor. Mark it 'distributed' on the first claim regardless of
+  // per-pool failures, log+alert on any partial failure, and rely on
+  // a manual operator patch for the missing pool rather than retrying.
   const errors = [];
   try {
     const { creditHolderPoolDirect } = await import("./magpie-holder-rewards.js");
@@ -404,8 +411,8 @@ async function distributeRecoveryCredit(row) {
     if (reserveShare > 0n) {
       await creditProtocolReserveDirect({
         loanDbId: null,
-        amountLamports: reserveShare,
-        eventType: `recovery_${row.kind}`,
+        lamports: reserveShare,
+        eventType: `recovery_${row.kind}_${row.id}`,
       });
     }
   } catch (err) {
@@ -414,23 +421,24 @@ async function distributeRecoveryCredit(row) {
 
   await query(
     `UPDATE recovery_credits
-        SET distribution_status = $2,
-            holder_share_lamports = $3,
-            lp_loyalty_share_lamports = $4,
-            protocol_reserve_share_lamports = $5,
-            distributed_at = CASE WHEN $2 = 'distributed' THEN NOW() ELSE NULL END,
+        SET distribution_status = 'distributed',
+            holder_share_lamports = $2,
+            lp_loyalty_share_lamports = $3,
+            protocol_reserve_share_lamports = $4,
+            distributed_at = NOW(),
             updated_at = NOW()
       WHERE id = $1`,
     [
       row.id,
-      errors.length === 0 ? "distributed" : "awaiting_distribution",
       holderShare.toString(),
       lpShare.toString(),
       reserveShare.toString(),
     ],
   );
   if (errors.length > 0) {
-    console.warn(`[liq-distribute] recovery_credit #${row.id} partial fail: ${errors.join("; ")}`);
+    console.error(
+      `[liq-distribute] CRIT recovery_credit #${row.id} marked DISTRIBUTED with partial-credit failures (no retry — pool ledgers are not idempotent, retrying would double-credit): ${errors.join("; ")}. Manual operator patch required for failed slices.`,
+    );
     return { ok: false, reason: errors.join("; ") };
   }
   console.log(


### PR DESCRIPTION
## Summary
- `distributeRecoveryCredit` had a key-name typo (`amountLamports:` instead of `lamports:`) that threw on every protocol-reserve credit attempt.
- That threw error reverted `distribution_status` back to `awaiting_distribution`, but `creditHolderPoolDirect` and `creditLpLoyaltyPoolDirect` had ALREADY succeeded (their pools have no event ledger and no idempotency key).
- Every 90s watcher tick re-claimed the same row and re-credited holder + LP.
- For `recovery_credits` id=1 (the 4 SOL operator deposit), ~10 cycles ran, over-crediting the holder pool by ~31.46 SOL and LP pool by ~3.6 SOL while the reserve pool was never credited.

## Fix
- Pass `lamports:` (the destructured key) plus a per-row event_type so each recovery_credits row has its own ON CONFLICT identity.
- Always mark the row `'distributed'` on first successful claim. The `recovery_credits` row is the SINGLE idempotency anchor; pool ledgers cannot safely retry without double-crediting.
- Partial failures are logged as CRIT for manual operator patch — the retry-loop is closed by design.

## Follow-up (operator action required)
- DB correction to reverse the existing over-credit on holder + LP pools and credit the missing 0.4 SOL to the protocol-reserve pool, plus mark recovery_credits row #1 distributed. Presented to operator for explicit greenlight under the no-admin-DB-writes rule.

## Test plan
- [x] `node --check` clean on the watcher
- [ ] After merge + deploy, recovery_credits row #1 no longer re-processed each tick
- [ ] Future recovery_credits rows distribute all three pools (holder/LP/reserve) in one shot