### PR TITLE
fix(twap): startup pre-warm + cosign-borrow sim-TWAP retry — never reaches user

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -1134,12 +1134,70 @@ export async function handleCosignBorrow(req) {
   // failure we fail CLOSED — refuse to broadcast — because the cost of
   // a missed drain is much higher than a transient unavailability.
   try {
-    const drainCheck = await detectLenderBalanceDrain(connection, tx, LENDER_PUBKEY);
+    let drainCheck = await detectLenderBalanceDrain(connection, tx, LENDER_PUBKEY);
+    // Sim-time TWAP retry: when the simulation rejects specifically
+    // because TwapInsufficientHistory is in the logs (sim err contains
+    // 0x1780 / "TwapInsufficientHistory"), the on-chain PriceHistory
+    // PDA hasn't ripened despite the JIT warmer thinking it had. Re-warm
+    // up to 3 times before giving up. This closes the race condition
+    // where samples fall out of the rolling 300s window between the
+    // ensureV4TwapReady measurement and the broadcast moment. Operator
+    // hit this on SPCX 2026-06-18 PM.
+    let twapRetries = 0;
+    while (
+      !drainCheck.ok &&
+      typeof drainCheck.detail === "string" &&
+      /TwapInsufficientHistory|0x1780|"Custom":\s*6016/i.test(drainCheck.detail) &&
+      twapRetries < 3
+    ) {
+      twapRetries++;
+      console.warn(
+        `[cosign-borrow] Layer 2 sim hit TwapInsufficient — re-warming (retry ${twapRetries}/3)`,
+      );
+      try {
+        const { ensureV4TwapReady } = await import("../services/price-attestor.js");
+        const magpieIxForRetry = tx.instructions.find((ix) => isMagpieProgram(ix.programId));
+        const retryProgramId = magpieIxForRetry?.programId;
+        const collateralMintForRetry = magpieIxForRetry?.keys?.[4]?.pubkey?.toBase58();
+        if (collateralMintForRetry && retryProgramId) {
+          const { rows: [mr] } = await query(
+            `SELECT decimals FROM supported_mints WHERE mint = $1`,
+            [collateralMintForRetry],
+          );
+          if (mr) {
+            await ensureV4TwapReady(collateralMintForRetry, Number(mr.decimals), {
+              programIdOverride: retryProgramId,
+              requiredInWindow: 12,
+              spacingMs: 1_000,
+              maxWaitMs: 30_000,
+            });
+          }
+        }
+      } catch (warmErr) {
+        console.warn(
+          `[cosign-borrow] re-warm retry ${twapRetries} threw: ${warmErr.message?.slice(0, 120)}`,
+        );
+      }
+      drainCheck = await detectLenderBalanceDrain(connection, tx, LENDER_PUBKEY);
+    }
     if (!drainCheck.ok) {
       // tx is now signed but we never broadcast — the lender signature
       // is wasted but the funds stay safe. The attacker learned nothing
       // they couldn't have learned from any other failed tx.
       console.error(`[cosign-borrow] LAYER-2 BLOCK: ${drainCheck.error}. detail=${drainCheck.detail}`);
+      // Surface TWAP-specific failures as a clean retry hint instead of
+      // the generic drain-block message — the user just needs to wait
+      // for warming and tap Borrow again.
+      if (/TwapInsufficientHistory|0x1780|"Custom":\s*6016/i.test(drainCheck.detail || "")) {
+        return {
+          status: 503,
+          body: {
+            error: "Oracle is finalizing — please tap Borrow again in 20–30 seconds.",
+            oracle_warming: true,
+            retry_after_seconds: 25,
+          },
+        };
+      }
       return {
         status: 403,
         body: {

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -206,10 +206,18 @@ export async function getV4TwapSampleCount(mintStr, windowSec = 300, programIdOv
  * For non-V4 callers this is a no-op (returns ok:true immediately).
  */
 export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
-  const REQUIRED_IN_WINDOW = 8;
+  // Safety margin above the on-chain MIN_SAMPLES_FOR_TWAP=8 — sample can
+  // age out between the moment we measure and the moment the cosigned
+  // tx lands on-chain. Targeting 10 gives 2 samples of headroom.
+  const REQUIRED_IN_WINDOW = Number(opts.requiredInWindow ?? 10);
   const WINDOW_SEC = 300;
-  const MAX_WAIT_MS = Number(opts.maxWaitMs ?? process.env.V4_TWAP_WARM_MAX_MS ?? 45_000);
-  const SPACING_MS = Number(opts.spacingMs ?? process.env.V4_TWAP_WARM_SPACING_MS ?? 4_000);
+  // 90s budget, 1.5s spacing — comfortably fits 10 samples even from a
+  // cold-start PDA that needs init first. Previous 45s/4s budget was too
+  // tight: init took ~1s, then 8 attests × 4s = 32s, plus ~2s/attest
+  // confirmation latency pushed us past the deadline. Operator hit this
+  // on SPCX 2026-06-18 PM after three earlier fixes.
+  const MAX_WAIT_MS = Number(opts.maxWaitMs ?? process.env.V4_TWAP_WARM_MAX_MS ?? 90_000);
+  const SPACING_MS = Number(opts.spacingMs ?? process.env.V4_TWAP_WARM_SPACING_MS ?? 1_500);
   const START = Date.now();
   let attests = 0;
   let lastErr = null;
@@ -588,6 +596,64 @@ export function startPriceAttestor(intervalMs = 30_000) {
       }
     }
   }
+
+  // Startup pre-warm pass — initialize V3 + V4 PriceHistory PDAs for
+  // every enabled mint in parallel, IMMEDIATELY, bypassing the per-tick
+  // init cap. Operator-mandated 2026-06-18 PM after SPCX V3 borrow
+  // failed because its V3 PDA had never been initialized — the regular
+  // tick's drip-feed (MAX_INITS_PER_TICK=5) would've taken many ticks
+  // to get to SPCX. This eager init means the FIRST tick already finds
+  // initialized PDAs and just attests them, instead of having to
+  // bootstrap from scratch.
+  //
+  // Bounded concurrency = 4 so we don't burst the RPC.
+  (async function startupPrewarm() {
+    try {
+      const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
+      const programs = [
+        PROGRAM_ID_V4 ? { id: PROGRAM_ID_V4, label: "V4" } : null,
+        PROGRAM_ID_V3 ? { id: PROGRAM_ID_V3, label: "V3" } : null,
+      ].filter(Boolean);
+      if (programs.length === 0) return;
+      const tokens = await fetchMintsToAttest();
+      console.log(
+        `[PriceAttestor] startup pre-warm: ${tokens.length} mint(s) × ${programs.length} program(s) — initializing missing PriceHistory PDAs in parallel (4-wide)`,
+      );
+      const queue = [];
+      for (const t of tokens) {
+        for (const prog of programs) {
+          queue.push({ mint: t.mint, decimals: t.decimals, prog });
+        }
+      }
+      let initialized = 0;
+      let alreadyExisted = 0;
+      let errored = 0;
+      const CONCURRENCY = 4;
+      let idx = 0;
+      async function worker() {
+        while (idx < queue.length) {
+          const task = queue[idx++];
+          try {
+            const result = await initializePriceFeed(task.mint, task.prog.id);
+            if (result.alreadyExists) alreadyExisted++;
+            else { initialized++;
+              console.log(`[PriceAttestor] startup init ${task.prog.label} for ${task.mint.slice(0, 8)}... sig=${result.signature?.slice(0, 16) || "(skip)"}`);
+            }
+          } catch (err) {
+            errored++;
+            console.warn(`[PriceAttestor] startup init ${task.prog.label} for ${task.mint.slice(0, 8)} failed: ${err.message?.slice(0, 100)}`);
+          }
+        }
+      }
+      const workers = Array.from({ length: CONCURRENCY }, () => worker());
+      await Promise.all(workers);
+      console.log(
+        `[PriceAttestor] startup pre-warm DONE — initialized=${initialized}, alreadyExisted=${alreadyExisted}, errored=${errored}`,
+      );
+    } catch (err) {
+      console.warn(`[PriceAttestor] startup pre-warm threw: ${err.message?.slice(0, 200)}`);
+    }
+  })();
 
   // Run immediately, then on interval
   tick();


### PR DESCRIPTION
## Summary
Operator hit `TwapInsufficientHistory` on SPCX borrow 4 times today. Root cause: SPCX PriceHistory PDA was UNINITIALIZED on both V3 and V4 programs at the time of borrow. The JIT warmer's 45s budget was too tight for a cold-start PDA + the windowed sample count threshold.

## Three-layer fix
1. **Tighter attestor cadence on cold tokens.** `price-attestor.js` — MAX_WAIT_MS 45→90s, SPACING_MS 4→1.5s, REQUIRED_IN_WINDOW 8→10. Per-tick pre-warm iterates `[V4, V3]` targets per mint via `programIdOverride`.
2. **Startup pre-warm IIFE.** On boot, iterate every enabled mint with 4-wide concurrency and initialize V3+V4 PriceHistory PDAs, bypassing the per-tick init cap so cold tokens are warm before the first borrow attempt.
3. **cosign-borrow sim-TWAP retry loop.** If pre-flight sim returns `TwapInsufficientHistory` / `0x1780` / `Custom 6016`, call `ensureV4TwapReady` again with `{ requiredInWindow: 12, spacingMs: 1_000, maxWaitMs: 30_000 }` and re-check. Up to 3 retries. On final failure, return 503 with `oracle_warming: true` + clean retry message — never reaches the user.

## Test plan
- [x] Local `node --check` clean across price-attestor.js + cosign-borrow.js
- [ ] After deploy: verify SPCX borrow succeeds without TWAP error
- [ ] After deploy: `/v4-status` shows V3+V4 PDAs warm at boot
- [ ] Probe `probeV4TwapHealth` reports both programs healthy