### PR TITLE
fix(borrow): kill AccountNotInitialized + false 'warming up' for any approved token

### DIFF
--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -7,6 +7,7 @@ import {
 import { PublicKey } from "@solana/web3.js";
 import { query } from "../db/pool.js";
 import { connection } from "../solana/connection.js";
+import { ensureMintFeedsInitialized } from "../services/price-attestor.js";
 import { estimateCostUsd } from "../services/ai-support.js";
 import { getHealthSnapshot } from "../services/infra-health.js";
 import {
@@ -383,8 +384,19 @@ async function executeEnableMint(ctx, args) {
              enabled = TRUE`,
       [mint, symbol.toUpperCase(), name, decimals],
     );
+    // IMMEDIATELY initialize the price-feed PDA(s) so it's borrowable at once —
+    // never AccountNotInitialized. The boot/90s feed-init sweep retries on error.
+    let feedNote = "";
+    try {
+      const feeds = await ensureMintFeedsInitialized(mint);
+      const created = feeds.filter((f) => f.signature).length;
+      feedNote = created ? ` Initialized ${created} price feed(s).` : " Price feeds already initialized.";
+    } catch (e) {
+      feedNote = " ⚠️ Price-feed init failed — the sweep will retry within ~90s.";
+      console.warn(`[enablemint] feed init for ${mint} failed: ${e.message?.slice(0, 120)}`);
+    }
     await logAdminCommand(ctx, "enablemint", { outcome: "success", args: `${symbol.toUpperCase()} ${mint}` });
-    await ctx.reply(`✅ ${symbol.toUpperCase()} enabled (decimals=${decimals}, verified on-chain).`);
+    await ctx.reply(`✅ ${symbol.toUpperCase()} enabled (decimals=${decimals}, verified on-chain).${feedNote}`);
     return { ok: true };
   } catch (err) {
     await logAdminCommand(ctx, "enablemint", { outcome: "error", args: `${symbol} ${mint}`, error: err.message });

--- a/src/commands/submit.js
+++ b/src/commands/submit.js
@@ -12,6 +12,7 @@
 import { query } from "../db/pool.js";
 import { Connection, PublicKey } from "@solana/web3.js";
 import { connection } from "../solana/connection.js";
+import { ensureMintFeedsInitialized } from "../services/price-attestor.js";
 import { InlineKeyboard } from "grammy";
 import {
   checkSellable,
@@ -367,6 +368,16 @@ export async function handleSubmit(ctx) {
       `INSERT INTO token_screen_seen (mint) VALUES ($1) ON CONFLICT DO NOTHING`,
       [mint],
     );
+
+    // IMMEDIATELY initialize the on-chain price-feed PDA(s) so the token is
+    // borrowable the instant it's approved — never AccountNotInitialized for a
+    // freshly-approved token. Best-effort: the boot/90s feed-init sweep retries
+    // if this throws. (operator P0 2026-06-27, $ANSEM)
+    try {
+      await ensureMintFeedsInitialized(mint);
+    } catch (e) {
+      console.warn(`[submit] price-feed init for ${mint} failed (sweep will retry): ${e.message?.slice(0, 120)}`);
+    }
 
     const kb = new InlineKeyboard()
       .text("💰 Borrow", "start:borrow")

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ import { startDailyOpsReport } from "./services/daily-ops-report.js";
 import { startX402DailyDigest } from "./services/x402-daily-digest.js";
 import { startUsedNoncesCleaner } from "./services/used-nonces-cleaner.js";
 import { startCreditOraclePublisher } from "./services/credit-oracle-publisher.js";
-import { startPriceAttestor } from "./services/price-attestor.js";
+import { startPriceAttestor, ensureAllEnabledFeedsInitialized } from "./services/price-attestor.js";
 import {
   startExploitDetector,
   registerExploitDetectorCallbacks,
@@ -893,6 +893,13 @@ bot.start({
     // Operator hit it 2026-06-17 PM. Forensic: scripts/diagnose-spcx-twap-lag.mjs
     const PRICE_ATTESTOR_TICK_MS = Number(process.env.PRICE_ATTESTOR_TICK_MS) || 20_000;
     setTimeout(() => startPriceAttestor(PRICE_ATTESTOR_TICK_MS), 35_000);
+    // FEED-INIT SWEEP — guarantees every enabled mint's price-feed PDA(s) exist
+    // (category pool + V4) so a user can NEVER hit AccountNotInitialized on a
+    // borrow, especially for a freshly-approved token. Boot heals any token
+    // already in that state (e.g. $ANSEM was); the 90s tick covers new approvals
+    // even if an approval-path hook is missed. Cheap (skips confirmed mints).
+    setTimeout(() => ensureAllEnabledFeedsInitialized().catch((e) => console.warn("[feed-init-sweep] boot failed:", e.message?.slice(0, 120))), 45_000);
+    setInterval(() => ensureAllEnabledFeedsInitialized().catch((e) => console.warn("[feed-init-sweep] tick failed:", e.message?.slice(0, 120))), 90_000);
     // RWA screener — discovers Backed Finance xStocks + similar via DexScreener
     // search every 4h. Auto-adds new mints meeting liquidity/volume thresholds.
     // Auto-disables enabled RWAs that degrade or get paused by the issuer.

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -5,7 +5,7 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import "dotenv/config";
 import { getPriceInSol, getPricesInSolBatch } from "./price.js";
-import { getProgramForSigner, chooseProgramIdForCategory } from "../solana/program.js";
+import { getProgramForSigner, chooseProgramIdForCategory, PROGRAM_ID_V4 } from "../solana/program.js";
 import { connection } from "../solana/connection.js";
 import { lendingPoolPda, priceFeedPda } from "../solana/pdas.js";
 import { query } from "../db/pool.js";
@@ -158,7 +158,13 @@ export async function getV4TwapSampleCount(mintStr, windowSec = 300, programIdOv
     const SAMPLES_OFFSET = 112;
     const STRIDE = 16; // price(8) + timestamp(8)
     const SLOTS = 32;
-    const slotsPopulated = Math.min(totalCount, SLOTS);
+    // Clamp to what the on-chain buffer ACTUALLY holds. A freshly-initialized /
+    // still-growing PriceHistory can report totalCount>=1 before its data has
+    // realloc'd to fit that many sample slots; reading past the end throws
+    // "offset out of range", which broke this readiness check and left brand-new
+    // tokens (e.g. $ANSEM) stuck "warming up" forever. Only read samples that fit.
+    const maxSlotsInBuffer = Math.max(0, Math.floor((info.data.length - SAMPLES_OFFSET) / STRIDE));
+    const slotsPopulated = Math.min(totalCount, SLOTS, maxSlotsInBuffer);
     const nowSec = Math.floor(Date.now() / 1000);
     const cutoff = nowSec - windowSec;
     let inWindow = 0;
@@ -329,6 +335,71 @@ export async function initializePriceFeed(mintStr, programIdOverride = null) {
 
   console.log(`Price feed initialized for ${mintStr}: ${sig}`);
   return { signature: sig, priceFeed: priceFeed.toBase58() };
+}
+
+// Mints whose feeds we've CONFIRMED initialized this process — so the sweep
+// doesn't re-check every enabled mint on every tick (only new/unconfirmed ones).
+const _feedsConfirmed = new Set();
+
+/**
+ * Ensure a mint's on-chain price-feed PDA exists for EVERY program a user could
+ * borrow it on — its category pool (memecoin→V1, RWA→V3) AND V4 (in-vault
+ * exits), each of which has its own feed PDA. Idempotent (initializePriceFeed
+ * no-ops when the feed already exists). This is the FUNCTIONAL fix for the
+ * AccountNotInitialized borrow class: a freshly-approved token must never be
+ * borrowable before its feed(s) exist. Call it the moment a token is approved,
+ * and on a periodic sweep. See feedback_init_price_feed_pda_on_token_approval.
+ */
+export async function ensureMintFeedsInitialized(mintStr) {
+  const category = await resolveCategory(mintStr);
+  const defaultPid = chooseProgramIdForCategory(category);
+  const programs = [];
+  if (defaultPid) programs.push(defaultPid);
+  if (PROGRAM_ID_V4 && !programs.some((p) => p.equals(PROGRAM_ID_V4))) programs.push(PROGRAM_ID_V4);
+
+  const out = [];
+  let allExist = true;
+  for (const pid of programs) {
+    try {
+      const r = await initializePriceFeed(mintStr, pid);
+      out.push({ program: pid.toBase58(), ...r });
+      if (r.signature) allExist = false; // we just created it (so it didn't exist)
+    } catch (e) {
+      allExist = false;
+      out.push({ program: pid.toBase58(), error: e.message?.slice(0, 140) });
+    }
+  }
+  if (allExist) _feedsConfirmed.add(mintStr);
+  return out;
+}
+
+/**
+ * Sweep every enabled mint and ensure its feeds are initialized. Cheap on
+ * steady state (skips mints already confirmed this process; the rest is one
+ * getAccountInfo per program). Run at boot (heals any token already in the
+ * AccountNotInitialized state, like $ANSEM was) and on a short interval so a
+ * newly-approved token is covered even if an approval-path hook is missed.
+ */
+export async function ensureAllEnabledFeedsInitialized({ log = console.log } = {}) {
+  const { rows } = await query(`SELECT mint, symbol FROM supported_mints WHERE enabled = TRUE`);
+  let checked = 0;
+  let initialized = 0;
+  for (const r of rows) {
+    if (_feedsConfirmed.has(r.mint)) continue;
+    checked++;
+    try {
+      const res = await ensureMintFeedsInitialized(r.mint);
+      const created = res.filter((x) => x.signature).length;
+      if (created) {
+        initialized += created;
+        log(`[feed-init-sweep] ${r.symbol} (${r.mint.slice(0, 8)}…): initialized ${created} missing price feed(s)`);
+      }
+    } catch (e) {
+      log(`[feed-init-sweep] ${r.symbol}: ${e.message?.slice(0, 80)}`);
+    }
+  }
+  if (initialized) log(`[feed-init-sweep] ${initialized} feed(s) initialized across ${checked} unconfirmed mint(s)`);
+  return { checked, initialized };
 }
 
 /**


### PR DESCRIPTION
Operator P0 ($ANSEM). Two functional root-cause fixes:

1. **False "Market is warming up"** — `getV4TwapSampleCount` read `totalCount` slots even when the still-growing PriceHistory buffer had not reallocd to hold them → `offset out of range` thrown → readiness check reported not-ready even when the window was full ($ANSEM had **13/8** but showed "warming up"). Clamp `slotsPopulated` to what the buffer actually holds.
2. **AccountNotInitialized on a freshly-approved token** — `ensureMintFeedsInitialized(mint)` inits the feed for every borrow program (category pool + V4); `ensureAllEnabledFeedsInitialized()` boot+90s sweep heals any enabled mint missing a feed (boot fixes ones already broken, like $ANSEM); approval paths (user-submit auto-approve, `/enablemint`) init the feed the moment a token is approved.

$ANSEM already initialized + warmed live. All files syntax-checked.