### PR TITLE
x402: bot-side zero-touch creation of standard-rail destination ATAs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,7 @@ import { startImpersonatorWatchdog } from "./services/impersonator-watchdog.js";
 import { startCanaryWatcher } from "./services/canary-watcher.js";
 import { startBorrowCanary } from "./services/borrow-canary.js";
 import { startBootV4FeedSync } from "./services/boot-v4-feed-sync.js";
+import { ensureX402DestinationAtas } from "./services/x402-destination-atas.js";
 import { startFeedReadinessWarmup } from "./services/v4-feed-readiness.js";
 import { startLoanProgramIdHealer } from "./services/loan-program-id-healer.js";
 import { startV4LoanHealthProbe } from "./services/v4-loan-health-probe.js";
@@ -988,6 +989,13 @@ bot.start({
     // against mints. Per V4 loan lifecycle mandate NN1 (operator-
     // mandated 2026-06-19 PM after user 948 incident).
     startBootV4FeedSync(bot);
+    // x402 standard-rail destination ATAs — idempotently ensure the payTo
+    // wallet's USDC + wSOL ATAs exist so the standard v2 SVM rail can settle
+    // (the x402 service is keyless; the bot owns the payTo == lender wallet).
+    // No-ops once they exist. +50s so the RPC + keypair are ready.
+    setTimeout(() => ensureX402DestinationAtas(bot).catch((e) =>
+      console.warn("[x402-atas] boot ensure threw:", e.message)
+    ), 50_000);
     // V4 feed readiness — priority-mint burst warmup on boot. After
     // a 30s settle window so DB pool + attestor are alive. State
     // surfaces on /api/v1/health.v4_feeds; the site reads it to gate

--- a/src/services/x402-destination-atas.js
+++ b/src/services/x402-destination-atas.js
@@ -1,0 +1,113 @@
+/**
+ * x402 standard-rail destination ATAs (zero-touch, idempotent).
+ *
+ * The standard x402 v2 SVM "exact" rail settles USDC / wSOL to the protocol's
+ * payTo wallet. For an SPL transfer to land, that wallet's Associated Token
+ * Accounts must already exist on-chain. The x402 service is KEYLESS by design
+ * (custody boundary — it never holds a secret key), so the bot creates them
+ * here: the payTo wallet IS the lender wallet (LENDER_PUBKEY == payTo ==
+ * 4JSSS…), so the bot's lender keypair both owns the ATAs and pays their rent.
+ *
+ * Safe under "never affect existing user loans/collateral": this touches ONLY
+ * the protocol's OWN receiving ATAs — never a borrower loan, collateral vault,
+ * or price feed. Fully idempotent (existence-checked first + idempotent create
+ * instruction), so it is safe to run on every boot; it no-ops once the ATAs
+ * exist. Each ATA costs ~0.002 SOL rent, paid once.
+ */
+import {
+  PublicKey,
+  Transaction,
+  Keypair,
+  sendAndConfirmRawTransaction,
+} from "@solana/web3.js";
+import {
+  NATIVE_MINT,
+  TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountIdempotentInstruction,
+} from "@solana/spl-token";
+import bs58 from "bs58";
+import fs from "node:fs";
+import { connection, withFailover } from "../solana/connection.js";
+
+const USDC_MINT = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+// payTo for the x402 standard rail == the lender/treasury wallet.
+const PAY_TO = new PublicKey(
+  process.env.X402_PAY_TO ||
+    process.env.LENDER_PUBKEY ||
+    "4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx",
+);
+
+function loadLenderKeypair() {
+  const b58 = process.env.LENDER_PRIVATE_KEY;
+  if (b58) {
+    const decode = bs58.decode || (bs58.default && bs58.default.decode);
+    return Keypair.fromSecretKey(decode(b58));
+  }
+  const kpPath = process.env.LENDER_KEYPAIR_PATH;
+  if (!kpPath) {
+    throw new Error(
+      "[x402-atas] LENDER_PRIVATE_KEY or LENDER_KEYPAIR_PATH must be set",
+    );
+  }
+  return Keypair.fromSecretKey(
+    new Uint8Array(JSON.parse(fs.readFileSync(kpPath, "utf8"))),
+  );
+}
+
+/**
+ * Ensure the USDC + wSOL destination ATAs for the x402 payTo wallet exist.
+ * Returns the list of ATAs it actually created (empty if all already present).
+ */
+export async function ensureX402DestinationAtas(bot = null) {
+  // Derivation MUST match the x402 service's destinationAtas()
+  // (getAssociatedTokenAddressSync(mint, owner, allowOwnerOffCurve=true)).
+  const targets = [
+    { name: "USDC", mint: USDC_MINT },
+    { name: "wSOL", mint: NATIVE_MINT },
+  ];
+  let lender = null;
+  const created = [];
+  for (const { name, mint } of targets) {
+    try {
+      const ata = getAssociatedTokenAddressSync(mint, PAY_TO, true, TOKEN_PROGRAM_ID);
+      const info = await withFailover((c) => c.getAccountInfo(ata));
+      if (info) {
+        console.log(`[x402-atas] ${name} destination ATA already exists: ${ata.toBase58()}`);
+        continue;
+      }
+      if (!lender) lender = loadLenderKeypair();
+      const ix = createAssociatedTokenAccountIdempotentInstruction(
+        lender.publicKey, // payer
+        ata,
+        PAY_TO, // owner
+        mint,
+        TOKEN_PROGRAM_ID,
+      );
+      const tx = new Transaction().add(ix);
+      tx.feePayer = lender.publicKey;
+      const { blockhash } = await withFailover((c) => c.getLatestBlockhash("confirmed"));
+      tx.recentBlockhash = blockhash;
+      tx.sign(lender);
+      const sig = await sendAndConfirmRawTransaction(connection, tx.serialize(), {
+        commitment: "confirmed",
+        skipPreflight: false,
+      });
+      console.log(`[x402-atas] created ${name} destination ATA ${ata.toBase58()} sig=${sig}`);
+      created.push({ name, ata: ata.toBase58(), sig });
+    } catch (e) {
+      console.warn(`[x402-atas] ensure ${name} ATA failed: ${e.message?.slice(0, 160)}`);
+    }
+  }
+  if (created.length && bot) {
+    try {
+      const { notifyAdmin } = await import("./admin-notify.js");
+      await notifyAdmin(
+        `[x402-atas] created standard-rail destination ATA(s): ` +
+          created.map((c) => `${c.name}=${c.ata.slice(0, 8)}…`).join(", ") +
+          `. The x402 standard v2 rail can now settle these assets to payTo — flip X402_STANDARD_RAIL_ENABLED=true to go live.`,
+      );
+    } catch {}
+  }
+  return created;
+}


### PR DESCRIPTION
Zero-touch creation of the x402 standard-rail destination ATAs so the operator never touches a key.

The standard v2 SVM rail settles USDC/wSOL to the payTo wallet; those ATAs must exist on-chain for a transfer to land. The x402 service is **keyless** by design, so the bot — which holds the payTo wallet's keypair (`LENDER_PUBKEY == payTo == 4JSSS…`) — creates them idempotently at boot (+50s).

- **`ensureX402DestinationAtas()`** — existence-checks then creates the USDC + wSOL ATAs via a lender-signed `createAssociatedTokenAccountIdempotent`. Touches **only** the protocol's own receiving ATAs (hardcoded mints, env-pinned owner, bounded cost) — never a borrower loan/collateral. No-ops once present. DMs admin on creation. **Passed the standard-rail security audit (custody lens).**
- Wired into boot in `index.js`.

Once the USDC ATA exists + the x402 security hardening (magpiecapital/magpie-x402#65) is deployed, flip `X402_STANDARD_RAIL_ENABLED=true` to go live.