### PR TITLE
chore: de-hardcode local dev paths in two legacy scripts

### DIFF
--- a/scripts/audit-lp-positions.mjs
+++ b/scripts/audit-lp-positions.mjs
@@ -9,9 +9,10 @@ const conn = new Connection(RPC, "confirmed");
 
 const LENDER = new PublicKey("4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx");
 
+const IDL_DIR = process.env.MAGPIE_IDL_DIR || "./src/solana/idl";
 const TARGETS = [
-  ["V1", "/Users/bradleylubetkin/bagbank-bot/src/solana/idl/magpie_lending.json", "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh"],
-  ["V2", "/Users/bradleylubetkin/bagbank-bot/src/solana/idl/magpie_lending_v2.json", "6wSpKAGuiRf3nYHj9raVwmoTPbG5MswBzTy6aMXZHBe"],
+  ["V1", `${IDL_DIR}/magpie_lending.json`, "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh"],
+  ["V2", `${IDL_DIR}/magpie_lending_v2.json`, "6wSpKAGuiRf3nYHj9raVwmoTPbG5MswBzTy6aMXZHBe"],
 ];
 
 for (const [name, idlPath, programIdStr] of TARGETS) {

--- a/scripts/v3-deposit-smoke.mjs
+++ b/scripts/v3-deposit-smoke.mjs
@@ -25,14 +25,13 @@ const V3 = new PublicKey("B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP");
 const RPC = process.env.SOLANA_RPC_URL || "https://api.mainnet-beta.solana.com";
 const conn = new Connection(RPC, "confirmed");
 
+const IDL_DIR = process.env.MAGPIE_IDL_DIR || "./src/solana/idl";
 const lender = Keypair.fromSecretKey(
   Uint8Array.from(
-    JSON.parse(readFileSync("/Users/bradleylubetkin/bagbank-bot/lender-keypair-v2.json", "utf8")),
+    JSON.parse(readFileSync(process.env.LENDER_KEYPAIR || "./lender-keypair-v2.json", "utf8")),
   ),
 );
-const idl = JSON.parse(
-  readFileSync("/Users/bradleylubetkin/bagbank-bot/src/solana/idl/magpie-v3.json", "utf8"),
-);
+const idl = JSON.parse(readFileSync(`${IDL_DIR}/magpie-v3.json`, "utf8"));
 const provider = new AnchorProvider(conn, new Wallet(lender), { commitment: "confirmed" });
 const program = new Program(idl, provider);
 


### PR DESCRIPTION
Replaces machine-specific absolute paths in `scripts/audit-lp-positions.mjs` and `scripts/v3-deposit-smoke.mjs` with `MAGPIE_IDL_DIR` / `LENDER_KEYPAIR` env vars (relative defaults). Portable, and carries no local-checkout path. Both scripts still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)