### PR TITLE
Audit fixes (MED): attestor uninit-detection via err.logs + restore V4 NULL-engine sentinel

### DIFF
--- a/src/services/limit-close-engine-program-id-sentinel.js
+++ b/src/services/limit-close-engine-program-id-sentinel.js
@@ -51,7 +51,7 @@ let lastAlertedCount = -1;
 function fmtRows(rows) {
   if (rows.length === 0) return "";
   const sample = rows.slice(0, 8).map((r) =>
-    `  • order_id=${r.id} loan_id=${r.loan_id} direction=${r.direction} status=${r.status} armed=${new Date(r.created_at).toISOString().slice(0, 16)}Z`,
+    `  • order_id=${r.id} loan_id=${r.loan_id} direction=${r.trigger_direction} status=${r.status} armed=${new Date(r.created_at).toISOString().slice(0, 16)}Z`,
   ).join("\n");
   const more = rows.length > 8 ? `\n  ... and ${rows.length - 8} more` : "";
   return sample + more;
@@ -59,7 +59,7 @@ function fmtRows(rows) {
 
 async function runOneCycle(bot) {
   const { rows } = await query(
-    `SELECT id, loan_id, direction, status, created_at
+    `SELECT id, loan_id, trigger_direction, status, created_at
        FROM limit_close_orders
       WHERE engine_program_id IS NULL
         AND created_at > $1::date

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -403,6 +403,33 @@ export async function attestPrice(mintStr, decimals, priceSolOverride, programId
   throw lastErr;
 }
 
+// Detect the "price-feed PDA not initialized" failure across BOTH err.message
+// AND err.logs. updatePrice runs with skipPreflight:true, so the program's
+// AccountNotInitialized signature (3012 / 0xbc4) surfaces in the on-chain
+// program logs (err.logs / err.transactionLogs), not always in err.message —
+// a message-only check missed it, so a mint with an uninitialized feed never
+// hit the auto-init branch and stuck on fail++ forever (MERLIN, 2026-06-21).
+// initializePriceFeed is idempotent (alreadyExists guard) + tick-capped, so a
+// rare false-positive is harmless.
+function isUninitFeedError(err) {
+  const logs = Array.isArray(err?.logs)
+    ? err.logs.join(" ")
+    : Array.isArray(err?.transactionLogs)
+      ? err.transactionLogs.join(" ")
+      : "";
+  const text = `${err?.message || ""} ${logs}`;
+  return /AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(text);
+}
+
+// Fuller failure detail for diagnosing a genuinely-stuck mint — name + message
+// + the tail of the program logs — instead of a blank .slice(0,100) that hid
+// MERLIN's real cause for hours.
+function attestErrDetail(err) {
+  const logArr = Array.isArray(err?.logs) ? err.logs : Array.isArray(err?.transactionLogs) ? err.transactionLogs : null;
+  const logs = logArr && logArr.length ? ` logs=[${logArr.slice(-3).join(" | ").slice(0, 240)}]` : "";
+  return `${err?.name || "Error"}: ${(err?.message || "(no message)").slice(0, 160)}${logs}`;
+}
+
 /**
  * Mints we need to keep continuously fresh on-chain:
  *   1. Those backing any active loan (risk engine / health watcher / repay
@@ -769,7 +796,7 @@ export function startPriceAttestor(intervalMs = 30_000) {
               lastAttestAt.set(task.mint, Date.now());
               succeeded++;
             } catch (attestErr) {
-              if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(attestErr.message || "")) {
+              if (isUninitFeedError(attestErr)) {
                 if (initsThisTick < MAX_INITS_PER_TICK) {
                   initsThisTick++; // claim slot before async to avoid race
                   const init = await initializePriceFeed(task.mint);
@@ -780,7 +807,7 @@ export function startPriceAttestor(intervalMs = 30_000) {
                 }
               } else {
                 failed++;
-                console.warn(`[PriceAttestor] legacy attest failed for ${task.mint.slice(0, 8)}: ${attestErr.message?.slice(0, 100)}`);
+                console.warn(`[PriceAttestor] legacy attest failed for ${task.mint.slice(0, 8)}: ${attestErrDetail(attestErr)}`);
               }
             }
           } else {
@@ -790,7 +817,7 @@ export function startPriceAttestor(intervalMs = 30_000) {
               task.target.lastMap.set(task.mint, Date.now());
               succeeded++;
             } catch (twapErr) {
-              if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(twapErr.message || "")) {
+              if (isUninitFeedError(twapErr)) {
                 if (initsThisTick < MAX_INITS_PER_TICK) {
                   initsThisTick++;
                   await initializePriceFeed(task.mint, task.target.id);
@@ -799,7 +826,7 @@ export function startPriceAttestor(intervalMs = 30_000) {
                 }
               } else {
                 failed++;
-                console.warn(`[PriceAttestor] ${task.target.label} attest failed for ${task.mint.slice(0, 8)}: ${twapErr.message?.slice(0, 100)}`);
+                console.warn(`[PriceAttestor] ${task.target.label} attest failed for ${task.mint.slice(0, 8)}: ${attestErrDetail(twapErr)}`);
               }
             }
           }


### PR DESCRIPTION
Two MED-severity gaps from the 2026-06-21 full protocol audit. No on-chain / borrow-tx changes.

## 1. Attestor stuck-mint class (MERLIN dead-end)
The attestor's auto-init branch only fired when `err.message` matched `AccountNotInitialized`/`3012`/`0xbc4`. But `updatePrice` runs with `skipPreflight:true`, so the program's `AccountNotInitialized` signature surfaces in **`err.logs`**, not `err.message`. A mint whose V1 feed PDA was never initialized missed auto-init and stuck on `fail++` **every tick forever** → a borrower selecting it dead-ends in warmup.

**MERLIN** (`AvxFBjWy…`, priceable on Jupiter $0.001112 + DexScreener) hit exactly this — `safe-collateral-value` returns `v1_attestation_uninitialized_or_empty`.

Fix: `isUninitFeedError()` now checks `message` **and** `logs`/`transactionLogs`. `initializePriceFeed` is idempotent (`alreadyExists` guard) + tick-capped, so a rare false-positive is harmless. `attestErrDetail()` logs name + message + log-tail instead of a blank `.slice(0,100)` that hid the real cause for hours — so any future stuck mint is instantly diagnosable.

## 2. V4 NULL-engine safety sentinel was inert
`limit-close-engine-program-id-sentinel.js` SELECTed column `direction`, which doesn't exist (real column `trigger_direction`, migration 039) → threw every 5-min tick, blinding the escape-detection alarm for armed/fired limit-close orders with a NULL `engine_program_id`. The actual misfire defense (migration 050's 3-layer) was always intact; this restores the alarm net.

Verified: both files `node --check` clean; no message-only regex remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)