### PR TITLE
fix(rpc): complete user-facing withFailover sweep — 5 remaining sites

### DIFF
--- a/src/api/agent-manage.js
+++ b/src/api/agent-manage.js
@@ -36,7 +36,7 @@ import {
 } from "@solana/spl-token";
 import BN from "bn.js";
 import { query } from "../db/pool.js";
-import { connection } from "../solana/connection.js";
+import { connection, withFailover } from "../solana/connection.js";
 import { chooseProgramIdForLoan, getProgramForSigner } from "../solana/program.js";
 import { rejectIfSiteDisabled } from "../services/site-global.js";
 import { rejectIfLocked } from "../services/site-lock.js";
@@ -64,7 +64,7 @@ async function readJsonBody(req) {
 }
 
 async function getMintTokenProgram(mintStr) {
-  const info = await connection.getAccountInfo(new PublicKey(mintStr));
+  const info = await withFailover((conn) => conn.getAccountInfo(new PublicKey(mintStr)));
   if (!info) throw new Error(`Mint ${mintStr} not found on-chain`);
   return info.owner.equals(TOKEN_2022_PROGRAM_ID) ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID;
 }

--- a/src/api/agent-repay.js
+++ b/src/api/agent-repay.js
@@ -50,7 +50,7 @@ import {
 } from "@solana/spl-token";
 import BN from "bn.js";
 import { query } from "../db/pool.js";
-import { connection } from "../solana/connection.js";
+import { connection, withFailover } from "../solana/connection.js";
 import {
   chooseProgramIdForLoan,
   getProgramForSigner,
@@ -83,7 +83,7 @@ async function readJsonBody(req) {
 }
 
 async function getMintTokenProgram(mintStr) {
-  const info = await connection.getAccountInfo(new PublicKey(mintStr));
+  const info = await withFailover((conn) => conn.getAccountInfo(new PublicKey(mintStr)));
   if (!info) throw new Error(`Mint ${mintStr} not found on-chain`);
   return info.owner.equals(TOKEN_2022_PROGRAM_ID) ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID;
 }

--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -56,7 +56,7 @@ import {
 } from "@solana/spl-token";
 import BN from "bn.js";
 import { query } from "../db/pool.js";
-import { connection } from "../solana/connection.js";
+import { connection, withFailover } from "../solana/connection.js";
 import {
   PROGRAM_ID,
   PROGRAM_ID_V2,
@@ -384,7 +384,7 @@ export async function buildBorrowTx({
 }
 
 async function getMintTokenProgram(mintStr) {
-  const info = await connection.getAccountInfo(new PublicKey(mintStr));
+  const info = await withFailover((conn) => conn.getAccountInfo(new PublicKey(mintStr)));
   if (!info) throw new Error(`Mint ${mintStr} not found on-chain`);
   return info.owner.equals(TOKEN_2022_PROGRAM_ID)
     ? TOKEN_2022_PROGRAM_ID

--- a/src/api/withdraw.js
+++ b/src/api/withdraw.js
@@ -47,7 +47,7 @@ import {
 } from "@solana/spl-token";
 import bs58 from "bs58";
 import { createPublicKey, verify as cryptoVerify } from "node:crypto";
-import { connection } from "../solana/connection.js";
+import { connection, withFailover } from "../solana/connection.js";
 import { query } from "../db/pool.js";
 import { loadKeypair } from "../services/wallet.js";
 import { alertWithdraw } from "../services/security-alerts.js";
@@ -125,7 +125,7 @@ async function readJsonBody(req) {
 }
 
 async function getMintTokenProgram(mint) {
-  const info = await connection.getAccountInfo(new PublicKey(mint));
+  const info = await withFailover((conn) => conn.getAccountInfo(new PublicKey(mint)));
   if (!info) throw new Error(`Mint ${mint} not found`);
   if (info.owner.equals(TOKEN_2022_PROGRAM_ID)) return TOKEN_2022_PROGRAM_ID;
   return TOKEN_PROGRAM_ID;
@@ -311,7 +311,7 @@ export async function handleSiteWithdraw(req) {
   // pattern as src/commands/withdraw.js. Float displays never enter.
   if (Asset === "SOL") {
     decimals = 9;
-    const bal = BigInt(await connection.getBalance(signer.publicKey));
+    const bal = BigInt(await withFailover((conn) => conn.getBalance(signer.publicKey)));
     maxLamports = bal > SOL_GAS_RESERVE_LAMPORTS ? bal - SOL_GAS_RESERVE_LAMPORTS : 0n;
   } else {
     let mintPk;
@@ -321,10 +321,10 @@ export async function handleSiteWithdraw(req) {
       return { status: 400, body: { error: "Asset must be SOL or a valid mint pubkey" } };
     }
     const tokenProgram = await getMintTokenProgram(Asset);
-    const mintInfo = await connection.getParsedAccountInfo(mintPk);
+    const mintInfo = await withFailover((conn) => conn.getParsedAccountInfo(mintPk));
     decimals = mintInfo.value?.data?.parsed?.info?.decimals ?? 9;
     const ata = getAssociatedTokenAddressSync(mintPk, signer.publicKey, false, tokenProgram);
-    const ataInfo = await connection.getTokenAccountBalance(ata).catch(() => null);
+    const ataInfo = await withFailover((conn) => conn.getTokenAccountBalance(ata)).catch(() => null);
     maxLamports = ataInfo ? BigInt(ataInfo.value.amount) : 0n;
   }
   if (rawAmount > maxLamports) {

--- a/src/commands/repay.js
+++ b/src/commands/repay.js
@@ -5,7 +5,7 @@ import { query } from "../db/pool.js";
 import { executeRepay, markLoanRepaid, getLiveOwedLamports, checkLoanOwnership } from "../services/loans.js";
 import { scopeLoansToActiveWallet } from "../services/wallet-scoped-loans.js";
 import { ensureWallet } from "../services/wallet.js";
-import { connection } from "../solana/connection.js";
+import { connection, withFailover } from "../solana/connection.js";
 import { incrementRepaid } from "../services/reputation.js";
 import { translateTxError, errorActionKeyboard, renderWalletMismatchMessage } from "../services/tx-error-translator.js";
 import { formatLoanButtonLabel, totalOwedSol, countDueWithin } from "../services/loan-display.js";
@@ -163,7 +163,7 @@ export function registerRepayCallbacks(bot) {
     // actionable message. Check BEFORE we even build the tx.
     try {
       const { publicKey } = await ensureWallet(user.id);
-      const balanceLamports = BigInt(await connection.getBalance(new PublicKey(publicKey)));
+      const balanceLamports = BigInt(await withFailover((conn) => conn.getBalance(new PublicKey(publicKey))));
       const needed = owedNow + REPAY_GAS_BUFFER_LAMPORTS;
       if (balanceLamports < needed) {
         const short = needed - balanceLamports;


### PR DESCRIPTION
## Summary

Completes the user-facing withFailover sweep started in PRs #395, #396, #397. Five remaining sites that had direct `connection.<method>()` calls on user-facing paths are now wrapped, so a Helius blip can't cascade to a user-visible error.

Sites:
- `src/api/withdraw.js` — site withdraw endpoint (4 calls)
- `src/api/agent.js` — Pip x402 borrow (1 call)
- `src/api/agent-repay.js` — Pip x402 repay (1 call)
- `src/api/agent-manage.js` — Pip x402 manage (1 call)
- `src/commands/repay.js` — TG /repay insufficient-SOL preflight (1 call)

Mechanical change, same shape, no behavior change on the happy path.

References:
- feedback_user_facing_rpc_calls_must_use_with_failover

## Test plan

- [ ] Each flow still works normally
- [ ] Helius blip transparently falls through to backup RPC