### PR TITLE
fix(community): appeals never re-admit a Magpie/persona impostor name

### DIFF
--- a/src/handlers/community-handlers.js
+++ b/src/handlers/community-handlers.js
@@ -957,6 +957,24 @@ async function applyAppealOutcome(ctx, modAction, userReason) {
 
   const modActionId = String(modAction.id);
   const isRemoval = REMOVAL_ACTIONS.has(modAction.action);
+
+  // OPERATOR POLICY (hard gate, no LLM, no benefit of the doubt): a user whose
+  // CURRENT display name impersonates Magpie / Pip / a protocol persona
+  // ("Magpie Support", "MagpieMatt", etc.) is NEVER appealed back in. Appeals
+  // exist for BEHAVIOURAL misreads (something they SAID), not to launder an
+  // impostor name. They're welcome back only with a clean name.
+  if (isImpersonationName(ctx.from)) {
+    await recordModAction(modAction.chat_id, modAction.user_id, "appeal_upheld",
+      "impersonation display name — no benefit of the doubt", modActionId);
+    await resolveAppeal(modActionId, {
+      status: "upheld", decision: "uphold",
+      reason: "display name impersonates Magpie/protocol", confidence: 1,
+    });
+    await softWarn(ctx, modAction.user_id,
+      `Your appeal was reviewed and the removal stands.\n\nYour display name impersonates official Magpie / Pip / protocol staff, which is never allowed here. If you're a genuine member, change your display name so it no longer resembles Magpie, MagpieMatt, or any protocol/staff name, and you're welcome to rejoin.`);
+    return;
+  }
+
   const member = await getMember(modAction.chat_id, modAction.user_id).catch(() => null);
   const trusted = await isTrustedMember(modAction.user_id).catch(() => false);
   // For a name-based ban the "flagged content" is mostly the NAME (in `reason`)

--- a/src/services/community-appeals.js
+++ b/src/services/community-appeals.js
@@ -41,8 +41,8 @@ UPHOLD (the action stands) when it is a clear violation, e.g.:
 
 NAME-BASED BANS (verdict 'ban_impersonator' / 'watchdog_auto_ban_impersonation' / 'kick_captcha_timeout'): the member was REMOVED, and the "flagged" text is mostly their DISPLAY NAME (e.g. name="..."). Judge the NAME:
 - OVERTURN — a regular member who is NOT posing as Magpie staff: a fan name that merely contains the word "magpie" ("MagpieFan", "I love Magpie"), a generic name ("CryptoDev", "Team Solana", "John | Founder"), a common nickname ("Pip"), or someone removed only for missing the join captcha. These are the people we must NOT keep kicking out — default to OVERTURN for them.
-- UPHOLD — a name actively posing as Magpie/Pip STAFF or the official brand: "Magpie Support", "Magpie Admin", "Official Magpie", "Magpie Capital", "Pip Support", "Magpie Customer Service". These are real impersonators.
-Default posture for name-based bans: lean OVERTURN unless the name clearly poses as official Magpie/Pip staff.
+- UPHOLD — a name posing as Magpie/Pip STAFF, the official brand, OR a named protocol persona: "Magpie Support", "Magpie Admin", "Official Magpie", "Magpie Capital", "Pip Support", "Magpie Customer Service", "MagpieMatt", "Magpie Matt". OPERATOR POLICY: NEVER give a Magpie/Pip/protocol-persona impersonation name the benefit of the doubt — uphold it regardless of how reasonable the member's explanation sounds. The appeal can only excuse something the member SAID (a misread message/mute), never an impersonation display name.
+Default posture for name-based bans: OVERTURN only a clearly generic/fan name with NO staff/persona impersonation; UPHOLD anything posing as Magpie/Pip/protocol.
 
 You will receive: the moderation verdict, the auto-confidence, the flagged text/OCR (and/or display name), the member's prior-warning count and trusted status, and (optionally) the member's own explanation. Weigh the member's explanation but do not let a clever explanation excuse content that is plainly a scam or a name plainly posing as Magpie staff.
 

--- a/src/services/community-moderation.js
+++ b/src/services/community-moderation.js
@@ -73,6 +73,13 @@ export const CAPTCHA_TIMEOUT_MS = 5 * 60 * 1000;
 // staff/official role, OR "Pip" used in a staff capacity. A brand word ALONE
 // or a generic role word ALONE is NOT enough. Residual edge cases self-heal
 // via the instant /appeal flow + the cleared-users memory.
+// Named Magpie protocol personas that must never be impersonated (e.g.
+// "MagpieMatt"). Env-extensible (comma-separated PROTECTED_PERSONA_NAMES) so a
+// new persona can be protected without a code change; "matt" is the default.
+const PROTECTED_PERSONA_NAMES = (process.env.PROTECTED_PERSONA_NAMES || "matt")
+  .split(",").map((s) => s.trim().toLowerCase().replace(/[^a-z0-9]/g, "")).filter(Boolean);
+const PERSONA_ALT = (PROTECTED_PERSONA_NAMES.length ? PROTECTED_PERSONA_NAMES : ["matt"]).join("|");
+
 export const IMPERSONATION_PATTERNS = [
   // (Near-)exact brand name as the whole display name — no legitimate use.
   /^\s*magpie(\s*(capital|loans?|lending|finance|labs?|team|support|admin|official|mod|help))?\s*[.!]*$/i,
@@ -82,6 +89,9 @@ export const IMPERSONATION_PATTERNS = [
   /magpie[\s._@-]*(support|admin|team|mod(?:erator)?|official|help(?:\s*desk)?|staff|service|founder|owner|ceo|customer)\b/i,
   /\b(support|admin|official|staff|mod(?:erator)?|help\s*desk|customer\s*service)[\s._@-]*magpie\b/i,
   /\bofficial\s+magpie\b/i,
+  // Impersonating a named protocol persona — "MagpieMatt", "Magpie Matt".
+  new RegExp(`magpie[\\s._@-]*(${PERSONA_ALT})\\b`, "i"),
+  new RegExp(`\\b(${PERSONA_ALT})[\\s._@-]*magpie\\b`, "i"),
   // Posing as the in-chat assistant "Pip" in a staff/bot capacity (bare "Pip"
   // is a real nickname, so it alone no longer triggers a ban).
   /\bpip[\s._@-]*(support|admin|official|bot|team|mod|help)\b/i,


### PR DESCRIPTION
Operator policy: impostors using **Magpie / MagpieMatt / any protocol or staff name** must **never** get the benefit of the doubt in an appeal. Appeals are for **behavioural misreads** (something a member *said* that Pip misinterpreted, or a missed captcha) — not to launder an impersonation display name back in.

- **Hard gate**: if the appealing user's **current display name** is an impersonation, the appeal auto-**upholds** (no LLM, no re-admit) and tells them they're welcome back only with a clean name.
- **Persona detection**: catches "MagpieMatt" / "Magpie Matt" (not just staff roles). Env-extensible via `PROTECTED_PERSONA_NAMES` (default `matt`). Battery: MagpieMatt/MattMagpie caught; bare Matt/Matthew/MagpieFan/Magpie Supporter/Magpie Matters all clear.
- Pip prompt reinforced to never overturn a Magpie/Pip/protocol-persona name.

Follow-up to #496. Syntax-checked; battery all-pass.