### PR TITLE
Fix $MU as tokenized STOCK (V3/V4 + Tokenized Stocks column)

### DIFF
--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -935,15 +935,21 @@ export async function applyStartupPatches() {
     `CREATE INDEX IF NOT EXISTS idx_smtc_mint_created
        ON supported_mints_tier_changes (mint, created_at DESC)`,
 
-    // $MU — operator-trusted MANUAL approval (full authorization 2026-06-22).
-    // Permanently approved + protected + hot-tier, mirroring the $MAGPIE
-    // protocol-token pattern so it can NEVER be auto-disabled and its V1/V4
-    // price_feed PDAs are always pre-warmed (the boot + 30-min attestor
-    // pre-warm walks every enabled mint). decimals=6 + Token-2022 owner
-    // (TokenzQd…) verified on-chain for mint MUxEsUKSMAC…NGay1. ON CONFLICT
-    // re-asserts enabled+protected+hot on EVERY boot, so the hourly token-
-    // health watcher / screener can never take it off. Placed after the
-    // attestation_tier column patch above so the column exists.
+    // $MU — Micron Technology tokenized stock (Backpack Securities / Trek Labs,
+    // Token-2022), operator-trusted MANUAL approval (full authorization
+    // 2026-06-22). category='stock' so it (a) shows in the site's Tokenized
+    // Stocks column, (b) routes to V3 (no-exit) + V4 (with-exit) per
+    // chooseProgramId RWA routing, (c) is force-kept hot+protected by the
+    // stocks-rwa-protection-sentinel. Mirrors the $MAGPIE permanent-seed
+    // pattern so it can NEVER be auto-disabled and its V3/V4 price_feed PDAs
+    // are always pre-warmed (boot + 30-min attestor walks every enabled mint;
+    // hot tier keeps the 8-sample TWAP window filled — required for the V3/V4
+    // TWAP gate on low-liquidity xStocks). decimals=6 + Token-2022 owner +
+    // name "Micron Technology" verified on-chain; Jupiter prices it (~$1.95M
+    // liquidity) so the attestor can fill the TWAP window. ON CONFLICT
+    // re-asserts symbol/name/category/enabled/protected/hot on EVERY boot, so
+    // no health watcher / screener can ever take it off or mis-categorize it.
+    // Placed after the attestation_tier column patch above so the column exists.
     `INSERT INTO supported_mints
        (mint, symbol, name, decimals, category, image_url,
         liquidity_usd, holder_count, market_cap_usd,
@@ -951,12 +957,16 @@ export async function applyStartupPatches() {
         token_age_hours, auto_approved, screened_at, source,
         enabled, protected, attestation_tier)
      VALUES ('MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1',
-             'MU', 'MU', 6, 'memecoin', NULL,
+             'MU', 'Micron Technology', 6, 'stock', NULL,
              0, 0, 0,
              TRUE, TRUE, FALSE,
              0, FALSE, NOW(), 'operator_trusted',
              TRUE, TRUE, 'hot')
      ON CONFLICT (mint) DO UPDATE SET
+       symbol = 'MU',
+       name = 'Micron Technology',
+       category = 'stock',
+       decimals = 6,
        enabled = TRUE,
        protected = TRUE,
        attestation_tier = 'hot',


### PR DESCRIPTION
Follow-up to #463. \$MU is **Micron Technology**, tokenized by **Backpack Securities** (Token-2022) — name/symbol/decimals verified on-chain, Jupiter prices it at ~\$1.95M liquidity. The initial seed mis-set `category='memecoin'`; this corrects it to `'stock'`.

## Effect (operator wants V3+V4 + Tokenized Stocks column, zero errors)

- **Tokenized Stocks column** — `/tokens` reads `category` from `/api/v1/tokens` and filters `category==='stock'` (TokensClient.tsx:182). No site change needed; it auto-appears once the bot serves the row.
- **V3 + V4 routing** — `chooseProgramId` sends RWA categories (`stock`) to V3 (no-exit) and V4 (with-exit). `ROUTE_RWA_TO_V3` is already live for the other xStocks.
- **Hot + protected** — the `stocks-rwa-protection-sentinel` force-keeps `category IN ('stock','rwa')` hot+protected; the hot tier keeps the 8-sample TWAP window filled so V3/V4 borrows never hit `StalePriceAttestation` / `TwapInsufficientHistory`.
- `ON CONFLICT` re-asserts symbol/name/category/decimals/enabled/protected/hot on every boot — permanent + self-correcting.

Per the operator's standing rule, a manually-approved token bypasses the user-submission screening, so the non-Backed freeze authority is intentionally not a blocker.

> Not yet deployed when #463 merged, so nothing live was mis-categorized.