### PR TITLE
feat(x402): accrue x402 call fees to $MAGPIE holder pool (C6 delivery)

### DIFF
--- a/src/api/x402-metrics.js
+++ b/src/api/x402-metrics.js
@@ -77,14 +77,17 @@ export async function handleX402Record(req) {
     return { status: 400, body: { error: "invalid_record_shape" } };
   }
 
+  let inserted = false;
   try {
-    await query(
+    const { rows } = await query(
       `INSERT INTO x402_paid_calls
          (endpoint_path, method, amount_lamports, payer_pubkey, tx_signature, nonce)
        VALUES ($1, $2, $3, $4, $5, $6)
-       ON CONFLICT (tx_signature) DO NOTHING`,
+       ON CONFLICT (tx_signature) DO NOTHING
+       RETURNING tx_signature`,
       [endpointPath, method, amountLamports, payerPubkey, txSignature, nonce],
     );
+    inserted = rows.length > 0;
   } catch (err) {
     // DB hiccup — log and acknowledge so the x402 service doesn't retry
     // forever on a transient issue. Worst case we miss a metric, not a
@@ -92,6 +95,40 @@ export async function handleX402Record(req) {
     console.warn("[x402-metrics] record insert failed:", err.message?.slice(0, 200));
     return { status: 200, body: { recorded: false, reason: "db_blip" } };
   }
+
+  // $MAGPIE holder-rewards flywheel (the x402 leg). Accrue the LIVE
+  // governance holder_reward_bps share of this x402 fee to the $MAGPIE
+  // holder pool, idempotently keyed on the payment signature. This is what
+  // makes "x402 API call fees feed $MAGPIE holder rewards" literally true —
+  // every paid agent call now contributes the same governance-ratified
+  // (MGP-001) share that loan fees do (10% today, auto-picks-up 70% the
+  // moment governance flips holder_reward_bps; no code change needed).
+  //
+  // Safety: ONLY on a genuinely new row (inserted===true) so retries don't
+  // re-attempt; the pool_credit_events UNIQUE(source_type,source_id,pool_kind)
+  // is a hard idempotency backstop regardless. Fully isolated in try/catch —
+  // an accrual hiccup must NEVER fail the payment-record ack or the agent's
+  // call. Gated by X402_FEE_HOLDER_ACCRUAL (default on; set "false" to pause
+  // the x402 leg without touching loan-fee accrual). Crucially the accrual
+  // only credits a ledger obligation — it moves no SOL; distributions stay on
+  // the existing governance/manual cadence.
+  if (inserted && process.env.X402_FEE_HOLDER_ACCRUAL !== "false") {
+    try {
+      const { accrueToHolderPool } = await import(
+        "../services/magpie-holder-rewards.js"
+      );
+      await accrueToHolderPool(amountLamports, {
+        sourceType: "x402_fee",
+        sourceId: txSignature,
+      });
+    } catch (err) {
+      console.warn(
+        "[x402-metrics] holder accrual failed (non-fatal):",
+        err.message?.slice(0, 200),
+      );
+    }
+  }
+
   return { status: 200, body: { recorded: true } };
 }
 


### PR DESCRIPTION
Delivers the x402 leg of the $MAGPIE flywheel so 'x402 fees feed holder rewards' is literally true (verification C6 was an OVERPROMISE — x402 sent 100% to PAY_TO with no accrual).

On each NEW x402_paid_calls row, `accrueToHolderPool()` credits the **live governance holder_reward_bps** share (MGP-001: 10% now, auto-70% when ratified) to `magpie_holder_pool` via the idempotent `pool_credit_events` ledger, keyed on the payment signature.

**Safety:** idempotent (inserted-only + UNIQUE backstop); failure-isolated (never breaks the payment ack); **ledger-only — moves no SOL** (distributions stay governance/manual); governance-sourced bps; gated by `X402_FEE_HOLDER_ACCRUAL` (default on). Pairs with magpie-x402 PR #44 (truthful copy).