### PR TITLE
limit-close: refuse ambiguous (multi-row) arm lookup (audit low #8)

### DIFF
--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -484,7 +484,17 @@ async function armOrderImpl({
         WHERE user_id = $1 AND loan_id = $2`,
       [userId, loanIdChain],
     );
-    if (rows.length > 0) {
+    if (rows.length > 1) {
+      // Defensive (audit low #8): (user_id, loan_id) is expected to resolve to
+      // exactly one row because loans.loan_id is globally UNIQUE. If that ever
+      // changes (per-program scoping), this lookup would be ambiguous and could
+      // arm an exit against the WRONG program. Refuse rather than guess at rows[0].
+      console.error(
+        `[limit-close-arm] CRIT ambiguous loan lookup: ${rows.length} rows for user=${userId} loan_id=${loanIdChain} — loans.loan_id uniqueness violated; refusing to arm`,
+      );
+      break; // exits with loan=null → clean failure path below
+    }
+    if (rows.length === 1) {
       loan = rows[0];
       break;
     }


### PR DESCRIPTION
Defensive guard: the `(user_id, loan_id)` arm lookup takes `rows[0]`, relying on `loans.loan_id` being globally UNIQUE. If that ever changed (per-program scoping) it could arm against the wrong program. Now refuses on >1 row (logs CRIT, clean-fails) instead of guessing. **No behavior change today** — `loan_id` is unique, so this path is never hit. Last of the adversarial audit's low-tier items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)