### PR TITLE
lp-loyalty: gate pre-flight on actual third-party payout (not full pool)

### DIFF
--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -390,14 +390,14 @@ export async function snapshotAndDistributeLpLoyalty() {
   // Sync from chain so positions are current
   await syncOnChainPositions();
 
-  // Pre-flight distributor balance (REWARDS_DISTRIBUTOR_PRIVATE_KEY,
-  // with backward-compat fallback to LENDER_PRIVATE_KEY).
+  // Distributor (REWARDS_DISTRIBUTOR_PRIVATE_KEY, fallback LENDER_PRIVATE_KEY).
+  // NOTE: the balance pre-flight is DEFERRED until after allocatedSum is known
+  // (below). Exempt wallets (the operator's ~96% LP seed) stay in the
+  // denominator so only the third-party slice is actually paid; gating here on
+  // the FULL pool would wrongly skip a correctly-sized run whenever most LP
+  // weight is the operator's exempt seed. We check against the real payout.
   const distributor = getRewardsDistributorKeypair();
   const distributorBalance = BigInt(await connection.getBalance(distributor.publicKey));
-  if (distributorBalance < pool + MIN_LENDER_RESERVE_LAMPORTS) {
-    console.warn(`[lp-loyalty] Skipped: distributor balance too low for pool ${pool}`);
-    return null;
-  }
 
   // Pull eligible LPs
   const { rows } = await query(
@@ -452,6 +452,21 @@ export async function snapshotAndDistributeLpLoyalty() {
     items.push({ wallet: r.wallet_address, shares, seconds, weight });
   }
   if (totalWeight === 0n || items.length === 0) return null;
+
+  // Deferred pre-flight: gate on the ACTUAL third-party payout (allocatedSum),
+  // not the full pool. Exempt seed stays in the denominator, so the real spend
+  // is (sum of third-party weight / totalWeight) × pool — typically a small
+  // slice. Requiring the full pool here was an over-block that stranded
+  // correctly-sized runs. [[feedback_lender_wallet_exempt_from_lp_loyalty]]
+  let previewAlloc = 0n;
+  for (const it of items) previewAlloc += (pool * it.weight) / totalWeight;
+  if (previewAlloc <= 0n) return null;
+  if (distributorBalance < previewAlloc + MIN_LENDER_RESERVE_LAMPORTS) {
+    console.warn(
+      `[lp-loyalty] Skipped: distributor balance ${distributorBalance} < payout ${previewAlloc} + reserve ${MIN_LENDER_RESERVE_LAMPORTS}`,
+    );
+    return null;
+  }
 
   // Phase 1: insert distribution row + reward rows (transactional)
   const { pool: dbPool } = await import("../db/pool.js");


### PR DESCRIPTION
## Why
`snapshotAndDistributeLpLoyalty` keeps exempt wallets (operator's ~96% LP seed) in the weight **denominator** but pays only the third-party slice — so the real spend is `allocatedSum` (e.g. **0.192 SOL** of a 4.655 pool). The pre-flight gated on `distributorBalance < pool + reserve` (the full 4.655), wrongly **skipping a correctly-sized run** whenever most LP weight is the operator's exempt seed. This is part of the "never a deficit" funding hardening.

## Change (`src/services/lp-loyalty.js`)
Defer the balance check until after the per-LP allocation is computed; gate on `allocatedSum + reserve` instead of the full pool. No change to amounts, recipients, exemption logic, or the pool decrement.

Verified live: drove the 0.192 SOL → 15 third-party LP distribution (dist 24) with this fix; operator's 4.463 retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)