### PR TITLE
V4 exit-reliability audit fixes (bot): P0 canary alerting + partial_fired display + V4-exclusivity

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -454,10 +454,15 @@ export async function handleSiteLimitCloseList(req, url) {
               cancellation_reason
          FROM limit_close_orders
         WHERE loan_id = ANY($1::bigint[])
-          AND status IN ('armed','firing','twap_in_progress','awaiting_user','fired','cancelled','failed','max_retries_exceeded')
+          -- 'partial_fired' MUST be included (audit 2026-06-28 P1 #3): a TWAP/
+          -- chunked exit that sold SOME collateral into the vault lands in
+          -- 'partial_fired'. Omitting it dropped the order from the dashboard
+          -- entirely → the banner showed "No exit set" despite real proceeds.
+          AND status IN ('armed','firing','twap_in_progress','awaiting_user','fired','partial_fired','cancelled','failed','max_retries_exceeded')
         ORDER BY
-          -- Active states sort first by armed_at DESC, history by fired_at DESC
-          CASE WHEN status IN ('fired','cancelled','failed','max_retries_exceeded') THEN 1 ELSE 0 END,
+          -- Active states sort first by armed_at DESC, history by fired_at DESC.
+          -- partial_fired is a FIRED (terminal) state → sort with history.
+          CASE WHEN status IN ('fired','partial_fired','cancelled','failed','max_retries_exceeded') THEN 1 ELSE 0 END,
           armed_at DESC`,
       [loanIds],
     );

--- a/src/commands/lc-status.js
+++ b/src/commands/lc-status.js
@@ -228,13 +228,21 @@ async function showEngine(ctx) {
   // most recent one's overall_ok + which checks failed (if any).
   let canaryLines = [];
   try {
+    // Filter to the V4 program's canary specifically (audit 2026-06-28 P2 #11):
+    // the engine writes one row PER program per tick, so an unfiltered "latest"
+    // surfaces whichever program wrote last and dilutes the V4 pass-rate. V4 is
+    // the in-vault exit product, so show ITS health. Falls back to any program
+    // when PROGRAM_ID_V4 is unset.
+    const v4Pid = process.env.PROGRAM_ID_V4 || null;
     const { rows: [c] } = await query(
       `SELECT run_at, overall_ok, duration_ms, checks, jupiter_ok,
               dexscreener_ok, cross_source_ok, program_ok
          FROM engine_canary_runs
         WHERE service = 'limit_close_watcher'
+          AND ($1::text IS NULL OR COALESCE(program_id, 'legacy') = $1)
         ORDER BY run_at DESC
         LIMIT 1`,
+      [v4Pid],
     );
     if (c) {
       const tag = c.overall_ok ? "passed" : "*FAILED*";

--- a/src/services/canary-watcher.js
+++ b/src/services/canary-watcher.js
@@ -1,19 +1,27 @@
 /**
  * Canary watcher — reads engine_canary_runs and alerts the operator
- * on consecutive failures.
+ * on consecutive failures, PER PROGRAM (V1/V2/V3/V4).
  *
  * Pairs with magpie-limitclose/src/canary.js which writes one row
- * per canary tick (default every hour). The watcher polls every
- * POLL_INTERVAL_MS and surfaces the operator-relevant signals:
+ * PER PROGRAM per canary tick, each tagged with program_id. The watcher
+ * polls every POLL_INTERVAL_MS and surfaces the operator-relevant signals:
  *
  *   - 2 consecutive failures → WARN ("canary degraded")
  *   - 3+ consecutive failures → CRITICAL ("canary blocked — fires
  *     would likely fail right now")
  *   - Recovery from any failure tier → one-shot "recovered" DM
- *   - Canary row stale > 3h → engine not running canaries
- *     (different from engine_heartbeats staleness but related; this
- *     watcher only alerts on canary-specific staleness so we don't
- *     duplicate the heartbeat watcher's alerts)
+ *   - Canary row stale > 3h → engine not running canaries for that program
+ *
+ * CRITICAL CORRECTNESS (audit 2026-06-28, P0): the engine writes up to 4
+ * rows per tick (one per program), interleaved by run_at. Evaluating them
+ * as one mixed stream collapses a V4-ONLY fire regression into the V1/V2/V3
+ * OK rows on the same tick — consecFails resets to 0 every tick, so a real
+ * V4 fire regression NEVER reaches WARN/CRIT and pages NOBODY (the exact
+ * thing the "memecoins must never regress" + "RWA/xStock must execute"
+ * mandates rely on this to catch). So we compute consecutive-fails and hold
+ * alert/recovery/staleness state PER program_id. The V4 program is labeled
+ * explicitly so the operator immediately knows the in-vault exit path is
+ * the one degraded.
  *
  * Distinct from engine-heartbeat-watcher (liveness) and the existing
  * status-aware alerts (Jupiter degraded) — canary is the highest-
@@ -29,9 +37,12 @@ const WARN_CONSEC_FAILS = 2;
 const CRIT_CONSEC_FAILS = 3;
 const ALERT_RE_NOTIFY_MS = 6 * 60 * 60_000; // re-alert every 6h if still degraded
 
-let lastAlertedTier = null;
-let lastAlertedAt = 0;
-let lastStalenessAlertedAt = 0;
+// Per-program alert state (keyed by program_id, or 'legacy' for NULL rows).
+// Previously module-level scalars collapsed all programs into one alert
+// state, so a V1 OK could "recover" a V4 degradation. Maps fix that.
+const lastAlertedTier = new Map();        // program_id -> "WARN" | "CRITICAL"
+const lastAlertedAt = new Map();          // program_id -> epoch ms
+const lastStalenessAlertedAt = new Map(); // program_id -> epoch ms
 
 function fmtAgeMs(ms) {
   if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
@@ -39,79 +50,110 @@ function fmtAgeMs(ms) {
   return `${Math.round(ms / 3_600_000)}h`;
 }
 
+function programLabel(program, v4ProgramId) {
+  if (v4ProgramId && program === v4ProgramId) return "V4 (in-vault exits)";
+  if (program === "legacy") return "legacy/V1";
+  return `program ${String(program).slice(0, 8)}…`;
+}
+
 async function tick(bot) {
   const adminId = getAdminId();
   if (!adminId || !bot) return;
 
-  // Pull the most recent N canary runs to compute consecutive-fails
-  // window. CRIT requires 3 consecutive failures so we read 5 to be
-  // safe.
+  // Which programs have written canary rows recently? Evaluate each on its
+  // OWN stream so a V4-only regression can never be masked by V1/V2/V3.
+  let programs;
+  try {
+    const r = await query(
+      `SELECT DISTINCT COALESCE(program_id, 'legacy') AS program_id
+         FROM engine_canary_runs
+        WHERE service = 'limit_close_watcher'
+          AND run_at > NOW() - INTERVAL '6 hours'`,
+    );
+    programs = r.rows.map((x) => x.program_id);
+  } catch (err) {
+    console.warn("[canary-watch] program list read failed:", err.message?.slice(0, 80));
+    return;
+  }
+  if (programs.length === 0) return;
+
+  const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
+  for (const program of programs) {
+    try {
+      await evaluateProgram(bot, adminId, program, v4ProgramId);
+    } catch (err) {
+      console.warn(`[canary-watch] evaluate ${program} threw:`, err.message?.slice(0, 80));
+    }
+  }
+}
+
+async function evaluateProgram(bot, adminId, program, v4ProgramId) {
+  const label = programLabel(program, v4ProgramId);
+
+  // Pull the most recent N canary runs FOR THIS PROGRAM to compute the
+  // consecutive-fails window. CRIT requires 3 in a row so 5 is enough.
   let rows;
   try {
     const r = await query(
       `SELECT id, run_at, overall_ok, duration_ms, checks
          FROM engine_canary_runs
         WHERE service = 'limit_close_watcher'
+          AND COALESCE(program_id, 'legacy') = $1
         ORDER BY run_at DESC
         LIMIT 5`,
+      [program],
     );
     rows = r.rows;
   } catch (err) {
-    console.warn("[canary-watch] read failed:", err.message?.slice(0, 80));
+    console.warn(`[canary-watch] read failed (${label}):`, err.message?.slice(0, 80));
     return;
   }
+  if (rows.length === 0) return;
 
-  // Staleness check first — if the engine hasn't written a canary
-  // row in over STALE_THRESHOLD_MS, that's an "engine not running
-  // canaries" signal. Distinct from heartbeat staleness.
+  // Staleness (per program) — a V4-only scheduler stall is no longer masked
+  // by fresh V1/V2/V3 ticks because we read THIS program's newest row.
   const newestAt = rows[0]?.run_at ? new Date(rows[0].run_at).getTime() : 0;
   const staleness = newestAt ? Date.now() - newestAt : null;
   if (staleness != null && staleness > STALE_THRESHOLD_MS) {
     const now = Date.now();
-    if (now - lastStalenessAlertedAt > ALERT_RE_NOTIFY_MS) {
+    if (now - (lastStalenessAlertedAt.get(program) || 0) > ALERT_RE_NOTIFY_MS) {
       try {
         await bot.api.sendMessage(
           adminId,
           [
-            `*Canary stale*`,
+            `*Canary stale — ${label}*`,
             "",
-            `Last engine canary run: ${fmtAgeMs(staleness)} ago.`,
+            `Last engine canary run for this program: ${fmtAgeMs(staleness)} ago.`,
             `Threshold: ${fmtAgeMs(STALE_THRESHOLD_MS)}.`,
             "",
-            `The engine should be writing a canary row hourly. If this is stale, the canary scheduler stopped (separately from the heartbeat). Check engine logs for [canary] entries.`,
+            `The engine should write a canary row for each program every tick. If this program is stale, its canary scheduler stalled. Check engine logs for [canary] entries.`,
           ].join("\n"),
           { parse_mode: "Markdown" },
         );
-        lastStalenessAlertedAt = now;
+        lastStalenessAlertedAt.set(program, now);
       } catch (err) {
-        console.warn("[canary-watch] staleness DM failed:", err.message?.slice(0, 80));
+        console.warn(`[canary-watch] staleness DM failed (${label}):`, err.message?.slice(0, 80));
       }
     }
     return;
   }
 
-  if (rows.length === 0) {
-    // No rows yet — engine hasn't written its first canary. Could
-    // be a brand-new deploy. Skip silently.
-    return;
-  }
-
-  // Count consecutive failures at the head of the result list.
+  // Count consecutive failures at the head of THIS program's stream.
   let consecFails = 0;
   for (const r of rows) {
     if (r.overall_ok) break;
     consecFails++;
   }
 
-  // Recovery — were we in a degraded state and now the latest run is OK?
-  if (rows[0].overall_ok && lastAlertedTier) {
+  // Recovery — were we degraded for THIS program and is the latest run OK?
+  if (rows[0].overall_ok && lastAlertedTier.get(program)) {
     try {
       await bot.api.sendMessage(
         adminId,
-        `Canary recovered — latest run OK. (was alerted at ${lastAlertedTier}.)`,
+        `Canary recovered — ${label}: latest run OK. (was alerted at ${lastAlertedTier.get(program)}.)`,
         { parse_mode: "Markdown" },
       );
-      lastAlertedTier = null;
+      lastAlertedTier.delete(program);
     } catch { /* silent */ }
     return;
   }
@@ -119,10 +161,10 @@ async function tick(bot) {
   if (consecFails < WARN_CONSEC_FAILS) return;
 
   const tier = consecFails >= CRIT_CONSEC_FAILS ? "CRITICAL" : "WARN";
-  const tierEscalated = lastAlertedTier === "WARN" && tier === "CRITICAL";
+  const tierEscalated = lastAlertedTier.get(program) === "WARN" && tier === "CRITICAL";
   const now = Date.now();
-  const elapsedSinceAlert = now - lastAlertedAt;
-  if (!tierEscalated && lastAlertedTier === tier && elapsedSinceAlert < ALERT_RE_NOTIFY_MS) return;
+  const elapsedSinceAlert = now - (lastAlertedAt.get(program) || 0);
+  if (!tierEscalated && lastAlertedTier.get(program) === tier && elapsedSinceAlert < ALERT_RE_NOTIFY_MS) return;
 
   // Build a single-line summary of the failing checks from the latest run.
   const latestChecks = rows[0].checks || {};
@@ -135,9 +177,9 @@ async function tick(bot) {
     await bot.api.sendMessage(
       adminId,
       [
-        `*Canary ${tier} — ${consecFails} consecutive failures*`,
+        `*Canary ${tier} — ${label} — ${consecFails} consecutive failures*`,
         "",
-        `The engine's fire-path canary has failed ${consecFails} runs in a row. A real fire would likely fail right now.`,
+        `The engine's fire-path canary for ${label} has failed ${consecFails} runs in a row. A real fire on this program would likely fail right now.`,
         "",
         `Failing checks on the latest run:`,
         failingChecks || "(no per-check details)",
@@ -148,15 +190,15 @@ async function tick(bot) {
       ].join("\n"),
       { parse_mode: "Markdown" },
     );
-    lastAlertedTier = tier;
-    lastAlertedAt = now;
+    lastAlertedTier.set(program, tier);
+    lastAlertedAt.set(program, now);
   } catch (err) {
-    console.warn("[canary-watch] alert DM failed:", err.message?.slice(0, 80));
+    console.warn(`[canary-watch] alert DM failed (${label}):`, err.message?.slice(0, 80));
   }
 }
 
 export function startCanaryWatcher(bot) {
-  console.log(`[canary-watch] armed — polling every ${POLL_INTERVAL_MS / 60_000} min`);
+  console.log(`[canary-watch] armed — polling every ${POLL_INTERVAL_MS / 60_000} min, PER PROGRAM (V4 tripwire isolated)`);
   setTimeout(() => tick(bot).catch((e) => console.warn("[canary-watch] tick:", e.message?.slice(0, 80))), 60_000);
   setInterval(() => tick(bot).catch((e) => console.warn("[canary-watch] tick:", e.message?.slice(0, 80))), POLL_INTERVAL_MS);
 }

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -1339,9 +1339,16 @@ async function armOrderBatchImpl({
   if (loan.enabled === false) {
     return { ok: false, error: "collateral_not_enabled" };
   }
+  // Exits are V4-ONLY — "no exceptions" (operator mandate). Enforce this
+  // STRUCTURALLY on the batch/ladder arm path too (audit 2026-06-28 P2 #6),
+  // not behind an off-by-default env flag: an exit armed on a V1/V2/V3 loan
+  // would fire through the legacy fire-and-close model, breaking the in-vault
+  // thesis. The single-arm path already enforces this structurally; this makes
+  // the highest-traffic batch path consistent. (V4_EXIT_EXCLUSIVE_ENFORCE is
+  // retained only as an explicit OVERRIDE to disable, never as the default.)
   const v4Pid = process.env.PROGRAM_ID_V4 ?? null;
-  const v4EnforceOn = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
-  if (v4EnforceOn && v4Pid && loan.program_id && loan.program_id !== v4Pid) {
+  const v4EnforceDisabled = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "false";
+  if (!v4EnforceDisabled && v4Pid && loan.program_id && loan.program_id !== v4Pid) {
     return { ok: false, error: "exits_require_v4_loan" };
   }
 


### PR DESCRIPTION
From the adversarial V4-exit-reliability audit (18 confirmed findings; this PR carries the bot-side fixes).

- **P0** — `canary-watcher.js` now evaluates consecutive-fails + alert/recovery/staleness **per program_id**. The engine writes 4 rows/tick (V1/V2/V3/V4); reading them as one mixed stream meant a V4-only fire regression was always 'recovered' by the same-tick V1/V2/V3 OK rows → never reached WARN/CRIT → **paged nobody**. Also fixes the staleness-masking variant (#14).
- **P1 #3** — include `partial_fired` in `site-limit-close.js` filter+sort so a chunked exit that sold SOME collateral into the vault isn't dropped from the dashboard.
- **P2 #6** — batch/ladder arm V4-exclusivity gate is now **structural**, not an off-by-default env flag (exits are V4-only, no exceptions).
- **P2 #11** — `/lc-status` reads the V4 program's canary specifically.

All four files `node --check` clean. No loan/collateral/user state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)