### PR TITLE
sec: harden tweet symbol + client-IP (full-audit LOW findings)

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -146,10 +146,19 @@ const ipRateLimitStore = new Map();
 const PUBLIC_IP_LIMIT_RPM = parseInt(process.env.PUBLIC_IP_LIMIT_RPM || "240", 10);
 
 function extractClientIp(req) {
-  // Trust the leftmost x-forwarded-for value when behind Railway's proxy.
+  // SECURITY (audit 2026-06-28): the LEFTMOST x-forwarded-for value is
+  // client-SUPPLIED and therefore spoofable — trusting xff[0] let an attacker
+  // rotate it to defeat the per-IP rate limit (e.g. spam /v4/warm-mint). Trust
+  // only the hop our OWN infra appended: Railway's edge appends the real
+  // connecting IP as the rightmost entry, so take the PUBLIC_TRUSTED_PROXY_HOPS-th
+  // hop from the right (default 1 = the rightmost).
   const xff = req.headers["x-forwarded-for"];
   if (typeof xff === "string" && xff.length > 0) {
-    return xff.split(",")[0].trim();
+    const hops = xff.split(",").map((s) => s.trim()).filter(Boolean);
+    if (hops.length) {
+      const trusted = Math.max(1, parseInt(process.env.PUBLIC_TRUSTED_PROXY_HOPS || "1", 10));
+      return hops[Math.max(0, hops.length - trusted)];
+    }
   }
   return req.socket?.remoteAddress ?? "unknown";
 }

--- a/src/services/token-catalog-announcer.js
+++ b/src/services/token-catalog-announcer.js
@@ -35,11 +35,14 @@ const TOKENS_URL = "https://www.magpie.capital/tokens";
 
 /** Strip a token symbol to a tweet-safe token. Removes anything that could
  *  hijack the post (newlines, @, #, $, URLs, control chars) and caps length.
- *  Returns "" if nothing safe remains (caller falls back to neutral copy). */
+ *  Returns "" if nothing safe remains (caller falls back to neutral copy).
+ *  SECURITY (audit 2026-06-28): also drop '.' and spaces — an attacker-controlled
+ *  symbol like "evilsite.com" otherwise survives and X AUTO-LINKIFIES it into a
+ *  clickable phishing link on the verified @MagpieLoans feed. Charset is now
+ *  strictly [A-Za-z0-9_-], which cannot form a linkifiable URL/handle/cashtag. */
 function safeSymbol(raw) {
   return String(raw || "")
-    .replace(/[^A-Za-z0-9 ._-]/g, "")
-    .trim()
+    .replace(/[^A-Za-z0-9_-]/g, "")
     .slice(0, 16);
 }
 


### PR DESCRIPTION
Full security audit found 2 LOW non-fund-loss issues, both fixed: (1) tweet symbol could auto-linkify a phishing URL on @MagpieLoans — charset tightened; (2) leftmost XFF spoofable → rate-limit bypass — now trusts the infra-appended hop. The 'drain lender SOL via warm-on-enable' worry was disproven. 🤖 Generated with [Claude Code](https://claude.com/claude-code)