### PR TITLE
fix(withdraw): humanize user-facing withdraw error strings

### DIFF
--- a/src/api/withdraw.js
+++ b/src/api/withdraw.js
@@ -230,7 +230,10 @@ export async function handleSiteWithdraw(req) {
   if (!walletRow) {
     return {
       status: 403,
-      body: { error: "Signer wallet is not linked to a Magpie account" },
+      body: {
+        error: "This wallet isn't linked to a Magpie account yet. Open Telegram and run /start with @magpie_capital_bot to link it.",
+        friendly: true,
+      },
     };
   }
   const userId = walletRow.user_id;
@@ -283,7 +286,13 @@ export async function handleSiteWithdraw(req) {
     );
   } catch (e) {
     if (e.code === "23505") {
-      return { status: 409, body: { error: "Nonce already used — re-sign a fresh message" } };
+      return {
+        status: 409,
+        body: {
+          error: "This request already went through — refresh the page to start fresh.",
+          friendly: true,
+        },
+      };
     }
     throw e;
   }
@@ -397,7 +406,21 @@ export async function handleSiteWithdraw(req) {
       [auditId, (e.message || "unknown").slice(0, 500)],
     );
     console.error(`[site-withdraw] tx failed for user ${userId}:`, e.message);
-    return { status: 500, body: { error: "Withdraw transaction failed", detail: e.message?.slice(0, 200) } };
+    // Humanize the user-facing error. The raw e.message is usually a
+    // chain-of-Custom-N-error chain that means nothing to a borrower.
+    // [[feedback_loans_must_never_fail_no_regressions]]
+    const msg = (e.message || "").toLowerCase();
+    let friendly;
+    if (/insufficient.*funds|0x1$|0x1\b/.test(msg)) {
+      friendly = "Not enough balance to cover the withdraw + network fee. Reduce the amount slightly and try again.";
+    } else if (/blockhash.*not found|block height exceeded|expired/.test(msg)) {
+      friendly = "The transaction expired before it landed. Please try again in a few seconds.";
+    } else if (/timeout|timed out/.test(msg)) {
+      friendly = "The network is slow right now — your withdraw didn't confirm in time. Please retry in 10–15 seconds.";
+    } else {
+      friendly = "We couldn't complete the withdraw right now. Please refresh and try again in a few seconds.";
+    }
+    return { status: 500, body: { error: friendly, friendly: true, detail: e.message?.slice(0, 200) } };
   }
 
   await query(


### PR DESCRIPTION
## Summary

Continuation of the world-class-conversion sweep that #399 started for cosign-borrow. Same pattern applied to `src/api/withdraw.js`.

### Before
- "Withdraw transaction failed" + raw error chain
- "Signer wallet is not linked to a Magpie account"
- "Nonce already used — re-sign a fresh message"

### After
- Tx failure now branches by inner-error pattern: insufficient funds, blockhash expired, timeout, or generic — each with a friendly + actionable message.
- Unlinked wallet now tells the user exactly how to link (open TG, run /start).
- Nonce reuse now says "This request already went through — refresh the page to start fresh."

Technical detail preserved in `body.detail` for ops logs; top-level `error` is friendly. `body.friendly: true` flag tells the site to render directly instead of mapping a code.

## Test plan

- [ ] Normal withdraw still succeeds
- [ ] Insufficient SOL → "Reduce the amount slightly" message
- [ ] Blockhash expired → "expired before it landed" message
- [ ] Unlinked wallet → "Open Telegram, run /start" message
- [ ] Replay of same signed payload → "This request already went through" message