### PR TITLE
x402: daily operator DM digest (the 4 numbers, 9am EST)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -155,6 +155,7 @@ import { setSecurityAlertBot } from "./services/security-alerts.js";
 import { setLenderAlarmBot } from "./api/lender-alarm-webhook.js";
 import { setNotifyBot } from "./services/admin-notify.js";
 import { startDailyOpsReport } from "./services/daily-ops-report.js";
+import { startX402DailyDigest } from "./services/x402-daily-digest.js";
 import { startUsedNoncesCleaner } from "./services/used-nonces-cleaner.js";
 import { startCreditOraclePublisher } from "./services/credit-oracle-publisher.js";
 import { startPriceAttestor } from "./services/price-attestor.js";
@@ -742,6 +743,7 @@ bot.start({
       m.startShadowPoolWatcher(),
     );
     setTimeout(() => startDailyOpsReport(bot), 60_000);
+    setTimeout(() => startX402DailyDigest(bot), 75_000);
     startUsedNoncesCleaner();
     // startDepositWatcher(bot);
     setTimeout(() => startLoanWatcher(bot), 5_000);

--- a/src/services/x402-daily-digest.js
+++ b/src/services/x402-daily-digest.js
@@ -1,0 +1,122 @@
+/**
+ * x402-daily-digest.js
+ * ─────────────────────────────────────────────────────────────────────────
+ * Once a day at 9:00 AM Eastern, DM the operator a compact x402 scorecard —
+ * the four numbers that say whether x402 is winning:
+ *   • paying agents (24h)   • paid x402 calls (24h)
+ *   • x402 fees collected   • protocol borrows (24h)
+ * …each with a 7-day trend line for context.
+ *
+ * DST-correct (fires at 9am Eastern wall-clock via America/New_York).
+ * Tune the hour with X402_DIGEST_HOUR_EST (default 9). Disable with
+ * X402_DIGEST_DISABLED=true. Self-throttles to once per Eastern calendar day.
+ */
+import { query } from "../db/pool.js";
+import { getAdminId } from "./admin-notify.js";
+
+const DIGEST_HOUR_EST = Number(process.env.X402_DIGEST_HOUR_EST ?? 9);
+const CHECK_INTERVAL_MS = 15 * 60 * 1000; // coarse — the daily throttle does the real gating
+let lastDigestYmd = null;
+
+// Eastern wall-clock hour + YYYY-MM-DD, DST-correct via Intl. The operator
+// mandate is "always Eastern", and America/New_York handles EST/EDT for us.
+function easternNow(date) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const get = (t) => parts.find((p) => p.type === t)?.value;
+  let hour = Number(get("hour"));
+  if (hour === 24) hour = 0; // some engines emit 24 for midnight
+  return { ymd: `${get("year")}-${get("month")}-${get("day")}`, hour };
+}
+
+const sol = (lamports) => (Number(lamports) / 1e9).toFixed(4);
+
+// Run a query but never let a missing table / transient error break the digest.
+async function safeRow(qText, params = []) {
+  try {
+    const { rows } = await query(qText, params);
+    return rows[0] || {};
+  } catch (err) {
+    console.warn("[x402-digest] query failed:", err.message);
+    return {};
+  }
+}
+
+async function buildDigest() {
+  // x402 paid-call metrics (24h headline + 7d trend). 'settled' = native-SOL
+  // rail; 'reserve' rows are pre-settlement markers and are excluded.
+  const x = await safeRow(`
+    SELECT
+      COUNT(*) FILTER (WHERE kind <> 'reserve' AND recorded_at > NOW() - INTERVAL '24 hours')::int AS calls_24h,
+      COUNT(DISTINCT payer_pubkey) FILTER (WHERE kind <> 'reserve' AND payer_pubkey <> '' AND recorded_at > NOW() - INTERVAL '24 hours')::int AS agents_24h,
+      COALESCE(SUM(amount_lamports::numeric) FILTER (WHERE kind = 'settled' AND recorded_at > NOW() - INTERVAL '24 hours'), 0)::text AS fees_24h,
+      COUNT(*) FILTER (WHERE kind <> 'reserve')::int AS calls_7d,
+      COUNT(DISTINCT payer_pubkey) FILTER (WHERE kind <> 'reserve' AND payer_pubkey <> '')::int AS agents_7d,
+      COALESCE(SUM(amount_lamports::numeric) FILTER (WHERE kind = 'settled'), 0)::text AS fees_7d
+    FROM x402_paid_calls
+    WHERE recorded_at > NOW() - INTERVAL '7 days'
+  `);
+
+  // Protocol borrow activity (SOL disbursed to borrowers).
+  const b = await safeRow(`
+    SELECT
+      COUNT(*) FILTER (WHERE start_timestamp > NOW() - INTERVAL '24 hours')::int AS borrows_24h,
+      COALESCE(SUM(loan_amount_lamports::numeric) FILTER (WHERE start_timestamp > NOW() - INTERVAL '24 hours'), 0)::text AS vol_24h,
+      COUNT(*) FILTER (WHERE start_timestamp > NOW() - INTERVAL '7 days')::int AS borrows_7d,
+      COALESCE(SUM(loan_amount_lamports::numeric) FILTER (WHERE start_timestamp > NOW() - INTERVAL '7 days'), 0)::text AS vol_7d
+    FROM loans
+    WHERE start_timestamp > NOW() - INTERVAL '7 days'
+  `);
+
+  const c24 = x.calls_24h ?? 0;
+  const lines = [
+    `📊 *Magpie x402 — daily digest*  ·  ${DIGEST_HOUR_EST}:00 EST`,
+    ``,
+    `🤖 Paying agents (24h):  *${x.agents_24h ?? 0}*`,
+    `⚡ Paid x402 calls (24h):  *${c24}*`,
+    `💸 x402 fees collected (24h):  *${sol(x.fees_24h ?? 0)} SOL*`,
+    `🏦 Protocol borrows (24h):  *${b.borrows_24h ?? 0}*  ·  *${sol(b.vol_24h ?? 0)} SOL*`,
+    ``,
+    `_7d — agents ${x.agents_7d ?? 0} · calls ${x.calls_7d ?? 0} · fees ${sol(x.fees_7d ?? 0)} SOL · borrows ${b.borrows_7d ?? 0}_`,
+  ];
+  if (c24 === 0) {
+    lines.push(``, `_No x402 calls in the last 24h yet — keep the outbound marketing pushing._`);
+  }
+  return lines.join("\n");
+}
+
+async function tick(bot) {
+  try {
+    const { ymd, hour } = easternNow(new Date());
+    if (hour < DIGEST_HOUR_EST) return; // not yet 9am Eastern today
+    if (lastDigestYmd === ymd) return; // already sent today — self-throttle
+    const adminId = getAdminId();
+    if (!adminId || !bot) return;
+    const text = await buildDigest();
+    await bot.api.sendMessage(Number(adminId), text, { parse_mode: "Markdown" });
+    lastDigestYmd = ymd;
+    console.log("[x402-digest] sent daily digest");
+  } catch (err) {
+    console.warn("[x402-digest] tick failed:", err.message);
+  }
+}
+
+export function startX402DailyDigest(bot) {
+  if (!bot) return null;
+  if (process.env.X402_DIGEST_DISABLED === "true") {
+    console.log("[x402-digest] disabled via X402_DIGEST_DISABLED — not starting");
+    return null;
+  }
+  console.log(`[x402-digest] starting — DMs admin daily at ${DIGEST_HOUR_EST}:00 EST`);
+  setTimeout(() => tick(bot), 45_000); // first check shortly after boot; throttle handles the rest
+  return setInterval(() => tick(bot), CHECK_INTERVAL_MS);
+}
+
+// Exported for an admin "/x402digest now" command or tests.
+export { buildDigest };


### PR DESCRIPTION
Wires the daily DM the operator asked for — a one-glance x402 scorecard each morning.

### `src/services/x402-daily-digest.js`
Once a day at **9:00 AM Eastern**, DMs the operator:
```
📊 Magpie x402 — daily digest · 9:00 EST

🤖 Paying agents (24h):  3
⚡ Paid x402 calls (24h):  47
💸 x402 fees collected (24h):  0.062 SOL
🏦 Protocol borrows (24h):  5 · 12.30 SOL

7d — agents 21 · calls 310 · fees 0.41 SOL · borrows 18
```
(When a day is quiet it appends a 'keep the marketing pushing' nudge.)

### Notes
- **DST-correct**: fires at 9am Eastern *wall-clock* via `America/New_York` Intl (verified: 13:00Z→9 in June/EDT, 14:00Z→9 in Jan/EST). Honors the 'always Eastern' mandate. Hour tunable via `X402_DIGEST_HOUR_EST`.
- Mirrors the existing `daily-ops-report.js` job pattern — 15-min coarse check, daily self-throttle by Eastern calendar day; DMs via `getAdminId` + `bot.api.sendMessage`.
- **Fail-soft**: each SQL query falls back to zeros on a missing table / transient error, so the digest never crashes the bot. Disable with `X402_DIGEST_DISABLED=true`.
- Queries verified against schema: `x402_paid_calls(kind, payer_pubkey, amount_lamports, recorded_at)` and `loans(start_timestamp, loan_amount_lamports)`.
- Wired into `index.js` startup at +75s. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)