### PR TITLE
fix(cosign-borrow): classify TWAP-warming user-facing returns into borrow-failure tracker

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -606,6 +606,7 @@ export async function handleCosignBorrow(req) {
       // Fail CLOSED across primary + every backup. User UX must not leak
       // the technical reason — friendly retry + DM operator with detail.
       console.error("[cosign-borrow] DRAIN-CHECK RPC failure (all RPCs failed) — failing closed:", rpcErr.message);
+      recordBorrowFailure("drain_check_rpc");
       try {
         const { notifyAdmin } = await import("../services/admin-notify.js");
         await notifyAdmin(
@@ -1187,6 +1188,17 @@ export async function handleCosignBorrow(req) {
             console.warn(
               `[cosign-borrow] TWAP warming TIMED OUT prog=${borrowProgramId.toBase58().slice(0, 8)}… mint=${mintStr.slice(0, 8)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests} reason=${warm.reason}`,
             );
+            recordBorrowFailure("twap_warming_timeout");
+            // CRIT-DM operator the FIRST time the JIT warmer can't deliver
+            // 8 samples in its budget — this is the symptom of an attestor
+            // stall, Jupiter outage, or unattested mint. The user-facing
+            // message is friendly; this DM is the trip wire.
+            try {
+              const { notifyAdmin } = await import("../services/admin-notify.js");
+              await notifyAdmin(
+                `CRIT [cosign-borrow] JIT TWAP warmer TIMED OUT — user hit TwapInsufficientHistory on borrow. prog=${borrowProgramId.toBase58().slice(0, 8)} mint=${mintStr.slice(0, 12)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests} reason=${warm.reason}`,
+              );
+            } catch {}
             return {
               status: 503,
               body: {
@@ -1313,6 +1325,7 @@ export async function handleCosignBorrow(req) {
       // the generic drain-block message — the user just needs to wait
       // for warming and tap Borrow again.
       if (/TwapInsufficientHistory|0x1780|"Custom":\s*6016/i.test(drainCheck.detail || "")) {
+        recordBorrowFailure("twap_sim_reject");
         return {
           status: 503,
           body: {
@@ -1374,6 +1387,7 @@ export async function handleCosignBorrow(req) {
         }
         // StalePriceAttestation (price feed too old at broadcast time).
         if (/StalePriceAttestation|"Custom":\s*6019/i.test(detail)) {
+          recordBorrowFailure("stale_price_attestation");
           return {
             status: 503,
             body: {

--- a/src/services/self-monitor.js
+++ b/src/services/self-monitor.js
@@ -801,6 +801,14 @@ async function probeBorrowFailures(bot) {
         return "sim_failed: tx would fail on-chain — check recent CRIT DMs for inner reason";
       if (k === "unclassified")
         return "unclassified: a new failure shape — pull recent CRIT DMs for the inner error";
+      if (k === "twap_warming_timeout")
+        return "twap_warming_timeout: JIT warmer couldn't deliver 8 samples in budget — check price-attestor logs + Jupiter health";
+      if (k === "twap_sim_reject")
+        return "twap_sim_reject: program rejected with TwapInsufficientHistory at sim — JIT warm + post-sim re-warm both insufficient; investigate attestor + PriceHistory PDA per mint";
+      if (k === "stale_price_attestation")
+        return "stale_price_attestation: PriceHistory age > MAX_PRICE_AGE_SEC at sim — attestor is falling behind for these mints";
+      if (k === "drain_check_rpc")
+        return "drain_check_rpc: primary + every backup RPC failed getMultipleAccountsInfo — provider status";
       return `${k}: investigate`;
     }).join(" | ");
     await alertIfNew(bot, KIND,


### PR DESCRIPTION
## Summary
Today's tokenized-stock TwapInsufficientHistory P0 surfaced through user reports, not through the rolling-failure tracker, because the four user-facing `oracle_warming: true` return paths in cosign-borrow.js never called recordBorrowFailure(). The tracker stayed at 0 even while users were hitting the symptom.

This PR adds classification at each tripwire so the next time *anything* in the TWAP/oracle chain breaks, operator gets a CRIT-DM the moment the first user hits it.

## Changes
- `src/api/cosign-borrow.js` — recordBorrowFailure() added to 4 return sites:
  - drain_check_rpc — all RPCs failed getMultipleAccountsInfo
  - twap_warming_timeout — JIT warmer couldn't deliver 8 samples in budget (plus immediate CRIT-DM with prog/mint/inWindow/waited)
  - twap_sim_reject — Anchor 6016 (TwapInsufficientHistory) at sim time
  - stale_price_attestation — Anchor 6019 at sim time
- `src/services/self-monitor.js` — probeBorrowFailures now has per-class guidance text for those four classes.

## Test plan
- Merge + Railway redeploy.
- Confirm classifier wiring by tailing logs after a manually-warm-then-immediately-stale scenario (or wait for natural traffic).
- Verify the CRIT-DM on twap_warming_timeout fires the FIRST time a user hits it (no aggregation delay).