### PR TITLE
chore(sentinel): tighten cadence 30min -> 5min

### DIFF
--- a/src/services/wallet-attribution-sentinel.js
+++ b/src/services/wallet-attribution-sentinel.js
@@ -30,7 +30,12 @@
 import { query } from "../db/pool.js";
 import { getAdminId, notifyAdmin } from "./admin-notify.js";
 
-const POLL_INTERVAL_MS = Number(process.env.WALLET_ATTR_SENTINEL_MS) || 30 * 60_000;
+// Cadence tightened from 30min -> 5min 2026-06-18 PM. With Layer 4
+// auto-repair (PR #393), the sentinel now FIXES drift inline, so a
+// faster tick = tighter window before the user sees "no active loans"
+// on /repay after a fresh borrow. 5min is still cheap (one indexed
+// SQL per tick). Operator-mandated. [[feedback_never_misattribute_loans]]
+const POLL_INTERVAL_MS = Number(process.env.WALLET_ATTR_SENTINEL_MS) || 5 * 60_000;
 const ALERT_REPEAT_MS = 6 * 60 * 60 * 1000;
 
 let lastAlertedAt = 0;


### PR DESCRIPTION
## Summary

Tightens wallet-attribution sentinel cadence from 30 min to 5 min. With Layer 4 auto-repair already shipped in #393, the sentinel now FIXES drift inline — faster cadence = tighter window between any fresh mis-attribution and the auto-fix. 5 min is still cheap (one indexed SQL per tick).

## Test plan

- [ ] Sentinel runs every 5 min by default
- [ ] `WALLET_ATTR_SENTINEL_MS` env var still works as override