### PR TITLE
fix(borrow-canary): stop twap_missing_field false alarm

### DIFF
--- a/src/services/borrow-canary.js
+++ b/src/services/borrow-canary.js
@@ -122,10 +122,28 @@ async function probeTwap(mint) {
       throw new Error(`twap http_${res.status}`);
     }
     const body = await res.json();
-    if (!body || body.error || !body.twap_lamports_per_whole) {
-      throw new Error(body?.error || "twap_missing_field");
+    if (!body) throw new Error("twap_empty_response");
+    if (body.error) throw new Error(body.error);
+    // Key off the endpoint's STABLE contract — its `recommendation` enum — NOT a
+    // specific field name. (The old check looked for `twap_lamports_per_whole`,
+    // but the endpoint emits `twap_lamports_per_whole_token`; that field-name
+    // drift made the canary throw `twap_missing_field` on perfectly healthy
+    // responses. Keying off `recommendation` can't drift on a rename.)
+    //
+    // - use_precise_value  → healthy precise TWAP (verify the value is present).
+    // - wait_for_warmup    → FUNCTIONAL: the site falls back to fallback_multiplier
+    //                        (0.89) and the borrow still succeeds, so this is NOT a
+    //                        user-facing borrow failure. Pass it as a soft "warming"
+    //                        state (visible in logs, never alarms).
+    if (body.recommendation === "wait_for_warmup") {
+      return { ok: true, latencyMs: Date.now() - start, warming: body.reason || true };
     }
-    return { ok: true, latencyMs: Date.now() - start };
+    if (body.recommendation === "use_precise_value" && body.twap_lamports_per_whole_token) {
+      return { ok: true, latencyMs: Date.now() - start };
+    }
+    // 200 but neither a usable precise value nor a warmup fallback — a real data
+    // shape problem a borrower could actually hit.
+    throw new Error("twap_unexpected_shape");
   } catch (e) {
     return { ok: false, latencyMs: Date.now() - start, error: e, class: classifyError(e) };
   }


### PR DESCRIPTION
The 'Borrow canary degraded · twap_memecoin · twap_missing_field' alert was a CANARY BUG, not a borrow failure. (1) Field-name drift: canary checked `twap_lamports_per_whole` but the endpoint emits `twap_lamports_per_whole_token` — so it threw on healthy responses (verified live: BONK returns use_precise_value + the value). (2) Warmup treated as failure: `wait_for_warmup` is functional (site falls back to 0.89, borrow succeeds). Fix keys off the endpoint's stable `recommendation` enum (use_precise_value→pass, wait_for_warmup→soft warming pass, body.error→fail), which can't drift on a field rename. No user was blocked. 🤖 Generated with [Claude Code](https://claude.com/claude-code)