### PR TITLE
holder-rewards: fire overdue distribution ~3min after boot (not 1h)

### DIFF
--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -1261,6 +1261,15 @@ export function startHolderDistributor(bot) {
     }
   }
 
-  setTimeout(tick, 60 * 60 * 1000); // first check 1h after boot
+  // First check shortly after boot so an OVERDUE + funded distribution fires
+  // promptly instead of waiting a full hour. tick() is self-gating
+  // (next_distribution_at in the past + distributor funded) and idempotent —
+  // after a fire it reschedules next_distribution_at to a future window, so a
+  // subsequent boot inside that window won't re-fire. Env-tunable.
+  const firstCheckMs = Math.max(
+    30 * 1000,
+    Number(process.env.HOLDER_DISTRIBUTOR_FIRST_CHECK_MS) || 3 * 60 * 1000,
+  );
+  setTimeout(tick, firstCheckMs); // first check ~3min after boot
   setInterval(tick, 6 * 60 * 60 * 1000); // then every 6h
 }


### PR DESCRIPTION
Pairs with #529. The distributor's first post-boot check waited a full hour, so an **overdue + funded** $MAGPIE holder distribution sat idle up to an hour after each deploy. Reduce the first check to ~3 min (env-tunable `HOLDER_DISTRIBUTOR_FIRST_CHECK_MS`, 30s floor).

`tick()` is self-gating (`next_distribution_at` in the past + distributor funded) and idempotent — it reschedules `next_distribution_at` to a future window after a fire, so a boot inside that window won't re-fire. With #529's pre-flight wSOL unwrap, the distributor self-funds from wrapped fees at tick time.

No loan/collateral impact. Lets today's overdue snapshot fire within minutes of the rewards-distributor key being set, instead of waiting an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)