### PR TITLE
feat(points): idempotent points ledger + retroactive backfill + /api/v1/points

### DIFF
--- a/src/api/activity-api.js
+++ b/src/api/activity-api.js
@@ -36,7 +36,7 @@ export async function handleActivity(req, url) {
   const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
   const resolvedUserId = await resolveWalletOwner(wallet);
   if (!resolvedUserId) {
-    return { status: 200, body: { linked: false, events: [] } };
+    return { status: 200, body: { ok: true, linked: false, events: [], total_points: 0 } };
   }
   const userId = resolvedUserId;
 
@@ -322,6 +322,11 @@ export async function handleActivity(req, url) {
   return {
     status: 200,
     body: {
+      // The dashboard gates its state update on `d.ok`; without this field the
+      // points counter (and anything else reading this response) silently stays
+      // at 0. (The points NUMBER now comes from /api/v1/points, but keep this
+      // honest so the activity feed + any legacy consumer work.)
+      ok: true,
       linked: true,
       events: events.slice(0, limit),
       // Total credit points across the user's entire history. Surfaced

--- a/src/api/points-api.js
+++ b/src/api/points-api.js
@@ -1,0 +1,67 @@
+/**
+ * points-api.js — GET /api/v1/points?wallet=<pubkey>
+ * Returns a user's lifetime points total + per-category breakdown + recent
+ * point events, resolved wallet→user via the canonical resolver (same as
+ * activity-api). Body ALWAYS includes `ok: true` so the dashboard's gate works
+ * (the legacy /api/v1/activity omitting `ok` is exactly why points read 0).
+ * Read-only; public (added to PUBLIC_ROUTES) like /api/v1/activity.
+ */
+import { query } from "../db/pool.js";
+
+function isValidPubkey(s) {
+  return typeof s === "string" && /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(s);
+}
+
+export async function handlePoints(req, url) {
+  const wallet = url.searchParams.get("wallet");
+  if (!isValidPubkey(wallet)) {
+    return { status: 400, body: { ok: false, error: "Invalid wallet pubkey" } };
+  }
+
+  const { resolveWalletOwner } = await import("../services/wallet-owner-resolver.js");
+  const userId = await resolveWalletOwner(wallet);
+  if (!userId) {
+    // Not linked yet — a real, honest zero (no user behind this wallet).
+    return { status: 200, body: { ok: true, linked: false, total_points: 0, by_category: [], recent: [] } };
+  }
+
+  const [bal, byCat, recent] = await Promise.all([
+    query(`SELECT total_points FROM user_points_balance WHERE user_id = $1`, [userId]),
+    query(
+      `SELECT category, SUM(points)::bigint AS points
+         FROM points_events WHERE user_id = $1 GROUP BY category ORDER BY points DESC`,
+      [userId],
+    ),
+    query(
+      `SELECT source_type, category, points, created_at AS at, metadata
+         FROM points_events WHERE user_id = $1 ORDER BY created_at DESC LIMIT 20`,
+      [userId],
+    ),
+  ]);
+
+  // Fast read from the counter; fall back to a live SUM if the counter row is
+  // missing (e.g. mid-backfill) so the number is never falsely 0.
+  let total = bal.rows[0]?.total_points;
+  if (total == null) {
+    const s = await query(`SELECT COALESCE(SUM(points), 0)::bigint AS t FROM points_events WHERE user_id = $1`, [userId]);
+    total = s.rows[0]?.t ?? 0;
+  }
+
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      linked: true,
+      user_id: Number(userId),
+      total_points: Number(total),
+      by_category: byCat.rows.map((r) => ({ category: r.category, points: Number(r.points) })),
+      recent: recent.rows.map((r) => ({
+        source_type: r.source_type,
+        category: r.category,
+        points: Number(r.points),
+        at: r.at,
+        metadata: r.metadata,
+      })),
+    },
+  };
+}

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -98,6 +98,7 @@ import { handleDistributionQuery } from "./governance-distribution-api.js";
 import { handleDistributionsListQuery } from "./governance-distributions-list-api.js";
 import { handleGovernanceTally } from "./governance-tally-api.js";
 import { handleActivity } from "./activity-api.js";
+import { handlePoints } from "./points-api.js";
 import { handleAiChat } from "./ai-chat.js";
 import { handlePipSession } from "./pip-session.js";
 import { handleMeExport } from "./me-export.js";
@@ -1797,6 +1798,7 @@ const PUBLIC_ROUTES = new Set([
   // Unified activity feed (borrows, repays, auto-protect, withdraws,
   // referral payouts, holder rewards). Same risk envelope as /loans.
   "/api/v1/activity",
+  "/api/v1/points",
   // Ephemeral AI chat — signed message OR Bearer session token.
   "/api/v1/ai/chat",
   // Mint a Pip chat session — sign once, chat for 24h.
@@ -2335,6 +2337,9 @@ async function router(req, res) {
         break;
       case "/api/v1/activity":
         result = await handleActivity(req, url);
+        break;
+      case "/api/v1/points":
+        result = await handlePoints(req, url);
         break;
       case "/api/v1/ai/chat":
         result = await handleAiChat(req);

--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -714,6 +714,28 @@ export async function applyStartupPatches() {
     // it seq-scans community_mod_actions.
     `CREATE INDEX IF NOT EXISTS community_mod_actions_user_idx
        ON community_mod_actions(user_id, created_at DESC)`,
+    // User POINTS ledger (truth) + fast-read balance. Idempotent per
+    // (source_type, source_id); points are forward-only/positive. Read-side
+    // derivation over activity — never touches loan/collateral state. Canonical
+    // DDL also in src/services/points.js for standalone backfill/reconciler runs.
+    `CREATE TABLE IF NOT EXISTS points_events (
+       id          BIGSERIAL PRIMARY KEY,
+       user_id     BIGINT      NOT NULL,
+       source_type TEXT        NOT NULL,
+       source_id   TEXT        NOT NULL,
+       category    TEXT        NOT NULL,
+       points      BIGINT      NOT NULL CHECK (points > 0),
+       metadata    JSONB,
+       created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+       UNIQUE (source_type, source_id)
+     )`,
+    `CREATE INDEX IF NOT EXISTS points_events_user_created_idx ON points_events(user_id, created_at DESC)`,
+    `CREATE INDEX IF NOT EXISTS points_events_user_cat_idx ON points_events(user_id, category)`,
+    `CREATE TABLE IF NOT EXISTS user_points_balance (
+       user_id      BIGINT PRIMARY KEY,
+       total_points BIGINT NOT NULL DEFAULT 0 CHECK (total_points >= 0),
+       updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+     )`,
     // Per-rule cooldown for operator anomaly DMs so a single incident
     // doesn't page the operator every 2-min watcher tick.
     `CREATE TABLE IF NOT EXISTS community_anomaly_alerts (

--- a/src/services/points-backfill.js
+++ b/src/services/points-backfill.js
@@ -1,0 +1,97 @@
+/**
+ * points-backfill.js — one-shot, fully idempotent retroactive points.
+ * ─────────────────────────────────────────────────────────────────────────
+ * Re-runnable any number of times with ZERO double-credit: every credit goes
+ * through creditPoints()'s ON CONFLICT (source_type, source_id) DO NOTHING. The
+ * source_ids are computed deterministically so this backfill and the live
+ * forward-sync produce IDENTICAL ids (no drift, no duplicates).
+ *
+ * Covers BORROW (every loan), FIRST_LOAN (+500, once per user), and REPAY
+ * bonuses (early +25% / on-time +10% of the loan's base). Streak + diversity
+ * bonuses are layered in by the reconciler/forward-sync. Reads only; never
+ * touches loan/collateral state.
+ *
+ * Run standalone: `railway run node src/services/points-backfill.js`
+ */
+import { query } from "../db/pool.js";
+import { ensurePointsTables, creditPoints, borrowPoints, repayBonusPoints, FIRST_LOAN_BONUS } from "./points.js";
+
+export async function backfillPoints({ log = console.log } = {}) {
+  await ensurePointsTables();
+  let borrowN = 0, firstN = 0, repayN = 0;
+
+  // (1) BORROW — every loan ever opened earns base borrow points.
+  const loans = await query(
+    `SELECT user_id, loan_pda, loan_amount_lamports, duration_days
+       FROM loans ORDER BY start_timestamp ASC`,
+  );
+  for (const l of loans.rows) {
+    const pts = borrowPoints({ loanLamports: l.loan_amount_lamports, durationDays: l.duration_days });
+    const res = await creditPoints({
+      userId: l.user_id,
+      sourceType: "borrow",
+      sourceId: `borrow:${l.loan_pda}`,
+      category: "lending",
+      points: pts,
+      metadata: { loan_pda: l.loan_pda, duration_days: l.duration_days },
+    });
+    if (res !== null) borrowN++;
+  }
+
+  // (2) FIRST_LOAN — +500, once per user, attributed to their earliest loan.
+  const firsts = await query(
+    `SELECT DISTINCT ON (user_id) user_id, loan_pda
+       FROM loans ORDER BY user_id, start_timestamp ASC`,
+  );
+  for (const f of firsts.rows) {
+    const res = await creditPoints({
+      userId: f.user_id,
+      sourceType: "first_loan",
+      sourceId: `first_loan:${f.user_id}`,
+      category: "bonus",
+      points: FIRST_LOAN_BONUS,
+      metadata: { loan_pda: f.loan_pda },
+    });
+    if (res !== null) firstN++;
+  }
+
+  // (3) REPAY — early/on-time bonus as a fraction of the loan's base, one per
+  // repaid loan, variant taken from credit_events (early beats on-time).
+  const repays = await query(
+    `SELECT l.user_id, l.loan_pda, l.loan_amount_lamports, l.duration_days,
+            CASE WHEN bool_or(ce.event_type = 'repay_early')  THEN 'repay_early'
+                 WHEN bool_or(ce.event_type = 'repay_ontime') THEN 'repay_ontime'
+                 ELSE NULL END AS variant
+       FROM loans l
+       JOIN credit_events ce
+         ON ce.loan_id = l.id
+        AND ce.event_type IN ('repay_early','repay_ontime','repay_late')
+      WHERE l.status = 'repaid'
+      GROUP BY l.user_id, l.loan_pda, l.loan_amount_lamports, l.duration_days`,
+  );
+  for (const r of repays.rows) {
+    if (!r.variant) continue;
+    const base = borrowPoints({ loanLamports: r.loan_amount_lamports, durationDays: r.duration_days });
+    const bonus = repayBonusPoints(base, r.variant);
+    const res = await creditPoints({
+      userId: r.user_id,
+      sourceType: "repay",
+      sourceId: `repay:${r.loan_pda}`,
+      category: "repayment",
+      points: bonus,
+      metadata: { loan_pda: r.loan_pda, variant: r.variant },
+    });
+    if (res !== null) repayN++;
+  }
+
+  const summary = { loans: loans.rows.length, borrowN, firstN, repayN };
+  log(`[points-backfill] credited ${borrowN} borrow + ${firstN} first-loan + ${repayN} repay events (of ${loans.rows.length} loans)`);
+  return summary;
+}
+
+// Run directly via `node src/services/points-backfill.js`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  backfillPoints()
+    .then((r) => { console.log("backfill done:", JSON.stringify(r)); process.exit(0); })
+    .catch((e) => { console.error("backfill failed:", e); process.exit(1); });
+}

--- a/src/services/points.js
+++ b/src/services/points.js
@@ -1,0 +1,109 @@
+/**
+ * points.js — the user POINTS ledger (truth) + a fast-read running balance.
+ * ─────────────────────────────────────────────────────────────────────────
+ * Mirrors the pool_credit_events idempotency pattern verbatim: an append-only
+ * `points_events` table whose UNIQUE(source_type, source_id) IS the entire
+ * double-credit guarantee, plus a single-row-per-user `user_points_balance`
+ * counter kept in lock-step via a gated CTE. Every credit goes through
+ * `creditPoints`, so the retroactive backfill, the live forward-sync, and the
+ * reconciler all converge on the SAME ids and can never double-count.
+ *
+ * Invariants:
+ *  - Points are FORWARD-ONLY (positive only). Penalties (e.g. liquidation) write
+ *    ZERO points, never a subtraction — matching the published "Liquidation =
+ *    0 pts, existing balance untouched".
+ *  - This module is a READ-SIDE derivation over activity. It NEVER writes to
+ *    loans / collateral / vault state. Safe by construction.
+ */
+import { query } from "../db/pool.js";
+
+// DDL also lives in pool.js applyStartupPatches (so the deployed bot creates it);
+// re-declared here so the backfill/reconciler can run standalone via `railway run`.
+export const POINTS_TABLES_SQL = [
+  `CREATE TABLE IF NOT EXISTS points_events (
+     id          BIGSERIAL PRIMARY KEY,
+     user_id     BIGINT      NOT NULL,
+     source_type TEXT        NOT NULL,
+     source_id   TEXT        NOT NULL,
+     category    TEXT        NOT NULL,
+     points      BIGINT      NOT NULL CHECK (points > 0),
+     metadata    JSONB,
+     created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+     UNIQUE (source_type, source_id)
+   )`,
+  `CREATE INDEX IF NOT EXISTS points_events_user_created_idx ON points_events(user_id, created_at DESC)`,
+  `CREATE INDEX IF NOT EXISTS points_events_user_cat_idx ON points_events(user_id, category)`,
+  `CREATE TABLE IF NOT EXISTS user_points_balance (
+     user_id      BIGINT PRIMARY KEY,
+     total_points BIGINT NOT NULL DEFAULT 0 CHECK (total_points >= 0),
+     updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+   )`,
+];
+
+let _ensured = false;
+export async function ensurePointsTables() {
+  if (_ensured) return;
+  for (const sql of POINTS_TABLES_SQL) await query(sql);
+  _ensured = true;
+}
+
+/**
+ * Idempotently credit points. Safe to call repeatedly with the same
+ * (sourceType, sourceId): the ledger INSERT is a no-op on conflict and the
+ * balance only moves when the insert actually inserted. Returns the new running
+ * total, or null when it was a duplicate / invalid / non-positive (0 writes
+ * nothing). Callers on hot paths still wrap this in try/catch — it must never
+ * delay or fail a loan/repay tx.
+ */
+export async function creditPoints({ userId, sourceType, sourceId, category, points, metadata }) {
+  if (!userId || !sourceType || !sourceId || !category) {
+    console.warn("[points] refusing credit — missing id fields", { userId, sourceType, sourceId, category });
+    return null;
+  }
+  const pts = Math.floor(Number(points) || 0);
+  if (pts <= 0) return null; // points are positive-only (liquidation etc. = 0 = no row)
+  const r = await query(
+    `WITH ins AS (
+       INSERT INTO points_events (user_id, source_type, source_id, category, points, metadata)
+       VALUES ($1, $2, $3, $4, $5::bigint, $6::jsonb)
+       ON CONFLICT (source_type, source_id) DO NOTHING
+       RETURNING points
+     ),
+     bal AS (
+       INSERT INTO user_points_balance (user_id, total_points)
+       SELECT $1, points FROM ins
+       ON CONFLICT (user_id) DO UPDATE
+         SET total_points = user_points_balance.total_points + EXCLUDED.total_points,
+             updated_at = NOW()
+       RETURNING total_points
+     )
+     SELECT total_points FROM bal`,
+    [String(userId), sourceType, sourceId, category, pts, metadata ? JSON.stringify(metadata) : null],
+  );
+  return r.rows[0]?.total_points ?? null;
+}
+
+/** Tier multiplier from a loan's duration (published: Express 2d ×1.5,
+ *  Quick 3d ×1.25, Standard 7d ×1.0). */
+export function tierMultForDuration(durationDays) {
+  const d = Number(durationDays) || 7;
+  if (d <= 2) return 1.5;
+  if (d <= 3) return 1.25;
+  return 1.0;
+}
+
+/** Canonical borrow points for a loan: floor(loanSOL × 100 × tierMult). */
+export function borrowPoints({ loanLamports, durationDays }) {
+  const sol = Number(loanLamports) / 1e9;
+  if (!Number.isFinite(sol) || sol <= 0) return 0;
+  return Math.floor(sol * 100 * tierMultForDuration(durationDays));
+}
+
+/** Repay bonus as a fraction of the loan's base borrow points: early +25%,
+ *  on-time +10%, late 0 (published). One repay bonus per loan. */
+export function repayBonusPoints(base, variant) {
+  const pct = variant === "repay_early" ? 0.25 : variant === "repay_ontime" ? 0.10 : 0;
+  return Math.floor(base * pct);
+}
+
+export const FIRST_LOAN_BONUS = 500;


### PR DESCRIPTION
Fixes "dashboard Points read 0" at the root: (1) the counter only updated when the bot response had an `ok` field that `/api/v1/activity` never sent, and (2) there was no ledger — nothing was ever credited.

- **Ledger**: `points_events` (UNIQUE(source_type,source_id), points>0) + `user_points_balance` counter via a gated CTE (mirrors `pool_credit_events`). Forward-only; **read-side derivation over activity, never touches loan/collateral state**.
- **`points.js`**: idempotent `creditPoints()` + published formula (borrow `floor(SOL×100×tier)`, repay early +25% / on-time +10% of base, first-loan +500).
- **`points-backfill.js`**: one-shot, re-runnable **retroactive** backfill over every loan (borrow + first-loan + repay). Zero double-credit (`ON CONFLICT DO NOTHING`).
- **`/api/v1/points`** (public): `{ok:true, total_points, by_category, recent}`.
- **`activity-api.js`**: add `ok:true` (fixes the legacy gate).

Forward-sync (live emits), reconciler, streak/diversity, and the dashboard repoint are the immediate next step. No loan-path writes; all syntax-checked.