### PR TITLE
fix: paid agent x402 endpoints were never in PUBLIC_ROUTES (root cause of borrow 401)

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1667,6 +1667,21 @@ const PUBLIC_ROUTES = new Set([
   "/api/v1/internal/agent/limit-close/list",
   "/api/v1/internal/agent/limit-close/delegations",
   "/api/v1/internal/agent/limit-close/eligible-loans",
+  // PAID agent endpoints (x402). The x402 service forwards to these with
+  // X-Internal-Token AFTER it has verified the agent's on-chain x402 payment;
+  // each handler enforces INTERNAL_API_TOKEN at the handler level (agent.js /
+  // agent-repay.js / agent-manage.js / agent-intents.js — same pattern as the
+  // internal endpoints above). They MUST bypass the external x-api-key gate
+  // (authenticateRequest) — otherwise the x402 service's internal token is
+  // rejected with "Invalid or missing API key" (401) and EVERY agent borrow/
+  // repay is charged-but-denied. ROOT-CAUSE FIX: these were never added here.
+  "/api/v1/agent/build-borrow",
+  "/api/v1/agent/build-repay",
+  "/api/v1/agent/build-extend",
+  "/api/v1/agent/build-topup",
+  "/api/v1/agent/build-partial-repay",
+  "/api/v1/agent/intent",
+  "/api/v1/agent/intents",
   // Pre-borrow price refresh. Site calls this BEFORE buildBorrowTransaction
   // so the on-chain feed is fresh by the time the wallet simulates the
   // tx — closes the window where Phantom rejects with StalePriceAttestation


### PR DESCRIPTION
Re-do of #479 on the rewritten main (the earlier branch conflicted after the history scrub).

## Root cause of the live borrow failure
Every x402 `build-borrow`/`build-repay` returned **`401 'Invalid or missing API key'` AFTER payment** — charged-but-denied on the core agent path. `authenticateRequest()` only accepts an external `x-api-key`; the paid agent endpoints were never added to the `PUBLIC_ROUTES` bypass that the internal endpoints use, so they hit that gate before reaching their handler's `INTERNAL_API_TOKEN` check.

## Fix
Add `build-borrow|repay|extend|topup|partial-repay`, `intent`, `intents` to `PUBLIC_ROUTES`. Each handler already enforces `INTERNAL_API_TOKEN` (verified). Same pattern as the working internal `record`/`release`/`limit-close` endpoints — proving token values match. No security change, no secret rotation. Paired with magpie-x402 #81 (401→503 refund).

🤖 Generated with [Claude Code](https://claude.com/claude-code)