### PR TITLE
feat(community): Pip-reviewed appeal flow + fix silently-failing mod DMs

### DIFF
--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -679,6 +679,23 @@ export async function applyStartupPatches() {
      )`,
     `CREATE INDEX IF NOT EXISTS community_mod_actions_chat_idx
        ON community_mod_actions(chat_id, created_at DESC)`,
+    // Pip-reviewed appeals against an auto-moderation action. One appeal per
+    // mod action (UNIQUE) makes a double-tap idempotent. status:
+    // reviewing | overturned | upheld | escalated.
+    `CREATE TABLE IF NOT EXISTS community_appeals (
+       id BIGSERIAL PRIMARY KEY,
+       mod_action_id BIGINT NOT NULL UNIQUE,
+       chat_id BIGINT NOT NULL,
+       user_id BIGINT NOT NULL,
+       status TEXT NOT NULL DEFAULT 'reviewing',
+       decision TEXT,
+       reason TEXT,
+       confidence REAL,
+       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+       resolved_at TIMESTAMPTZ
+     )`,
+    `CREATE INDEX IF NOT EXISTS community_appeals_user_idx
+       ON community_appeals(user_id, created_at DESC)`,
     // Per-rule cooldown for operator anomaly DMs so a single incident
     // doesn't page the operator every 2-min watcher tick.
     `CREATE TABLE IF NOT EXISTS community_anomaly_alerts (

--- a/src/handlers/community-handlers.js
+++ b/src/handlers/community-handlers.js
@@ -17,6 +17,7 @@
  */
 import { InlineKeyboard } from "grammy";
 import { isAdmin } from "../services/admin.js";
+import { query } from "../db/pool.js";
 import {
   isChatEnabled,
   isVerifiedAccount,
@@ -113,10 +114,29 @@ async function isChatAdmin(ctx, userId) {
 }
 
 /** Soft warning DM. If the user blocks the bot, falls back silent. */
-async function softWarn(ctx, userId, msg) {
+async function softWarn(ctx, userId, msg, replyMarkup) {
+  // The whole point of a soft-warn is that the user LEARNS why their message
+  // was actioned — so delivery must be reliable. Try Markdown for nice
+  // formatting; if the body has a stray markup char that 400s the parse, retry
+  // as plain text so the notice ALWAYS lands. Only a hard block (user never
+  // started the bot) is allowed to silently drop.
+  const base = { disable_web_page_preview: true };
+  if (replyMarkup) base.reply_markup = replyMarkup;
   try {
-    await ctx.api.sendMessage(userId, msg);
-  } catch { /* user blocked bot — silent */ }
+    await ctx.api.sendMessage(userId, msg, { ...base, parse_mode: "Markdown" });
+  } catch (e1) {
+    try {
+      await ctx.api.sendMessage(userId, msg, base);
+    } catch { /* user blocked bot / never opened DM — nothing we can do */ }
+  }
+}
+
+/** Inline keyboard offering a one-tap appeal that Pip reviews. The button
+ *  carries the originating mod-action id so the callback can pull full
+ *  context. Only attached to actions that actually restrict the user. */
+function appealKeyboard(modActionId) {
+  if (!modActionId) return undefined;
+  return new InlineKeyboard().text("⚖️ Appeal this decision", `appeal:${modActionId}`);
 }
 
 /* ────────────────── NEW MEMBER HANDLER ───────────────────── */
@@ -322,7 +342,7 @@ async function handleGroupMessage(ctx) {
       try {
         const { notifyAdmin } = await import("../services/admin-notify.js");
         await notifyAdmin(
-          ctx.api,
+          { api: ctx.api },
           `🛡 *Magpie impersonator banned*\n\n` +
           `*Name:* ${sender.username ? `@${sender.username}` : (sender.first_name || sender.id)}\n` +
           `*ID:* \`${sender.id}\`\n` +
@@ -346,6 +366,7 @@ async function handleGroupMessage(ctx) {
         await recordModAction(ctx.chat.id, sender.id, "delete_link", "url not on allowlist", u);
         const count = await bumpWarnedCount(ctx.chat.id, sender.id);
         await softWarn(
+          ctx,
           sender.id,
           `Your message was removed from the Magpie community group because it contained a link.\n\n` +
           `*Only tweets from the official @MagpieLoans X account are allowed.* This is to keep scammers and phishing links out — almost every other "useful link" in a DeFi community turns out to be a scam.\n\n` +
@@ -366,6 +387,7 @@ async function handleGroupMessage(ctx) {
       await recordModAction(ctx.chat.id, sender.id, "delete_scam_pattern", scam, msg.text || msg.caption);
       const count = await bumpWarnedCount(ctx.chat.id, sender.id);
       await softWarn(
+        ctx,
         sender.id,
         `Your message was removed from the Magpie group — it matched a pattern we automatically flag (seed phrase requests, "send X SOL", "DM me", "claim airdrop", etc.). If this was a misunderstanding, just rephrase.` +
         (count >= 3 ? `\n\n#${count} warning. Repeated matches may result in a mute.` : ``),
@@ -387,6 +409,7 @@ async function handleGroupMessage(ctx) {
       );
       const count = await bumpWarnedCount(ctx.chat.id, sender.id);
       await softWarn(
+        ctx,
         sender.id,
         `Your message was removed because it referenced an unofficial Magpie-related handle (${impersonators.join(", ")}). The ONLY official Magpie accounts are *@MagpieLoans* on X and *@magpie_capital_bot* on Telegram. Anyone else claiming to be Magpie support is a scammer.` +
         (count >= 3 ? `\n\n#${count} warning. Repeated removals may result in a mute.` : ``),
@@ -408,6 +431,7 @@ async function handleGroupMessage(ctx) {
         await tryDelete(ctx, msg.message_id);
         await recordModAction(ctx.chat.id, sender.id, "delete_quarantine_media", "media/forward during quarantine", null);
         await softWarn(
+          ctx,
           sender.id,
           `Heads up — new members can't post images / videos / forwards for the first 7 days. This is to keep scammers out. Plain-text messages still work.`,
         );
@@ -514,14 +538,15 @@ async function maybeRunImageCheck(ctx, msg, sender) {
   if (decision.action === "delete") {
     await tryDelete(ctx, msg.message_id);
   }
-  await recordModAction(
+  const imageActionId = await recordModAction(
     ctx.chat.id, sender.id,
     `image_${result.verdict}`,
     `confidence=${result.confidence.toFixed(2)} reason=${result.reason}`,
     result.extractedText?.slice(0, 500) || null,
   );
 
-  if (decision.mute_sec > 0) {
+  const wasMuted = decision.mute_sec > 0;
+  if (wasMuted) {
     try {
       await ctx.api.restrictChatMember(ctx.chat.id, sender.id, {
         until_date: Math.floor(Date.now() / 1000) + decision.mute_sec,
@@ -540,9 +565,16 @@ async function maybeRunImageCheck(ctx, msg, sender) {
       nsfw_or_violence: "NSFW or violent imagery",
     }[result.verdict] || "policy violation";
 
+    // A mute is appealable (Pip re-reviews and can lift it). A delete-only
+    // warn has nothing to restore, so it gets no button.
+    const appealLine = wasMuted
+      ? ` If you think this was a mistake, tap *Appeal* below — Pip will re-review it and lift the mute if it was wrong.`
+      : ` If this was a mistake, post a plain-text follow-up explaining and someone will review.`;
     await softWarn(
+      ctx,
       sender.id,
-      `Your image was removed from the Magpie community — our vision moderator flagged it as a *${verdictLabel}*. If this was a mistake, post a plain-text follow-up explaining and someone will review.`,
+      `Your image was removed from the Magpie community — our vision moderator flagged it as a *${verdictLabel}*.${appealLine}`,
+      wasMuted ? appealKeyboard(imageActionId) : undefined,
     );
   }
 
@@ -550,7 +582,7 @@ async function maybeRunImageCheck(ctx, msg, sender) {
     try {
       const { notifyAdmin } = await import("../services/admin-notify.js");
       await notifyAdmin(
-        ctx.api,
+        { api: ctx.api },
         `🖼 *Community image flagged*\n\n` +
         `*Verdict:* ${escMd(result.verdict)} (conf ${result.confidence.toFixed(2)})\n` +
         `*From:* ${sender.username ? `@${escMd(sender.username)}` : escMd(sender.first_name || sender.id)}\n` +
@@ -642,12 +674,26 @@ async function maybeRunFudCheck(ctx, msg, sender) {
     const muteLine = wasMuted
       ? `\n\nYou've been muted for ${Math.round(action.mute_sec / 3600)}h. After it expires you're welcome back if the conversation stays civil.`
       : ``;
+    // When we mute, record an appealable action that captures the verdict +
+    // the flagged text so Pip has full context to re-review on appeal.
+    let appealActionId = null;
+    if (wasMuted) {
+      appealActionId = await recordModAction(
+        ctx.chat.id, sender.id,
+        `fud_${verdictObj.verdict}`,
+        verdictObj.reason || verdictObj.verdict,
+        JSON.stringify({ verdict: verdictObj.verdict, confidence: verdictObj.confidence, text: text.slice(0, 600) }),
+      );
+    }
+    const appealOrDmLine = wasMuted
+      ? `\n\nIf you think this was a mistake, tap *Appeal* below — Pip will re-review it thoroughly and lift the mute if it was wrong.`
+      : `\n\nIf this was a misread, DM @magpie_capital_bot and an operator will review.`;
     const warnText =
       `Your message was removed from the Magpie community — our moderator flagged it as *${verdictHuman}*.` +
       muteLine +
-      `\n\nIf this was a misread, DM @magpie_capital_bot and an operator will review.` +
+      appealOrDmLine +
       strikeFooter(strikeAction);
-    await softWarn(sender.id, warnText);
+    await softWarn(ctx, sender.id, warnText, wasMuted ? appealKeyboard(appealActionId) : undefined);
   }
   if (action.mute_sec > 0) {
     try {
@@ -813,6 +859,151 @@ async function tryDelete(ctx, messageId) {
   }
 }
 
+/* ─────────────────────── APPEALS ─────────────────────── */
+
+// Full posting permissions — used to LIFT a mute on an overturned appeal.
+const FULL_SEND_PERMS = {
+  can_send_messages: true,
+  can_send_audios: true,
+  can_send_documents: true,
+  can_send_photos: true,
+  can_send_videos: true,
+  can_send_video_notes: true,
+  can_send_voice_notes: true,
+  can_send_polls: true,
+  can_send_other_messages: true,
+  can_add_web_page_previews: true,
+  can_invite_users: true,
+  can_pin_messages: false,
+  can_change_info: false,
+};
+
+/** Page the operator only when Pip couldn't decide (model down / low
+ *  confidence). This is the ONLY path that still needs a human. */
+async function escalateAppealToOperator(ctx, modAction, review, flaggedText) {
+  try {
+    const { notifyAdmin } = await import("../services/admin-notify.js");
+    await notifyAdmin(
+      { api: ctx.api },
+      [
+        `⚖️ *Appeal needs your call* — Pip wasn't confident enough to auto-decide`,
+        ``,
+        `User: \`${escMd(String(modAction.user_id))}\``,
+        `Original verdict: *${escMd(modAction.action)}*`,
+        `Reason: ${escMd(modAction.reason || "—")}`,
+        review ? `Pip leaned: *${escMd(review.decision)}* (conf ${review.confidence.toFixed(2)}) — ${escMd(review.explanation)}` : `Pip: model unavailable`,
+        ``,
+        `Flagged content:`,
+        "```",
+        (flaggedText || "(image / no text)").slice(0, 600).replace(/```/g, "'''"),
+        "```",
+        ``,
+        `To lift: unmute the user in the group admin UI. To uphold: do nothing (a temporary mute expires on its own).`,
+      ].join("\n"),
+      { parse_mode: "Markdown" },
+    );
+  } catch (err) {
+    console.warn("[appeals] operator escalation failed:", err.message);
+  }
+}
+
+/** A member tapped "⚖️ Appeal" on a mute DM. Re-review the original action
+ *  with Pip and act: overturn → lift the mute; uphold → explain; unsure →
+ *  escalate to the operator. Idempotent per mod action. */
+async function handleAppeal(ctx) {
+  try {
+    const m = ctx.callbackQuery?.data?.match(/^appeal:(\d+)$/);
+    if (!m) return;
+    const modActionId = m[1];
+    const tapperId = ctx.from?.id;
+
+    const {
+      loadModAction, openAppeal, resolveAppeal, reviewAppealWithPip,
+      extractFlaggedText, APPEAL_ESCALATE_BELOW,
+    } = await import("../services/community-appeals.js");
+
+    const modAction = await loadModAction(modActionId);
+    if (!modAction) {
+      await ctx.answerCallbackQuery({ text: "This appeal link has expired.", show_alert: true });
+      return;
+    }
+    // Only the affected member may appeal their own action.
+    if (String(modAction.user_id) !== String(tapperId)) {
+      await ctx.answerCallbackQuery({ text: "Only the affected member can appeal this.", show_alert: true });
+      return;
+    }
+
+    const { row, isNew } = await openAppeal(modActionId, modAction.chat_id, modAction.user_id);
+    if (!isNew) {
+      const statusMsg = {
+        overturned: "✅ Already reviewed — your mute was lifted.",
+        upheld: "Already reviewed — the action stands.",
+        escalated: "Already with a human reviewer — hang tight.",
+        reviewing: "Your appeal is already being reviewed — hang tight.",
+      }[row?.status] || "Your appeal is already on file.";
+      await ctx.answerCallbackQuery({ text: statusMsg, show_alert: true });
+      return;
+    }
+
+    await ctx.answerCallbackQuery({ text: "⚖️ Pip is reviewing your appeal now…" });
+    try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch { /* msg too old */ }
+
+    const member = await getMember(modAction.chat_id, modAction.user_id).catch(() => null);
+    const trusted = await isTrustedMember(modAction.user_id).catch(() => false);
+    const flaggedText = extractFlaggedText(modAction.payload);
+
+    const review = await reviewAppealWithPip({
+      verdict: modAction.action,
+      reason: modAction.reason,
+      flaggedText,
+      warnedCount: member?.warned_count ?? 0,
+      trusted,
+    });
+
+    // Model unavailable or genuinely unsure → a human makes the final call.
+    if (!review || review.confidence < APPEAL_ESCALATE_BELOW) {
+      await resolveAppeal(modActionId, {
+        status: "escalated",
+        decision: review?.decision || null,
+        reason: review?.explanation || "model unavailable / low confidence",
+        confidence: review?.confidence ?? null,
+      });
+      await escalateAppealToOperator(ctx, modAction, review, flaggedText);
+      await softWarn(ctx, modAction.user_id,
+        "Thanks — your appeal needs a closer look, so a human reviewer has been notified. You'll hear back here shortly.");
+      return;
+    }
+
+    if (review.decision === "overturn") {
+      let lifted = false;
+      try {
+        await ctx.api.restrictChatMember(modAction.chat_id, Number(modAction.user_id), { permissions: FULL_SEND_PERMS });
+        lifted = true;
+      } catch (err) {
+        console.warn("[appeals] unmute failed:", err.message);
+      }
+      await query(
+        `UPDATE community_members SET quarantine_until = NULL WHERE chat_id = $1 AND user_id = $2`,
+        [String(modAction.chat_id), String(modAction.user_id)],
+      ).catch(() => {});
+      await recordModAction(modAction.chat_id, modAction.user_id, "appeal_overturned", review.explanation, String(modActionId));
+      await resolveAppeal(modActionId, { status: "overturned", decision: "overturn", reason: review.explanation, confidence: review.confidence });
+      await softWarn(ctx, modAction.user_id,
+        `✅ *Appeal approved.* ${review.explanation}` +
+        (lifted ? `\n\nYou can post in the group again — sorry for the mix-up.` : `\n\nYour mute should lift momentarily.`));
+    } else {
+      await recordModAction(modAction.chat_id, modAction.user_id, "appeal_upheld", review.explanation, String(modActionId));
+      await resolveAppeal(modActionId, { status: "upheld", decision: "uphold", reason: review.explanation, confidence: review.confidence });
+      await softWarn(ctx, modAction.user_id,
+        `Your appeal was reviewed and the original action stands.\n\n${review.explanation}\n\n` +
+        `If your mute was temporary it will expire on its own. If you still believe this is wrong, DM @magpie_capital_bot and a human will take a final look.`);
+    }
+  } catch (err) {
+    console.warn("[appeals] handler error:", err.message);
+    try { await ctx.answerCallbackQuery({ text: "Something went wrong — please try again in a moment." }); } catch { /* ignore */ }
+  }
+}
+
 /* ─────────────────────── REGISTRATION ─────────────────────── */
 
 export function registerCommunityHandlers(bot) {
@@ -820,6 +1011,7 @@ export function registerCommunityHandlers(bot) {
   bot.on("message", handleGroupMessage);
   bot.on("edited_message", handleGroupMessage);
   bot.callbackQuery(/^comm:captcha:(-?\d+)$/, handleCaptchaCallback);
+  bot.callbackQuery(/^appeal:(\d+)$/, handleAppeal);
   console.log("[community] handlers registered");
 }
 

--- a/src/services/community-appeals.js
+++ b/src/services/community-appeals.js
@@ -1,0 +1,153 @@
+/**
+ * community-appeals.js — Pip-reviewed moderation appeals.
+ * ──────────────────────────────────────────────────────────────────────────
+ * A muted member taps "⚖️ Appeal"; this re-reviews the ORIGINAL auto-moderation
+ * decision with full context and a deliberately skeptical, false-positive-aware
+ * prompt, then returns overturn / uphold + a confidence. The handler lifts the
+ * mute on a confident overturn, posts the reason to the user on a confident
+ * uphold, and escalates to the operator ONLY when Pip is genuinely unsure — so
+ * the operator stops being the first responder for every auto-mute.
+ *
+ * Fail-safe: if the model is unavailable or errors, we return null and the
+ * caller escalates to a human. We never auto-uphold blindly on an error.
+ */
+import { query } from "../db/pool.js";
+
+const REVIEW_MODEL =
+  process.env.APPEAL_REVIEW_MODEL ||
+  process.env.COMMUNITY_CLASSIFIER_MODEL ||
+  "claude-sonnet-4-6";
+
+// Below this confidence, the decision is treated as "unsure" → escalate to a
+// human instead of auto-acting. Tunable without a redeploy.
+export const APPEAL_ESCALATE_BELOW = Number(process.env.APPEAL_ESCALATE_BELOW || 0.6);
+
+const SYSTEM_PROMPT = `You are Pip, the appeals reviewer for the Magpie ($MAGPIE) Solana lending community on Telegram.
+
+A member's message or image was auto-actioned (deleted and/or muted) by automated moderation, and they are appealing. Automated moderation OVER-FLAGS — your job is to catch its false positives while still upholding genuine violations. Default posture: protect real members. When the flagged content is plausibly legitimate, OVERTURN.
+
+OVERTURN (lift the mute) when the content is plausibly legitimate, e.g.:
+- Sharing a screenshot of a scammer / impersonator to WARN others (the member is alerting the group, NOT impersonating anyone themselves).
+- An honest question, a factual correction, or normal criticism misread as "misinformation" or "FUD".
+- Benignly naming an official account, a competitor, or a third-party handle.
+- Venting, sarcasm, or heated-but-civil disagreement that isn't actual harassment.
+- The member already has a Magpie wallet / is an established trusted member and the content is borderline.
+
+UPHOLD (the action stands) when it is a clear violation, e.g.:
+- Actual phishing / scam promotion: "DM me", "send X SOL", "claim airdrop", wallet-drainer or fake-support links, seed-phrase requests.
+- Real impersonation: the member is claiming to BE Magpie / Magpie support.
+- Genuine harassment, slurs, threats, NSFW or violent imagery.
+- Clear bad-faith coordinated FUD designed to manipulate, not honest concern.
+
+You will receive: the moderation verdict, the auto-confidence, the flagged text/OCR, the member's prior-warning count and trusted status, and (optionally) the member's own explanation. Weigh the member's explanation but do not let a clever explanation excuse content that is plainly a scam.
+
+Reply with STRICT JSON only, no prose:
+{"decision":"overturn"|"uphold","explanation":"<one short plain-English sentence addressed to the member, <=240 chars>","confidence":<0..1, how sure you are of THIS decision>}
+If you are genuinely unsure, return your best decision but a LOW confidence — a human will then make the final call.`;
+
+/** Pull the human-readable flagged content out of a mod-action payload.
+ *  image-mod stores plain OCR text; the FUD path stores JSON {verdict,text}. */
+export function extractFlaggedText(payload) {
+  if (!payload) return "";
+  try {
+    const j = JSON.parse(payload);
+    if (j && typeof j === "object" && typeof j.text === "string") return j.text;
+  } catch { /* not JSON — fall through to plain text */ }
+  return String(payload);
+}
+
+/** Run Pip's appeal review. Returns {decision, explanation, confidence} or
+ *  null on any failure (caller escalates to a human). */
+export async function reviewAppealWithPip({ verdict, reason, flaggedText, warnedCount, trusted, userReason }) {
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (!key) return null;
+
+  const lines = [
+    `Moderation verdict: ${verdict || "(unknown)"}`,
+    reason ? `Auto-moderator reason: ${String(reason).slice(0, 300)}` : null,
+    `Member prior warnings: ${warnedCount ?? 0}`,
+    `Member has a Magpie wallet (trusted): ${trusted ? "yes" : "no"}`,
+    "",
+    "Flagged content (text / OCR):",
+    (flaggedText ? String(flaggedText).slice(0, 1500) : "(none / image with no extractable text)"),
+  ];
+  if (userReason) {
+    lines.push("", "Member's appeal explanation:", String(userReason).slice(0, 700));
+  }
+
+  try {
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: REVIEW_MODEL,
+        max_tokens: 300,
+        temperature: 0,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: lines.filter((l) => l !== null).join("\n") }],
+      }),
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!res.ok) {
+      console.warn("[appeals] review HTTP", res.status, "→ escalate");
+      return null;
+    }
+    const body = await res.json();
+    const txt = Array.isArray(body?.content) ? body.content[0]?.text : null;
+    if (!txt) return null;
+    const m = txt.match(/\{[\s\S]*\}/);
+    if (!m) return null;
+    const parsed = JSON.parse(m[0]);
+    const decision = String(parsed.decision || "").toLowerCase();
+    if (decision !== "overturn" && decision !== "uphold") return null;
+    let confidence = Number(parsed.confidence);
+    if (!Number.isFinite(confidence)) confidence = 0;
+    confidence = Math.max(0, Math.min(1, confidence));
+    const explanation = String(parsed.explanation || "").slice(0, 280);
+    return { decision, explanation, confidence };
+  } catch (err) {
+    console.warn("[appeals] review error → escalate:", err.message);
+    return null;
+  }
+}
+
+// ── persistence (idempotent per mod action) ──────────────────────────────────
+
+/** The mod action being appealed (verdict in `action`, flagged text in `payload`). */
+export async function loadModAction(modActionId) {
+  const r = await query(
+    `SELECT id, chat_id, user_id, action, reason, payload, created_at
+       FROM community_mod_actions WHERE id = $1`,
+    [modActionId],
+  );
+  return r.rows[0] || null;
+}
+
+/** Open (or fetch) the appeal for a mod action. One appeal per action — the
+ *  UNIQUE(mod_action_id) makes a double-tap return the existing record rather
+ *  than re-running a review. Returns {row, isNew}. */
+export async function openAppeal(modActionId, chatId, userId) {
+  const ins = await query(
+    `INSERT INTO community_appeals (mod_action_id, chat_id, user_id, status)
+     VALUES ($1, $2, $3, 'reviewing')
+     ON CONFLICT (mod_action_id) DO NOTHING
+     RETURNING *`,
+    [modActionId, String(chatId), String(userId)],
+  );
+  if (ins.rows[0]) return { row: ins.rows[0], isNew: true };
+  const cur = await query(`SELECT * FROM community_appeals WHERE mod_action_id = $1`, [modActionId]);
+  return { row: cur.rows[0] || null, isNew: false };
+}
+
+export async function resolveAppeal(modActionId, { status, decision, reason, confidence }) {
+  await query(
+    `UPDATE community_appeals
+        SET status = $2, decision = $3, reason = $4, confidence = $5, resolved_at = NOW()
+      WHERE mod_action_id = $1`,
+    [modActionId, status, decision || null, reason ? String(reason).slice(0, 500) : null, confidence ?? null],
+  );
+}

--- a/src/services/community-moderation.js
+++ b/src/services/community-moderation.js
@@ -510,11 +510,14 @@ export async function quarantineRateLimit(chatId, userId) {
 }
 
 export async function recordModAction(chatId, userId, action, reason, payload) {
-  await query(
+  const res = await query(
     `INSERT INTO community_mod_actions (chat_id, user_id, action, reason, payload)
-     VALUES ($1, $2, $3, $4, $5)`,
+     VALUES ($1, $2, $3, $4, $5) RETURNING id`,
     [String(chatId), String(userId), action, reason || null, payload?.slice?.(0, 2000) || null],
   );
+  // Returned so a caller (e.g. a mute) can offer a one-tap appeal that
+  // references this exact action. Existing callers ignore it harmlessly.
+  return res.rows?.[0]?.id ?? null;
 }
 
 /** Recent mod-action stats for the operator dashboard / anomaly alerts. */


### PR DESCRIPTION
Makes the community self-service so the operator stops being the first responder for every auto-mute.

## What was broken
- **All mute/warn DMs silently failed.** `softWarn(ctx,userId,msg)` was called as `softWarn(sender.id,msg)` at all 7 sites → `ctx.api` undefined → throws → swallowed. Users got muted with **zero** notification, so they DM the operator. Fixed signature + every call site + Markdown→plain-text retry so the notice always lands.
- **Two operator alerts also silently failed** — `notifyAdmin(ctx.api,…)` (impersonator-ban + image-flag) where `bot.api.sendMessage` is expected. Fixed to `{ api: ctx.api }`.

## New: self-service appeals reviewed by Pip
- Mute DMs now carry **⚖️ Appeal this decision**.
- On tap, Pip (LLM) re-reviews the **original** action with full context (verdict, auto-confidence, flagged text/OCR, prior-warning count, trusted status) under a skeptical, false-positive-aware prompt, then:
  - **overturn (confident)** → lifts the mute + clears quarantine, DMs "approved"
  - **uphold (confident)** → DMs the reason, action stands
  - **unsure / model down** → escalates to the operator (the only remaining human path)
- `recordModAction` now returns its id so the button references the exact action. New `community_appeals` table is **idempotent per mod action** (UNIQUE) — a double-tap returns the standing outcome.

## Net effect
Clear-cut false positives (e.g. sharing a screenshot to *warn* about an impersonator — exactly what got @baves215 muted) auto-overturn in seconds. The operator only sees genuinely ambiguous cases. Only `community-handlers.js` / new `community-appeals.js` / `community-moderation.js` / `pool.js` (DDL) touched; all syntax-checked.