### PR TITLE
premium-tier-screener: remove weekend origination block — 24/7/365 borrowing

### DIFF
--- a/src/services/premium-tier-screener.js
+++ b/src/services/premium-tier-screener.js
@@ -103,18 +103,18 @@ export async function screenPremiumBorrow(opts) {
   const gateStart = Date.now();
   const gateTimes = {};
 
-  // ── Gate 0: Friday-close cutoff ───────────────────────────────────
-  // Refuse to ORIGINATE new premium-tier loans during the weekend window.
-  // Cheap to evaluate (no DB / RPC) so it short-circuits before the rest.
-  // Existing premium loans roll through the weekend unaffected.
-  const at = opts.now ? new Date(opts.now * 1000) : new Date();
-  if (isInWeekendCutoff(at)) {
-    const reopens = nextWeekendOpenIso(at);
-    return refused(
-      "weekend_cutoff",
-      `New premium-tier borrows pause Friday ${PREMIUM_TIER_WEEKEND_CLOSE_HOUR_UTC.toString().padStart(2, "0")}:00 UTC → Monday ${PREMIUM_TIER_WEEKEND_OPEN_HOUR_UTC.toString().padStart(2, "0")}:${PREMIUM_TIER_WEEKEND_OPEN_MINUTE_UTC.toString().padStart(2, "0")} UTC so US-equity peg + oracle data stay reliable. Existing premium loans are unaffected — repay/extend/topup remain available. New borrows reopen ${reopens}.`,
-    );
-  }
+  // ── No weekend / market-hours block on origination (operator 2026-06-29) ──
+  // Magpie operates 24/7/365. Collateral here is an ON-CHAIN tokenized stock
+  // trading around the clock on Jupiter — the on-chain price IS the live
+  // (after-hours/weekend) price. A user must NEVER be unable to open a loan at
+  // any hour of any day, just as they must always be able to repay or have an
+  // exit order fill. The old Friday-close → Monday-open origination gate was
+  // REMOVED. Weekend-peg drift (~3-5%) is absorbed by the protections that
+  // remain below — the tier-aware max-LTV cap (Gate 2b), the robust
+  // cross-sourced collateral price, and the on-chain attestation cap — NOT by
+  // blocking the borrow. (The arm path's weekend slippage *bump* in
+  // limit-close-arm-core.js is intentionally kept: it only widens headroom
+  // within the user's own cap to help off-hours fills succeed — it never blocks.)
 
   // ── Gate 1: category gate ────────────────────────────────────────
   let t = Date.now();


### PR DESCRIPTION
**Operator mandate (2026-06-29):** crypto is 24/7 — there must NEVER be a moment any day where a user can't **take a loan, repay, or have an exit fill.** We operate 24/7/365.

Removes **Gate 0** (the Friday-close → Monday-open premium-tier *origination* block). Tokenized stocks are on-chain tokens trading 24/7 on Jupiter — the on-chain price IS the live after-hours/weekend price; blocking weekend borrows was a failed conversion and anti-crypto.

Weekend-peg drift (~3–5%) is absorbed by the protections that **remain** — not a time block:
- tier-aware **max-LTV cap** (Gate 2b — crypto-adjacent equities capped lower)
- **robust cross-sourced** collateral price (Jupiter-primary)
- **on-chain attestation cap**

The arm path's weekend slippage *bump* (`limit-close-arm-core.js`) is kept — it only widens headroom within the user's own cap to help off-hours fills; it never blocks.

Companion to the engine change (`magpie-limitclose/watcher.js`) that removed the exit-fire market-hours gate. Together: **borrow + repay + exit all 24/7/365.** Repay was already never time-gated (verified). `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)