### PR TITLE
feat(x402-metrics): derive x402-originated borrow count (read-only)

### DIFF
--- a/src/api/x402-metrics.js
+++ b/src/api/x402-metrics.js
@@ -285,6 +285,45 @@ export async function handleX402Metrics() {
     LIMIT 10
   `);
 
+  // x402-ORIGINATED BORROWS — READ-ONLY correlation. There is no origin column on
+  // loans and we deliberately do NOT add one (a write to the borrow critical path
+  // would risk existing loans + couple lanes). Instead we DERIVE the count: an x402
+  // borrow is a loan whose borrower_wallet paid for a `/api/v1/agent/build-borrow`
+  // call (the x402-ONLY endpoint, which cryptographically binds payer == borrower)
+  // shortly before the loan was funded. This is an INTERSECTION (paid AND funded),
+  // so it never counts paid-but-rejected attempts; the website/Telegram borrow flows
+  // never hit build-borrow, so a pure human borrow produces no match. It is a
+  // wallet+30-min-window heuristic — NOT exact — and the site captions it as such
+  // ("approximate"), so it never over-states. Wrapped in try/catch so a failure here
+  // can never break the rest of this public metrics endpoint.
+  let x402Borrows = {
+    x402_borrows_24h: 0,
+    x402_borrows_total: 0,
+    last_x402_borrow_at: null,
+    last_x402_borrow_tx: null,
+  };
+  try {
+    const { rows: [xb] } = await query(`
+      SELECT
+        COUNT(DISTINCT l.id) FILTER (WHERE l.start_timestamp > NOW() - INTERVAL '24 hours')::int AS x402_borrows_24h,
+        COUNT(DISTINCT l.id)::int AS x402_borrows_total,
+        MAX(l.start_timestamp) AS last_x402_borrow_at,
+        (ARRAY_AGG(l.tx_signature ORDER BY l.start_timestamp DESC))[1] AS last_x402_borrow_tx
+      FROM loans l
+      JOIN x402_paid_calls p
+        ON p.payer_pubkey = l.borrower_wallet
+       AND p.endpoint_path = $1
+       AND p.kind <> 'reserve'           -- native ('settled') + SPL ('settled-spl'); excludes pre-settle gates
+       AND p.payer_pubkey <> ''
+       AND l.borrower_wallet IS NOT NULL  -- old loans predate borrower_wallet → correctly excluded
+       AND l.start_timestamp >= p.recorded_at
+       AND l.start_timestamp <  p.recorded_at + INTERVAL '30 minutes'
+    `, ["/api/v1/agent/build-borrow"]);
+    if (xb) x402Borrows = xb;
+  } catch (err) {
+    console.warn("[x402-metrics] x402-borrows correlation failed (non-fatal):", err.message);
+  }
+
   return {
     status: 200,
     body: {
@@ -295,6 +334,13 @@ export async function handleX402Metrics() {
       revenue_24h_sol: Number(agg.revenue_24h_lamports) / 1e9,
       revenue_7d_sol: Number(w.revenue_7d_lamports) / 1e9,
       unique_payers_24h: agg.unique_payers_24h,
+      // x402-originated borrows (approximate; see correlation comment above). Counts
+      // loans funded by a wallet that paid for build-borrow within 30 min. Proof that
+      // agents are not just PAYING for calls but actually completing loans.
+      x402_borrows_24h: x402Borrows.x402_borrows_24h,
+      x402_borrows_total: x402Borrows.x402_borrows_total,
+      last_x402_borrow_at: x402Borrows.last_x402_borrow_at || null,
+      last_x402_borrow_tx: x402Borrows.last_x402_borrow_tx || null,
       // Standard SPL rail (USDC/wSOL) — reported in native atomic units (USDC 6dp,
       // wSOL 9dp), NEVER folded into the SOL revenue above.
       standard_rail: {


### PR DESCRIPTION
Surfaces a truthful **"agents have actually borrowed via x402"** proof — the one thing the site couldn't show (it proved *protocol alive* and *agents pay for calls*, but not *an agent completed a loan*).

## Approach: read-only correlation (designed + adversarially verified)
A 3-agent investigation confirmed: the loans row is written at **cosign** time (shared by website + Telegram + x402, so not a reliable origin signal), there's **no origin column**, and `recordLoan` threads no metadata. Rather than touch the borrow critical path, this **derives** the count:

> An x402 borrow = a loan whose `borrower_wallet` paid for a `/api/v1/agent/build-borrow` call (the **x402-only** endpoint, which cryptographically binds `payer == borrower` via `enforcePayerMatchesWallet`) within **30 min** before the loan was funded.

New fields on `GET /api/v1/public/x402-metrics`: `x402_borrows_24h`, `x402_borrows_total`, `last_x402_borrow_at`, `last_x402_borrow_tx`.

## Why this is safe (adversarial check)
- **Zero writes to loans, no migration, no `recordLoan` change, no borrow/cosign/sync code** — existing V1/V3/V4 rows are byte-for-byte unchanged; lanes never coupled. Honors *"never affect existing user loans"*.
- **Can't over-count humans:** the JOIN requires a settled row on the x402-only `build-borrow` endpoint, which website/Pip/TG borrows never hit.
- **INTERSECTION** — never counts paid-but-rejected build-borrow attempts (gate denials are charged but create no loan).
- **Honest, not exact:** wallet+window heuristic; the site captions it **"approximate."** The one residual edge (a wallet that pays x402 *and* borrows via site within 30 min) is over-count only, disclosed by the caption.
- **No PII:** only counts, a timestamp, and the loan-funding tx signature — matches the route's existing no-PII contract.
- **Defensively wrapped:** the correlation query is in try/catch → a failure returns zeros and can never break the rest of the metrics endpoint.

`node --check` clean. **Not auto-merged** — queue it into your next bot redeploy window. The matching site strip (gated on these fields being present) is a separate magpie-site PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)