### PR TITLE
cosign-borrow: always force-attest V1/V3 right before signing

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -1342,19 +1342,31 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
             `[cosign-borrow] TWAP ready prog=${borrowProgramId.toBase58().slice(0, 8)}… mint=${mintStr.slice(0, 8)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests}`,
           );
         } else {
-          // V1/V3 path: single-shot freshness check (PR was already
-          // adequate — no TWAP gate on legacy programs).
-          const age = await getPriceFeedAgeSeconds(mintStr, borrowProgramId);
-          if (age === null || age > FRESH_THRESHOLD_SEC) {
-            try {
+          // V1/V3 path: ALWAYS force-attest immediately before signing.
+          //
+          // Operator-mandated 2026-06-19 PM after V1 FARM borrow failed
+          // with StalePriceAttestation: even when the per-tick attestor
+          // is running, the sample on-chain can be 30-60s old when the
+          // user clicks Borrow. They then take 30-60s to review the
+          // wallet prompt. By submit time the sample could be 60-120s
+          // old — racing the program's 120s stale wall. Wallet sim
+          // rejects, user sees "Transaction rejected: StalePriceAttestation."
+          //
+          // Force-attesting RIGHT BEFORE returning the cosigned tx means
+          // the sample is <2s old when the bot returns. Even with a 60s
+          // user-review delay, submit time is 62s — well under 120s.
+          // Cost: 1 extra attest per borrow = ~5000 lamports = negligible.
+          //
+          // This is the "real-time price" guarantee the operator asked
+          // for, enforced at the cosign step where it actually matters.
+          try {
+            await attestPrice(mintStr, Number(mintRow.decimals), undefined, borrowProgramId);
+          } catch (attestErr) {
+            if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(attestErr.message)) {
+              await initializePriceFeed(mintStr, borrowProgramId);
               await attestPrice(mintStr, Number(mintRow.decimals), undefined, borrowProgramId);
-            } catch (attestErr) {
-              if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(attestErr.message)) {
-                await initializePriceFeed(mintStr, borrowProgramId);
-                await attestPrice(mintStr, Number(mintRow.decimals), undefined, borrowProgramId);
-              } else {
-                throw attestErr;
-              }
+            } else {
+              throw attestErr;
             }
           }
         }


### PR DESCRIPTION
## Summary
Drop the FRESH_THRESHOLD_SEC=60 gate in cosign-borrow's V1/V3 JIT path. Always attest immediately before returning the signed tx so the user's signature lands on a <2s-old sample. Closes the StalePriceAttestation race entirely.

## Why
Operator-mandated 2026-06-19 PM (URGENT) after V1 FARM borrow failed with StalePriceAttestation despite continuous attestation (PR #434):
> "If anything, put something in place where the loan price updates in real time on the site, so that doesn't happen. you know we cannot have errors!!!"

Even with the per-tick legacy attestor running every 30s, the sample can be 30-60s old when the user clicks Borrow. They take 30-60s to review the wallet prompt. By submit time: 60-120s old, racing the program's 120s wall.

## Fix
Always attest at cosign time → sample is <2s old when the bot returns the tx. Even with a 60s wallet-review delay, submit time is ~62s. Plenty under 120s.

## Cost
~5000 lamports per borrow = negligible.

## Test plan
- [ ] V1 FARM borrow succeeds without StalePriceAttestation
- [ ] V3 RWA borrow succeeds same way
- [ ] V4 borrows unaffected (use ensureV4TwapReady, not this path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)