### PR TITLE
feat(reliability): liveness probe + zero-downtime deploys (BOT DOWN prevention)

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,19 @@
 [deploy]
 startCommand = "node src/index.js"
+# Cheap, dependency-free liveness probe (returns 200 the moment the HTTP server
+# is listening). Railway gates deploy cutover on this — so a new instance only
+# takes traffic once it's actually live (zero-downtime deploys, no deploy-time
+# 502 window) — and restarts the service if the process hangs/dies. NOT
+# /api/v1/health: that does a DB ping + heartbeat checks and 503s on a transient
+# DB blip, which would block deploys / cause restart loops. See server.js.
+healthcheckPath = "/api/v1/livez"
+# Generous window: the HTTP server listens a few seconds into boot (after
+# bot.start connects to Telegram). If a slow connect ever exceeded this, the
+# deploy just fails its healthcheck and the OLD instance keeps serving — zero
+# downtime either way.
+healthcheckTimeout = 120
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10
 
 [service]
 # Expose HTTP API alongside the Telegram bot

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1627,6 +1627,8 @@ async function handleLeaderboard() {
 
 const PUBLIC_ROUTES = new Set([
   "/api/v1/health",
+  "/api/v1/livez",
+  "/healthz",
   "/api/v1/tokens",
   "/api/v1/loans",
   "/api/v1/wallet/balance",
@@ -1849,7 +1851,23 @@ async function router(req, res) {
     }
   }
 
-  // Health check (no auth) — real liveness probe
+  // Liveness probe (no auth, ZERO dependencies). Railway's healthcheckPath
+  // targets THIS — not /api/v1/health. It returns 200 the instant the event
+  // loop is responsive, regardless of DB / RPC / heartbeat state.
+  //
+  // Why a separate probe: /api/v1/health does a DB ping + heartbeat checks and
+  // 503s on a transient DB blip. Pointing Railway's healthcheck at that would
+  // (a) block zero-downtime deploy cutover whenever the DB hiccups and (b) risk
+  // a restart loop on a DB blip. /livez only fails when the process is genuinely
+  // dead or hung — exactly when Railway SHOULD restart it — and lets Railway gate
+  // deploy cutover on the new instance being live, eliminating the deploy-time
+  // 502 window. /api/v1/health stays the rich readiness/monitoring signal.
+  if (path === "/api/v1/livez" || path === "/healthz") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    return res.end(JSON.stringify({ live: true, ts: new Date().toISOString() }));
+  }
+
+  // Health check (no auth) — rich readiness/monitoring signal (DB + heartbeats)
   if (path === "/api/v1/health") {
     const checks = { db: "unknown", screener: "unknown", "token-health": "unknown" };
     const reasons = [];


### PR DESCRIPTION
Transient 502 root cause: single bot instance + **no Railway healthcheckPath** → deploys cut over immediately (boot-time 502 window) and a *hung* process never restarts.

- New cheap **GET /api/v1/livez** (+ /healthz): 200 the instant the event loop is responsive, zero DB/RPC deps. (/api/v1/health stays the rich readiness signal — it 503s on a DB blip, so it must not gate deploys.)
- **railway.toml healthcheckPath = /api/v1/livez** → Railway gates deploy cutover on liveness = **zero-downtime deploys** (no more deploy-time 502, incl. mine) + hung-process restart.
- Fail-safe: if a slow boot failed the healthcheck, the OLD instance keeps serving. node --check clean.