### PR TITLE
Option A: /rewardsrecon read-only fee-revenue reconciliation

### DIFF
--- a/src/commands/admin.js
+++ b/src/commands/admin.js
@@ -1669,6 +1669,93 @@ export async function handleDistribute(ctx) {
 }
 
 /**
+ * /rewardsrecon — READ-ONLY holder-rewards reconciliation (Option A support).
+ *
+ * Implements the "size payouts to real fee revenue" decision: shows what the
+ * holder pool has accrued (by fee source), what has actually been distributed,
+ * and how much REAL fee revenue is sitting in the distribution wallet right now
+ * — so distributions are sized to genuine fees, never a subsidy.
+ *
+ * SAFETY: strictly read-only. No SOL moves, no DB writes, no payout/loan/
+ * collateral state touched — zero exploit surface. Admin-gated. All SQL is
+ * parameter-free aggregation over existing ledgers.
+ */
+export async function handleRewardsRecon(ctx) {
+  if (!(await requireAdmin(ctx))) return;
+  try {
+    const LAMPORTS = 1e9;
+    const sol = (v) => (Number(v || 0) / LAMPORTS).toFixed(4);
+
+    // 1. Current accrued IOU on the holder pool.
+    const accruedRow = await query(
+      `SELECT COALESCE(accrued_lamports, 0)::text AS amt FROM magpie_holder_pool WHERE id = 1`,
+    ).then((r) => r.rows[0]).catch(() => null);
+    const accrued = BigInt(accruedRow?.amt || 0);
+
+    // 2. Accrual breakdown by fee source (what really drove the IOU).
+    const bySource = await query(
+      `SELECT source_type,
+              COALESCE(SUM(lamports), 0)::text AS total,
+              COUNT(*)::int                    AS n
+         FROM pool_credit_events
+        WHERE pool_kind = 'holder'
+        GROUP BY source_type
+        ORDER BY SUM(lamports) DESC`,
+    ).then((r) => r.rows).catch(() => []);
+    const totalCredited = bySource.reduce((s, r) => s + BigInt(r.total), 0n);
+
+    // 3. Lifetime distributed to holders (paid rows are the truth).
+    const distributed = await query(
+      `SELECT COALESCE(SUM(reward_lamports), 0)::text AS amt
+         FROM magpie_holder_rewards WHERE status = 'paid'`,
+    ).then((r) => BigInt(r.rows[0]?.amt || 0)).catch(() => 0n);
+
+    // 4. REAL fee revenue available right now = distribution wallet native SOL.
+    //    (The auto-funder fills this only from real fees — never a subsidy.)
+    let distWalletSol = null;
+    try {
+      const { connection } = await import("../solana/connection.js");
+      const { PublicKey } = await import("@solana/web3.js");
+      const distPk = new PublicKey(
+        process.env.REWARDS_DISTRIBUTOR_PUBKEY || "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac",
+      );
+      distWalletSol = Number(await connection.getBalance(distPk, "confirmed")) / LAMPORTS;
+    } catch { /* RPC blip — show null */ }
+
+    const RESERVE_SOL = 0.1;
+    const distributableNow =
+      distWalletSol == null ? null : Math.max(0, distWalletSol - RESERVE_SOL);
+
+    const lines = [
+      "*Holder-rewards reconciliation* (read-only)",
+      "",
+      `Accrued (owed IOU): \`${sol(accrued)} SOL\``,
+      `Lifetime distributed: \`${sol(distributed)} SOL\``,
+      "",
+      "*Accrual by fee source:*",
+      ...(bySource.length
+        ? bySource.map((r) => `  • ${r.source_type}: \`${sol(r.total)}\` (${r.n})`)
+        : ["  _(no pool_credit_events rows)_"]),
+      `  total credited: \`${sol(totalCredited)} SOL\``,
+      "",
+      `Distribution wallet now: \`${distWalletSol == null ? "?" : distWalletSol.toFixed(4)} SOL\` (real fee revenue)`,
+      `*Distributable now (Option A): \`${distributableNow == null ? "?" : distributableNow.toFixed(4)} SOL\`*`,
+      "",
+      "_Option A = size the next distribution to the line above (real fees), not the accrued IOU. The auto-funder keeps this topped from genuine fee revenue; it never subsidizes._",
+    ];
+    if (Math.abs(Number(totalCredited - accrued)) > LAMPORTS) {
+      lines.push(
+        "",
+        `_Note: credited (${sol(totalCredited)}) ≠ accrued (${sol(accrued)}) — difference = lifetime distributions already drawn down._`,
+      );
+    }
+    await ctx.reply(lines.join("\n"), { parse_mode: "Markdown" });
+  } catch (err) {
+    await ctx.reply(`❌ rewardsrecon failed: ${err.message?.slice(0, 200)}`);
+  }
+}
+
+/**
  * /aistats — last-24h snapshot of the AI support agent.
  *
  * Shows total conversations, turns, tool usage breakdown,

--- a/src/index.js
+++ b/src/index.js
@@ -127,6 +127,7 @@ import {
   handleFundPool,
   handleSnapshotOnly,
   handleDistribute,
+  handleRewardsRecon,
   handleReconcile,
   handleReply,
   handleTickets,
@@ -372,6 +373,7 @@ bot.command("reviewtokens", handleReviewTokens);
 bot.command("fundpool", handleFundPool);
 bot.command("snapshotonly", handleSnapshotOnly);
 bot.command("distribute", handleDistribute);
+bot.command("rewardsrecon", handleRewardsRecon); // read-only Option-A reconciliation
 bot.command("reconcile", handleReconcile);
 bot.command("reply", handleReply);
 bot.command("tickets", handleTickets);


### PR DESCRIPTION
Implements the operator's **Option A** (size payouts to real fee revenue, never subsidize).

New **read-only** admin command `/rewardsrecon` reports:
- Holder-pool accrued IOU
- Accrual broken down by fee source (`borrow_fee`, `extend_fee`, `limit_close_fee`, `x402_fee`, …)
- Lifetime distributed
- Distribution wallet's actual on-chain balance
- **Distributable now** = real fee revenue available → size the next distribution to this, not the accrued IOU

Pairs with the auto-funder (#523/#524), which already enforces no-subsidy at the funding layer.

**Safety:** strictly read-only — SELECT aggregations + one on-chain `getBalance`, admin-gated, parameter-free SQL, no writes, no SOL movement, no payout/loan/collateral state touched. Zero exploit surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)