### PR TITLE
fix(price-attestor): CTE USING column mismatch caught by boot sanity check

### DIFF
--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -477,7 +477,11 @@ async function fetchMintsToAttest() {
               OR aem.collateral_mint IS NOT NULL
               OR rim.collateral_mint IS NOT NULL) AS needs_continuous
        FROM supported_mints sm
-       LEFT JOIN active_loan_mints alm USING (mint)
+       -- USING (mint) was wrong: active_loan_mints exposes
+       -- collateral_mint, not mint. That mismatch threw and the boot
+       -- sanity check caught it on the first deploy of the loan_id cast
+       -- fix. Match the explicit-ON pattern used by the other two CTEs.
+       LEFT JOIN active_loan_mints alm ON alm.collateral_mint = sm.mint
        LEFT JOIN armed_exit_mints aem ON aem.collateral_mint = sm.mint
        LEFT JOIN recent_intent_mints rim ON rim.collateral_mint = sm.mint
       WHERE sm.enabled = TRUE


### PR DESCRIPTION
## Summary
PR #413's boot sanity check caught a second bug on the very first deploy: `active_loan_mints` CTE exposes `collateral_mint`, not `mint`, so the `USING (mint)` JOIN threw before Postgres ever evaluated the loan_id cast. The fallback (also added in #413) is what's been keeping attestation alive today.

This PR replaces `USING (mint)` with the explicit-ON pattern matching the two adjacent LEFT JOINs.

## Test plan
- Merge + Railway redeploy.
- Boot log should now read "primary mint query OK" instead of the BOOT SANITY CHECK FAILED CRIT.
- Fallback log line ("Primary mint query failed — falling back...") should stop appearing on every tick.
- V4 PriceHistory PDA samples for tokenized stocks should continue climbing; this PR doesn't change attestation cadence, only restores the precise mint-set targeting.

Generated with Claude Code