### PR TITLE
fix(agent): add /api/v1/risk/token to PUBLIC_ROUTES (unblocks live agent borrow)

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -1682,6 +1682,15 @@ const PUBLIC_ROUTES = new Set([
   "/api/v1/agent/build-partial-repay",
   "/api/v1/agent/intent",
   "/api/v1/agent/intents",
+  // PUBLIC risk reads. The x402 token-risk handler (magpie-x402 routes/token-risk.ts)
+  // forwards here WITHOUT an auth header after charging the agent 0.001 SOL, then
+  // passes our status straight through. Not in PUBLIC_ROUTES => the external x-api-key
+  // gate 401s => the agent is charged-but-denied and CANNOT obtain a risk score, so an
+  // autonomous agent can never clear its risk gate to borrow. These are read-only risk
+  // scores (no PII, no mutation), safe to serve publicly like /api/v1/public/*. Found
+  // LIVE 2026-06-24 (dry-run skips the paid risk call, so it was never exercised before).
+  "/api/v1/risk/token",
+  "/api/v1/risk/flagged",
   // Pre-borrow price refresh. Site calls this BEFORE buildBorrowTransaction
   // so the on-chain feed is fresh by the time the wallet simulates the
   // tx — closes the window where Phantom rejects with StalePriceAttestation


### PR DESCRIPTION
**P0 — found on the first LIVE autonomous-agent run.** The agent paid 0.001 SOL per risk-check and got `401`, never got a risk score, and correctly **held** instead of borrowing.

## Root cause
The x402 token-risk handler forwards to the bot's `/api/v1/risk/token` **with no auth header** and passes our status straight back. That route was **not in `PUBLIC_ROUTES`**, so the external `x-api-key` gate returned `401`. Same class as the original build-borrow `PUBLIC_ROUTES` bug; missed because dry-run skips the paid risk call.

## Fix
Add `/api/v1/risk/token` + `/api/v1/risk/flagged` to `PUBLIC_ROUTES`. Both are read-only risk scores (no PII, no mutation), safe to serve publicly like `/api/v1/public/*`.

## Note (auth surface)
This DOES make those two read-only endpoints reachable on the bot without the `x-api-key` gate — consistent with the other `/api/v1/public/*` reads. No funds, no mutation, no PII.

`node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)