### PR TITLE
fix(lp-excess-sweeper): default-import @coral-xyz/anchor — Node 22+ crash

### DIFF
--- a/src/services/lp-excess-sweeper.js
+++ b/src/services/lp-excess-sweeper.js
@@ -61,7 +61,10 @@ import {
   createAssociatedTokenAccountIdempotentInstruction,
   createCloseAccountInstruction,
 } from "@solana/spl-token";
-import { BN } from "@coral-xyz/anchor";
+// Named { BN } breaks on Node 22+ (strict ESM-from-CJS). Default-import
+// then destructure. [[feedback_anchor_cjs_node22_import_pattern]]
+import anchorPkg from "@coral-xyz/anchor";
+const { BN } = anchorPkg;
 import bs58 from "bs58";
 
 import { connection, withFailover } from "../solana/connection.js";


### PR DESCRIPTION
P0 — sweeper crashes at boot with unhandledRejection on `import { BN }` from anchor under Node 26. Fixed via default-import-then-destructure pattern per [[feedback_anchor_cjs_node22_import_pattern]].