### PR TITLE
feat(visibility): rolling counter + self-monitor probe for cosign-borrow failures

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -48,6 +48,35 @@ import { rejectIfSiteDisabled } from "../services/site-global.js";
 import { rejectIfLocked } from "../services/site-lock.js";
 import { getTierByOption } from "../services/loan-tier-resolver.js";
 
+// Rolling counter of borrow failure classifications. self-monitor reads
+// this via getRecentBorrowFailures() and CRIT-alerts the operator when
+// the rate of any class exceeds the threshold. Lets us see in real time
+// whether the problem is stale-blockhash (signing-window issue), rpc-
+// exhausted (infrastructure issue), or sim-failed (program-side reject).
+const _borrowFailureCounts = new Map(); // klass -> array of timestamps (ms)
+const FAILURE_RETENTION_MS = 60 * 60 * 1000; // 1h rolling
+
+function recordBorrowFailure(klass) {
+  const now = Date.now();
+  const arr = _borrowFailureCounts.get(klass) || [];
+  arr.push(now);
+  // Trim entries older than retention window
+  const cutoff = now - FAILURE_RETENTION_MS;
+  while (arr.length > 0 && arr[0] < cutoff) arr.shift();
+  _borrowFailureCounts.set(klass, arr);
+}
+
+/** Snapshot for self-monitor — returns { klass: count_last_hour, ... } */
+export function getRecentBorrowFailures() {
+  const out = {};
+  const cutoff = Date.now() - FAILURE_RETENTION_MS;
+  for (const [klass, arr] of _borrowFailureCounts.entries()) {
+    const recent = arr.filter((ts) => ts >= cutoff).length;
+    if (recent > 0) out[klass] = recent;
+  }
+  return out;
+}
+
 // Programs the lender authority has privileges over
 const V1_PROGRAM_ID = new PublicKey(
   process.env.PROGRAM_ID || "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh",
@@ -1256,6 +1285,7 @@ export async function handleCosignBorrow(req) {
       if (drainCheck.kind === "sim_failed") {
         // The user's tx itself would fail on-chain. Classify by inner code
         // so the user gets actionable guidance + operator gets a CRIT DM.
+        recordBorrowFailure("sim_failed");
         const detail = drainCheck.detail || "";
         try {
           const { notifyAdmin } = await import("../services/admin-notify.js");
@@ -1348,6 +1378,7 @@ export async function handleCosignBorrow(req) {
     // gets a CRIT DM with the actual root cause every time.
     // [[feedback_loans_must_never_fail_no_regressions]]
     const klass = simErr.classification || "unclassified";
+    recordBorrowFailure(klass);
     console.error(`[cosign-borrow] LAYER-2 SIM-ERROR [${klass}]: ${simErr.message?.slice(0, 240)}`);
     try {
       const { notifyAdmin } = await import("../services/admin-notify.js");

--- a/src/services/self-monitor.js
+++ b/src/services/self-monitor.js
@@ -751,6 +751,67 @@ function isSwitchOn(v) {
   return /^(1|true|yes|on)$/i.test(String(v || "").trim());
 }
 
+// Borrow failure rate probe — reads the rolling in-memory counter in
+// cosign-borrow.js and CRIT-alerts if any classification exceeds the
+// per-hour threshold. Real-time visibility into how often each failure
+// mode fires so operator can act on patterns (e.g. high stale_blockhash
+// rate means site signing window needs widening).
+// [[feedback_loans_must_never_fail_no_regressions]]
+const BORROW_FAILURE_THRESHOLD_PER_HOUR = Number(process.env.BORROW_FAILURE_THRESHOLD_PER_HOUR) || 5;
+const BORROW_FAILURE_COOLDOWN_MS = Number(process.env.BORROW_FAILURE_COOLDOWN_MS) || 30 * 60_000;
+let _lastBorrowFailureAlertAt = 0;
+let _lastBorrowFailureSnapshot = "";
+
+async function probeBorrowFailures(bot) {
+  const KIND = "borrow_failures_high";
+  try {
+    const { getRecentBorrowFailures } = await import("../api/cosign-borrow.js");
+    const failures = getRecentBorrowFailures();
+    const klasses = Object.keys(failures);
+    if (klasses.length === 0) {
+      recordOutcome(KIND, false);
+      await alertRecovery(bot, KIND, "borrow failure rate back to zero");
+      return;
+    }
+    const overThreshold = klasses.filter((k) => failures[k] >= BORROW_FAILURE_THRESHOLD_PER_HOUR);
+    const isBad = overThreshold.length > 0;
+    recordOutcome(KIND, isBad);
+    if (!isBad) {
+      // Below threshold but non-zero — fine, no alert.
+      await alertRecovery(bot, KIND, "borrow failure rate normalized");
+      return;
+    }
+    const snapshot = klasses
+      .sort((a, b) => failures[b] - failures[a])
+      .map((k) => `${k}=${failures[k]}`)
+      .join(" ");
+    // Throttle — don't re-DM if snapshot hasn't materially changed.
+    if (snapshot === _lastBorrowFailureSnapshot
+        && Date.now() - _lastBorrowFailureAlertAt < BORROW_FAILURE_COOLDOWN_MS) {
+      return;
+    }
+    _lastBorrowFailureAlertAt = Date.now();
+    _lastBorrowFailureSnapshot = snapshot;
+    const guidance = overThreshold.map((k) => {
+      if (k === "stale_blockhash")
+        return "stale_blockhash: users signing too late — site should refresh the blockhash if signing takes >30s";
+      if (k === "rpc_exhausted")
+        return "rpc_exhausted: Helius + every backup failing simulateTransaction — check provider status";
+      if (k === "sim_failed")
+        return "sim_failed: tx would fail on-chain — check recent CRIT DMs for inner reason";
+      if (k === "unclassified")
+        return "unclassified: a new failure shape — pull recent CRIT DMs for the inner error";
+      return `${k}: investigate`;
+    }).join(" | ");
+    await alertIfNew(bot, KIND,
+      `cosign-borrow failures over threshold in last 1h: ${snapshot}. Guidance: ${guidance}`,
+      "crit",
+    );
+  } catch (err) {
+    console.warn("[self-monitor] borrow_failures probe error:", err.message?.slice(0, 160));
+  }
+}
+
 async function probeKillSwitches(bot) {
   const KIND = "killswitch_stale";
   try {
@@ -799,6 +860,7 @@ async function tick(bot) {
       probeLenderWalletBalance(bot).catch((e) => console.warn("[self-monitor] lender_wallet_balance probe threw:", e.message)),
       probePoolCreditDrift(bot).catch((e) => console.warn("[self-monitor] pool_credit_drift probe threw:", e.message)),
       probeKillSwitches(bot).catch((e) => console.warn("[self-monitor] killswitch_stale probe threw:", e.message)),
+      probeBorrowFailures(bot).catch((e) => console.warn("[self-monitor] borrow_failures probe threw:", e.message)),
     ]);
   } catch (err) {
     // Belt-and-suspenders catch — Promise.all shouldn't throw because


### PR DESCRIPTION
## Summary

Real-time visibility into borrow failure rate by classification, building on #404. Without this, operator has to manually count CRIT DMs to know which failure class is biting.

### Mechanic

- `cosign-borrow.js` maintains an in-memory rolling 1h `Map<klass, ts[]>`. Exports `getRecentBorrowFailures()`.
- `self-monitor.js probeBorrowFailures` runs every 60s, reads the snapshot, CRIT-alerts when any klass exceeds `BORROW_FAILURE_THRESHOLD_PER_HOUR` (default 5/h) with per-klass guidance string.

### Per-klass guidance baked into the alert

- `stale_blockhash` → "site should refresh blockhash if signing >30s"
- `rpc_exhausted` → "Helius + every backup failing — check provider"
- `sim_failed` → "tx would fail on-chain — check CRIT DMs"
- `unclassified` → "new failure shape — pull CRIT DMs"

### Throttling

Re-DMs only when the snapshot changes OR 30 min has elapsed. Fresh signal without spam.

## Test plan

- [ ] Each failure-class catch increments the counter
- [ ] Probe DMs CRIT once threshold exceeded
- [ ] Recovery DM fires when rate returns to zero
- [ ] Same snapshot doesn't re-alert within cooldown