### PR TITLE
fix(lp-loyalty): cron honors lp_loyalty_exempt_wallets table

### DIFF
--- a/migrations/084_lp_loyalty_exempt_wallets.sql
+++ b/migrations/084_lp_loyalty_exempt_wallets.sql
@@ -1,0 +1,30 @@
+-- 084_lp_loyalty_exempt_wallets.sql
+--
+-- LP loyalty exemption list. Wallets in this table are excluded from
+-- LP loyalty snapshots so they never receive a payout share even when
+-- their lp_positions row has positive shares × seconds weight.
+--
+-- Created 2026-06-19 to exempt the operator's lender wallet
+-- (4JSSSaG3...zPAx) which holds the largest LP position by formula
+-- but is operator's own money. Paying it would be operator-to-operator
+-- round-tripping that obscures the real third-party LP payouts.
+--
+-- Mirrors the airdrop_exempt_wallets pattern used by $MAGPIE holder
+-- rewards.
+--
+-- See [[feedback_lender_wallet_exempt_from_lp_loyalty]] for the rule
+-- and economic rationale.
+CREATE TABLE IF NOT EXISTS lp_loyalty_exempt_wallets (
+  wallet_address TEXT PRIMARY KEY,
+  reason         TEXT,
+  added_by       TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed the lender wallet exemption.
+INSERT INTO lp_loyalty_exempt_wallets (wallet_address, reason, added_by)
+VALUES (
+  '4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx',
+  'operator lender wallet — funds protocol LP, paying it would be operator-to-operator round-trip',
+  'migration 084 / operator-mandated 2026-06-19'
+) ON CONFLICT (wallet_address) DO NOTHING;

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -408,10 +408,31 @@ export async function snapshotAndDistributeLpLoyalty() {
   );
   if (rows.length === 0) return null;
 
+  // Operator-curated exempt list (migration 084). The operator's
+  // lender wallet is excluded permanently so the auto-cron doesn't
+  // pay 95% of every cycle back to the wallet that funded LP in the
+  // first place — that would be a wasteful operator-to-operator
+  // round-trip. See [[feedback_lender_wallet_exempt_from_lp_loyalty]].
+  // Empty table = no exemptions, behavior identical to pre-migration.
+  let exempt = new Set();
+  try {
+    const { rows: exemptRows } = await query(
+      `SELECT wallet_address FROM lp_loyalty_exempt_wallets`,
+    );
+    exempt = new Set(exemptRows.map((r) => r.wallet_address));
+    if (exempt.size > 0) {
+      console.log(`[lp-loyalty] honoring ${exempt.size} exempt wallet(s)`);
+    }
+  } catch (err) {
+    // Table missing (pre-migration deploy) — fall back to no exemptions.
+    console.warn("[lp-loyalty] lp_loyalty_exempt_wallets read failed (using empty exemption set):", err.message);
+  }
+
   // Compute weights
   let totalWeight = 0n;
   const items = [];
   for (const r of rows) {
+    if (exempt.has(r.wallet_address)) continue;
     const shares = BigInt(r.shares);
     const seconds = BigInt(r.seconds_held ?? 0);
     if (seconds <= 0n) continue; // brand-new deposits get no loyalty this round


### PR DESCRIPTION
## Summary
Today's manual LP loyalty distribution (cycle id=22) honored the lender-wallet exemption via the one-off script + DB table. This PR brings the automatic cron path to parity so future cycles do the same thing without manual intervention. Next cycle is armed for 2026-06-27 5:18am EST.

## Changes
- `migrations/084_lp_loyalty_exempt_wallets.sql` — table + seed row for the lender wallet (`4JSSSaG3...zPAx`). Idempotent.
- `src/services/lp-loyalty.js` — `snapshotAndDistributeLpLoyalty()` reads the exempt list and filters wallets before computing weights. Defensive try/catch around the read so a pre-migration deploy degrades to empty-exemption-set rather than throwing.

## Test plan
- Merge + redeploy. Migration 084 applies idempotently.
- Tail log on next LP cron tick — expect `[lp-loyalty] honoring 1 exempt wallet(s)`.
- Verify next cycle's `lp_loyalty_distributions` row's `eligible_count` matches third-party LP count, NOT total positions.

Memory: feedback_lender_wallet_exempt_from_lp_loyalty