### PR TITLE
fix(cosign): correct on-chain error classification codes (6014/6013/6016)

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -1513,9 +1513,12 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
             },
           };
         }
-        // CollateralValueExceedsAttestation (V4 custom 6018 / V3 custom 6018).
-        // Price moved between site quote and broadcast.
-        if (/CollateralValueExceedsAttestation|"Custom":\s*601[68]/i.test(detail)) {
+        // CollateralValueExceedsAttestation = custom 6014 (0x177e) on ALL
+        // versions (V1/V2/V3/V4 — verified against every IDL). The old regex
+        // matched 6016/6018 (TwapInsufficientHistory / PriceTimestampWentBackwards)
+        // and MISSED a bare-Custom 6014 (no program logs), dropping it to the
+        // generic "we hit a snag" instead of this retryable price-moved path.
+        if (/CollateralValueExceedsAttestation|"Custom":\s*6014\b|0x177e/i.test(detail)) {
           return {
             status: 503,
             body: {
@@ -1526,10 +1529,27 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
             },
           };
         }
-        // StalePriceAttestation (price feed too old at broadcast time).
-        if (/StalePriceAttestation|"Custom":\s*6019/i.test(detail)) {
+        // StalePriceAttestation = custom 6013 (0x177d). Price feed too old at
+        // broadcast time. (Old regex matched 6019, which is not a real code.)
+        if (/StalePriceAttestation|"Custom":\s*6013\b|0x177d/i.test(detail)) {
           recordBorrowFailure("stale_price_attestation");
           _recordBorrowConversionFailure(_convCtx, "stale_price_attestation", { detail: detail?.slice(0, 220) });
+          return {
+            status: 503,
+            body: {
+              error: "Oracle is finalizing — please tap Borrow again in 20–30 seconds.",
+              oracle_warming: true,
+              retry_after_seconds: 25,
+              detail,
+            },
+          };
+        }
+        // TwapInsufficientHistory = custom 6016 (0x1780) — V3/V4 feed lacks
+        // enough TWAP samples yet. Same warming UX as a stale feed (was being
+        // mis-caught by the CollateralValueExceeds regex and shown "price moved").
+        if (/TwapInsufficientHistory|"Custom":\s*6016\b|0x1780/i.test(detail)) {
+          recordBorrowFailure("twap_insufficient_history");
+          _recordBorrowConversionFailure(_convCtx, "twap_insufficient_history", { detail: detail?.slice(0, 220) });
           return {
             status: 503,
             body: {


### PR DESCRIPTION
Audit finding (MED, **deployed**): the cosign-borrow sim-error translator matched the **wrong** custom codes, so a bare-`Custom` rejection (program logs absent) fell through to the generic "we hit a snag" instead of the correct retryable message — hurting borrow conversion.

Verified against **every IDL** (V1/V2/V3/V4):
| code | name | old (wrong) match |
|---|---|---|
| **6014** | CollateralValueExceedsAttestation | `601[68]` |
| **6013** | StalePriceAttestation | `6019` (not a real code) |
| **6016** | TwapInsufficientHistory | mis-caught as "price moved" |
| 6018 | PriceTimestampWentBackwards | — |

Fixes: CollateralValueExceeds → `6014` (+`0x177e`); StalePrice → `6013` (+`0x177d`); add a dedicated `TwapInsufficientHistory` (`6016`/`0x1780`) handler with the oracle-warming UX. The rest of the file already used the correct codes — this aligns the translation block. With the drift-headroom fix deployed, `6014` is rare, but when it occurs the user now gets the correct "price moved, tap Borrow again" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)