### PR TITLE
fix(db): allow canary paths in conversion_events CHECK constraint

### DIFF
--- a/migrations/087_conversion_events_canary_paths.sql
+++ b/migrations/087_conversion_events_canary_paths.sql
@@ -1,0 +1,20 @@
+-- 087_conversion_events_canary_paths.sql
+--
+-- Bug fix (2026-06-28): the borrow-canary (src/services/borrow-canary.js) and
+-- x402-path-canary (src/services/x402-path-canary.js) record their synthetic
+-- probe results to conversion_events with path='borrow_canary' and
+-- path='x402_path_canary'. But the original CHECK constraint (migration 083)
+-- only allowed the four real user paths ('borrow','arm','fire','repay'), so
+-- EVERY canary tick violated conversion_events_path_check and its row was
+-- silently dropped — flooding the bot logs with
+--   [conv-tracker] DB write failed (swallowing): ... violates check constraint
+--                  "conversion_events_path_check"
+-- and losing all canary conversion telemetry.
+--
+-- Fix: widen the allowed set to include the two canary paths. Idempotent
+-- (DROP IF EXISTS + ADD) so it is safe to re-run and safe if the constraint
+-- was already widened out-of-band.
+
+ALTER TABLE conversion_events DROP CONSTRAINT IF EXISTS conversion_events_path_check;
+ALTER TABLE conversion_events ADD CONSTRAINT conversion_events_path_check
+  CHECK (path IN ('borrow', 'arm', 'fire', 'repay', 'borrow_canary', 'x402_path_canary'));


### PR DESCRIPTION
## Bug (found in live bot logs)
```
[conv-tracker] DB write failed (swallowing): new row for relation "conversion_events" violates check constraint "conversion_events_path_check"
```
repeating constantly. The borrow-canary and x402-path-canary write `path='borrow_canary'` / `path='x402_path_canary'`, but migration 083's CHECK only allowed the four user paths — so every canary tick was rejected and its telemetry silently dropped.

## Fix
Migration `087` widens the CHECK to include the two canary paths (idempotent DROP IF EXISTS + ADD). Auto-applied by the migration runner on next boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)