### PR TITLE
P0: points forward-sync + reconciler; P1: transparency 500 fix

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -493,7 +493,7 @@ async function handleTransparency() {
     `SELECT
        (SELECT accrued_lamports::text FROM magpie_holder_pool WHERE id = 1) AS current_pool_lamports,
        (SELECT COUNT(*)::int FROM magpie_holder_distributions) AS lifetime_distributions,
-       (SELECT total_distributed_lamports::text FROM magpie_holder_distributions
+       (SELECT pool_lamports::text FROM magpie_holder_distributions
           ORDER BY id DESC LIMIT 1) AS last_distribution_lamports,
        (SELECT created_at FROM magpie_holder_distributions ORDER BY id DESC LIMIT 1)
          AS last_distribution_at`,

--- a/src/index.js
+++ b/src/index.js
@@ -708,6 +708,11 @@ bot.start({
     // until X_API_KEY/SECRET + X_ACCESS_TOKEN/SECRET are set; seeds state
     // meanwhile so it never backlog-dumps. See token-catalog-announcer.js.
     import("./services/token-catalog-announcer.js").then((m) => m.startTokenCatalogAnnouncer(bot));
+    // Points reconciler — self-heals the points ledger (backstop to the inline
+    // forward-sync in loans.js) AND clears the historical backlog of loans
+    // opened after the 2026-06-27 manual backfill. Idempotent; audit 2026-06-28
+    // P0/P1 (points were frozen — new loans accrued zero). See points-reconciler.js.
+    import("./services/points-reconciler.js").then((m) => m.startPointsReconciler());
     // Raid monitor — DISABLED 2026-06-12 per operator. The Nitter
     // upstream instances die constantly and the X API requires a paid
     // bearer token; alerts about "data sources offline" were noise.

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -785,6 +785,36 @@ export async function recordLoan({
     console.error("[loans.recordLoan] credit event failed (non-fatal):", err.message);
   }
 
+  // POINTS forward-sync (audit 2026-06-28 P0): credit borrow + first-loan points
+  // the SAME turn the loan lands. Previously creditPoints was only ever called by
+  // the one-shot backfill, so every loan opened after 2026-06-27 accrued ZERO
+  // points (the "dashboard reads 0" regression the points mandate forbids). Uses
+  // the SAME deterministic source_ids as the backfill (borrow:<loan_pda>,
+  // first_loan:<user_id>) so live + backfill/reconciler stay idempotent. The
+  // first_loan credit is keyed on user_id, so calling it on every borrow lands
+  // exactly once (ON CONFLICT). Best-effort — never delays/fails the loan record.
+  try {
+    const { creditPoints, borrowPoints, FIRST_LOAN_BONUS } = await import("./points.js");
+    await creditPoints({
+      userId,
+      sourceType: "borrow",
+      sourceId: `borrow:${loanPda}`,
+      category: "lending",
+      points: borrowPoints({ loanLamports: loanAmountLamports, durationDays }),
+      metadata: { loan_pda: loanPda, duration_days: durationDays },
+    });
+    await creditPoints({
+      userId,
+      sourceType: "first_loan",
+      sourceId: `first_loan:${userId}`,
+      category: "bonus",
+      points: FIRST_LOAN_BONUS,
+      metadata: { loan_pda: loanPda },
+    });
+  } catch (err) {
+    console.error("[loans.recordLoan] points credit failed (non-fatal):", err.message);
+  }
+
   // Bump the user's lifetime-borrowed counter. Also previously TG-only.
   try {
     await query(
@@ -864,7 +894,7 @@ export async function recordLoan({
  */
 export async function markLoanRepaid(loanDbId, txSignature) {
   const { rows: [loan] } = await query(
-    `SELECT user_id, due_timestamp FROM loans WHERE id = $1`,
+    `SELECT user_id, due_timestamp, loan_pda, loan_amount_lamports, duration_days FROM loans WHERE id = $1`,
     [loanDbId],
   );
 
@@ -885,6 +915,26 @@ export async function markLoanRepaid(loanDbId, txSignature) {
       await recordCreditEvent(loan.user_id, eventType, loanDbId);
     } catch (err) {
       console.error("[loans] recordCreditEvent failed on repay:", err.message);
+    }
+    // POINTS forward-sync (audit 2026-06-28 P0): repay bonus (early +25% /
+    // on-time +10% of the loan's base borrow points), one per loan, SAME
+    // source_id as the backfill (repay:<loan_pda>) so live + reconciler stay
+    // idempotent. Late repays earn 0 (no row). Best-effort.
+    if (eventType === "repay_early" || eventType === "repay_ontime") {
+      try {
+        const { creditPoints, borrowPoints, repayBonusPoints } = await import("./points.js");
+        const base = borrowPoints({ loanLamports: loan.loan_amount_lamports, durationDays: loan.duration_days });
+        await creditPoints({
+          userId: loan.user_id,
+          sourceType: "repay",
+          sourceId: `repay:${loan.loan_pda}`,
+          category: "repayment",
+          points: repayBonusPoints(base, eventType),
+          metadata: { loan_pda: loan.loan_pda, variant: eventType },
+        });
+      } catch (err) {
+        console.error("[loans] repay points credit failed (non-fatal):", err.message);
+      }
     }
     // Streak tracking — increment on on-time, reset on late.
     try {

--- a/src/services/points-reconciler.js
+++ b/src/services/points-reconciler.js
@@ -1,0 +1,43 @@
+/**
+ * points-reconciler.js — periodic self-heal for the points ledger.
+ * ─────────────────────────────────────────────────────────────────────────
+ * The live forward-sync (loans.js recordLoan/markLoanRepaid) credits points
+ * INLINE the same turn a borrow/repay lands. This reconciler is the backstop
+ * the points mandate requires: if the bot crashed mid-tx (or was down during a
+ * borrow), the inline credit could be missed. Re-running the fully-idempotent
+ * backfill — every credit goes through creditPoints' ON CONFLICT(source_type,
+ * source_id) DO NOTHING — self-heals any gap with zero double-credit.
+ *
+ * It also clears the historical backlog: every loan opened between the
+ * 2026-06-27 manual backfill and the forward-sync deploy (audit 2026-06-28 P0/
+ * P1) gets credited on the first run after deploy.
+ *
+ * Read-only on loan/collateral/vault state; writes ONLY points_events +
+ * user_points_balance. Best-effort — a failed run never affects loans.
+ */
+import { backfillPoints } from "./points-backfill.js";
+
+const INTERVAL_MS = Number(process.env.POINTS_RECONCILE_INTERVAL_MS) || 2 * 60 * 60_000; // 2h
+const FIRST_RUN_DELAY_MS = Number(process.env.POINTS_RECONCILE_FIRST_DELAY_MS) || 90_000; // 90s after boot
+
+async function run() {
+  try {
+    const s = await backfillPoints({ log: () => {} });
+    // Only log when it actually healed something — quiet at steady state.
+    if (s.borrowN || s.firstN || s.repayN) {
+      console.log(
+        `[points-reconciler] healed ${s.borrowN} borrow + ${s.firstN} first-loan + ${s.repayN} repay point-event(s) (of ${s.loans} loans)`,
+      );
+    }
+  } catch (e) {
+    console.warn("[points-reconciler] run failed:", e.message?.slice(0, 140));
+  }
+}
+
+export function startPointsReconciler() {
+  setTimeout(run, FIRST_RUN_DELAY_MS);
+  setInterval(run, INTERVAL_MS);
+  console.log(
+    `[points-reconciler] armed — first run in ${Math.round(FIRST_RUN_DELAY_MS / 1000)}s, then every ${Math.round(INTERVAL_MS / 60_000)} min`,
+  );
+}


### PR DESCRIPTION
Protocol functional verification (evidence-based, adversarially confirmed) found two live problems.

## P0 — points were not accruing for new loans
`creditPoints` was only ever called by the one-shot backfill; the live borrow/repay paths never called it. Points froze at the 2026-06-27 backfill — **96 loans missing, 22 users short, 2 users with loans showing literal 0** (the 'dashboard reads 0' regression the points mandate forbids; the gap grew every borrow).

- **Forward-sync:** `recordLoan` credits borrow + first-loan inline; `markLoanRepaid` credits the early/on-time repay bonus inline. Same deterministic source_ids as the backfill → idempotent (ON CONFLICT DO NOTHING). try/catch-guarded.
- **Reconciler** (`points-reconciler.js`): re-runs the idempotent backfill on boot (clears the backlog → the 2 zero-users get credited) + every 2h as self-heal. Started from index.js.

## P1 — /api/v1/transparency was 500'ing
Selected non-existent column `total_distributed_lamports`; real column is `pool_lamports` (verified against live schema).

Read-only on loan/collateral state; writes only points_events + balances. Latent P2/P3 hardening tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)