### PR TITLE
feat(defenses): Layer 3+4 misattribution + kill-switch self-monitor probe

### DIFF
--- a/migrations/080_wallets_public_key_unique.sql
+++ b/migrations/080_wallets_public_key_unique.sql
@@ -1,0 +1,47 @@
+-- 080_wallets_public_key_unique.sql
+--
+-- Permanent fix for the loan-misattribution bug class. Operator-mandated
+-- 2026-06-19 PM after 4 active loans (867, 848, 873, 874) were attributed
+-- to the wrong user_id because the wallets table had DUPLICATE rows for
+-- the same public_key — one for the rightful TG-linked user, one for a
+-- synthetic "site_xxxx" user created by the agent (Pip x402) endpoint.
+-- The resolver picked whichever row pg returned first.
+--
+-- This migration:
+--   1. Creates loan_user_attribution_audit (audit trail for repairs).
+--   2. Adds a partial UNIQUE index on wallets.public_key — physically
+--      prevents duplicates going forward.
+--
+-- The actual DE-DUPE of existing rows + RE-ATTRIBUTION of the 4 misattributed
+-- loans happens in a separate one-off script (operator-authorized 2026-06-19).
+-- That script must run BEFORE this migration's UNIQUE constraint will succeed
+-- on creation (the constraint creation will fail if duplicates exist).
+--
+-- See [[feedback_never_misattribute_loans]].
+
+-- Audit trail for every user_id re-attribution. INSERTED by the de-dupe
+-- script + by the wallet-attr-sentinel auto-repair path.
+CREATE TABLE IF NOT EXISTS loan_user_attribution_audit (
+  id            BIGSERIAL PRIMARY KEY,
+  loan_id       BIGINT NOT NULL REFERENCES loans(id),
+  prev_user_id  BIGINT,
+  new_user_id   BIGINT NOT NULL,
+  reason        TEXT NOT NULL,
+  repaired_by   TEXT,
+  metadata      JSONB,
+  repaired_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_loan_attr_audit_loan_id
+  ON loan_user_attribution_audit (loan_id);
+
+CREATE INDEX IF NOT EXISTS idx_loan_attr_audit_repaired_at
+  ON loan_user_attribution_audit (repaired_at DESC);
+
+-- Partial UNIQUE index on wallets.public_key.
+-- Partial (NOT NULL) so legacy NULL rows (if any) don't block the
+-- creation. Once de-dupe is complete this becomes the structural
+-- guarantee that the resolver never sees ambiguous rows.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_wallets_public_key
+  ON wallets (public_key)
+  WHERE public_key IS NOT NULL;

--- a/scripts/dedupe-wallets-and-repair-loans.mjs
+++ b/scripts/dedupe-wallets-and-repair-loans.mjs
@@ -1,0 +1,122 @@
+/**
+ * One-off: de-dupe the wallets table + repair the 4 mis-attributed
+ * active loans. Operator-authorized 2026-06-19 PM after the loan-867
+ * incident.
+ *
+ * Strategy for each duplicate group (same public_key, multiple user_id):
+ *   - PREFER the row whose user_id ties to a real TG user (non-synthetic
+ *     telegram_username NOT LIKE 'site_%' and telegram_id > 0).
+ *   - FALLBACK: highest user_id (most recent link).
+ *   - Re-attribute every loan referencing the kept user.
+ *   - DELETE the synthetic wallet row.
+ *   - INSERT audit row for every loan re-attribution.
+ *
+ * Idempotent — re-run is a no-op once duplicates are cleared.
+ *
+ * Run AFTER migration 080 is applied (table created) but BEFORE the
+ * UNIQUE index, OR before applying the migration entirely (the dedupe
+ * unlocks the constraint creation).
+ *
+ *   node scripts/dedupe-wallets-and-repair-loans.mjs
+ */
+import "dotenv/config";
+import { query } from "../src/db/pool.js";
+
+function pickKeeperRow(rows, users) {
+  // Sort: real TG user (non-synthetic, positive telegram_id) first,
+  // then highest user_id (most recent).
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  return rows
+    .map((r) => ({ ...r, _user: userMap.get(r.user_id) }))
+    .sort((a, b) => {
+      const aReal = a._user && !String(a._user.telegram_username || "").startsWith("site_") && a._user.telegram_id > 0;
+      const bReal = b._user && !String(b._user.telegram_username || "").startsWith("site_") && b._user.telegram_id > 0;
+      if (aReal && !bReal) return -1;
+      if (bReal && !aReal) return 1;
+      return b.user_id - a.user_id;
+    })[0];
+}
+
+await query("BEGIN");
+try {
+  // 1. Find duplicate groups
+  const dups = await query(
+    `SELECT public_key, ARRAY_AGG(id::text) AS ids, ARRAY_AGG(user_id::text) AS user_ids, COUNT(*)::int AS n
+       FROM wallets
+      WHERE public_key IS NOT NULL
+      GROUP BY public_key
+     HAVING COUNT(*) > 1`,
+  );
+  console.log(`Duplicate wallet groups: ${dups.rowCount}`);
+
+  let walletsDeleted = 0;
+  let loansRepaired = 0;
+
+  for (const dup of dups.rows) {
+    const rows = await query(
+      `SELECT id, user_id::int FROM wallets WHERE public_key = $1 ORDER BY id`,
+      [dup.public_key],
+    );
+    const uids = rows.rows.map((r) => r.user_id);
+    const users = (await query(
+      `SELECT id, telegram_id, telegram_username FROM users WHERE id = ANY($1::bigint[])`,
+      [uids],
+    )).rows;
+    const keeper = pickKeeperRow(rows.rows, users);
+    console.log(
+      `  public_key=${dup.public_key.slice(0, 12)}... rows=[${rows.rows.map((r) => r.id).join(",")}] user_ids=[${uids.join(",")}] keeper=wallet#${keeper.id}(user=${keeper.user_id}, ${keeper._user?.telegram_username || "?"})`,
+    );
+
+    // Re-attribute every loan referencing a doomed wallet's user to the keeper's user
+    for (const row of rows.rows) {
+      if (row.id === keeper.id) continue;
+      const loans = await query(
+        `SELECT id FROM loans WHERE borrower_wallet = $1 AND user_id = $2`,
+        [dup.public_key, row.user_id],
+      );
+      for (const l of loans.rows) {
+        await query(
+          `INSERT INTO loan_user_attribution_audit (loan_id, prev_user_id, new_user_id, reason, repaired_by, metadata)
+           VALUES ($1, $2, $3, 'dedupe_wallets_2026_06_19', 'one-off-script',
+                   jsonb_build_object('borrower_wallet', $4::text,
+                                      'doomed_wallet_row_id', $5::bigint,
+                                      'keeper_wallet_row_id', $6::bigint))`,
+          [l.id, row.user_id, keeper.user_id, dup.public_key, row.id, keeper.id],
+        );
+        await query(
+          `UPDATE loans SET user_id = $1, updated_at = NOW() WHERE id = $2`,
+          [keeper.user_id, l.id],
+        );
+        loansRepaired++;
+        console.log(`    loan#${l.id} user_id ${row.user_id} -> ${keeper.user_id}`);
+      }
+      await query(`DELETE FROM wallets WHERE id = $1`, [row.id]);
+      walletsDeleted++;
+    }
+  }
+
+  await query("COMMIT");
+  console.log(
+    `\nSUMMARY: ${dups.rowCount} duplicate groups; ${walletsDeleted} wallet rows deleted; ${loansRepaired} loans re-attributed.`,
+  );
+
+  // Verify post-state
+  const remaining = await query(
+    `SELECT COUNT(*)::int AS n FROM (
+       SELECT public_key FROM wallets WHERE public_key IS NOT NULL GROUP BY public_key HAVING COUNT(*) > 1
+     ) t`,
+  );
+  console.log(`Post-dedupe duplicate groups: ${remaining.rows[0].n} (should be 0)`);
+
+  const mismatched = await query(
+    `SELECT COUNT(*)::int AS n
+       FROM loans l JOIN wallets w ON w.public_key = l.borrower_wallet
+      WHERE l.user_id != w.user_id AND l.status = 'active'`,
+  );
+  console.log(`Post-dedupe active mismatched loans: ${mismatched.rows[0].n} (should be 0)`);
+} catch (e) {
+  await query("ROLLBACK");
+  console.error(`ROLLED BACK: ${e.message}`);
+  process.exit(1);
+}
+process.exit(0);

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -598,6 +598,33 @@ export async function recordLoan({
     );
   }
 
+  // LAYER 3 — pre-write user_id validation. Operator-mandated 2026-06-19
+  // after 22 loans were mis-attributed because callers passed a context-
+  // derived user_id that didn't match the wallet's true owner. Re-verify
+  // RIGHT BEFORE the INSERT that the userId arg matches what the wallets
+  // table says for borrowerWallet. If mismatch: log loudly + use the
+  // wallet's user_id (chain-of-trust: wallets row > caller's context).
+  //
+  // After migration 080 added UNIQUE on wallets.public_key, this check is
+  // unambiguous — exactly one wallets row exists per pubkey.
+  // [[feedback_never_misattribute_loans]]
+  if (borrowerWallet && userId) {
+    try {
+      const { rows: walletCheck } = await query(
+        `SELECT user_id::int AS uid FROM wallets WHERE public_key = $1`,
+        [borrowerWallet],
+      );
+      if (walletCheck.length > 0 && walletCheck[0].uid !== Number(userId)) {
+        console.warn(
+          `[loans.recordLoan] USER_ID DRIFT — caller passed user_id=${userId} but wallets.user_id for ${borrowerWallet.slice(0, 12)}... is ${walletCheck[0].uid}. Overriding with wallets row (the canonical owner) to prevent attribution bug.`,
+        );
+        userId = walletCheck[0].uid;
+      }
+    } catch (err) {
+      console.warn(`[loans.recordLoan] user_id pre-write check failed: ${err.message?.slice(0, 80)}`);
+    }
+  }
+
   const { rows } = await query(
     `INSERT INTO loans (
        user_id, loan_id, loan_pda, collateral_mint, collateral_amount,

--- a/src/services/self-monitor.js
+++ b/src/services/self-monitor.js
@@ -725,6 +725,64 @@ async function probePoolCreditDrift(bot) {
   }
 }
 
+// Kill-switch probe — operator-mandated 2026-06-18 PM.
+// Any *_DISABLED=true or *_PAUSED=true env var that blocks a USER-FACING flow
+// must alert CRIT once it has been on for > KILLSWITCH_STALE_MS. Catches cases
+// like COSIGN_BORROW_DISABLED being flipped by an alarm and never cleared.
+// [[feedback_loans_must_never_fail_no_regressions]]
+const KILLSWITCH_STALE_MS = Number(process.env.KILLSWITCH_STALE_MS) || 10 * 60_000;
+// User-facing switches. Background-only switches (FEE_WALLET_SWEEPER_DISABLED,
+// TREASURY_SWEEP_DISABLED, DIST_GAP_MONITOR_DISABLED, EXPLOIT_DETECTOR_DISABLED,
+// PRICE_SNAPSHOTTER_DISABLED, RAID_MONITOR_DISABLED, FUNDING_GRAPH_DISABLED,
+// PIP_PROACTIVE_DISABLED, PENDING_ARM_WATCHER_DISABLED) are intentionally
+// EXCLUDED — they don't block users from borrowing/repaying. Add to this list
+// any future env var that, when set, would surface as a user-visible error.
+const USER_FACING_KILL_SWITCHES = [
+  "COSIGN_BORROW_DISABLED",
+  "V4_BORROWS_PAUSED",
+  "LIQUIDATION_DISTRIBUTION_DISABLED",
+  "AGENT_API_DISABLED",
+  "LIMIT_CLOSE_AGENT_DISABLED",
+  "PIP_ASK_DISABLED",
+];
+const _killswitchFirstSeen = new Map(); // name -> timestamp ms
+
+function isSwitchOn(v) {
+  return /^(1|true|yes|on)$/i.test(String(v || "").trim());
+}
+
+async function probeKillSwitches(bot) {
+  const KIND = "killswitch_stale";
+  try {
+    const now = Date.now();
+    const active = [];
+    const stale = [];
+    for (const name of USER_FACING_KILL_SWITCHES) {
+      if (isSwitchOn(process.env[name])) {
+        if (!_killswitchFirstSeen.has(name)) _killswitchFirstSeen.set(name, now);
+        const age = now - _killswitchFirstSeen.get(name);
+        active.push({ name, ageMin: Math.round(age / 60_000) });
+        if (age > KILLSWITCH_STALE_MS) stale.push({ name, ageMin: Math.round(age / 60_000) });
+      } else {
+        _killswitchFirstSeen.delete(name);
+      }
+    }
+    const isBad = stale.length > 0;
+    recordOutcome(KIND, isBad);
+    if (isBad) {
+      const list = stale.map((s) => `${s.name} (~${s.ageMin}min)`).join(", ");
+      await alertIfNew(bot, KIND,
+        `user-facing kill switch(es) stale: ${list}. Users may be hitting borrow/repay errors. Flip OFF on Railway if no longer needed.`,
+        "crit",
+      );
+    } else if (active.length === 0) {
+      await alertRecovery(bot, KIND, "all user-facing kill switches are OFF");
+    }
+  } catch (err) {
+    console.warn("[self-monitor] killswitch_stale probe error:", err.message?.slice(0, 160));
+  }
+}
+
 async function tick(bot) {
   try {
     await Promise.all([
@@ -740,6 +798,7 @@ async function tick(bot) {
       probeV4TwapHealth(bot).catch((e) => console.warn("[self-monitor] v4_twap_health probe threw:", e.message)),
       probeLenderWalletBalance(bot).catch((e) => console.warn("[self-monitor] lender_wallet_balance probe threw:", e.message)),
       probePoolCreditDrift(bot).catch((e) => console.warn("[self-monitor] pool_credit_drift probe threw:", e.message)),
+      probeKillSwitches(bot).catch((e) => console.warn("[self-monitor] killswitch_stale probe threw:", e.message)),
     ]);
   } catch (err) {
     // Belt-and-suspenders catch — Promise.all shouldn't throw because

--- a/src/services/wallet-attribution-sentinel.js
+++ b/src/services/wallet-attribution-sentinel.js
@@ -86,30 +86,69 @@ async function runOneCycle(bot) {
     now - lastAlertedAt > ALERT_REPEAT_MS ||
     count > lastAlertedCount * 1.5;
 
-  if (shouldAlert) {
+  // LAYER 4 — auto-repair. Operator-mandated 2026-06-19 ("never misattribute").
+  // The sentinel used to alert and wait for manual repair. Now it repairs
+  // atomically and DMs the operator with what it fixed. Loans become
+  // visible to their rightful owners within ONE tick instead of waiting
+  // for human-in-the-loop. Each repair writes an audit row so the entire
+  // history of mutations is reconstructable. [[feedback_never_misattribute_loans]]
+  const repaired = [];
+  const repairErrors = [];
+  for (const r of rows) {
+    try {
+      await query("BEGIN");
+      await query(
+        `INSERT INTO loan_user_attribution_audit (loan_id, prev_user_id, new_user_id, reason, repaired_by, metadata)
+         VALUES ($1, $2, $3, 'sentinel_auto_repair', 'wallet_attribution_sentinel',
+                 jsonb_build_object('borrower_wallet', $4::text, 'program_id', $5::text))`,
+        [r.id, r.current_uid, r.correct_uid, r.borrower_wallet, r.program_id],
+      );
+      await query(
+        `UPDATE loans SET user_id = $1, updated_at = NOW() WHERE id = $2 AND user_id = $3`,
+        [r.correct_uid, r.id, r.current_uid],
+      );
+      await query("COMMIT");
+      repaired.push(r);
+    } catch (err) {
+      await query("ROLLBACK").catch(() => {});
+      repairErrors.push({ id: r.id, err: err?.message?.slice(0, 100) });
+    }
+  }
+
+  if (shouldAlert || repaired.length > 0 || repairErrors.length > 0) {
     const sample = rows.slice(0, 12).map((r) => {
       const pool = r.program_id?.startsWith("B8AwYz") ? "V3"
                  : r.program_id?.startsWith("6wSpKA") ? "V2"
-                 : r.program_id?.startsWith("4FEFPe") ? "V1" : "?";
+                 : r.program_id?.startsWith("4FEFPe") ? "V1"
+                 : r.program_id?.startsWith("HA1hgv") ? "V4" : "?";
       const owed = (Number(r.owed_lamports) / 1e9).toFixed(2);
-      return `  loan.id=${r.id} ${pool} ${owed}SOL user ${r.current_uid} -> ${r.correct_uid}`;
+      const status = repaired.find((x) => x.id === r.id)
+        ? "REPAIRED"
+        : repairErrors.find((x) => x.id === r.id)
+        ? "REPAIR_FAILED"
+        : "DETECTED";
+      return `  ${status} loan.id=${r.id} ${pool} ${owed}SOL user ${r.current_uid} -> ${r.correct_uid}`;
     }).join("\n");
     const more = rows.length > 12 ? `\n  ... and ${rows.length - 12} more` : "";
+    const headline = repaired.length === count
+      ? `[wallet-attr-sentinel] AUTO-REPAIRED — ${count} mis-attributed loan(s) fixed atomically.`
+      : repaired.length > 0
+      ? `[wallet-attr-sentinel] PARTIAL REPAIR — ${repaired.length}/${count} fixed; ${repairErrors.length} failed. Inspect logs.`
+      : `[wallet-attr-sentinel] ALERT — ${count} active/overdue loan(s) attributed to the wrong user_id (auto-repair attempt failed).`;
     const msg = [
-      `[wallet-attr-sentinel] ALERT — ${count} active/overdue loan(s) attributed to the wrong user_id.`,
-      `These loans are invisible in their owner's /repay et al. until repaired.`,
+      headline,
       ``,
       `Affected:`,
       sample + more,
       ``,
-      `Likely root cause: a recent loan-recording path bypassed wallet-owner-resolver.js. Audit recent code changes that touch loans.user_id or wallets-to-user resolution.`,
-      `Manual repair pattern: UPDATE loans SET user_id = <correct_uid> WHERE id = <loan_id>;`,
+      `Audit trail: SELECT * FROM loan_user_attribution_audit WHERE repaired_at > NOW() - INTERVAL '5 min';`,
+      `Root-cause guidance: recent loan-recording path may have bypassed wallet-owner-resolver. Layer 3 (recordLoan pre-write guard) catches this at WRITE time; sentinel is Layer 4 (after-the-fact safety net).`,
     ].join("\n");
     await notifyAdmin(bot, msg, { parse_mode: undefined });
     lastAlertedAt = now;
     lastAlertedCount = count;
   }
-  return { count };
+  return { count, repaired: repaired.length, errors: repairErrors.length };
 }
 
 export function startWalletAttributionSentinel(bot) {


### PR DESCRIPTION
## Summary

Three layered guards against the loan-mis-attribution bug class + a self-monitor probe so a stuck kill-switch can never silently block borrows for more than 10 min.

- **Layer 3** (write-time): `src/services/loans.js` recordLoan now resolves the canonical wallets.user_id for the borrower_wallet BEFORE the INSERT. If the caller's userId disagrees, the canonical value wins. The bug never reaches the loans table.
- **Layer 4** (after-the-fact): `src/services/wallet-attribution-sentinel.js` now AUTO-REPAIRS instead of asking for manual SQL. Each tick: INSERT audit row + UPDATE loans.user_id atomically, then DM operator with REPAIRED / DETECTED / REPAIR_FAILED per loan.
- **Kill-switch probe**: `src/services/self-monitor.js` watches a curated list of user-facing kill switches (`COSIGN_BORROW_DISABLED`, `V4_BORROWS_PAUSED`, `LIQUIDATION_DISTRIBUTION_DISABLED`, `AGENT_API_DISABLED`, `LIMIT_CLOSE_AGENT_DISABLED`, `PIP_ASK_DISABLED`). Any of them ON for more than 10 min → CRIT alert.

Migration 080 (already applied on prod): `loan_user_attribution_audit` table + partial UNIQUE index on `wallets.public_key`.

## Test plan

- [ ] Sentinel auto-repairs a fresh mis-attribution within one tick
- [ ] Kill-switch probe DMs CRIT 10 min after `COSIGN_BORROW_DISABLED=true`
- [ ] Layer 3 logs USER_ID DRIFT line on wrong user_id
- [ ] No regression to V1/V2/V3/V4 borrow + repay