### PR TITLE
Protocol-verification P2/P3 hardening (#54)

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -571,6 +571,12 @@ function classifyBorrowOutcome(result) {
   if (result.status === 503 && b.paused === true) {
     return { outcome: "failure", klass: "killswitch" };
   }
+  // Security-relevant rejections get their OWN failure_class (audit 2026-06-28
+  // P3): the cosign LTV category-byte guard + malformed-tx refusal would
+  // otherwise bucket into generic bad_request, so adversarial probing of the
+  // on-chain LTV byte wasn't alertable. Per the proactive-error-prevention rule.
+  if (b.error === "category_byte_mismatch") return { outcome: "failure", klass: "category_byte_mismatch" };
+  if (b.error === "malformed_borrow_tx") return { outcome: "failure", klass: "malformed_borrow_tx" };
   if (result.status === 400) return { outcome: "failure", klass: "bad_request" };
   if (result.status === 503) return { outcome: "failure", klass: "unavailable" };
   if (result.status === 500) return { outcome: "failure", klass: "server_error" };
@@ -1065,7 +1071,11 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
           // refusal is the structural guarantee: even with stale client
           // code, a wrong-program borrow CANNOT be signed by the lender.
           // The user sees a clear error and is forced to refresh.
-          const isRwaMint = ["stock", "etf", "metal"].includes(mintRow.category);
+          // Includes 'rwa' (audit 2026-06-28 P3): unify the RWA-category set with
+          // the rest of the codebase (token-catalog-announcer, engine carve-outs)
+          // so a category='rwa' mint is consistently treated as RWA for the LTV
+          // category byte. Fail-closed today, but the divergence was a latent footgun.
+          const isRwaMint = ["stock", "etf", "metal", "rwa"].includes(mintRow.category);
           const ixProgramId = magpieIx.programId;
           // V4-exclusive routing (2026-06-15): V4 is the only pool that
           // services exit-armed borrows, regardless of category. Routing

--- a/src/governance/pipeline.js
+++ b/src/governance/pipeline.js
@@ -370,8 +370,18 @@ export async function processProposal(proposal) {
       // Plurality among the non-ABSTAIN options.
       let topWeight = -1n;
       let tie = false;
+      // Constrain winner math to choices ACTUALLY on the ballot (audit
+      // 2026-06-28 P3): an off-ballot / stale vote bucket (e.g. a legacy 'E'
+      // cast before the API rejected invalid choices) must never enter the
+      // plurality. Symmetric to the submission-side choices.includes(vote)
+      // guard; empty/absent proposal.choices falls back to prior behavior.
+      const ballotChoices = new Set(
+        (Array.isArray(proposal.choices) ? proposal.choices : []).map((c) => String(c).toUpperCase()),
+      );
       for (const [choice, raw] of Object.entries(perChoice)) {
-        if (String(choice).toUpperCase() === "ABSTAIN") continue;
+        const cu = String(choice).toUpperCase();
+        if (cu === "ABSTAIN") continue;
+        if (ballotChoices.size > 0 && !ballotChoices.has(cu)) continue;
         const w = BigInt(raw || "0");
         if (w > topWeight) { topWeight = w; winnerChoice = choice; tie = false; }
         else if (w === topWeight && w > 0n) { tie = true; }

--- a/src/services/pending-arm-retry-watcher.js
+++ b/src/services/pending-arm-retry-watcher.js
@@ -42,6 +42,7 @@
  */
 import { query } from "../db/pool.js";
 import { notifyAdmin } from "./admin-notify.js";
+import { markCycle } from "../lib/heartbeat.js";
 
 const INTERVAL_MS = Number(
   process.env.PENDING_ARM_WATCHER_INTERVAL_MS || 10_000,
@@ -59,20 +60,21 @@ export function startPendingArmRetryWatcher(bot) {
     console.log("[pending-arm] DISABLED via PENDING_ARM_WATCHER_DISABLED env");
     return;
   }
-  // First tick after 30s so the boot storm settles.
+  // First tick after 30s so the boot storm settles. markCycle on each
+  // successful run → provable on /health heartbeats (audit 2026-06-28 P2).
   setTimeout(() => {
-    runOnce(bot).catch((e) =>
-      console.warn(`[pending-arm] first tick failed: ${e.message?.slice(0, 160)}`),
-    );
+    runOnce(bot)
+      .then(() => markCycle("pending-arm-watcher"))
+      .catch((e) => console.warn(`[pending-arm] first tick failed: ${e.message?.slice(0, 160)}`));
     _timer = setInterval(() => {
       if (_running) {
         // Previous tick still in flight — skip this one so we don't
         // pile up overlapping iterations during slow DB queries.
         return;
       }
-      runOnce(bot).catch((e) =>
-        console.warn(`[pending-arm] tick failed: ${e.message?.slice(0, 160)}`),
-      );
+      runOnce(bot)
+        .then(() => markCycle("pending-arm-watcher"))
+        .catch((e) => console.warn(`[pending-arm] tick failed: ${e.message?.slice(0, 160)}`));
     }, INTERVAL_MS);
   }, 30_000);
   console.log(

--- a/src/services/protocol-reserve.js
+++ b/src/services/protocol-reserve.js
@@ -41,27 +41,43 @@ export async function accrueToProtocolReserve({ loanDbId, feeLamports, eventType
   if (reward <= 0n) return null;
 
   try {
-    // Insert the event idempotently first. If the unique constraint
-    // catches a duplicate, the pool counter must NOT bump again.
-    const ins = await query(
-      `INSERT INTO protocol_reserve_events
-         (loan_db_id, event_type, fee_lamports, reward_lamports, reward_bps)
-       VALUES ($1, $2, $3, $4, $5)
-       ON CONFLICT (loan_db_id, event_type) DO NOTHING
-       RETURNING id`,
-      [loanDbId, eventType, fee.toString(), reward.toString(), liveBps],
-    );
-    if (ins.rows.length === 0) return null; // duplicate — already accrued
-
-    await query(
-      `UPDATE protocol_reserve_pool
-          SET accrued_lamports = accrued_lamports + $1::numeric,
+    // ATOMIC idempotent accrual (audit 2026-06-28 P2): previously this was TWO
+    // separate statements (INSERT event, then UPDATE pool), so a crash between
+    // them could record the event but skip the pool bump. Now ONE statement:
+    //   - protocol_reserve_events (UNIQUE(loan_db_id,event_type)) is the
+    //     idempotency GUARD — kept so existing accruals (not yet in
+    //     pool_credit_events) are never re-credited;
+    //   - a forward dual-write into the CANONICAL pool_credit_events ledger
+    //     happens ONLY when the event was newly inserted (matches the
+    //     creditProtocolReserveDirect pattern — pool-credit idempotency mandate);
+    //   - the pool UPDATE gates on EXISTS(the new event) so it can never
+    //     double-bump.
+    const sourceId = `loan:${loanDbId}:${eventType}`;
+    const { rows } = await query(
+      `WITH ev AS (
+         INSERT INTO protocol_reserve_events
+           (loan_db_id, event_type, fee_lamports, reward_lamports, reward_bps)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (loan_db_id, event_type) DO NOTHING
+         RETURNING id
+       ),
+       pce AS (
+         INSERT INTO pool_credit_events (source_type, source_id, pool_kind, lamports, metadata)
+         SELECT 'protocol_reserve_accrual', $6, 'protocol_reserve', $4::numeric,
+                jsonb_build_object('loan_db_id', $1, 'event_type', $2)
+         FROM ev
+         ON CONFLICT (source_type, source_id, pool_kind) DO NOTHING
+         RETURNING id
+       )
+       UPDATE protocol_reserve_pool
+          SET accrued_lamports = accrued_lamports + $4::numeric,
               last_accrual_at = NOW(),
               updated_at = NOW()
-        WHERE id = 1`,
-      [reward.toString()],
+        WHERE id = 1 AND EXISTS (SELECT 1 FROM ev)
+        RETURNING accrued_lamports::text AS new_total`,
+      [loanDbId, eventType, fee.toString(), reward.toString(), liveBps, sourceId],
     );
-    return reward;
+    return rows.length > 0 ? reward : null;
   } catch (err) {
     console.error("[protocol-reserve] accrual failed:", err.message);
     return null;

--- a/src/services/stocks-rwa-protection-sentinel.js
+++ b/src/services/stocks-rwa-protection-sentinel.js
@@ -25,6 +25,7 @@
  * the drift the moment it happens.
  */
 import { query } from "../db/pool.js";
+import { markCycle } from "../lib/heartbeat.js";
 
 const PERIODIC_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -90,9 +91,12 @@ export function startStocksRwaProtectionSentinel() {
   console.log(
     "[stocks-rwa-sentinel] starting — boot enforcement now, then every 5 min",
   );
-  enforceStocksRwaProtection("boot");
+  // markCycle on each successful enforcement → provable "doing its job" on
+  // /api/v1/health heartbeats (audit 2026-06-28 P2). Reported only, does not
+  // gate overall health status. enforceStocksRwaProtection never throws.
+  enforceStocksRwaProtection("boot").then(() => markCycle("stocks-rwa-sentinel"));
   setInterval(
-    () => enforceStocksRwaProtection("periodic"),
+    () => enforceStocksRwaProtection("periodic").then(() => markCycle("stocks-rwa-sentinel")),
     PERIODIC_INTERVAL_MS,
   );
 }

--- a/src/services/wallet-attribution-sentinel.js
+++ b/src/services/wallet-attribution-sentinel.js
@@ -29,6 +29,7 @@
 
 import { query } from "../db/pool.js";
 import { getAdminId, notifyAdmin } from "./admin-notify.js";
+import { markCycle } from "../lib/heartbeat.js";
 
 // Cadence tightened from 30min -> 5min 2026-06-18 PM. With Layer 4
 // auto-repair (PR #393), the sentinel now FIXES drift inline, so a
@@ -163,6 +164,7 @@ export function startWalletAttributionSentinel(bot) {
   setTimeout(async function tick() {
     try {
       await runOneCycle(bot);
+      markCycle("wallet-attr-sentinel"); // audit P2 — provable on /health heartbeats
     } catch (err) {
       console.error("[wallet-attr-sentinel] tick failed:", err?.message?.slice(0, 200));
     } finally {


### PR DESCRIPTION
From the 2026-06-28 protocol functional verification — all latent / no live user impact (the live P0/P1 shipped in #516).

- **P2 idempotency:** `accrueToProtocolReserve` → one atomic statement; `protocol_reserve_events` stays the idempotency guard, forward dual-write into the canonical `pool_credit_events` ledger, pool UPDATE gated on EXISTS(new event). Mirrors the proven `creditProtocolReserveDirect` CTE.
- **P2 observability:** stocks-rwa / wallet-attribution / pending-arm sentinels now `markCycle()` → visible in /health heartbeats (reported only, doesn't gate status → no false BOT-DOWN).
- **P3 governance:** plurality winner loop intersects with `proposal.choices`.
- **P3 security:** cosign `isRwaMint` includes 'rwa'; `classifyBorrowOutcome` gives `category_byte_mismatch`/`malformed_borrow_tx` their own failure_class.

All 6 files node --check clean. Read-only on loan/collateral state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)