### PR TITLE
feat(x): auto-announce token catalog adds/removes to @MagpieLoans

### DIFF
--- a/migrations/089_token_catalog_announce.sql
+++ b/migrations/089_token_catalog_announce.sql
@@ -1,0 +1,31 @@
+-- 089 — Token-catalog → @MagpieLoans X announcement reconciliation state.
+--
+-- The announcer worker (services/token-catalog-announcer.js) diffs the live
+-- supported_mints.enabled set against this table and tweets on every
+-- add (disabled→enabled) / remove (enabled→disabled) transition, then
+-- upserts the new state. This reconciliation pattern catches EVERY catalog
+-- change — the RWA screener's auto-add/auto-disable AND any manual /tier or
+-- admin change — so the X feed always matches the /tokens page (protocol
+-- uniformity).
+--
+-- IDEMPOTENCY: announcing only happens on a recorded state transition, and
+-- the row is upserted in the same pass — so a crash/restart never re-tweets
+-- a change already announced. The FIRST run (empty table) seeds every mint
+-- silently (last_change_type='seed'), so deploying this never tweet-storms
+-- the existing catalog; only changes AFTER the seed are announced.
+
+CREATE TABLE IF NOT EXISTS token_catalog_announce_state (
+  mint               TEXT PRIMARY KEY,
+  symbol             TEXT,
+  category           TEXT,
+  last_enabled       BOOLEAN     NOT NULL,
+  last_change_type   TEXT,                 -- 'seed' | 'added' | 'removed' | 'seed_overflow' | '*_failed'
+  last_announced_at  TIMESTAMPTZ,          -- set only when an add/remove was actually tweeted
+  last_tweet_id      TEXT,
+  seeded_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Fast lookup of rows that still need an announcement retry (failed posts).
+CREATE INDEX IF NOT EXISTS idx_token_catalog_announce_change
+  ON token_catalog_announce_state (last_change_type);

--- a/src/index.js
+++ b/src/index.js
@@ -702,6 +702,12 @@ bot.start({
     // X_BEARER_TOKEN is set. No-op without the token; operator can
     // still manually use /crosspost <tweet-url> in either path.
     import("./services/community-x-crosspost.js").then((m) => m.startXCrosspostPoller(bot));
+    // Token-catalog → @MagpieLoans auto-announce — reconciliation worker that
+    // diffs supported_mints.enabled and tweets when a token is added/removed
+    // from the approved-collateral catalog (the /tokens page). No-op posting
+    // until X_API_KEY/SECRET + X_ACCESS_TOKEN/SECRET are set; seeds state
+    // meanwhile so it never backlog-dumps. See token-catalog-announcer.js.
+    import("./services/token-catalog-announcer.js").then((m) => m.startTokenCatalogAnnouncer());
     // Raid monitor — DISABLED 2026-06-12 per operator. The Nitter
     // upstream instances die constantly and the X API requires a paid
     // bearer token; alerts about "data sources offline" were noise.

--- a/src/services/token-catalog-announcer.js
+++ b/src/services/token-catalog-announcer.js
@@ -1,0 +1,164 @@
+/**
+ * token-catalog-announcer.js — auto-announces @MagpieLoans when a token is
+ * ADDED or REMOVED from the approved-collateral catalog (the /tokens page).
+ *
+ * DESIGN (reconciliation worker, matching the protocol-uniformity pattern):
+ * every tick we read the live supported_mints.enabled set and diff it
+ * against token_catalog_announce_state (migration 089). A disabled→enabled
+ * flip = "added" tweet; enabled→disabled = "removed" tweet. Because we diff
+ * STATE rather than hook the screener's code paths, this catches EVERY
+ * change — the RWA screener's auto-add/auto-disable, a manual /tier, an
+ * admin disable — so the X feed can never drift from /tokens.
+ *
+ * SAFETY:
+ *  - First run (empty state table) SEEDS every mint silently — deploying
+ *    this never tweet-storms the existing catalog. Only post-seed changes
+ *    announce.
+ *  - Per-tick announce cap (anti-spam) — if many mints flip at once (a bulk
+ *    backfill or a screener mass-disable) we post at most N and seed the
+ *    rest silently, so we never look like a spam bot.
+ *  - Idempotent — the state row is upserted in the same pass as the post,
+ *    so a crash/restart never re-tweets an already-announced change.
+ *  - Symbol SANITIZATION — a token symbol is attacker-influenceable, so it
+ *    is stripped to a safe charset + length before it ever enters a tweet
+ *    (no newline/URL/@handle/$cashtag injection into our public feed).
+ *  - Read-only on supported_mints; writes ONLY its own state table. Never
+ *    touches loans/collateral/user state.
+ */
+import { query } from "../db/pool.js";
+import { postTweet, xPosterConfigured } from "./x-poster.js";
+
+const POLL_MS = Number(process.env.TOKEN_ANNOUNCE_POLL_MS || 5 * 60_000);
+const MAX_PER_TICK = Number(process.env.TOKEN_ANNOUNCE_MAX_PER_TICK || 3);
+const ANNOUNCE_REMOVALS = process.env.TOKEN_ANNOUNCE_REMOVALS !== "false";
+const TOKENS_URL = "https://www.magpie.capital/tokens";
+
+/** Strip a token symbol to a tweet-safe token. Removes anything that could
+ *  hijack the post (newlines, @, #, $, URLs, control chars) and caps length.
+ *  Returns "" if nothing safe remains (caller falls back to neutral copy). */
+function safeSymbol(raw) {
+  return String(raw || "")
+    .replace(/[^A-Za-z0-9 ._-]/g, "")
+    .trim()
+    .slice(0, 16);
+}
+
+function isRwaCategory(category) {
+  return category === "stock" || category === "rwa";
+}
+
+function composeAdded(row) {
+  const sym = safeSymbol(row.symbol);
+  const label = sym ? `$${sym}` : "A new token";
+  const kind = isRwaCategory(row.category) ? "tokenized stock / RWA" : "token";
+  return (
+    `🦅 New collateral on Magpie\n\n` +
+    `${label} (${kind}) is now borrowable — deposit it, borrow SOL against it, and set auto-sell exits that fire in-vault.\n\n` +
+    `All approved collateral → ${TOKENS_URL}`
+  );
+}
+
+function composeRemoved(row) {
+  const sym = safeSymbol(row.symbol);
+  const label = sym ? `$${sym}` : "A token";
+  return (
+    `Collateral update on Magpie\n\n` +
+    `${label} is no longer accepted as NEW collateral. Existing loans are unaffected and continue under their original terms.\n\n` +
+    `Current approved collateral → ${TOKENS_URL}`
+  );
+}
+
+async function upsertState(row, enabled, changeType, tweetId) {
+  await query(
+    `INSERT INTO token_catalog_announce_state
+        (mint, symbol, category, last_enabled, last_change_type, last_announced_at, last_tweet_id, updated_at)
+     VALUES ($1, $2, $3, $4, $5,
+             CASE WHEN $5 IN ('added','removed') THEN now() ELSE NULL END,
+             $6, now())
+     ON CONFLICT (mint) DO UPDATE SET
+        symbol            = EXCLUDED.symbol,
+        category          = EXCLUDED.category,
+        last_enabled      = EXCLUDED.last_enabled,
+        last_change_type  = EXCLUDED.last_change_type,
+        last_announced_at = COALESCE(EXCLUDED.last_announced_at, token_catalog_announce_state.last_announced_at),
+        last_tweet_id     = COALESCE(EXCLUDED.last_tweet_id, token_catalog_announce_state.last_tweet_id),
+        updated_at        = now()`,
+    [row.mint, row.symbol ?? null, row.category ?? null, enabled, changeType, tweetId],
+  );
+}
+
+async function tick() {
+  const { rows: current } = await query(
+    `SELECT mint, symbol, category, enabled FROM supported_mints`,
+  );
+  const { rows: stateRows } = await query(
+    `SELECT mint, last_enabled FROM token_catalog_announce_state`,
+  );
+  const stateMap = new Map(stateRows.map((r) => [r.mint, r.last_enabled]));
+  const firstRun = stateRows.length === 0;
+
+  // Collect real transitions first; seed everything else silently.
+  const transitions = [];
+  for (const row of current) {
+    const prev = stateMap.get(row.mint);
+    if (prev === undefined) {
+      // Never tracked. On first run, seed silently. After first run, a
+      // brand-new ENABLED mint is a genuine "added"; a new disabled mint
+      // just seeds (nothing to announce).
+      if (firstRun || !row.enabled) {
+        await upsertState(row, row.enabled, "seed", null);
+      } else {
+        transitions.push({ row, type: "added" });
+      }
+    } else if (prev !== row.enabled) {
+      transitions.push({ row, type: row.enabled ? "added" : "removed" });
+    }
+  }
+
+  let posted = 0;
+  for (const t of transitions) {
+    if (t.type === "removed" && !ANNOUNCE_REMOVALS) {
+      await upsertState(t.row, t.row.enabled, "seed", null); // record silently
+      continue;
+    }
+    if (posted >= MAX_PER_TICK) {
+      // Anti-spam overflow — record the new state so we don't re-announce,
+      // but skip the tweet. (Mass flips shouldn't tweet-storm.)
+      await upsertState(t.row, t.row.enabled, "seed_overflow", null);
+      continue;
+    }
+    const text = t.type === "added" ? composeAdded(t.row) : composeRemoved(t.row);
+    const res = await postTweet(text);
+    await upsertState(
+      t.row,
+      t.row.enabled,
+      res.ok ? t.type : `${t.type}_failed`,
+      res.tweetId ?? null,
+    );
+    if (res.ok) posted++;
+  }
+
+  if (transitions.length > 0) {
+    console.log(
+      `[token-announcer] ${transitions.length} catalog change(s); ${posted} tweeted` +
+        (firstRun ? " (first run seeded silently)" : ""),
+    );
+  }
+}
+
+export function startTokenCatalogAnnouncer() {
+  // Run the loop even WITHOUT X creds so the state table tracks the catalog
+  // (seeding). Then the day creds are added, only FUTURE changes announce —
+  // never a backlog dump of everything that changed while creds were absent.
+  const run = () =>
+    tick().catch((e) =>
+      console.warn("[token-announcer] tick failed:", e.message?.slice(0, 160)),
+    );
+  setTimeout(run, 60_000); // delayed first run (let boot settle)
+  setInterval(run, POLL_MS);
+  console.log(
+    `[token-announcer] armed — polls every ${Math.round(POLL_MS / 1000)}s; ` +
+      `X posting ${xPosterConfigured() ? "ENABLED" : "disabled (no creds — seeding only)"}; ` +
+      `removals ${ANNOUNCE_REMOVALS ? "on" : "off"}`,
+  );
+}

--- a/src/services/x-poster.js
+++ b/src/services/x-poster.js
@@ -1,0 +1,127 @@
+/**
+ * x-poster.js — minimal, dependency-free OAuth 1.0a client for POSTING
+ * tweets to @MagpieLoans via the X API v2 (POST /2/tweets).
+ *
+ * WHY OAuth 1.0a (not the existing X_BEARER_TOKEN): a bearer token is
+ * app-only and can READ the timeline but CANNOT post on a user's behalf.
+ * Posting requires user-context auth. OAuth 1.0a (consumer key/secret +
+ * access token/secret) is the simplest server-to-server option and needs
+ * no extra dependency — we sign with Node's built-in crypto (HMAC-SHA1).
+ *
+ * PROVISIONING (operator, at developer.x.com → the @MagpieLoans app, with
+ * "Read and write" permission, then regenerate the access token AFTER
+ * enabling write): set four Railway variables on magpie-bot:
+ *     X_API_KEY         (consumer/api key)
+ *     X_API_SECRET      (consumer/api secret)
+ *     X_ACCESS_TOKEN    (access token, write-enabled)
+ *     X_ACCESS_SECRET   (access token secret)
+ *
+ * With any of the four missing, postTweet() is a safe no-op (logs the text
+ * it WOULD have posted, returns {ok:false, skipped:true}) — so every caller
+ * works before the creds exist and the announcer still seeds its state.
+ *
+ * SECURITY: secrets are read from env per-call and are NEVER logged or
+ * returned. The signing key + signature are local. No secret crosses a log
+ * line or the function boundary.
+ */
+import crypto from "node:crypto";
+
+function creds() {
+  return {
+    apiKey: process.env.X_API_KEY || "",
+    apiSecret: process.env.X_API_SECRET || "",
+    accessToken: process.env.X_ACCESS_TOKEN || "",
+    accessSecret: process.env.X_ACCESS_SECRET || "",
+  };
+}
+
+export function xPosterConfigured() {
+  const c = creds();
+  return !!(c.apiKey && c.apiSecret && c.accessToken && c.accessSecret);
+}
+
+/** RFC-3986 percent-encoding (encodeURIComponent + the four reserved chars). */
+function pctEncode(str) {
+  return encodeURIComponent(String(str)).replace(
+    /[!*'()]/g,
+    (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
+  );
+}
+
+/**
+ * Build the OAuth 1.0a Authorization header for a request. For POST
+ * /2/tweets the body is JSON (application/json), which per the OAuth spec
+ * does NOT contribute to the signature base string — only the oauth_*
+ * params do. (Form-encoded bodies would; JSON ones don't.)
+ */
+function buildOAuthHeader(method, url, c) {
+  const oauth = {
+    oauth_consumer_key: c.apiKey,
+    oauth_nonce: crypto.randomBytes(16).toString("hex"),
+    oauth_signature_method: "HMAC-SHA1",
+    oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    oauth_token: c.accessToken,
+    oauth_version: "1.0",
+  };
+  const paramStr = Object.keys(oauth)
+    .sort()
+    .map((k) => `${pctEncode(k)}=${pctEncode(oauth[k])}`)
+    .join("&");
+  const baseStr = [
+    method.toUpperCase(),
+    pctEncode(url),
+    pctEncode(paramStr),
+  ].join("&");
+  const signingKey = `${pctEncode(c.apiSecret)}&${pctEncode(c.accessSecret)}`;
+  const signature = crypto
+    .createHmac("sha1", signingKey)
+    .update(baseStr)
+    .digest("base64");
+  const headerParams = { ...oauth, oauth_signature: signature };
+  return (
+    "OAuth " +
+    Object.keys(headerParams)
+      .sort()
+      .map((k) => `${pctEncode(k)}="${pctEncode(headerParams[k])}"`)
+      .join(", ")
+  );
+}
+
+/**
+ * Post a tweet. Returns {ok, tweetId} on success, {ok:false, skipped:true}
+ * if creds are absent, {ok:false, status} on an API error. Never throws —
+ * a failed post must never break the caller's worker loop.
+ */
+export async function postTweet(text) {
+  const c = creds();
+  if (!(c.apiKey && c.apiSecret && c.accessToken && c.accessSecret)) {
+    console.log(`[x-poster] skipped (X OAuth creds not set) — would post: ${String(text).slice(0, 80).replace(/\n/g, " ")}`);
+    return { ok: false, skipped: true };
+  }
+  // Hard cap to the tweet limit so an over-long compose can never 403.
+  const body = { text: String(text).slice(0, 280) };
+  const url = "https://api.twitter.com/2/tweets";
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: buildOAuthHeader("POST", url, c),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      const errText = await res.text().catch(() => "");
+      console.warn(`[x-poster] POST /2/tweets failed ${res.status}: ${errText.slice(0, 180)}`);
+      return { ok: false, status: res.status };
+    }
+    const json = await res.json().catch(() => ({}));
+    const tweetId = json?.data?.id ?? null;
+    console.log(`[x-poster] posted tweet ${tweetId ?? "(no id)"}`);
+    return { ok: true, tweetId };
+  } catch (err) {
+    console.warn(`[x-poster] post threw: ${err.message?.slice(0, 140)}`);
+    return { ok: false, error: true };
+  }
+}


### PR DESCRIPTION
Auto-posts to @MagpieLoans when a token is **added or removed** from approved collateral (the /tokens page), as requested.

## How
Reconciliation worker (`token-catalog-announcer.js`) diffs `supported_mints.enabled` against new state table `token_catalog_announce_state` (migration 089) every 5 min. A disabled→enabled flip tweets "added", enabled→disabled tweets "removed". Diffing **state** (not hooking the screener) means it catches the RWA screener's auto-add/auto-disable **and** any manual `/tier`/admin change — the X feed can never drift from /tokens.

## Posting
`x-poster.js` — dependency-free OAuth 1.0a `POST /2/tweets` (bearer tokens can't post). **No-op until** `X_API_KEY` / `X_API_SECRET` / `X_ACCESS_TOKEN` / `X_ACCESS_SECRET` are set on Railway; secrets are read per-call and **never logged**.

## Safety / no-vuln review
- **First run seeds silently** → deploying never tweet-storms the existing catalog; only post-seed changes announce.
- **Anti-spam per-tick cap** (`TOKEN_ANNOUNCE_MAX_PER_TICK=3`) → a mass flip can't spam the feed.
- **Idempotent** — state upserted in the same pass as the post → crash/restart never re-tweets.
- **Symbol sanitization** — token symbols are attacker-influenceable, so they're stripped to `[A-Za-z0-9 ._-]` + 16 chars before entering a tweet (no newline/URL/@handle/$cashtag injection into our public feed).
- **Read-only** on `supported_mints`; writes only its own state table. Never touches loan/collateral/user state.
- Removals can be muted via `TOKEN_ANNOUNCE_REMOVALS=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)