### PR TITLE
tg /stats: net LP + per-cycle reserve (uniform with web /stats)

### DIFF
--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -133,14 +133,38 @@ export async function handleStats(ctx) {
       if (hp?.accr) holderAccrued = BigInt(hp.accr);
     } catch { /* table absent in old deploys */ }
     try {
+      // SOL LPs = THIRD-PARTY net (operator's exempt lender wallet taken out) —
+      // gross pool × (non-exempt LP weight / total weight), weight = shares ×
+      // seconds_held. Mirrors the distributor + magpie.capital/stats so every
+      // surface shows the same number. See feedback_lender_wallet_exempt_from_lp_loyalty.
       const { rows: [lp] } = await query(
-        `SELECT COALESCE(accrued_lamports, 0)::text AS accr FROM lp_loyalty_pool WHERE id = 1`,
+        `SELECT COALESCE(
+           (SELECT accrued_lamports FROM lp_loyalty_pool WHERE id = 1)::numeric
+           * COALESCE(
+               (SELECT SUM(shares * EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)))
+                  FROM lp_positions
+                 WHERE shares > 0 AND EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)) > 0
+                   AND wallet_address NOT IN (SELECT wallet_address FROM lp_loyalty_exempt_wallets))
+               / NULLIF(
+               (SELECT SUM(shares * EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)))
+                  FROM lp_positions
+                 WHERE shares > 0 AND EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)) > 0), 0)
+             , 1)
+         , 0)::bigint::text AS accr`,
       );
       if (lp?.accr) lpAccrued = BigInt(lp.accr);
     } catch { /* */ }
     try {
+      // Protocol reserve = PER-CYCLE (accrued since the last $MAGPIE snapshot),
+      // resets to 0 each distribution — Snapshot-rewards numbers must not
+      // accumulate. Mirrors magpie.capital/stats. See
+      // feedback_stats_snapshot_rewards_reset_per_cycle.
       const { rows: [pr] } = await query(
-        `SELECT COALESCE(accrued_lamports, 0)::text AS accr FROM protocol_reserve_pool WHERE id = 1`,
+        `SELECT COALESCE((
+           SELECT SUM(reward_lamports) FROM protocol_reserve_events
+            WHERE created_at > COALESCE(
+              (SELECT MAX(created_at) FROM magpie_holder_distributions), '1970-01-01'::timestamptz)
+         ), 0)::text AS accr`,
       );
       if (pr?.accr) reserveAccrued = BigInt(pr.accr);
     } catch { /* migration 049 not yet applied */ }

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -428,18 +428,28 @@ export async function snapshotAndDistributeLpLoyalty() {
     console.warn("[lp-loyalty] lp_loyalty_exempt_wallets read failed (using empty exemption set):", err.message);
   }
 
-  // Compute weights
+  // Compute weights.
+  //
+  // EXEMPT WALLETS STAY IN THE DENOMINATOR but are NOT paid (operator decision
+  // 2026-06-25, "calculate the figure with my share taken out"). The operator's
+  // lender wallet is ~96% of LP weight; if it were dropped from the denominator
+  // too, the remaining third-party LPs would be re-normalized onto the FULL pool
+  // (a ~26x windfall over what they earned). Instead, each third-party LP gets
+  // ONLY its own proportional share (weight / totalWeight × pool), and the exempt
+  // wallet's proportional slice is left UNDISTRIBUTED — the pool is decremented by
+  // allocatedSum (below), so that slice carries forward in lp_loyalty_pool.
+  // See [[feedback_lender_wallet_exempt_from_lp_loyalty]].
   let totalWeight = 0n;
   const items = [];
   for (const r of rows) {
-    if (exempt.has(r.wallet_address)) continue;
     const shares = BigInt(r.shares);
     const seconds = BigInt(r.seconds_held ?? 0);
     if (seconds <= 0n) continue; // brand-new deposits get no loyalty this round
     const weight = shares * seconds;
     if (weight <= 0n) continue;
+    totalWeight += weight; // exempt counts toward the denominator…
+    if (exempt.has(r.wallet_address)) continue; // …but receives no payout row
     items.push({ wallet: r.wallet_address, shares, seconds, weight });
-    totalWeight += weight;
   }
   if (totalWeight === 0n || items.length === 0) return null;
 


### PR DESCRIPTION
Protocol uniformity — the TG `/stats` showed the GROSS LP pool (4.55, 96% operator's exempt share) + lifetime protocol reserve (4.05). Now matches the web /stats: SOL LPs = third-party net (~0.19), Protocol reserve = per-cycle since last snapshot (~0.52). Same math as the transparency route. Operator-only admin view keeps gross. node --check clean.