### PR TITLE
fix(audit): friendly borrow kill-switch + constant-time admin compare + agent repay pre-sim

### DIFF
--- a/src/api/agent-repay.js
+++ b/src/api/agent-repay.js
@@ -180,6 +180,12 @@ export async function handleAgentBuildRepay(req) {
 
   // ── Build the tx (does NOT sign; agent signs with their wallet) ──
   let txB64, repayLamportsStr;
+  // Set by the pre-broadcast simulation below when the repay tx would
+  // definitively revert on-chain. We return a 4xx with the decoded reason
+  // instead of handing back a tx that's guaranteed to fail. An RPC/infra
+  // failure of the sim itself does NOT populate this (fail-open on infra —
+  // the lower defense layer is the on-chain program, which is authoritative).
+  let simRejection = null;
   try {
     const programId = chooseProgramIdForLoan(loan);
     const dummySigner = Keypair.generate();
@@ -284,11 +290,58 @@ export async function handleAgentBuildRepay(req) {
     const { blockhash } = await connection.getLatestBlockhash("confirmed");
     tx.recentBlockhash = blockhash;
 
+    // ── Pre-broadcast simulation (mirrors the TG executeRepay / site
+    // cosign-borrow pre-sim). REPAY MUST NEVER SIMULATE-FAIL: if the
+    // unsigned repay tx would revert on-chain, return a 4xx with the
+    // decoded reason rather than handing the agent a doomed tx.
+    // sigVerify:false so simulation reads the (still unsigned) tx.
+    // withFailover so a single-provider blip doesn't surface as an error.
+    // Fail-open on RPC/infra failure: only a definitive sim.value.err
+    // (i.e. the program itself rejected) blocks the response. The on-chain
+    // program is the authoritative lower defense layer.
+    try {
+      const sim = await withFailover((conn) =>
+        conn.simulateTransaction(tx, { sigVerify: false, commitment: "confirmed" }),
+      );
+      if (sim?.value?.err) {
+        const logs = (sim.value.logs || []).slice(-5).join(" | ").slice(0, 400);
+        const errStr = JSON.stringify(sim.value.err).slice(0, 200);
+        console.error(
+          "[agent/build-repay] pre-sim REVERT — loan_id=%s err=%s logs=%s",
+          loan?.loan_id,
+          errStr,
+          logs,
+        );
+        simRejection = {
+          status: 422,
+          body: {
+            error: "repay_would_fail",
+            detail: `Repay transaction would revert on-chain (pre-flight simulation rejected). err=${errStr}`,
+            sim_err: sim.value.err,
+            logs: sim.value.logs || [],
+          },
+        };
+      }
+    } catch (simErr) {
+      // RPC/infra failure of the simulation itself — do NOT block the repay.
+      // The on-chain program remains the final guard. Log loudly so the
+      // operator can see if sim infra is flaky, but proceed to serialize.
+      console.warn(
+        "[agent/build-repay] pre-sim RPC failed (failing open) — loan_id=%s detail=%s",
+        loan?.loan_id,
+        simErr?.message?.slice(0, 200),
+      );
+    }
+
     txB64 = tx.serialize({ requireAllSignatures: false, verifySignatures: false }).toString("base64");
   } catch (err) {
     console.error("[agent/build-repay] tx build failed:", err);
     return { status: 500, body: { error: "tx_build_failed", detail: err.message?.slice(0, 200) } };
   }
+
+  // A definitive pre-sim revert means we must not return a tx the agent
+  // would just waste a signature + fee on. Return the decoded reason.
+  if (simRejection) return simRejection;
 
   return {
     status: 200,

--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -83,6 +83,28 @@ import { Keypair } from "@solana/web3.js";
 const LENDER_PUBKEY = new PublicKey(process.env.LENDER_PUBKEY);
 const INTERNAL_API_TOKEN = process.env.INTERNAL_API_TOKEN || "";
 
+// Throttled operator alerting for the V4 borrow kill switch. Mirrors the
+// cosign-borrow COSIGN_BORROW_DISABLED alert: a drain-safety pause that we
+// NEVER auto-re-enable must also never be silently left on. Re-alert at
+// most once per ~10 min (in-memory) so it stays visible until cleared.
+const KILL_SWITCH_ALERT_INTERVAL_MS = 10 * 60 * 1000; // ~10 min
+let _v4PausedLastAlertAt = 0;
+
+function alertV4PausedThrottled() {
+  const now = Date.now();
+  if (now - _v4PausedLastAlertAt < KILL_SWITCH_ALERT_INTERVAL_MS) return;
+  _v4PausedLastAlertAt = now;
+  // Fire-and-forget — the borrow response must not wait on a Telegram alert.
+  (async () => {
+    try {
+      const { notifyAdmin } = await import("../services/admin-notify.js");
+      await notifyAdmin(
+        "PAUSED [agent-borrow] V4_BORROWS_PAUSED is ON — a new auto-sell borrow just bounced. This will keep alerting ~every 10 min until you clear V4_BORROWS_PAUSED. (Drain-safety control — never auto-re-enabled.)",
+      );
+    } catch {}
+  })();
+}
+
 // Legacy memecoin tier map — kept for back-compat callers that still
 // import TIERS directly. NEW code should use the category-aware
 // resolveTierForAgent helper below, which picks the right schedule
@@ -259,7 +281,23 @@ export async function buildBorrowTx({
     //     or pick a different collateral, will lift after V4 patch)
     //   - generic V4 not configured (503 — operational issue)
     if (err.message?.startsWith("V4_BORROWS_PAUSED")) {
-      return { blocked: true, status: 503, body: { error: "v4_borrows_paused", detail: err.message } };
+      // Throttled recurring operator alert so the pause is never silently
+      // left on. We deliberately do NOT auto-re-enable the switch.
+      alertV4PausedThrottled();
+      return {
+        blocked: true,
+        status: 503,
+        body: {
+          error:
+            "We're holding new auto-sell borrows for a quick safety check — please try again in about a minute.",
+          retry_after_seconds: 60,
+          friendly: true,
+          paused: true,
+          // `detail` retains the V4_BORROWS_PAUSED-prefixed message for any
+          // caller that branches on it; not shown verbatim to end users.
+          detail: err.message,
+        },
+      };
     }
     if (err.message?.startsWith("TOKEN2022_EXIT_ARMING_TEMPORARILY_BLOCKED")) {
       return { blocked: true, status: 422, body: { error: "token2022_exit_blocked", detail: err.message } };

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -77,6 +77,31 @@ export function getRecentBorrowFailures() {
   return out;
 }
 
+// Throttled operator alerting for borrow kill switches. A kill switch
+// (COSIGN_BORROW_DISABLED / V4_BORROWS_PAUSED) is a drain-safety control
+// that we NEVER auto-re-enable — but it must also never be silently left
+// on. Every time a request is bounced by a switch we re-alert the operator
+// at most once per ~10 min (in-memory, per switch key) so it stays
+// visible until it's deliberately cleared. Best-effort: a notify failure
+// never affects the borrow response.
+const KILL_SWITCH_ALERT_INTERVAL_MS = 10 * 60 * 1000; // ~10 min
+const _killSwitchLastAlertAt = new Map(); // switchKey -> last alert ms
+
+function alertKillSwitchOnThrottled(switchKey, message) {
+  const now = Date.now();
+  const last = _killSwitchLastAlertAt.get(switchKey) || 0;
+  if (now - last < KILL_SWITCH_ALERT_INTERVAL_MS) return;
+  _killSwitchLastAlertAt.set(switchKey, now);
+  // Fire-and-forget — do not await; the borrow response must not wait on
+  // (or fail because of) a Telegram alert.
+  (async () => {
+    try {
+      const { notifyAdmin } = await import("../services/admin-notify.js");
+      await notifyAdmin(message);
+    } catch {}
+  })();
+}
+
 // Layer 2 fail-open circuit breaker. When the sim infra fails, we fall
 // through to broadcast because Layer 1's static guard is already proven
 // safe for the canonical tx shape. BUT — sustained sim-infra failure
@@ -481,7 +506,7 @@ function classifyBorrowOutcome(result) {
   if (b.borrow_paused) return { outcome: "failure", klass: "borrow_paused" };
   if (b.exits_require_v4_loan) return { outcome: "failure", klass: "exits_require_v4_loan" };
   if (result.status === 405) return { outcome: "failure", klass: "method_not_allowed" };
-  if (result.status === 503 && /Site-borrow co-signing is temporarily disabled/i.test(b.error || "")) {
+  if (result.status === 503 && b.paused === true) {
     return { outcome: "failure", klass: "killswitch" };
   }
   if (result.status === 400) return { outcome: "failure", klass: "bad_request" };
@@ -561,11 +586,20 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
   // 503, the drain stops in seconds.
   if (process.env.COSIGN_BORROW_DISABLED === "true") {
     console.warn("[cosign-borrow] disabled via COSIGN_BORROW_DISABLED env var");
+    // Throttled recurring operator alert so a drain-safety pause is never
+    // silently left on. We deliberately do NOT auto-re-enable the switch.
+    alertKillSwitchOnThrottled(
+      "COSIGN_BORROW_DISABLED",
+      "PAUSED [cosign-borrow] COSIGN_BORROW_DISABLED is ON — site borrows are being held for a safety check and just bounced a borrow request. This will keep alerting ~every 10 min until you clear COSIGN_BORROW_DISABLED. (Drain-safety control — never auto-re-enabled.)",
+    );
     return {
       status: 503,
       body: {
-        error: "Site-borrow co-signing is temporarily disabled",
-        detail: "Use the Telegram bot for borrows while this is paused.",
+        error:
+          "We're holding new borrows for a quick safety check — please try again in about a minute.",
+        retry_after_seconds: 60,
+        friendly: true,
+        paused: true,
       },
     };
   }

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -14,6 +14,7 @@ import { gzip, brotliCompress } from "node:zlib";
 import { promisify } from "node:util";
 import { query } from "../db/pool.js";
 import crypto from "node:crypto";
+import { constantTimeEqual } from "./auth-utils.js";
 
 const gzipAsync = promisify(gzip);
 const brotliAsync = promisify(brotliCompress);
@@ -1100,7 +1101,10 @@ async function handleAdminPoolStats(req, url) {
   const provided = (req.headers["x-admin-token"] || "").toString().trim();
   const wallet = url.searchParams.get("wallet"); // still used downstream
   if (ADMIN_API_TOKEN) {
-    if (!provided || provided !== ADMIN_API_TOKEN) {
+    // Constant-time compare so an attacker can't time-probe the admin
+    // token byte-by-byte. constantTimeEqual guards type/empty/length
+    // before timingSafeEqual (which throws on unequal-length buffers).
+    if (!provided || !constantTimeEqual(provided, ADMIN_API_TOKEN)) {
       return { status: 403, body: { error: "Forbidden" } };
     }
   } else {
@@ -1427,7 +1431,8 @@ async function handleAdminLifetimeStats(req, url) {
   const wallet = url.searchParams.get("wallet");
   const LENDER_PUBKEY = process.env.LENDER_PUBKEY;
   if (ADMIN_API_TOKEN) {
-    if (!provided || provided !== ADMIN_API_TOKEN) {
+    // Constant-time compare (see handleAdminPoolStats for rationale).
+    if (!provided || !constantTimeEqual(provided, ADMIN_API_TOKEN)) {
       return { status: 403, body: { error: "Forbidden" } };
     }
   } else {

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -166,11 +166,16 @@ export function chooseProgramId(category, opts = {}) {
   // Operator-mandated 2026-06-15 PM as part of the Token-2022 V4
   // sol_proceeds_vault init bug recovery plan (tasks #281-285).
   if (hasExitArming && process.env.V4_BORROWS_PAUSED === "true") {
+    // NOTE: the "V4_BORROWS_PAUSED:" prefix is load-bearing — callers
+    // (agent.js, self-monitor.js) branch on err.message.startsWith(...).
+    // The text AFTER the colon is user-facing: keep it friendly and
+    // retryable, with no "temporarily disabled / use Telegram" phrasing
+    // (operator-escalated). [[feedback_loans_must_never_fail_no_regressions]]
     throw new Error(
-      "V4_BORROWS_PAUSED: New V4 borrows (with auto-sells) are temporarily " +
-      "paused while we ship a critical V4 program patch. Existing V4 loans " +
-      "are unaffected. This is expected to be brief — please try again shortly. " +
-      "If you need to borrow without an auto-sell, regular borrows still work.",
+      "V4_BORROWS_PAUSED: We're holding new auto-sell borrows for a quick " +
+      "safety check — please try again in about a minute. Your existing " +
+      "loans are completely unaffected, and a plain borrow (without an " +
+      "auto-sell) still works right now.",
     );
   }
   if (hasExitArming) {


### PR DESCRIPTION
MED: COSIGN_BORROW_DISABLED + V4_BORROWS_PAUSED kill-switches now return a friendly retryable body ({retry_after_seconds:60, friendly:true}, no 'temporarily disabled / use Telegram' — operator-escalated) + throttled (~10min) operator alert so a flipped switch is never silently left on; the switches still actually block, and the load-bearing 'V4_BORROWS_PAUSED:' prefix is preserved. LOW: admin stats endpoints use constant-time token compare. LOW: agent repay path pre-flight simulates (withFailover) and fails open so an RPC blip can never block a valid repay. node --check clean on all files; adversarially verified no breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)