### PR TITLE
tier: fix admin check + cold-tier safety net

### DIFF
--- a/src/commands/tier.js
+++ b/src/commands/tier.js
@@ -35,7 +35,7 @@ import { isAdmin } from "../services/admin.js";
 const VALID_TIERS = new Set(["hot", "warm", "cold"]);
 
 export async function handleTier(ctx) {
-  if (!isAdmin(ctx)) {
+  if (!isAdmin(ctx.from?.id)) {
     return ctx.reply("Admin only.");
   }
 
@@ -106,6 +106,35 @@ export async function handleTier(ctx) {
     );
   }
 
+  // Safety check: demoting a mint with active borrower activity is
+  // potentially risky. The Phase 2 SQL auto-includes any mint with
+  // borrower activity (regardless of tier), but the operator should
+  // still know they're demoting a mint that's currently in use.
+  if (newTier === "cold" || newTier === "warm") {
+    const { rows: activity } = await query(
+      `SELECT
+         (SELECT COUNT(*) FROM loans WHERE collateral_mint = $1 AND status = 'active') AS active_loans,
+         (SELECT COUNT(*) FROM limit_close_orders lc
+            JOIN loans l ON l.id = lc.loan_id
+           WHERE l.collateral_mint = $1
+             AND lc.status IN ('armed', 'firing', 'twap_in_progress', 'firing_started')
+         ) AS armed_orders`,
+      [row.mint],
+    );
+    const al = Number(activity[0]?.active_loans || 0);
+    const ao = Number(activity[0]?.armed_orders || 0);
+    if (al > 0 || ao > 0) {
+      // Don't refuse — just warn. The SQL auto-includes anyway.
+      // (Bot side: the attestor loops include any mint with activity
+      //  regardless of tier setting, so this is safe even if demoted.)
+      // But the operator should KNOW so they can make an informed call.
+      // ... continue and log the warning in the response below.
+      row._activity_warning = `⚠ ${al} active loan(s) + ${ao} armed order(s) on this mint. ` +
+        `Continuous attestation will still happen automatically for them — ` +
+        `the tier change only affects mints with NO borrower activity. Safe to proceed.`;
+    }
+  }
+
   // Atomic update + audit trail
   const changedBy =
     ctx.from?.username || ctx.from?.id?.toString() || "unknown";
@@ -127,10 +156,11 @@ export async function handleTier(ctx) {
     throw err;
   }
 
+  const warning = row._activity_warning ? `\n\n${row._activity_warning}` : "";
   return ctx.reply(
     `✓ \`${symbol}\` (${row.category}): ${fromTier} → **${newTier}**\n` +
       `mint: \`${row.mint.slice(0, 12)}...\`\n` +
-      `Audit row inserted. Takes effect next attestor tick.`,
+      `Audit row inserted. Takes effect next attestor tick.${warning}`,
     { parse_mode: "Markdown" },
   );
 }

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -496,16 +496,17 @@ async function fetchMintsToAttest() {
        LEFT JOIN recent_intent_mints rim ON rim.collateral_mint = sm.mint
       WHERE sm.enabled = TRUE
         AND (
+          -- hot tier: always continuous
           sm.attestation_tier = 'hot'
-          OR (
-            sm.attestation_tier = 'warm'
-            AND (
-              sm.protected = TRUE
-              OR alm.collateral_mint IS NOT NULL
-              OR aem.collateral_mint IS NOT NULL
-              OR rim.collateral_mint IS NOT NULL
-            )
-          )
+          -- ANY tier (warm/cold) with borrower activity gets auto-attested.
+          -- Safety net: a 'cold' mint with an active loan or armed exit
+          -- MUST keep its feed warm or the engine can't fire exits and
+          -- repay flows go stale. Operator's tier setting is respected
+          -- ONLY when there's no borrower interest.
+          OR sm.protected = TRUE
+          OR alm.collateral_mint IS NOT NULL
+          OR aem.collateral_mint IS NOT NULL
+          OR rim.collateral_mint IS NOT NULL
         )`,
   );
   return r.rows.map((row) => ({

--- a/src/services/v4-feed-readiness.js
+++ b/src/services/v4-feed-readiness.js
@@ -498,15 +498,13 @@ async function refreshContinuousList() {
         AND sm.category IN ('memecoin', 'stock')
         AND (
           sm.attestation_tier = 'hot'
-          OR (
-            sm.attestation_tier = 'warm'
-            AND (
-              sm.protected = TRUE
-              OR alm.collateral_mint IS NOT NULL
-              OR aem.collateral_mint IS NOT NULL
-              OR rim.collateral_mint IS NOT NULL
-            )
-          )
+          -- Safety net: ANY tier (incl. cold) with borrower activity
+          -- gets auto-attested. A cold mint with active loan/arm MUST
+          -- keep its V4 feed warm or the engine can't fire exits.
+          OR sm.protected = TRUE
+          OR alm.collateral_mint IS NOT NULL
+          OR aem.collateral_mint IS NOT NULL
+          OR rim.collateral_mint IS NOT NULL
         )`,
   );
   state.continuousList = rows.map((r) => ({


### PR DESCRIPTION
## Summary
Two fixes:
1. **Admin check bug** — /tier was calling `isAdmin(ctx)` but the signature is `isAdmin(telegramId)`. Caused operator to hit 'Admin only' on every /tier call.
2. **Cold-tier safety net** — Phase 2 SQL excluded 'cold' tier entirely, creating risk: a cold mint with an active loan would have its feed go stale, breaking engine exits + repay UX. Now: ANY mint with borrower activity gets auto-attested regardless of tier. Operator's tier setting is respected only when there's no borrower interest.
3. **Soft warning** — /tier <X> warm|cold now shows operator a warning when demoting a mint with active activity, informing them the attestor will still warm it.

## Why now
Operator reported 'Admin only' on /tier (#1) and the cold-tier safety hole was flagged during the same audit pass.