### PR TITLE
Approve + permanently exempt $MU (operator manual approval)

### DIFF
--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -935,6 +935,39 @@ export async function applyStartupPatches() {
     `CREATE INDEX IF NOT EXISTS idx_smtc_mint_created
        ON supported_mints_tier_changes (mint, created_at DESC)`,
 
+    // $MU — operator-trusted MANUAL approval (full authorization 2026-06-22).
+    // Permanently approved + protected + hot-tier, mirroring the $MAGPIE
+    // protocol-token pattern so it can NEVER be auto-disabled and its V1/V4
+    // price_feed PDAs are always pre-warmed (the boot + 30-min attestor
+    // pre-warm walks every enabled mint). decimals=6 + Token-2022 owner
+    // (TokenzQd…) verified on-chain for mint MUxEsUKSMAC…NGay1. ON CONFLICT
+    // re-asserts enabled+protected+hot on EVERY boot, so the hourly token-
+    // health watcher / screener can never take it off. Placed after the
+    // attestation_tier column patch above so the column exists.
+    `INSERT INTO supported_mints
+       (mint, symbol, name, decimals, category, image_url,
+        liquidity_usd, holder_count, market_cap_usd,
+        has_mint_authority, has_freeze_authority, lp_burned,
+        token_age_hours, auto_approved, screened_at, source,
+        enabled, protected, attestation_tier)
+     VALUES ('MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1',
+             'MU', 'MU', 6, 'memecoin', NULL,
+             0, 0, 0,
+             TRUE, TRUE, FALSE,
+             0, FALSE, NOW(), 'operator_trusted',
+             TRUE, TRUE, 'hot')
+     ON CONFLICT (mint) DO UPDATE SET
+       enabled = TRUE,
+       protected = TRUE,
+       attestation_tier = 'hot',
+       source = 'operator_trusted'`,
+
+    // Keep the screener from ever re-processing $MU through the audit
+    // pipeline (which could otherwise flag/disable an operator-trusted mint).
+    `INSERT INTO token_screen_seen (mint)
+     VALUES ('MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1')
+     ON CONFLICT DO NOTHING`,
+
     // 2026-06-17 — Fee-wallet auto-sweeper audit ledger
     // (feedback_distribution_wallet_must_be_auto_funded.md).
     // Records every move of accrued fees from fee_wallet (lender pubkey's


### PR DESCRIPTION
## What

Operator gave **full authorization** (3× escalation, 2026-06-22) to manually approve **\$MU** (`MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1`) and keep it on the exempt list so it can **never** be auto-disabled.

Per operator rule: a token the operator **manually** approves through me bypasses the strict screening that applies to website user-submissions.

## How

Adds \$MU to `applyStartupPatches` (runs on every boot, `index.js:805`), mirroring the proven `$MAGPIE` protocol-token pattern:

- `enabled = TRUE` → borrowable + appears in `/api/v1/tokens`
- `protected = TRUE` → exempt from the hourly token-health **auto-disable** watcher (`db/pool.js:97`) — can never be taken off
- `attestation_tier = 'hot'` → always attested, so the V1/V4 `price_feed` PDAs are pre-warmed by the boot + 30-min attestor pass (no `StalePriceAttestation`, no `AccountNotInitialized` from a never-warmed feed)
- `token_screen_seen` insert → the screener never re-processes/flags it
- `ON CONFLICT` re-asserts `enabled/protected/hot` on **every boot** → permanent

`decimals=6` + Token-2022 owner verified on-chain. Nothing gates borrows on the mint/freeze authority (verified — screening-only fields). Additive + idempotent; touches **no** existing loans or collateral.

## Why this also fixes the borrow failure

\$MU was **not enabled**, so no layer ever pre-warmed its `price_feed` PDA — the direct cause of the `AccountNotInitialized` the operator hit. Enabling it brings it under the boot prewarm + the cosign JIT-init (which keys on `supported_mints`), closing the gap for \$MU.

A separate PR will ship the **class-level** fix (cosign self-heals `AccountNotInitialized` for *any* mint by ensuring the lender fee-wallet wSOL ATA + price_feed before returning the tx).