### PR TITLE
structural: stocks/RWA mints must always be hot+protected

### DIFF
--- a/src/commands/tier.js
+++ b/src/commands/tier.js
@@ -106,6 +106,28 @@ export async function handleTier(ctx) {
     );
   }
 
+  // Category-level invariant: stocks/RWAs cannot be demoted to warm or
+  // cold. The cosign-borrow JIT attestation path cannot reliably fill
+  // the 8-sample/5-min V4 TWAP window for low-liquidity xStocks within
+  // the borrow envelope. TSLAx StalePriceAttestation incident 2026-06-19
+  // proved this. Memecoins are fine cold (deep Jupiter routes), stocks
+  // and RWAs are not. The stocks-rwa-protection-sentinel would auto-
+  // revert this on the next sweep anyway — refusing here gives the
+  // operator immediate feedback instead of silent drift.
+  if (
+    (newTier === "cold" || newTier === "warm") &&
+    (row.category === "stock" || row.category === "rwa")
+  ) {
+    return ctx.reply(
+      `❌ Cannot demote \`${symbol}\` (${row.category}) to \`${newTier}\`. ` +
+        `Stocks and RWAs MUST stay on \`hot\` tier — JIT attestation cannot ` +
+        `fill the 8-sample TWAP window for low-liquidity tokenized assets. ` +
+        `The stocks-rwa-protection-sentinel would auto-revert this in <5min. ` +
+        `Reference: TSLAx StalePriceAttestation incident 2026-06-19.`,
+      { parse_mode: "Markdown" },
+    );
+  }
+
   // Safety check: demoting a mint with active borrower activity is
   // potentially risky. The Phase 2 SQL auto-includes any mint with
   // borrower activity (regardless of tier), but the operator should

--- a/src/index.js
+++ b/src/index.js
@@ -195,6 +195,7 @@ import { startLoanProgramIdHealer } from "./services/loan-program-id-healer.js";
 import { startV4LoanHealthProbe } from "./services/v4-loan-health-probe.js";
 import { startLimitCloseEngineProgramIdSentinel } from "./services/limit-close-engine-program-id-sentinel.js";
 import { startWalletAttributionSentinel } from "./services/wallet-attribution-sentinel.js";
+import { startStocksRwaProtectionSentinel } from "./services/stocks-rwa-protection-sentinel.js";
 import { startLoanReceivedWatchdog } from "./services/loan-received-watchdog.js";
 import { startFirstV2FireWatcher } from "./services/first-v2-fire-watcher.js";
 import { startLimitCloseFirstV3FireWatcher } from "./services/limit-close-first-v3-fire-watcher.js";
@@ -1013,6 +1014,12 @@ bot.start({
     // canonical TG-linked user). Closes the failure-mode behind PR #231
     // + #232 — operator hit it on V3 SPCX loan id=720 not visible in /repay.
     setTimeout(() => startWalletAttributionSentinel(bot), 125_000);
+    // Stocks/RWA protection sentinel — enforces category-level invariant
+    // that every enabled stock/rwa mint MUST be hot+protected. Operator-
+    // mandated 2026-06-19 PM after TSLAx StalePriceAttestation. JIT
+    // attestation cannot fill the 8-sample TWAP window for low-liquidity
+    // xStocks. Runs immediately on boot, then every 5 min.
+    setTimeout(() => startStocksRwaProtectionSentinel(), 5_000);
     // V4 Hardening T5 (2026-06-15 PM) — sweeps every active V4 loan
     // every 15 min and verifies the sol_proceeds_vault PDA is either
     // uninitialized OR owned by classic SPL Token (NOT Token-2022).

--- a/src/services/stocks-rwa-protection-sentinel.js
+++ b/src/services/stocks-rwa-protection-sentinel.js
@@ -1,0 +1,98 @@
+/**
+ * Stocks/RWA protection sentinel.
+ *
+ * Enforces a category-level invariant: every enabled mint where
+ * category IN ('stock','rwa') MUST be `protected = TRUE` AND
+ * `attestation_tier = 'hot'`. No exceptions.
+ *
+ * Why: tokenized stocks (xStocks) and RWAs have low Jupiter liquidity
+ * relative to memecoins. The V4 on-chain TWAP needs 8 samples in a
+ * 5-min window. The cosign-borrow JIT attestation path cannot reliably
+ * burst 8 fresh samples within the borrow envelope window for a cold
+ * xStock — TSLAx StalePriceAttestation incident 2026-06-19 PM proved
+ * this. Memecoins are fine cold because their Jupiter routes are deep
+ * and TWAP fills in seconds; xStocks/RWAs are not.
+ *
+ * Operator-mandated 2026-06-19 PM ("This error message should NEVER
+ * happen again"). See [[feedback_stocks_rwa_always_hot_protected]].
+ *
+ * Runs:
+ *   - On boot, before the price-attestor's first tick.
+ *   - Every 5 min thereafter, in case anyone manually demotes via DB
+ *     or new stocks get added with the wrong defaults.
+ *
+ * Any auto-promotion triggers a CRIT-DM to the operator so they see
+ * the drift the moment it happens.
+ */
+import { query } from "../db/pool.js";
+
+const PERIODIC_INTERVAL_MS = 5 * 60 * 1000;
+
+export async function enforceStocksRwaProtection(reason = "boot") {
+  let promotedCount = 0;
+  let promotedDetail = [];
+  try {
+    const { rows } = await query(
+      `UPDATE supported_mints
+          SET protected = TRUE,
+              attestation_tier = 'hot'
+        WHERE enabled = TRUE
+          AND category IN ('stock', 'rwa')
+          AND (protected = FALSE OR attestation_tier <> 'hot')
+        RETURNING symbol, category, mint`,
+    );
+    promotedCount = rows.length;
+    promotedDetail = rows;
+
+    if (promotedCount > 0) {
+      // Audit each promotion
+      for (const r of rows) {
+        try {
+          await query(
+            `INSERT INTO supported_mints_tier_changes
+               (mint, from_tier, to_tier, changed_by, reason)
+             VALUES ($1, $2, 'hot', 'stocks-rwa-sentinel', $3)
+             ON CONFLICT DO NOTHING`,
+            [r.mint, "auto-detected", `${reason}: stocks/RWA must be hot+protected`],
+          );
+        } catch {
+          // Audit failure is non-fatal — the protection write already landed.
+        }
+      }
+
+      const detail = rows
+        .map((r) => `${r.symbol} (${r.category})`)
+        .join(", ");
+      console.warn(
+        `[stocks-rwa-sentinel] ${reason} auto-promoted ${promotedCount} mint(s): ${detail}`,
+      );
+
+      // CRIT-DM the operator so drift is visible immediately
+      try {
+        const { notifyAdmin } = await import("./admin-notify.js");
+        await notifyAdmin(
+          `CRIT [stocks-rwa-sentinel] ${reason} auto-promoted ${promotedCount} stock/RWA mint(s) to hot+protected: ${detail}. ` +
+            `These categories MUST stay hot+protected — JIT attestation cannot fill the TWAP window for low-liquidity xStocks.`,
+        );
+      } catch {
+        // Notification failure is non-fatal.
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[stocks-rwa-sentinel] ${reason} threw: ${err.message?.slice(0, 200)}`,
+    );
+  }
+  return { promotedCount, promotedDetail };
+}
+
+export function startStocksRwaProtectionSentinel() {
+  console.log(
+    "[stocks-rwa-sentinel] starting — boot enforcement now, then every 5 min",
+  );
+  enforceStocksRwaProtection("boot");
+  setInterval(
+    () => enforceStocksRwaProtection("periodic"),
+    PERIODIC_INTERVAL_MS,
+  );
+}


### PR DESCRIPTION
## Summary
- Adds category-level invariant: every enabled stock/RWA mint MUST be hot+protected. No exceptions.
- Boot-time sentinel + 5-min periodic sweep + /tier guard.
- Closes the class of bug exposed by TSLAx StalePriceAttestation 2026-06-19.

## Why
xStocks have low Jupiter liquidity. V4 TWAP needs 8 samples in 5 min. The JIT attestation path at cosign-borrow cannot burst that fast for low-liquidity tokenized assets. Cold tier is safe for memecoins (Jupiter routes are deep, TWAP fills in seconds), unsafe for stocks/RWAs.

## Test plan
- [ ] CI green
- [ ] Confirm `[stocks-rwa-sentinel] boot` log on first deploy
- [ ] Confirm any drift sends CRIT-DM via admin-notify
- [ ] Confirm `/tier TSLAx cold` is refused with clear message