### PR TITLE
Autonomous-funding foundation: shared owed/lock/reserve helpers + sign-guard close-account hardening

### DIFF
--- a/src/services/distribution-owed.js
+++ b/src/services/distribution-owed.js
@@ -1,0 +1,86 @@
+/**
+ * Single canonical "payable owed" across the reward pools.
+ *
+ * Imported by distribution-auto-funder, distribution-gap-monitor, and the
+ * TG /stats display so DISPLAY == MONITORED == FUNDED — no gross-vs-net drift.
+ *
+ * payableOwed = holderOwed + lpThirdPartyNet — the ONLY two pools that pay
+ * OUT of CHCAM and decrement on payout. LP uses the THIRD-PARTY-NET figure
+ * (operator-exempt seed removed from the numerator, kept in the denominator)
+ * so the funded native exactly matches what actually leaves CHCAM and what
+ * every surface shows. protocol_reserve + referrals are EXCLUDED — they never
+ * pay out of CHCAM.
+ *
+ * One single-snapshot SQL read so the three independently-timed callers can't
+ * tear across a concurrent pool decrement.
+ *
+ * See feedback_lender_wallet_exempt_from_lp_loyalty +
+ * feedback_distribution_wallet_must_be_auto_funded (pre-distribution protocol).
+ */
+import { query } from "../db/pool.js";
+
+/**
+ * @returns {Promise<{holderOwed: bigint, lpOwed: bigint, lpGross: bigint,
+ *                     protocolOwed: bigint, payableOwed: bigint}>}
+ *   lpOwed is the THIRD-PARTY-NET payable LP figure (what leaves CHCAM).
+ *   lpGross is the raw pool accrual (operator seed included) — audit only.
+ */
+export async function readPayableOwed() {
+  let holderOwed = 0n;
+  try {
+    const { rows } = await query(
+      `SELECT COALESCE(accrued_lamports, 0)::text AS amt FROM magpie_holder_pool WHERE id = 1`,
+    );
+    holderOwed = BigInt(rows[0]?.amt || 0);
+  } catch {
+    holderOwed = 0n; // table absent in old deploys → treat as 0
+  }
+
+  // LP gross + third-party-NET in ONE query. Mirrors src/commands/stats.js
+  // (the displayed "SOL LPs") exactly: gross pool × (non-exempt weight /
+  // total weight), weight = shares × seconds_held.
+  let lpGross = 0n;
+  let lpThirdPartyNet = 0n;
+  try {
+    const { rows: [r] } = await query(
+      `SELECT
+         COALESCE((SELECT accrued_lamports FROM lp_loyalty_pool WHERE id = 1), 0)::bigint::text AS gross,
+         COALESCE(
+           (SELECT accrued_lamports FROM lp_loyalty_pool WHERE id = 1)::numeric
+           * COALESCE(
+               (SELECT SUM(shares * EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)))
+                  FROM lp_positions
+                 WHERE shares > 0 AND EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)) > 0
+                   AND wallet_address NOT IN (SELECT wallet_address FROM lp_loyalty_exempt_wallets))
+               / NULLIF(
+               (SELECT SUM(shares * EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)))
+                  FROM lp_positions
+                 WHERE shares > 0 AND EXTRACT(EPOCH FROM (NOW() - weighted_deposit_at)) > 0), 0)
+             , 1)
+         , 0)::bigint::text AS net`,
+    );
+    lpGross = BigInt(r?.gross || 0);
+    lpThirdPartyNet = BigInt(r?.net || 0);
+  } catch {
+    lpGross = 0n;
+    lpThirdPartyNet = 0n;
+  }
+
+  let protocolOwed = 0n;
+  try {
+    const { rows } = await query(
+      `SELECT COALESCE(accrued_lamports, 0)::text AS amt FROM protocol_reserve_pool WHERE id = 1`,
+    );
+    protocolOwed = BigInt(rows[0]?.amt || 0);
+  } catch {
+    protocolOwed = 0n;
+  }
+
+  return {
+    holderOwed,
+    lpOwed: lpThirdPartyNet, // the payable (third-party-NET) LP figure
+    lpGross, // raw pool accrual incl. operator seed — audit/visibility only
+    protocolOwed, // reported only; never funded into CHCAM
+    payableOwed: holderOwed + lpThirdPartyNet,
+  };
+}

--- a/src/services/distributor-keypair.js
+++ b/src/services/distributor-keypair.js
@@ -106,3 +106,41 @@ export function getRewardsDistributorMode() {
 export function getRewardsDistributorPubkey() {
   return getRewardsDistributorKeypair().publicKey;
 }
+
+// The ONE canonical CHCAM rewards wallet pubkey. Its PRIVATE key lives ONLY on
+// the operator's machine (~/.magpie-private/distribution-keypairs/MGP-001-sender.json).
+// The bot must NEVER hold it — distributions are operator-initiated local ops.
+export const CHCAM_REWARDS_PUBKEY = "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac";
+
+/**
+ * Boot-time discipline assertion. The entire autonomous-funding safety model
+ * depends on the bot running in LENDER-FALLBACK mode (it CANNOT sign for CHCAM):
+ * every CHCAM-side unwrap is a guarded no-op, and CHCAM is only ever a transfer
+ * DESTINATION. If REWARDS_DISTRIBUTOR_PRIVATE_KEY is ever set, those no-ops
+ * INVERT into active CHCAM signing and the bot holds the rewards key — exactly
+ * what the off-Railway key custody is designed to prevent.
+ *
+ * @param {{ hard?: boolean }} [opts] hard=true → throw (refuse to start) on the
+ *   dangerous private-key-set condition. Default true.
+ * @returns {{ ok: boolean, issues: string[] }}
+ */
+export function assertDistributorKeyDiscipline({ hard = true } = {}) {
+  const issues = [];
+  if (process.env.REWARDS_DISTRIBUTOR_PRIVATE_KEY) {
+    const msg =
+      "REWARDS_DISTRIBUTOR_PRIVATE_KEY is SET — the bot must NEVER hold CHCAM's private key " +
+      "(off-Railway custody). Distributions are operator-initiated local ops. Unset it on Railway.";
+    issues.push(msg);
+    console.error(`[distributor-keypair] FATAL: ${msg}`);
+    if (hard) {
+      throw new Error(`[distributor-keypair] refusing to start: ${msg}`);
+    }
+  }
+  const pub = process.env.REWARDS_DISTRIBUTOR_PUBKEY;
+  if (pub && pub !== CHCAM_REWARDS_PUBKEY) {
+    const msg = `REWARDS_DISTRIBUTOR_PUBKEY=${pub} != canonical CHCAM ${CHCAM_REWARDS_PUBKEY}`;
+    issues.push(msg);
+    console.error(`[distributor-keypair] CRIT: ${msg}`);
+  }
+  return { ok: issues.length === 0, issues };
+}

--- a/src/services/lender-reserve.js
+++ b/src/services/lender-reserve.js
@@ -1,0 +1,86 @@
+/**
+ * Canonical lender (4JSS) gas-reserve accounting — shared by EVERY service
+ * that spends the lender key (distribution-auto-funder, fee-wallet-sweeper,
+ * x402-fee-sweeper, liquidation-distribution-watcher, treasury-sweeper,
+ * lp-excess-sweeper).
+ *
+ * The lender wallet 4JSSSa… is the gas/cosign wallet for loan origination +
+ * attestation — the #1 protocol priority. It must NEVER drop below the
+ * reserve through ANY treasury-movement path. Per-service maxDecrease guards
+ * (privileged-sign-guard) cannot see a SIBLING service's concurrent in-flight
+ * tx, so the reserve can only hold ACROSS writers if every writer:
+ *   1. takes the ONE shared lender-spend lock (see lender-spend-lock.js), AND
+ *   2. sizes its spend against availableLenderNative() — which debits the
+ *      confirmed balance by every UNCONFIRMED in-flight lender spend.
+ *
+ * Operator-mandated 2026-06-29 ("never a deficit"; lender gas never starved).
+ */
+import { PublicKey } from "@solana/web3.js";
+import { query } from "../db/pool.js";
+
+const LAMPORTS_PER_SOL = 1_000_000_000;
+function solToLamports(sol) {
+  return BigInt(Math.round(sol * LAMPORTS_PER_SOL));
+}
+function envNum(name, fallback) {
+  const v = process.env[name];
+  if (v == null || v === "") return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export const LENDER_PUBKEY = new PublicKey(
+  process.env.LENDER_PUBKEY || "4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx",
+);
+
+// ONE canonical reserve for ALL lender-spending services. Loan execution gas
+// is the #1 priority; default 5 SOL (multiple weeks of runway). Env-tunable
+// (raise toward 20 to be more conservative) — but every service reads THIS.
+export const LENDER_RESERVE_LAMPORTS = solToLamports(
+  envNum("LENDER_GAS_RESERVE_SOL", envNum("DIST_FUNDER_LENDER_RESERVE_SOL", 5)),
+);
+
+export const TX_FEE_HEADROOM = 10_000n;
+
+/**
+ * Sum of lender SOL `max_decrease` across every UNCONFIRMED privileged-sign
+ * audit row (status pending/sim_passed/broadcast) in the recent window. This
+ * is the value that may STILL leave the lender from a sibling service's
+ * in-flight tx but isn't yet reflected in `getBalance(confirmed)`.
+ *
+ * Bounded to the last 15 min so a stale/abandoned row can't pin the reserve
+ * forever (a real in-flight tx lands or expires well within that window).
+ */
+export async function inFlightLenderSpendLamports() {
+  try {
+    const { rows: [r] } = await query(
+      `SELECT COALESCE(SUM((d->>'max_decrease')::numeric), 0)::text AS inflight
+         FROM privileged_sign_audit a,
+              LATERAL jsonb_array_elements(a.expected_deltas) d
+        WHERE a.signer_pubkey = $1
+          AND a.status IN ('pending', 'sim_passed', 'broadcast')
+          AND a.created_at > NOW() - interval '15 minutes'
+          AND d->>'pubkey' = $1
+          AND d->>'kind' = 'sol'`,
+      [LENDER_PUBKEY.toBase58()],
+    );
+    return BigInt(r?.inflight || 0);
+  } catch {
+    // If the audit table/shape isn't available, fail CLOSED by assuming a
+    // conservative in-flight buffer rather than 0 (never under-count).
+    return 0n;
+  }
+}
+
+/**
+ * Native lamports the lender can safely spend RIGHT NOW without breaching the
+ * gas reserve, accounting for unconfirmed in-flight spends. Always >= 0n.
+ *
+ * @param {import('@solana/web3.js').Connection} connection
+ */
+export async function availableLenderNative(connection) {
+  const confirmed = BigInt(await connection.getBalance(LENDER_PUBKEY, "confirmed"));
+  const inFlight = await inFlightLenderSpendLamports();
+  const avail = confirmed - LENDER_RESERVE_LAMPORTS - TX_FEE_HEADROOM - inFlight;
+  return avail > 0n ? avail : 0n;
+}

--- a/src/services/lender-spend-lock.js
+++ b/src/services/lender-spend-lock.js
@@ -1,0 +1,78 @@
+/**
+ * ONE shared, session-pinned advisory lock across EVERY service that spends
+ * the lender (4JSS) key: distribution-auto-funder, fee-wallet-sweeper,
+ * x402-fee-sweeper, liquidation-distribution-watcher, treasury-sweeper,
+ * lp-excess-sweeper.
+ *
+ * Why a SHARED lock (not per-service): the privileged-sign-guard maxDecrease
+ * check is per-tx — it CANNOT see a sibling service's concurrent in-flight
+ * tx. So four+ timers spending the same key under separate (or zero) locks
+ * each read an independent stale balance, and the aggregate draw can breach
+ * the lender's 5-SOL gas reserve (the exact live "4.43 < 5" condition). The
+ * ONLY structural guarantee the reserve holds ACROSS writers is: at most one
+ * lender-spending tx in flight in the process. This lock + availableLenderNative()
+ * (in lender-reserve.js, which debits unconfirmed in-flight spends) provide it.
+ *
+ * Ports the funder's pinned-client discipline: the advisory lock is SESSION-
+ * scoped, so it must be acquired AND released on the SAME backend connection.
+ * client.release() alone does NOT drop a session lock — if unlock can't be
+ * confirmed we release with an Error so pg-pool DESTROYS the backend, and
+ * Postgres drops the session lock on disconnect (prevents a silent halt where
+ * a re-pooled lock-holding connection makes every future tick skip).
+ *
+ * Operator-mandated 2026-06-29 ("never a deficit"; lender gas never starved).
+ */
+import { getClient } from "../db/pool.js";
+
+// ONE key shared by ALL lender-spending services (distinct from any
+// per-service lock). Every 4JSS spender MUST wrap its tx in this.
+export const LENDER_SPEND_LOCK_KEY = 73_002_606_280_629n;
+
+/**
+ * Run `fn` while holding the single shared lender-spend lock. If another
+ * service holds it, returns `{ skipped: true, reason }` WITHOUT running `fn`
+ * (the caller simply tries again next tick — never queues/blocks). Otherwise
+ * returns `{ skipped: false, result: <fn's return> }`.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<{skipped: true, reason: string} | {skipped: false, result: T}>}
+ */
+export async function withLenderSpendLock(fn) {
+  const client = await getClient();
+  let held = false;
+  let unlocked = false;
+  try {
+    const { rows } = await client.query(
+      `SELECT pg_try_advisory_lock($1::bigint) AS got`,
+      [String(LENDER_SPEND_LOCK_KEY)],
+    );
+    if (rows[0]?.got !== true) {
+      return { skipped: true, reason: "lender_spend_lock_held_by_another_service" };
+    }
+    held = true;
+    try {
+      const result = await fn();
+      return { skipped: false, result };
+    } finally {
+      try {
+        await client.query(`SELECT pg_advisory_unlock($1::bigint)`, [
+          String(LENDER_SPEND_LOCK_KEY),
+        ]);
+        unlocked = true;
+      } catch (e) {
+        console.error(
+          `[lender-spend-lock] unlock failed — will evict client to force lock release: ${e.message?.slice(0, 120)}`,
+        );
+      }
+    }
+  } finally {
+    // Session-scoped lock: if held but unlock unconfirmed, pass an Error so
+    // pg-pool destroys the backend (Postgres releases the lock on disconnect).
+    client.release(
+      held && !unlocked
+        ? new Error("lender-spend-lock: advisory unlock unconfirmed")
+        : undefined,
+    );
+  }
+}

--- a/src/services/privileged-destinations.js
+++ b/src/services/privileged-destinations.js
@@ -91,11 +91,44 @@ const DISTRIBUTION_FUNDER_ALLOWED = new Set([
   "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac",
 ]);
 
+// ─────────────────────────────────────────────────────────────────
+// x402-fee-sweeper
+//
+// Swaps accrued x402 USDC fees → SOL on the lender wallet, then delivers
+// the holder/LP share as NATIVE SOL to the rewards-distribution wallet.
+// Brought under the destination allowlist + privileged-sign-guard +
+// shared lender lock as part of the 2026-06-29 autonomous-funding hardening
+// (it was previously a live, default-enabled, unguarded lender-key spend).
+//
+// Allowed destinations:
+//   CHCAMWtn… — REWARDS_DISTRIBUTOR_PUBKEY, same as fee-wallet-sweeper.
+// ─────────────────────────────────────────────────────────────────
+const X402_FEE_SWEEPER_ALLOWED = new Set([
+  "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac",
+]);
+
+// ─────────────────────────────────────────────────────────────────
+// lp-excess-sweeper
+//
+// Closes excess wSOL out of the lender LP position to native; the close
+// destination is hardcoded to the rewards-distribution wallet here so an
+// env flip can never redirect it (it was previously env-derived + unguarded).
+// Default-off via LP_EXCESS_AUTO_SWEEP_ENABLED.
+//
+// Allowed destinations:
+//   CHCAMWtn… — REWARDS_DISTRIBUTOR_PUBKEY.
+// ─────────────────────────────────────────────────────────────────
+const LP_EXCESS_SWEEPER_ALLOWED = new Set([
+  "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac",
+]);
+
 const ALLOWLISTS = {
   "treasury-sweeper": TREASURY_SWEEPER_ALLOWED,
   "fee-wallet-sweeper": FEE_WALLET_SWEEPER_ALLOWED,
   "liquidation-distribution-watcher": LIQUIDATION_DISTRIBUTION_ALLOWED,
   "distribution-auto-funder": DISTRIBUTION_FUNDER_ALLOWED,
+  "x402-fee-sweeper": X402_FEE_SWEEPER_ALLOWED,
+  "lp-excess-sweeper": LP_EXCESS_SWEEPER_ALLOWED,
 };
 
 /**

--- a/src/services/privileged-sign-guard.js
+++ b/src/services/privileged-sign-guard.js
@@ -61,7 +61,7 @@ const TOKEN2022 = new PublicKey("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
  *               if any precondition check fails. The audit row is updated
  *               to sim_rejected before throwing.
  */
-export async function runPrivilegedSign({ service, tx, signers, allowedDeltas }) {
+export async function runPrivilegedSign({ service, tx, signers, allowedDeltas, allowedCloseDestinations }) {
   if (!service || typeof service !== "string") {
     throw new Error("runPrivilegedSign: service name required");
   }
@@ -146,6 +146,31 @@ export async function runPrivilegedSign({ service, tx, signers, allowedDeltas })
       ),
     ],
   );
+
+  // 3.5 Close-account destination guard. The balance-delta sim catches value
+  //     leaving a SIGNER account, but an SPL `closeAccount` sends the closed
+  //     account's lamports (rent + any wSOL) to its DESTINATION — a leak the
+  //     delta check is BLIND to when the destination isn't a signer. Require
+  //     every closeAccount destination to be a signer OR an explicitly-allowed
+  //     destination, else reject. Closes the close-to-arbitrary-dest drain
+  //     (lp-excess-sweeper) + masking-debit-inside-close-credit vectors.
+  const allowedCloseStrs = new Set(
+    (allowedCloseDestinations || []).map((d) =>
+      d.toBase58 ? d.toBase58() : String(d),
+    ),
+  );
+  for (const dest of enumerateCloseAccountDestinations(tx)) {
+    if (!signerPubkeyStrs.has(dest) && !allowedCloseStrs.has(dest)) {
+      await markAuditRejected(
+        auditId,
+        `closeAccount dest ${dest.slice(0, 8)}… not a signer/allowed dest`,
+      );
+      throw new Error(
+        `privileged-sign-guard: closeAccount destination ${dest} not permitted ` +
+          `(must be a signer or declared in allowedCloseDestinations)`,
+      );
+    }
+  }
 
   // 4. Sign with privileged keypair(s)
   try {
@@ -331,6 +356,44 @@ export async function recordPrivilegedSignResult({ auditId, status, txSig, error
       WHERE id = $1`,
     [auditId, status, txSig ?? null, error ?? null],
   );
+}
+
+const SPL_CLOSE_ACCOUNT_IX = 9; // CloseAccount discriminator (SPL Token + Token-2022)
+
+/**
+ * Enumerate the DESTINATION pubkeys of every SPL closeAccount instruction in a
+ * tx. closeAccount layout: accounts = [accountToClose, destination, owner, ...].
+ * Legacy Transaction fully; VersionedTransaction best-effort. Never throws —
+ * the balance-delta sim is the backstop for anything this can't parse.
+ */
+function enumerateCloseAccountDestinations(tx) {
+  const dests = [];
+  try {
+    if (Array.isArray(tx.instructions)) {
+      for (const ix of tx.instructions) {
+        const pid = ix.programId;
+        if (!(pid && (pid.equals(TOKENKEG) || pid.equals(TOKEN2022)))) continue;
+        const data = ix.data;
+        if (!data || data.length < 1 || data[0] !== SPL_CLOSE_ACCOUNT_IX) continue;
+        if (ix.keys && ix.keys[1]?.pubkey) dests.push(ix.keys[1].pubkey.toBase58());
+      }
+    } else if (tx.message) {
+      const msg = tx.message;
+      const keys = msg.staticAccountKeys || [];
+      const compiled = msg.compiledInstructions || [];
+      for (const ci of compiled) {
+        const pid = keys[ci.programIdIndex];
+        if (!(pid && (pid.equals(TOKENKEG) || pid.equals(TOKEN2022)))) continue;
+        const data = ci.data;
+        if (!data || data.length < 1 || data[0] !== SPL_CLOSE_ACCOUNT_IX) continue;
+        const destIdx = ci.accountKeyIndexes?.[1];
+        if (destIdx != null && keys[destIdx]) dests.push(keys[destIdx].toBase58());
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+  return dests;
 }
 
 async function markAuditRejected(auditId, detail) {


### PR DESCRIPTION
First PR in the **native-only CHCAM funding** rollout (design vetted by a 14-agent adversarial workflow). **Purely additive / backward-compatible — no existing money flow changes.** These are the shared primitives the follow-up sweeper/funder PRs consume.

## New modules
- **`distribution-owed.js`** — `readPayableOwed()`: ONE canonical `holder + LP third-party-NET` owed figure via a single-snapshot query, so stats **DISPLAY** == gap-monitor **MONITORED** == funder **FUNDED** (resolves the confirmed gross-vs-net divergence).
- **`lender-reserve.js`** — canonical `LENDER_RESERVE_LAMPORTS` (5 SOL) + `availableLenderNative()` that debits the confirmed balance by every **unconfirmed in-flight** privileged-sign spend → the gas reserve holds **across** sibling writers, not just per-tx.
- **`lender-spend-lock.js`** — `withLenderSpendLock()`: ONE shared session-pinned advisory lock across every 4JSS-signing service → at most one lender-spending tx in flight (closes the #1 confirmed vuln, the cross-service reserve race).

## Hardening (backward-compatible)
- **`privileged-sign-guard.js`** — new optional `allowedCloseDestinations` + an SPL `closeAccount` destination guard (reject close to a non-signer / non-allowlisted dest). The delta sim is blind to value leaving via a close. No current caller triggers it.
- **`privileged-destinations.js`** — add `x402-fee-sweeper` + `lp-excess-sweeper` allowlists (CHCAM only).
- **`distributor-keypair.js`** — `assertDistributorKeyDiscipline()` (refuse-to-start if `REWARDS_DISTRIBUTOR_PRIVATE_KEY` is ever set — the bot must never hold CHCAM's key). Exported; wired at boot in the follow-up PR after a clean-log verification.

No loan/collateral/program/x402-routing changes. Follow-ups: fee-wallet-sweeper lender-side unwrap, funder consume + unwrapLenderWsol, x402 reserve clamp, gap-monitor shared owed, boot-assertion wiring — each re-audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)