### PR TITLE
attestor: V1/V3 falsy-zero protection same as V4 had

### DIFF
--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -691,7 +691,21 @@ export function startPriceAttestor(intervalMs = 30_000) {
 
     if (queue.length === 0) return;
 
-    const CONCURRENCY = Number(process.env.PRICE_ATTESTOR_CONCURRENCY) || 12;
+    // Falsy-zero protection (operator-mandated 2026-06-19 PM after the V4
+    // continuous loop hit the same bug). Explicit-undefined check so
+    // PRICE_ATTESTOR_CONCURRENCY=0 actually pauses V1/V3 attestation
+    // instead of silently falling back to 12. If someone ever needs to
+    // throttle V1/V3 to stop hammering Helius RPC, this lets them.
+    const PA_CONC_RAW = process.env.PRICE_ATTESTOR_CONCURRENCY;
+    const CONCURRENCY =
+      PA_CONC_RAW != null && PA_CONC_RAW !== ""
+        ? Number(PA_CONC_RAW)
+        : 12;
+    if (CONCURRENCY <= 0) {
+      console.warn(`[PriceAttestor] PRICE_ATTESTOR_CONCURRENCY=${CONCURRENCY} — V1/V3 attestation PAUSED until env flipped to nonzero`);
+      _lastTickError = "paused_by_env";
+      return;
+    }
     let initsThisTick = 0;
     let attempted = 0, succeeded = 0, initialized = 0, failed = 0;
     let cursor = 0;


### PR DESCRIPTION
## Summary
Mirror fix to PR #436: PRICE_ATTESTOR_CONCURRENCY had the same Number(env) || 12 falsy-zero bug as V4_CONTINUOUS_CONCURRENCY did. Now uses explicit-undefined check + clean pause behavior when set to 0.

## Why
Operator-mandated 2026-06-19 PM (V1/V3 protection): 'whatever problem you are solving for V4 also gets solved for V1 and V3 as well.' V4 just hit the silent-pause failure; preempt the same on V1/V3.

## Verification path
After deploy, the bot continues to attest V1+V3 normally. To pause cleanly: set PRICE_ATTESTOR_CONCURRENCY=0 -> next tick logs 'V1/V3 attestation PAUSED' and skips. Flip back to nonzero -> resumes within 30s.