### PR TITLE
fix(holder-rewards): mirror MAGPIE holder cycles into distribution_events ledger

### DIFF
--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -1546,6 +1546,16 @@ export async function handleDistribute(ctx) {
   }
   client.release();
 
+  // Sync to distribution_events ledger — every status transition must
+  // propagate so the protocol-wide ledger stays current.
+  // [[feedback_distributions_must_be_kept_organized_synced]]
+  try {
+    const { syncMagpieHolderDistributionEvent } = await import("../services/magpie-holder-rewards.js");
+    await syncMagpieHolderDistributionEvent(distId);
+  } catch (syncErr) {
+    console.warn(`[admin /distribute] distribution_events sync failed for dist ${distId}:`, syncErr.message);
+  }
+
   const allocSol = (Number(totalAllocated) / 1e9).toFixed(6);
   await ctx.reply(
     [

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -620,14 +620,14 @@ const BATCH_SIZE = 10; // SystemProgram.transfer ixs per tx (well under Solana t
  * (see [[feedback_distributions_must_be_kept_organized_synced]]).
  *
  * Reads canonical state from magpie_holder_distributions +
- * magpie_holder_rewards and INSERT-or-UPDATEs the matching
- * distribution_events row keyed by (kind, external_ref). Idempotent —
- * safe to call from every transition point (Phase 1 commit, each Phase 2
- * batch, retry loop, /distribute admin command, and a reconciler).
+ * magpie_holder_rewards and routes through upsertDistributionEvent()
+ * (which has ON CONFLICT (kind, external_ref) baked in). Kind +
+ * external_ref convention match the existing dictionary in
+ * src/services/distribution-events.js. Idempotent — safe to call from
+ * every transition point.
  */
 export async function syncMagpieHolderDistributionEvent(distributionId) {
-  const KIND = "magpie_holder";
-  const externalRef = `magpie-holder-${distributionId}`;
+  const { upsertDistributionEvent } = await import("./distribution-events.js");
   // Pull the snapshot row + aggregated reward state in one round-trip.
   const { rows: snapRows } = await query(
     `SELECT mhd.pool_lamports, mhd.total_balance, mhd.holder_count,
@@ -636,7 +636,6 @@ export async function syncMagpieHolderDistributionEvent(distributionId) {
             COUNT(mhr.*) FILTER (WHERE mhr.status IN ('accrued','snapshot_pending')) AS unpaid_count,
             COALESCE(SUM(mhr.reward_lamports) FILTER (WHERE mhr.status = 'paid'), 0)::numeric                      AS paid_lamports,
             COALESCE(SUM(mhr.reward_lamports) FILTER (WHERE mhr.status IN ('accrued','snapshot_pending')), 0)::numeric AS unpaid_lamports,
-            COALESCE(SUM(mhr.reward_lamports), 0)::numeric                 AS allocated_lamports,
             MIN(mhr.reward_lamports) FILTER (WHERE mhr.status = 'paid')    AS min_paid,
             MAX(mhr.reward_lamports) FILTER (WHERE mhr.status = 'paid')    AS max_paid,
             MIN(mhr.paid_at)                                               AS paid_first_at,
@@ -671,14 +670,11 @@ export async function syncMagpieHolderDistributionEvent(distributionId) {
   else if (Number(s.unpaid_count) === 0) status = "complete";
   else status = "partial";
 
-  const { rows: existing } = await query(
-    `SELECT id FROM distribution_events WHERE kind = $1 AND external_ref = $2`,
-    [KIND, externalRef],
-  );
-
-  const fields = {
-    kind: KIND,
-    external_ref: externalRef,
+  // kind='holder_reward' per the canonical dictionary enforced by the
+  // distribution_events.kind CHECK constraint.
+  return upsertDistributionEvent({
+    kind: "holder_reward",
+    external_ref: `holder-${distributionId}`,
     snapshot_at: s.snapshot_at,
     pool_lamports: s.pool_lamports,
     distributed_lamports: s.paid_lamports,
@@ -693,56 +689,11 @@ export async function syncMagpieHolderDistributionEvent(distributionId) {
     min_payout_lamports: s.min_paid,
     max_payout_lamports: s.max_paid,
     median_payout_lamports: medianPaid,
-    source_borrow_fees_lamports: s.pool_lamports, // pool source: 70% of borrow fees (MGP-001)
+    source_borrow_fees_lamports: s.pool_lamports, // 70% of borrow fees per MGP-001
     source_liquidation_lamports: 0,
     source_other_lamports: 0,
     status,
-  };
-
-  if (existing.length > 0) {
-    await query(
-      `UPDATE distribution_events SET
-         snapshot_at = $2, pool_lamports = $3, distributed_lamports = $4,
-         unpaid_lamports = $5, eligible_wallet_count = $6, paid_wallet_count = $7,
-         unpayable_wallet_count = $8, denominator_kind = $9, denominator_value = $10,
-         paid_first_at = $11, paid_last_at = $12,
-         min_payout_lamports = $13, max_payout_lamports = $14, median_payout_lamports = $15,
-         source_borrow_fees_lamports = $16, source_liquidation_lamports = $17, source_other_lamports = $18,
-         status = $19, updated_at = NOW()
-       WHERE id = $1`,
-      [
-        existing[0].id, fields.snapshot_at, fields.pool_lamports, fields.distributed_lamports,
-        fields.unpaid_lamports, fields.eligible_wallet_count, fields.paid_wallet_count,
-        fields.unpayable_wallet_count, fields.denominator_kind, fields.denominator_value,
-        fields.paid_first_at, fields.paid_last_at,
-        fields.min_payout_lamports, fields.max_payout_lamports, fields.median_payout_lamports,
-        fields.source_borrow_fees_lamports, fields.source_liquidation_lamports, fields.source_other_lamports,
-        fields.status,
-      ],
-    );
-    return existing[0].id;
-  }
-  const { rows: ins } = await query(
-    `INSERT INTO distribution_events (
-       kind, external_ref, snapshot_at, pool_lamports, distributed_lamports, unpaid_lamports,
-       eligible_wallet_count, paid_wallet_count, unpayable_wallet_count,
-       denominator_kind, denominator_value, paid_first_at, paid_last_at,
-       min_payout_lamports, max_payout_lamports, median_payout_lamports,
-       source_borrow_fees_lamports, source_liquidation_lamports, source_other_lamports,
-       status, created_at, updated_at
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20, NOW(), NOW())
-     RETURNING id`,
-    [
-      fields.kind, fields.external_ref, fields.snapshot_at, fields.pool_lamports,
-      fields.distributed_lamports, fields.unpaid_lamports,
-      fields.eligible_wallet_count, fields.paid_wallet_count, fields.unpayable_wallet_count,
-      fields.denominator_kind, fields.denominator_value, fields.paid_first_at, fields.paid_last_at,
-      fields.min_payout_lamports, fields.max_payout_lamports, fields.median_payout_lamports,
-      fields.source_borrow_fees_lamports, fields.source_liquidation_lamports, fields.source_other_lamports,
-      fields.status,
-    ],
-  );
-  return ins[0].id;
+  });
 }
 
 export async function snapshotAndDistribute() {

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -612,6 +612,139 @@ export async function snapshotMagpieHolders() {
  */
 const BATCH_SIZE = 10; // SystemProgram.transfer ixs per tx (well under Solana tx limit)
 
+/**
+ * Mirror a $MAGPIE-holder distribution cycle into the protocol-wide
+ * `distribution_events` analytics ledger so it sits alongside lp_loyalty
+ * and governance distributions. Operator-mandated 2026-06-19 — every
+ * distribution must be kept, organized, and synced across the protocol
+ * (see [[feedback_distributions_must_be_kept_organized_synced]]).
+ *
+ * Reads canonical state from magpie_holder_distributions +
+ * magpie_holder_rewards and INSERT-or-UPDATEs the matching
+ * distribution_events row keyed by (kind, external_ref). Idempotent —
+ * safe to call from every transition point (Phase 1 commit, each Phase 2
+ * batch, retry loop, /distribute admin command, and a reconciler).
+ */
+export async function syncMagpieHolderDistributionEvent(distributionId) {
+  const KIND = "magpie_holder";
+  const externalRef = `magpie-holder-${distributionId}`;
+  // Pull the snapshot row + aggregated reward state in one round-trip.
+  const { rows: snapRows } = await query(
+    `SELECT mhd.pool_lamports, mhd.total_balance, mhd.holder_count,
+            mhd.eligible_count, mhd.snapshot_at,
+            COUNT(mhr.*) FILTER (WHERE mhr.status = 'paid')                AS paid_count,
+            COUNT(mhr.*) FILTER (WHERE mhr.status IN ('accrued','snapshot_pending')) AS unpaid_count,
+            COALESCE(SUM(mhr.reward_lamports) FILTER (WHERE mhr.status = 'paid'), 0)::numeric                      AS paid_lamports,
+            COALESCE(SUM(mhr.reward_lamports) FILTER (WHERE mhr.status IN ('accrued','snapshot_pending')), 0)::numeric AS unpaid_lamports,
+            COALESCE(SUM(mhr.reward_lamports), 0)::numeric                 AS allocated_lamports,
+            MIN(mhr.reward_lamports) FILTER (WHERE mhr.status = 'paid')    AS min_paid,
+            MAX(mhr.reward_lamports) FILTER (WHERE mhr.status = 'paid')    AS max_paid,
+            MIN(mhr.paid_at)                                               AS paid_first_at,
+            MAX(mhr.paid_at)                                               AS paid_last_at
+       FROM magpie_holder_distributions mhd
+       LEFT JOIN magpie_holder_rewards mhr ON mhr.distribution_id = mhd.id
+      WHERE mhd.id = $1
+      GROUP BY mhd.id`,
+    [distributionId],
+  );
+  if (snapRows.length === 0) {
+    console.warn(`[holder-rewards] syncMagpieHolderDistributionEvent: distribution ${distributionId} not found`);
+    return null;
+  }
+  const s = snapRows[0];
+  // Median paid payout — second round-trip; ok at ~1k rows for the
+  // holder set, batches scale linearly.
+  let medianPaid = null;
+  if (Number(s.paid_count) > 0) {
+    const { rows: medRows } = await query(
+      `SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY reward_lamports::numeric) AS median
+         FROM magpie_holder_rewards
+        WHERE distribution_id = $1 AND status = 'paid'`,
+      [distributionId],
+    );
+    medianPaid = medRows[0]?.median ?? null;
+  }
+  // status: planned (no payouts yet) | partial (some paid, some unpaid)
+  //       | complete (all eligible paid). CHECK constraint enforces these.
+  let status;
+  if (Number(s.paid_count) === 0) status = "planned";
+  else if (Number(s.unpaid_count) === 0) status = "complete";
+  else status = "partial";
+
+  const { rows: existing } = await query(
+    `SELECT id FROM distribution_events WHERE kind = $1 AND external_ref = $2`,
+    [KIND, externalRef],
+  );
+
+  const fields = {
+    kind: KIND,
+    external_ref: externalRef,
+    snapshot_at: s.snapshot_at,
+    pool_lamports: s.pool_lamports,
+    distributed_lamports: s.paid_lamports,
+    unpaid_lamports: s.unpaid_lamports,
+    eligible_wallet_count: Number(s.eligible_count) || Number(s.holder_count) || 0,
+    paid_wallet_count: Number(s.paid_count) || 0,
+    unpayable_wallet_count: 0,
+    denominator_kind: "magpie_balance_at_snapshot",
+    denominator_value: s.total_balance,
+    paid_first_at: s.paid_first_at,
+    paid_last_at: s.paid_last_at,
+    min_payout_lamports: s.min_paid,
+    max_payout_lamports: s.max_paid,
+    median_payout_lamports: medianPaid,
+    source_borrow_fees_lamports: s.pool_lamports, // pool source: 70% of borrow fees (MGP-001)
+    source_liquidation_lamports: 0,
+    source_other_lamports: 0,
+    status,
+  };
+
+  if (existing.length > 0) {
+    await query(
+      `UPDATE distribution_events SET
+         snapshot_at = $2, pool_lamports = $3, distributed_lamports = $4,
+         unpaid_lamports = $5, eligible_wallet_count = $6, paid_wallet_count = $7,
+         unpayable_wallet_count = $8, denominator_kind = $9, denominator_value = $10,
+         paid_first_at = $11, paid_last_at = $12,
+         min_payout_lamports = $13, max_payout_lamports = $14, median_payout_lamports = $15,
+         source_borrow_fees_lamports = $16, source_liquidation_lamports = $17, source_other_lamports = $18,
+         status = $19, updated_at = NOW()
+       WHERE id = $1`,
+      [
+        existing[0].id, fields.snapshot_at, fields.pool_lamports, fields.distributed_lamports,
+        fields.unpaid_lamports, fields.eligible_wallet_count, fields.paid_wallet_count,
+        fields.unpayable_wallet_count, fields.denominator_kind, fields.denominator_value,
+        fields.paid_first_at, fields.paid_last_at,
+        fields.min_payout_lamports, fields.max_payout_lamports, fields.median_payout_lamports,
+        fields.source_borrow_fees_lamports, fields.source_liquidation_lamports, fields.source_other_lamports,
+        fields.status,
+      ],
+    );
+    return existing[0].id;
+  }
+  const { rows: ins } = await query(
+    `INSERT INTO distribution_events (
+       kind, external_ref, snapshot_at, pool_lamports, distributed_lamports, unpaid_lamports,
+       eligible_wallet_count, paid_wallet_count, unpayable_wallet_count,
+       denominator_kind, denominator_value, paid_first_at, paid_last_at,
+       min_payout_lamports, max_payout_lamports, median_payout_lamports,
+       source_borrow_fees_lamports, source_liquidation_lamports, source_other_lamports,
+       status, created_at, updated_at
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20, NOW(), NOW())
+     RETURNING id`,
+    [
+      fields.kind, fields.external_ref, fields.snapshot_at, fields.pool_lamports,
+      fields.distributed_lamports, fields.unpaid_lamports,
+      fields.eligible_wallet_count, fields.paid_wallet_count, fields.unpayable_wallet_count,
+      fields.denominator_kind, fields.denominator_value, fields.paid_first_at, fields.paid_last_at,
+      fields.min_payout_lamports, fields.max_payout_lamports, fields.median_payout_lamports,
+      fields.source_borrow_fees_lamports, fields.source_liquidation_lamports, fields.source_other_lamports,
+      fields.status,
+    ],
+  );
+  return ins[0].id;
+}
+
 export async function snapshotAndDistribute() {
   const state = await getHolderPoolState();
   const pool = state.accrued_lamports;
@@ -745,6 +878,15 @@ export async function snapshotAndDistribute() {
   }
   client.release();
 
+  // Mirror into distribution_events so this cycle sits next to lp_loyalty
+  // + governance in the protocol-wide ledger. Idempotent — re-callable.
+  // [[feedback_distributions_must_be_kept_organized_synced]]
+  try {
+    await syncMagpieHolderDistributionEvent(distributionId);
+  } catch (syncErr) {
+    console.error(`[holder-rewards] distribution_events sync (Phase 1) failed for dist ${distributionId}:`, syncErr.message);
+  }
+
   // Snapshot-only: bail out before any SOL transfers. Return the
   // captured allocation summary so the caller can DM admin.
   if (snapshotOnly) {
@@ -788,6 +930,14 @@ export async function snapshotAndDistribute() {
       );
       paidCount += batch.length;
       paidLamports += batch.reduce((acc, r) => acc + BigInt(r.reward_lamports), 0n);
+      // Keep distribution_events fresh after every successful batch so
+      // it never lags behind the canonical reward rows even if the
+      // process dies mid-cycle. [[feedback_distributions_must_be_kept_organized_synced]]
+      try {
+        await syncMagpieHolderDistributionEvent(distributionId);
+      } catch (syncErr) {
+        console.warn(`[holder-rewards] distribution_events sync (mid-batch) failed for dist ${distributionId}:`, syncErr.message);
+      }
     } catch (err) {
       console.error(
         `[holder-rewards] Batch payout failed (rows remain 'accrued' for retry):`,
@@ -795,6 +945,14 @@ export async function snapshotAndDistribute() {
       );
       // Leave 'accrued' — a manual /payaccrued admin command or next cycle can clean up.
     }
+  }
+
+  // Final sync — guarantees the row reflects final paid/unpaid state
+  // even if a mid-batch sync failed transiently.
+  try {
+    await syncMagpieHolderDistributionEvent(distributionId);
+  } catch (syncErr) {
+    console.error(`[holder-rewards] distribution_events sync (final) failed for dist ${distributionId}:`, syncErr.message);
   }
 
   return {
@@ -859,6 +1017,22 @@ export async function retryAccruedPayouts() {
     } catch (err) {
       console.error("[holder-rewards] retry batch failed:", err.message);
     }
+  }
+  // Sync every touched distribution into distribution_events so the
+  // ledger never lags after a retry sweep.
+  // [[feedback_distributions_must_be_kept_organized_synced]]
+  try {
+    const { rows: touched } = await query(
+      `SELECT DISTINCT distribution_id FROM magpie_holder_rewards
+        WHERE id = ANY($1::bigint[])`,
+      [rows.map((r) => r.id)],
+    );
+    for (const t of touched) {
+      try { await syncMagpieHolderDistributionEvent(t.distribution_id); }
+      catch (e) { console.warn(`[holder-rewards] retry-sync dist ${t.distribution_id}:`, e.message); }
+    }
+  } catch (syncErr) {
+    console.warn("[holder-rewards] retry-sweep distribution_events sync failed:", syncErr.message);
   }
   return { retried: rows.length, paid };
 }


### PR DESCRIPTION
## Summary
Sync gap caught while auditing ahead of the first MAGPIE holder snapshot (12:05pm EST today). snapshotAndDistribute() writes to magpie_holder_distributions + magpie_holder_rewards but NOT to distribution_events where lp_loyalty + governance cycles live. Closes that gap so every holder cycle lands in the protocol-wide analytics ledger from the very first row.

## Changes
- New helper syncMagpieHolderDistributionEvent(id): idempotent INSERT-or-UPDATE keyed by (kind='magpie_holder', external_ref='magpie-holder-${id}'). Aggregates min/max/median payout, eligible/paid counts, source breakdown, status.
- Wired at every status transition: Phase 1 commit, per-batch in Phase 2, final Phase 2, retryAccruedPayouts() sweep, /distribute admin command.

## Test plan
- Merge + Railway redeploy before 12:05pm EST.
- Watch the 12:05pm EST tick fire snapshot-only; confirm distribution_events gets a kind='magpie_holder' row with status='planned'.
- When operator runs /distribute later, confirm row updates to 'partial' then 'complete' with paid_first_at/paid_last_at populated.