### PR TITLE
fix(cosign): Gate 0b — catch Token-2022 TransferFeeExtension (opcode 26)

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -692,11 +692,24 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
   //  13  ApproveChecked
   //  14  MintToChecked       (skipping for same reason)
   //  15  BurnChecked
-  // Token-2022 adds:
-  //  27  TransferCheckedWithFee
+  // Token-2022 extension instructions (audit fix 2026-06-21): the OUTER
+  // discriminator selects the extension; the byte AFTER it selects the
+  // sub-op. The previous comment+set conflated these:
+  //  26  TransferFeeExtension       — sub-op 1 = TransferCheckedWithFee MOVES
+  //                                    tokens from account[0] (the source). The
+  //                                    old set was MISSING 26, so a real
+  //                                    fee-extension transfer FROM a lender ATA
+  //                                    skipped this static gate entirely.
+  //  27  ConfidentialTransferExtension — confidential transfers also move
+  //                                    tokens; keep it (it was mislabeled as
+  //                                    "TransferCheckedWithFee" before).
+  //  37  ConfidentialTransferFeeExtension — same family, also drain-capable.
+  // We match on the OUTER byte; the source-account == LENDER check below means
+  // benign sub-ops (e.g. InitializeTransferFeeConfig, whose account[0] is the
+  // mint, not a lender ATA) never false-positive a legitimate borrow.
   // Approve / Revoke / SetAuthority give a future drain capability even
   // if no immediate balance change — we treat them as if they drained.
-  const DRAIN_CAPABLE_OPS = new Set([3, 4, 5, 6, 8, 9, 12, 13, 15, 27]);
+  const DRAIN_CAPABLE_OPS = new Set([3, 4, 5, 6, 8, 9, 12, 13, 15, 26, 27, 37]);
   const lenderSourceIxs = [];
   for (let i = 0; i < tx.instructions.length; i++) {
     const ix = tx.instructions[i];


### PR DESCRIPTION
MED security (audit 2026-06-21). DRAIN_CAPABLE_OPS listed 27 as TransferCheckedWithFee, but Token-2022 **26 = TransferFeeExtension** (sub-op 1 = TransferCheckedWithFee, moves tokens from account[0]) and **27 = ConfidentialTransferExtension**. A fee-extension transfer from a lender ATA (outer byte 26) skipped the static gate. Add 26 (+ keep 27, + 37 ConfidentialTransferFee). Gate matches the outer byte and only blocks when account[0] is LENDER-owned, so benign config sub-ops never false-positive a borrow. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)