### PR TITLE
fix(holder-rewards): eligible_wallet_count from reward rows, not stale snapshot col

### DIFF
--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -632,6 +632,7 @@ export async function syncMagpieHolderDistributionEvent(distributionId) {
   const { rows: snapRows } = await query(
     `SELECT mhd.pool_lamports, mhd.total_balance, mhd.holder_count,
             mhd.eligible_count, mhd.snapshot_at,
+            COUNT(mhr.*)                                                   AS reward_row_count,
             COUNT(mhr.*) FILTER (WHERE mhr.status = 'paid')                AS paid_count,
             COUNT(mhr.*) FILTER (WHERE mhr.status IN ('accrued','snapshot_pending')) AS unpaid_count,
             COALESCE(SUM(mhr.reward_lamports) FILTER (WHERE mhr.status = 'paid'), 0)::numeric                      AS paid_lamports,
@@ -679,7 +680,11 @@ export async function syncMagpieHolderDistributionEvent(distributionId) {
     pool_lamports: s.pool_lamports,
     distributed_lamports: s.paid_lamports,
     unpaid_lamports: s.unpaid_lamports,
-    eligible_wallet_count: Number(s.eligible_count) || Number(s.holder_count) || 0,
+    // Eligible count = rows captured for payout, NOT enumerated holders.
+    // magpie_holder_distributions.eligible_count is currently miswritten
+    // (snapshotAndDistribute passes holders.length twice — same value as
+    // holder_count). The reward_row_count from the JOIN is the truth.
+    eligible_wallet_count: Number(s.reward_row_count) || Number(s.eligible_count) || Number(s.holder_count) || 0,
     paid_wallet_count: Number(s.paid_count) || 0,
     unpayable_wallet_count: 0,
     denominator_kind: "magpie_balance_at_snapshot",


### PR DESCRIPTION
## Summary
Surface-uniformity audit caught a miscount after today's holder distribution: distribution_events showed 1598/1935 paid when the actual breakdown was 1598/1599. Root cause: snapshotAndDistribute() writes magpie_holder_distributions.eligible_count = holders.length (enumerated count, ~1935), not the count of actually-allocated rows (1599 after dust filter). The sync helper was reading that wrong field.

Fix derives eligible_wallet_count by COUNTing magpie_holder_rewards rows in the same JOIN query. Live dist=2 now reads 1599/1598 — consistent with reality.

## Test plan
- Merged + redeploy.
- Confirm distribution_events.eligible_wallet_count = COUNT(mhr.*) for all kind='holder_reward' rows.
- Future cycles get correct numbers from Phase 1 sync (no manual fix needed).