### PR TITLE
fix(attestor+stats): retry on Helius 429 + unify awaiting_distribution between site/TG

### DIFF
--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -181,6 +181,7 @@ export async function handleStats(ctx) {
     let defaultedLoansWithProfit = 0;
     let defaultsAwaitingSale = 0;
     let defaultsAwaitingDistribution = 0n;
+    let defaultsAwaitingDistributionCount = 0;
     let magpieBurnedCount = 0, magpieBurnPendingCount = 0;
     // Mirror site /api/v1/stats — UNION recovery_credits so out-of-band
     // protocol contributions (operator-funded exploit recovery, etc.)
@@ -217,6 +218,7 @@ export async function handleStats(ctx) {
            COALESCE(SUM(net_profit_lamports) FILTER (
              WHERE distribution_status = 'awaiting_distribution'
            ), 0)::text AS awaiting_dist,
+           COUNT(*) FILTER (WHERE distribution_status = 'awaiting_distribution')::int AS awaiting_dist_count,
            COUNT(*) FILTER (WHERE distribution_status = 'magpie_burn_pending')::int AS magpie_pending,
            COUNT(*) FILTER (WHERE distribution_status = 'magpie_burned')::int AS magpie_burned
          FROM all_profit_events`,
@@ -241,6 +243,7 @@ export async function handleStats(ctx) {
              COALESCE(SUM(net_profit_lamports) FILTER (
                WHERE distribution_status = 'awaiting_distribution'
              ), 0)::text AS awaiting_dist,
+             COUNT(*) FILTER (WHERE distribution_status = 'awaiting_distribution')::int AS awaiting_dist_count,
              COUNT(*) FILTER (WHERE distribution_status = 'magpie_burn_pending')::int AS magpie_pending,
              COUNT(*) FILTER (WHERE distribution_status = 'magpie_burned')::int AS magpie_burned
            FROM liquidation_economics`,
@@ -252,6 +255,7 @@ export async function handleStats(ctx) {
         defaultedLoansWithProfit = Number(agg.profitable_count || 0);
         defaultsAwaitingSale = Number(agg.pending_sale_count || 0);
         defaultsAwaitingDistribution = BigInt(agg.awaiting_dist || "0");
+        defaultsAwaitingDistributionCount = Number(agg.awaiting_dist_count || 0);
         magpieBurnedCount = Number(agg.magpie_burned || 0);
         magpieBurnPendingCount = Number(agg.magpie_pending || 0);
       }
@@ -371,8 +375,8 @@ export async function handleStats(ctx) {
             row("Profitable defaults", String(defaultedLoansWithProfit)),
             ...(defaultsAwaitingSale > 0
               ? [row("Awaiting sale", String(defaultsAwaitingSale))] : []),
-            ...(defaultsAwaitingDistribution > 0n
-              ? [row("Pending distribute", `${fmtSol(defaultsAwaitingDistribution.toString())} SOL`)] : []),
+            ...(defaultsAwaitingDistribution > 0n || defaultsAwaitingDistributionCount > 0
+              ? [row("Pending distribute", `${defaultsAwaitingDistributionCount} (${fmtSol(defaultsAwaitingDistribution.toString())} SOL)`)] : []),
             ...(magpieBurnPendingCount > 0 || magpieBurnedCount > 0
               ? [row("$MAGPIE burns", `${magpieBurnedCount} done / ${magpieBurnPendingCount} pending`)] : []),
           ]

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -361,16 +361,37 @@ export async function attestPrice(mintStr, decimals, priceSolOverride, programId
   // Confidence: use 200 bps (2%) as default since Jupiter doesn't provide confidence
   const confidenceBps = 200;
 
-  const sig = await program.methods
-    .updatePrice(new BN(priceLamports), confidenceBps)
-    .accounts({
-      pool,
-      priceFeed,
-      authority: lender.publicKey,
-    })
-    .rpc({ commitment: "confirmed" });
-
-  return { signature: sig, priceLamports, priceSol };
+  // Retry-on-429 with exponential backoff. Helius rate-limits aggressively
+  // under high concurrency (~25% of attests 429'd at 18-way parallelism
+  // 2026-06-18 PM). Retry catches transient 429s without losing the
+  // attestation. Blockhash-expired errors also retry — likely caused by
+  // RPC queue lag.
+  const RETRY_DELAYS_MS = [500, 1500, 3000];
+  let lastErr = null;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      const sig = await program.methods
+        .updatePrice(new BN(priceLamports), confidenceBps)
+        .accounts({
+          pool,
+          priceFeed,
+          authority: lender.publicKey,
+        })
+        .rpc({ commitment: "confirmed" });
+      return { signature: sig, priceLamports, priceSol };
+    } catch (err) {
+      lastErr = err;
+      const msg = err.message || "";
+      const retriable =
+        /429|Too Many Requests|rate.?limit/i.test(msg) ||
+        /blockhash.*not.*found|block.*expired|TransactionExpiredBlockheightExceeded/i.test(msg);
+      if (!retriable || attempt >= RETRY_DELAYS_MS.length) {
+        throw err;
+      }
+      await new Promise((r) => setTimeout(r, RETRY_DELAYS_MS[attempt]));
+    }
+  }
+  throw lastErr;
 }
 
 /**


### PR DESCRIPTION
## Attestor (the user-impactful one)

Live logs showed Helius RPC 429-rate-limiting ~25% of attestPrice calls at 18-way concurrency. Per-tick sweep losing 50+ attestations to transient 429s, so most tokens were below the 8-samples-in-300s on-chain TWAP threshold.

Wrap attestPrice with exponential-backoff retry (500/1500/3000ms) on 429 and blockhash-expired errors. PRICE_ATTESTOR_CONCURRENCY dialed back to 8 — lower contention → fewer 429s → higher net throughput.

## Stats uniformity

TG was computing awaiting_distribution as SUM, site was computing it as COUNT. Same metric label, different numbers. Now both compute BOTH (count + lamports). TG displays as "N (X.XX SOL)"; site exposes `awaitingDistributionSol` alongside the existing `awaitingDistributionCount`. Mirrors the protocol-uniformity work from PR #386.

## Test plan
- [x] node --check clean on bot files
- [ ] Post-deploy: 429 retries log shows successful recoveries
- [ ] Post-deploy: random 10 enabled mints all show V3 inWindow ≥ 8 within ~5 min
- [ ] TG /stats and site /stats agree on awaiting_distribution numbers