### PR TITLE
feat(defenses): Layer 5 — TG loan read paths defend via wallets JOIN

### DIFF
--- a/src/commands/extend.js
+++ b/src/commands/extend.js
@@ -27,12 +27,15 @@ export async function handleExtend(ctx) {
 
   const user = await upsertUser(tgUser.id, tgUser.username);
 
+  // Layer 5 defense [[feedback_never_misattribute_loans]]
   const { rows } = await query(
     `SELECT l.*, sm.symbol
      FROM loans l
      LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-     WHERE l.user_id = $1 AND l.status = 'active'
+     WHERE l.status = 'active'
        AND COALESCE(l.suspended, FALSE) = FALSE
+       AND (l.user_id = $1
+            OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $1))
      ORDER BY l.due_timestamp ASC`,
     [user.id],
   );
@@ -109,7 +112,9 @@ export function registerExtendCallbacks(bot) {
       `SELECT l.*, sm.symbol
        FROM loans l
        LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-       WHERE l.id = $1 AND l.user_id = $2 AND l.status = 'active'`,
+       WHERE l.id = $1 AND l.status = 'active'
+         AND (l.user_id = $2
+              OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $2))`,
       [loanDbId, user.id],
     );
     const loan = rows[0];

--- a/src/commands/health.js
+++ b/src/commands/health.js
@@ -73,11 +73,14 @@ export async function handleHealth(ctx) {
   let loan;
   if (arg) {
     // Specific loan by loan_id
+    // Layer 5 defense [[feedback_never_misattribute_loans]]
     const { rows } = await query(
       `SELECT l.*, sm.symbol, sm.decimals
        FROM loans l
        LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-       WHERE l.loan_id = $1 AND l.user_id = $2 AND l.status = 'active'
+       WHERE l.loan_id = $1 AND l.status = 'active'
+         AND (l.user_id = $2
+              OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $2))
        LIMIT 1`,
       [arg, user.id],
     );
@@ -96,7 +99,9 @@ export async function handleHealth(ctx) {
       `SELECT l.*, sm.symbol, sm.decimals
        FROM loans l
        LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-       WHERE l.user_id = $1 AND l.status = 'active'
+       WHERE l.status = 'active'
+         AND (l.user_id = $1
+              OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $1))
        ORDER BY l.due_timestamp ASC`,
       [user.id],
     );

--- a/src/commands/partial-repay.js
+++ b/src/commands/partial-repay.js
@@ -20,12 +20,15 @@ export async function handlePartialRepay(ctx) {
 
   const user = await upsertUser(tgUser.id, tgUser.username);
 
+  // Layer 5 defense [[feedback_never_misattribute_loans]]
   const { rows } = await query(
     `SELECT l.*, sm.symbol
      FROM loans l
      LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-     WHERE l.user_id = $1 AND l.status = 'active'
+     WHERE l.status = 'active'
        AND COALESCE(l.suspended, FALSE) = FALSE
+       AND (l.user_id = $1
+            OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $1))
      ORDER BY l.due_timestamp ASC`,
     [user.id],
   );
@@ -89,7 +92,9 @@ export function registerPartialRepayCallbacks(bot) {
       `SELECT l.*, sm.symbol
        FROM loans l
        LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-       WHERE l.id = $1 AND l.user_id = $2 AND l.status = 'active'`,
+       WHERE l.id = $1 AND l.status = 'active'
+         AND (l.user_id = $2
+              OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $2))`,
       [loanDbId, user.id],
     );
     const loan = rows[0];

--- a/src/commands/positions.js
+++ b/src/commands/positions.js
@@ -71,11 +71,16 @@ export async function handlePositions(ctx) {
 
   const user = await upsertUser(tgUser.id, tgUser.username);
 
+  // Layer 5 defense — OR-clause picks up loans whose borrower_wallet
+  // is one of THIS user's wallets, even if loans.user_id has drifted.
+  // [[feedback_never_misattribute_loans]]
   const { rows: rawRows } = await query(
     `SELECT l.*, sm.symbol, sm.decimals
      FROM loans l
      LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-     WHERE l.user_id = $1 AND l.status = 'active'
+     WHERE l.status = 'active'
+       AND (l.user_id = $1
+            OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $1))
      ORDER BY l.due_timestamp ASC`,
     [user.id],
   );

--- a/src/commands/repay.js
+++ b/src/commands/repay.js
@@ -24,11 +24,18 @@ export async function handleRepay(ctx) {
 
   const user = await upsertUser(tgUser.id, tgUser.username);
 
+  // Layer 5 defense — even if loans.user_id ever drifts (caught + repaired
+  // by wallet-attribution-sentinel + Layer 3 pre-write guard), the OR
+  // clause picks up any loan whose borrower_wallet is one of THIS user's
+  // wallets. The sentinel runs every 30 min; this closes the gap to ZERO
+  // for /repay. [[feedback_never_misattribute_loans]]
   const { rows } = await query(
     `SELECT l.*, sm.symbol
      FROM loans l
      LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-     WHERE l.user_id = $1 AND l.status = 'active'
+     WHERE l.status = 'active'
+       AND (l.user_id = $1
+            OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $1))
      ORDER BY l.due_timestamp ASC`,
     [user.id],
   );
@@ -118,7 +125,9 @@ export function registerRepayCallbacks(bot) {
       `SELECT l.*, sm.symbol
        FROM loans l
        LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
-       WHERE l.id = $1 AND l.user_id = $2 AND l.status = 'active'`,
+       WHERE l.id = $1 AND l.status = 'active'
+         AND (l.user_id = $2
+              OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $2))`,
       [loanDbId, user.id],
     );
     const loan = rows[0];


### PR DESCRIPTION
## Summary

Final layer of the never-misattribute-a-loan stack. PR #393 shipped Layers 1-4 and a UNIQUE constraint on `wallets.public_key`. This PR adds Layer 5: the TG read paths now resolve loans through the borrower_wallet → user mapping, not just through `loans.user_id`.

Even if Layers 1-4 ever transiently fail (a code path that writes loans directly without `recordLoan`; a sentinel tick interrupted by deploy), the user ALWAYS sees their loan in /repay, /positions, /extend, /partial-repay, and /health.

Mechanical, low-risk change:

```sql
WHERE l.user_id = $1
->
WHERE l.user_id = $1
   OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $1)
```

Backward-compatible — same params, same row shape, only widens the result set defensively to catch mis-attributed rows.

## Test plan

- [ ] /repay, /positions, /extend, /partial-repay, /health all return identical results on the happy path (correctly-attributed loan)
- [ ] If a loan's user_id is manually corrupted, the user STILL sees it via /repay before the sentinel runs
- [ ] No expansion to loans the user doesn't own (UNIQUE wallets.public_key gives 1:1 wallet→user mapping)