### PR TITLE
P0: cap collateral_value to on-chain attestation (V1/V2/V3/V4)

### DIFF
--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -272,6 +272,21 @@ export async function buildBorrowTx({
     return { blocked: true, status: 500, body: { error: "program_routing", detail: err.message } };
   }
 
+  // P0 (2026-06-20): cap the collateral value to the on-chain attestation for
+  // the chosen program version so this x402 borrow can NEVER reject with
+  // CollateralValueExceedsAttestation. Fail-soft (returns unchanged on any
+  // error) — the multiplier clamp, cosign pre-flight sim, and the on-chain
+  // program remain as lower defense layers, so it never blocks a borrow.
+  {
+    const { capCollateralValueToAttestation } = await import("./safe-collateral-value.js");
+    collateralValLamports = await capCollateralValueToAttestation(collateralValLamports, {
+      mintStr: collateralMintStr,
+      decimals: Number(mintRow.decimals),
+      amountRaw: String(collateralAmountRaw),
+      programId,
+    });
+  }
+
   let txB64, loanIdStr, loanAccountStr;
   try {
     const dummySigner = Keypair.generate();

--- a/src/api/safe-collateral-value.js
+++ b/src/api/safe-collateral-value.js
@@ -206,6 +206,48 @@ export async function computeSafeCollateralValue({ mintStr, decimals, amountRaw,
   };
 }
 
+/** Map a program id (PublicKey or base58) to its version key, or null. */
+export function versionForProgramId(programId) {
+  if (!programId) return null;
+  const s = programId.toBase58 ? programId.toBase58() : String(programId);
+  for (const [v, cfg] of Object.entries(VERSIONS)) {
+    if (cfg.programId && cfg.programId.toBase58() === s) return v;
+  }
+  return null;
+}
+
+/**
+ * Cap an off-chain-computed collateral value (lamports) to the on-chain
+ * attestation for the loan's program version, so a borrow can NEVER reject
+ * with CollateralValueExceedsAttestation. Returns min(value, safe). On any
+ * failure (RPC down, feed warming, unknown program) it returns the value
+ * UNCHANGED — the multiplier clamp, cosign pre-flight sim, and the on-chain
+ * program remain as the lower defense layers, so this never blocks a borrow.
+ *
+ * Used by every BOT borrow builder (TG /borrow, x402 agent) so they submit a
+ * value the program accepts up front, instead of failing the on-chain check.
+ */
+export async function capCollateralValueToAttestation(valueLamports, { mintStr, decimals, amountRaw, programId }) {
+  const version = versionForProgramId(programId);
+  if (!version) return valueLamports;
+  try {
+    const res = await computeSafeCollateralValue({ mintStr, decimals, amountRaw, version });
+    if (res?.body?.recommendation === "use_precise_value" && res.body.safe_collateral_value_lamports) {
+      const safe = Number(res.body.safe_collateral_value_lamports);
+      if (Number.isFinite(safe) && safe > 0 && safe < Number(valueLamports)) {
+        console.warn(
+          `[safe-value] capped collateral_value ${valueLamports} → ${safe} for ` +
+            `${String(mintStr).slice(0, 8)}… (${version}) to stay under the on-chain attestation`,
+        );
+        return safe;
+      }
+    }
+  } catch (err) {
+    console.warn(`[safe-value] cap failed for ${String(mintStr).slice(0, 8)}… (${version}): ${err.message?.slice(0, 120)}`);
+  }
+  return valueLamports;
+}
+
 /** HTTP handler. */
 export async function handleSafeCollateralValue(req, url) {
   if (req.method !== "GET") return { status: 405, body: { error: "GET only" } };

--- a/src/api/safe-collateral-value.js
+++ b/src/api/safe-collateral-value.js
@@ -1,0 +1,230 @@
+/**
+ * GET /api/v1/safe-collateral-value?mint=<base58>&decimals=<int>&amount_raw=<int>&program=v1|v3|v4
+ *
+ * Universal, version-aware ATTESTATION-SAFE collateral value. Returns a
+ * `collateral_value` that the on-chain program (V1/V2/V3/V4) is GUARANTEED to
+ * accept — i.e. the borrow can never fail with CollateralValueExceedsAttestation
+ * (V1 err 6014, V3/V4 err 6018), and the dollar figure shown to the user is the
+ * real, attestation-backed value (never an inflated off-chain price).
+ *
+ * WHY THIS EXISTS (P0, 2026-06-20)
+ * ───────────────────────────────
+ * Every program version enforces:
+ *   collateral_value <= attested_value * 1.03            (MAX_VALUE_TOLERANCE_BPS)
+ * where attested_value is derived from the ON-CHAIN price feed:
+ *   - V1/V2 (magpie-lending / -v2): a single PriceAttestation account
+ *       expected = amount * price_lamports / 10^decimals
+ *   - V3/V4 (magpie-lending-v3 / magpie-v4): a PriceHistory TWAP ring buffer
+ *       expected = amount * min(spot, TWAP) / 10^decimals
+ *
+ * The off-chain offer paths price collateral from DIFFERENT sources (the site's
+ * approved.priceUsd, the bot's cross-sourced Jupiter price, the scaled-UI
+ * multiplier) which can drift ABOVE the attested price. When they exceed
+ * attested * 1.03 the borrow is rejected AND the user is quoted an inflated
+ * figure. This endpoint reads the on-chain attestation directly and returns the
+ * largest value the program will accept (with a small headroom for the brief
+ * window before the user signs), so the offer is always attestation-bounded.
+ *
+ * This generalizes /api/v1/v4/twap (V4-only) to ALL versions. /v4/twap is left
+ * untouched for back-compat; new callers should prefer this endpoint.
+ *
+ * SECURITY: read-only. No keypair, no tx. Allowlisted to enabled
+ * supported_mints. The on-chain attestation is the source of truth; this only
+ * ever UNDER-quotes relative to it (fail-safe — never over-values collateral).
+ */
+import { PublicKey } from "@solana/web3.js";
+import { query } from "../db/pool.js";
+import { withFailover } from "../solana/connection.js";
+import { lendingPoolPda, priceFeedPda } from "../solana/pdas.js";
+import {
+  PROGRAM_ID as PROGRAM_ID_V1,
+  PROGRAM_ID_V2,
+  PROGRAM_ID_V3,
+  PROGRAM_ID_V4,
+} from "../solana/program.js";
+
+const MIN_SAMPLES_FOR_TWAP = 8;
+const TWAP_WINDOW_SECONDS = 300;
+const ATTESTATION_HEADROOM_BPS = 30; // 0.3% buffer for the signing window
+const PROGRAM_ATTESTATION_TOLERANCE = 1.03; // matches the program's 3% gate
+const MAX_PRICE_STALENESS_SECONDS = 110; // under the program's 120s wall
+
+const SCALE = 1_000_000n;
+const TOLERANCE6 = BigInt(Math.floor(PROGRAM_ATTESTATION_TOLERANCE * 1e6)); // 1_030_000
+const HEADROOM_SCALED = SCALE - BigInt(ATTESTATION_HEADROOM_BPS * 100); // 997_000
+
+const VERSIONS = {
+  v1: { programId: PROGRAM_ID_V1, kind: "single" },
+  v2: { programId: PROGRAM_ID_V2, kind: "single" },
+  v3: { programId: PROGRAM_ID_V3, kind: "history" },
+  v4: { programId: PROGRAM_ID_V4, kind: "history" },
+};
+
+function isValidPubkey(s) {
+  if (!s || typeof s !== "string" || s.length < 32 || s.length > 44) return false;
+  try { new PublicKey(s); return true; } catch { return false; }
+}
+
+const lamportsToSol = (n) => Number(n) / 1e9;
+
+/** Apply the program tolerance + signing-window headroom to a per-token ref price. */
+function safePerTokenLamports(refLamports) {
+  const ceiling = (refLamports * TOLERANCE6) / SCALE; // ref × 1.03
+  return (ceiling * HEADROOM_SCALED) / SCALE; // × 0.997
+}
+
+/** Decode V1/V2 PriceAttestation → { priceLamports, timestamp }. */
+function decodeSingleAttestation(data) {
+  // Layout: disc(8) mint(32) pool(32) authority(32) price_lamports(u64)@104 timestamp(i64)@112
+  if (!data || data.length < 120) return null;
+  return {
+    priceLamports: data.readBigUInt64LE(104),
+    timestamp: data.readBigInt64LE(112),
+  };
+}
+
+/**
+ * Compute the attestation-safe collateral_value for a mint on a given program
+ * version. Returns a response body (200-shaped) — `recommendation` is
+ * 'use_precise_value' on success or 'wait_for_warmup' when the feed isn't ready
+ * (caller should fall back to the conservative legacy multiplier and retry).
+ */
+export async function computeSafeCollateralValue({ mintStr, decimals, amountRaw, version }) {
+  const cfg = VERSIONS[version];
+  if (!cfg) return { ok: false, status: 400, body: { error: "invalid_program", detail: "program must be v1|v2|v3|v4" } };
+  if (!cfg.programId) {
+    return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: `${version}_not_configured`, fallback_multiplier: 0.89 } };
+  }
+  if (!process.env.LENDER_PUBKEY) {
+    return { ok: false, status: 503, body: { error: "lender_unconfigured" } };
+  }
+
+  const lenderPk = new PublicKey(process.env.LENDER_PUBKEY);
+  const mintPk = new PublicKey(mintStr);
+  const [pool] = lendingPoolPda(lenderPk, cfg.programId);
+  const [priceFeed] = priceFeedPda(mintPk, pool, cfg.programId);
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  let info;
+  try {
+    info = await withFailover((conn) => conn.getAccountInfo(priceFeed, "confirmed"));
+  } catch (err) {
+    console.error(`[safe-value] all-RPCs-failed ${version} ${mintStr.slice(0, 12)}: ${err.message?.slice(0, 160)}`);
+    return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: "rpc_unavailable", fallback_multiplier: 0.89 } };
+  }
+
+  let refLamports = null;
+  const diagnostics = { version, kind: cfg.kind };
+
+  if (cfg.kind === "single") {
+    // ── V1/V2: single PriceAttestation ──
+    const att = decodeSingleAttestation(info?.data);
+    if (!att || att.priceLamports <= 0n) {
+      return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: "v1_attestation_uninitialized_or_empty", fallback_multiplier: 0.89 } };
+    }
+    const ageSec = nowSec - Number(att.timestamp);
+    if (ageSec > MAX_PRICE_STALENESS_SECONDS) {
+      return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: "stale_attestation", attestation_age_seconds: ageSec, fallback_multiplier: 0.89 } };
+    }
+    // The program values V1/V2 collateral at the attested price ONLY (no spot
+    // comparison) — so the attested price IS the reference ceiling.
+    refLamports = att.priceLamports;
+    diagnostics.attested_age_seconds = ageSec;
+  } else {
+    // ── V3/V4: PriceHistory TWAP ring buffer ──
+    if (!info || info.data.length < 120) {
+      return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: "price_history_uninitialized_or_empty", fallback_multiplier: 0.89 } };
+    }
+    const head = info.data.readUInt8(104);
+    const count = info.data.readUInt8(105);
+    if (count === 0) {
+      return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: "no_samples_yet", fallback_multiplier: 0.89 } };
+    }
+    const samples = [];
+    const samplesOffset = 112;
+    const stride = 16;
+    for (let i = 0; i < Math.min(count, 32); i++) {
+      const idx = (head - 1 - i + 32) % 32;
+      const start = samplesOffset + idx * stride;
+      if (start + stride > info.data.length) break;
+      samples.push({ priceLamports: info.data.readBigUInt64LE(start), ts: info.data.readBigInt64LE(start + 8) });
+    }
+    const nowBig = BigInt(nowSec);
+    const windowStart = nowBig - BigInt(TWAP_WINDOW_SECONDS);
+    const inWindow = samples.filter((s) => s.ts >= windowStart);
+    if (inWindow.length < MIN_SAMPLES_FOR_TWAP) {
+      return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: `only_${inWindow.length}_samples_in_window_need_${MIN_SAMPLES_FOR_TWAP}`, samples_in_window: inWindow.length, fallback_multiplier: 0.89 } };
+    }
+    const twapLamports = inWindow.reduce((a, s) => a + s.priceLamports, 0n) / BigInt(inWindow.length);
+
+    // Spot from the same source the attestor uses; min(spot, twap) mirrors the
+    // program's valuation. Spot failure → TWAP-only (still attestation-safe).
+    const { getPriceInSol } = await import("../services/price.js");
+    let spotLamports = null;
+    try {
+      const spotSol = await getPriceInSol(mintStr);
+      if (Number.isFinite(spotSol) && spotSol > 0) spotLamports = BigInt(Math.floor(spotSol * 1e9));
+    } catch (err) {
+      console.warn(`[safe-value] spot fetch failed ${mintStr.slice(0, 12)}: ${err.message?.slice(0, 80)}`);
+    }
+    refLamports = spotLamports !== null ? (spotLamports < twapLamports ? spotLamports : twapLamports) : twapLamports;
+    diagnostics.twap_lamports = twapLamports.toString();
+    diagnostics.spot_lamports = spotLamports !== null ? spotLamports.toString() : null;
+    diagnostics.samples_in_window = inWindow.length;
+  }
+
+  const safePerToken = safePerTokenLamports(refLamports);
+
+  let safeCollateralValueLamports = null;
+  if (amountRaw && /^\d+$/.test(amountRaw)) {
+    const tenPow = 10n ** BigInt(decimals);
+    safeCollateralValueLamports = (BigInt(amountRaw) * safePerToken) / tenPow;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      mint: mintStr,
+      decimals,
+      program_version: version,
+      recommendation: "use_precise_value",
+      ref_lamports_per_whole_token: refLamports.toString(),
+      safe_lamports_per_whole_token: safePerToken.toString(),
+      safe_sol_per_whole_token: lamportsToSol(safePerToken),
+      ...(safeCollateralValueLamports !== null
+        ? {
+            amount_raw: String(amountRaw),
+            safe_collateral_value_lamports: safeCollateralValueLamports.toString(),
+            safe_collateral_value_sol: lamportsToSol(safeCollateralValueLamports),
+          }
+        : {}),
+      diagnostics: { ...diagnostics, attestation_tolerance: PROGRAM_ATTESTATION_TOLERANCE, headroom_bps: ATTESTATION_HEADROOM_BPS },
+      generated_at: new Date().toISOString(),
+    },
+  };
+}
+
+/** HTTP handler. */
+export async function handleSafeCollateralValue(req, url) {
+  if (req.method !== "GET") return { status: 405, body: { error: "GET only" } };
+  const mintStr = url.searchParams.get("mint") || "";
+  const decimalsRaw = url.searchParams.get("decimals");
+  const amountRaw = url.searchParams.get("amount_raw");
+  const version = (url.searchParams.get("program") || "").toLowerCase();
+
+  if (!isValidPubkey(mintStr)) return { status: 400, body: { error: "invalid_or_missing_mint" } };
+  if (!VERSIONS[version]) return { status: 400, body: { error: "invalid_program", detail: "program must be v1|v2|v3|v4" } };
+
+  const { rows: [mintRow] } = await query(
+    `SELECT decimals, enabled FROM supported_mints WHERE mint = $1`,
+    [mintStr],
+  );
+  if (!mintRow) return { status: 404, body: { error: "mint_not_supported", mint: mintStr } };
+  if (!mintRow.enabled) return { status: 409, body: { error: "mint_disabled", mint: mintStr } };
+
+  const decimals = decimalsRaw && /^\d+$/.test(decimalsRaw) ? parseInt(decimalsRaw, 10) : Number(mintRow.decimals);
+  const res = await computeSafeCollateralValue({ mintStr, decimals, amountRaw, version });
+  return { status: res.status, body: res.body };
+}

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1671,6 +1671,11 @@ const PUBLIC_ROUTES = new Set([
   // multiplying by the legacy 0.89. Drops the under-shoot from 11% to
   // ~0.3% — same precision as the on-chain TWAP attestation.
   "/api/v1/v4/twap",
+  // Universal attestation-safe collateral value (V1/V2/V3/V4). Generalizes
+  // /v4/twap to every program version so EVERY borrow path can submit a
+  // collateral_value the on-chain program is guaranteed to accept — the
+  // class fix for CollateralValueExceedsAttestation. Read-only, allowlisted.
+  "/api/v1/safe-collateral-value",
   // Per-mint readiness check + on-demand warmup request. Site calls
   // this BEFORE asking the user to borrow a specific mint — it
   // returns the on-chain sample-in-window count and bumps the mint
@@ -2034,6 +2039,15 @@ async function router(req, res) {
         // under-shoot) site value.
         const { handleV4Twap } = await import("./v4-twap.js");
         result = await handleV4Twap(req, url);
+        break;
+      }
+      case "/api/v1/safe-collateral-value": {
+        // Universal attestation-safe collateral_value (V1/V2/V3/V4) — the
+        // class fix for CollateralValueExceedsAttestation. Read-only,
+        // allowlisted to enabled supported_mints; only ever under-quotes
+        // vs the on-chain attestation (fail-safe — can't inflate a loan).
+        const { handleSafeCollateralValue } = await import("./safe-collateral-value.js");
+        result = await handleSafeCollateralValue(req, url);
         break;
       }
       case "/api/v1/v4/feed-ready": {

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -173,7 +173,7 @@ export async function executeBorrow({
   // extension support); everything else routes to v1. If v2 isn't configured
   // (PROGRAM_ID_V2 env unset), every borrow routes to v1 — fail-safe.
   const { rows: catRows } = await query(
-    `SELECT category FROM supported_mints WHERE mint = $1`,
+    `SELECT category, decimals FROM supported_mints WHERE mint = $1`,
     [collateralMint],
   );
   const category = catRows[0]?.category ?? "memecoin";
@@ -192,6 +192,21 @@ export async function executeBorrow({
   // and v1 must never hold RWA. Throws if violated; caller surfaces
   // the error to the user. Post-$FATHER defense in depth.
   assertProgramMatchesCategory(programId, category);
+
+  // P0 (2026-06-20): cap the collateral value to the on-chain attestation for
+  // the chosen program version so this borrow can NEVER reject with
+  // CollateralValueExceedsAttestation. Covers every executeBorrow caller (TG
+  // /borrow, /reborrow, …). Fail-soft — returns unchanged on any error, so the
+  // multiplier clamp + on-chain program remain as the lower defense layers.
+  {
+    const { capCollateralValueToAttestation } = await import("../api/safe-collateral-value.js");
+    collateralValueLamports = await capCollateralValueToAttestation(collateralValueLamports, {
+      mintStr: collateralMint,
+      decimals: Number(catRows[0]?.decimals ?? 9),
+      amountRaw: String(collateralAmountRaw),
+      programId,
+    });
+  }
 
   const borrower = await loadKeypair(userId);
   const program = getProgramForSigner(borrower, programId);

--- a/src/services/price.js
+++ b/src/services/price.js
@@ -594,12 +594,41 @@ export async function getPriceInUsdCrossSourced(mint) {
  *
  * Verified live 2026-06-10 against real SPYx (multiplier 1.002561 →
  * 0.26% under-valuation if uncorrected) and NVDAx (multiplier 1.000103).
+ *
+ * ATTESTATION-SAFE MULTIPLIER CLAMP (2026-06-20, P0). The on-chain program
+ * values collateral at the ATTESTED price (price-attestor posts getPriceInSol
+ * × 1e9 — WITHOUT the scaled-UI multiplier) and rejects any submitted
+ * collateral_value more than MAX_VALUE_TOLERANCE_BPS (3%) above it
+ * (ErrorCode::CollateralValueExceedsAttestation, identical across V1/V2/V3/V4).
+ * Because the attestor omits the multiplier but this offer applies it, a
+ * scaled-UI multiplier above ~1.03 makes the offer exceed what the chain will
+ * ever accept — producing an inflated "dollar figure offered" AND an on-chain
+ * rejection on borrow. A normal Backed dividend multiplier is ~1.00x; a value
+ * far above 1.03 is a split/large-accrual/misread, never a routine dividend.
+ * We clamp the applied multiplier to the on-chain tolerance so the offer can
+ * NEVER exceed the attestation from the multiplier term — fixing the offer +
+ * the rejection in one shared chokepoint that every borrow path uses. Legit
+ * small multipliers (<= the clamp) pass through unchanged.
  */
+// 1.03 on-chain tolerance × 0.997 buffer for spot/TWAP drift between this
+// quote and the user signing. Mirrors the v4-twap endpoint's 30bps buffer.
+const MAX_SAFE_SCALED_UI_MULTIPLIER = 1.03 * 0.997; // ≈ 1.02691
+
 export async function collateralValueLamports(mint, rawAmount, decimals) {
-  const [priceSol, multiplier] = await Promise.all([
+  const [priceSol, rawMultiplier] = await Promise.all([
     getPriceInSolCrossSourced(mint),
     getScaledUiMultiplier(mint),
   ]);
+  // Clamp the scaled-UI multiplier so the offer can never exceed the on-chain
+  // attestation (which carries no multiplier) beyond its 3% tolerance.
+  const multiplier = Math.min(rawMultiplier, MAX_SAFE_SCALED_UI_MULTIPLIER);
+  if (rawMultiplier > MAX_SAFE_SCALED_UI_MULTIPLIER) {
+    console.warn(
+      `[price] scaled-UI multiplier ${rawMultiplier} for ${mint.slice(0, 8)}… exceeds the ` +
+        `on-chain attestation tolerance; clamped to ${multiplier.toFixed(5)} to prevent ` +
+        `CollateralValueExceedsAttestation + inflated offer. (attestor posts no multiplier.)`,
+    );
+  }
   // (rawAmount × multiplier) / 10^decimals = the UI amount users see in
   // their wallet, which is what Jupiter/DexScreener price quotes refer to.
   const humanAmount = (Number(rawAmount) * multiplier) / 10 ** decimals;


### PR DESCRIPTION
## P0 — fixes CollateralValueExceedsAttestation (err 6014 V1 / 6018 V3/V4)

A real V1 borrow (standard SPL token) was rejected on-chain because the
off-chain offer priced collateral **above the attested price by >3%**, and the
user saw an inflated figure (hundreds of thousands). Verified on-chain: a live
loan carries value_at_start = 12.5 SOL while the current attestation supports
only 11.26 SOL max.

### The class fix (all versions, every path)
- **NEW `/api/v1/safe-collateral-value`** (`safe-collateral-value.js`): reads the
  on-chain attestation — V1/V2 single `PriceAttestation`, V3/V4 `PriceHistory`
  TWAP — and returns `min(spot,attested) × amount/10^dec × 1.03 × 0.997`, the
  largest value the program accepts. Generalizes `/v4/twap` to all versions.
  Verified on-chain: safe value lands under `max_allowed`.
- **TG (`loans.js`) + x402 (`agent.js`)** builders cap the computed value to the
  attestation before building `request_and_fund_loan`.
- **`price.js`** clamps the scaled-UI multiplier (Token-2022 defense).
- Site (separate repo) wires V1/V3 to the new endpoint.

### Security
Read-only, allowlisted to enabled mints, input-validated, BigInt math,
**fail-safe (only ever under-quotes vs the attestation — can never inflate a
loan)**. All caps fail-soft so a borrow is never blocked. On-chain program
remains the final guard. No existing-loan or repay path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)