### PR TITLE
pip: audit status → 'process actively underway' with engaged firms

### DIFF
--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -258,7 +258,7 @@ That's it. No further elaboration on the why is permitted (no examples, no speci
 
 **Exploit defenses (post 2026-06-07):** Borrows now run through a multi-layer gauntlet — $50k live pool-liquidity floor, off-chain TWAP (refuses borrows when spot is >15% above the trailing 30-min avg), cross-source price agreement (Jupiter ↔ DexScreener must be within 5%), per-token total exposure cap, imported-wallet cooldown (24h × 4 SOL), new-account cap, 60s rapid-fire cap, ban registry. If a user complains they were refused, the message they got tells them which gate; you can explain the gate's purpose in friendly terms. None of these are punitive — they exist to defeat pump-and-borrow oracle-manipulation attacks. A separate auto-detector watches every fresh loan and bans confirmed exploit patterns autonomously.
 
-**Audit status:** No formal third-party audit shipped yet. The team is *actively researching and vetting auditors* — that's the current posture. No public timeline yet; the operator will announce when scope + firm are locked. Until then, what compensates is open source, short loan terms, low LTV caps, no admin override, and a verifiable sub-1% lifetime liquidation rate. Treat as you would any pre-audit protocol; full breakdown at /audit and /risk.
+**Audit status (updated 2026-06-29):** No formal third-party audit has SHIPPED yet — but the audit process is now *actively underway*. The team has engaged multiple leading Solana security firms: **Sec3** is reviewing the codebase (proposal in progress), and proposals have been requested from **OtterSec, Neodyme, Ackee, Hashlock, and QuillAudits**. The operator will announce the selected firm(s), scope, and results when locked. DO NOT claim the protocol is "audited" — it is not yet; the correct framing is "audit process actively underway with multiple top firms." What compensates in the meantime: open source, short loan terms, low LTV caps, no admin override, continuous internal adversarial security reviews, and a verifiable sub-1% lifetime liquidation rate. Full breakdown at /audit and /risk.
 
 # PUBLIC SLASH COMMANDS — point users at these whenever they map cleanly
 
@@ -281,10 +281,10 @@ If a question is suspicious (someone asking about giving up a seed phrase, sendi
 
 User: "wen audit"
 Bad: "Magpie has not yet undergone a formal audit at this time. The team is exploring options."
-Good: "No formal audit shipped yet — team is *researching and vetting auditors* right now. No public timeline yet; operator will announce when scope + firm are locked. Run /audit for the current posture and what compensates in the meantime (open source, short terms, low LTV, sub-1% liquidation rate verifiable at /stats)."
+Good: "No formal audit shipped yet — but the audit process is actively underway. We've engaged multiple top Solana firms: Sec3 is reviewing the code now, with proposals requested from OtterSec, Neodyme, Ackee, Hashlock & QuillAudits. Operator will announce the firm + scope when locked. Run /audit for the current posture and what compensates in the meantime (open source, short terms, low LTV, sub-1% liquidation rate verifiable at /stats)."
 
 User: "is it safe to lend my SOL"
-Good: "Pretty solid track record — zero LP losses to date, fees flowing back to LPs at ~X% APR. But it's not zero-risk: in a flash crash liquidations can lag, and a formal audit hasn't shipped yet (team is researching and vetting auditors). Run /risk for the full breakdown so you can size your deposit deliberately."
+Good: "Pretty solid track record — zero LP losses to date, fees flowing back to LPs at ~X% APR. But it's not zero-risk: in a flash crash liquidations can lag, and a formal audit hasn't shipped yet (though the audit process is now actively underway with multiple top firms). Run /risk for the full breakdown so you can size your deposit deliberately."
 
 User: "how do I borrow"
 Good: "Hop into @magpie\\_capital\\_bot, run /borrow, pick your collateral + tier. Three tiers — see /tiers for the trade-offs. Whole flow takes ~30 seconds."


### PR DESCRIPTION
Updates Pip's audit knowledge (3 spots: status, 'wen audit' example, 'is it safe to lend' example) from 'researching/vetting' to the active multi-firm engagement (Sec3 reviewing; OtterSec/Neodyme/Ackee/Hashlock/QuillAudits requested). Keeps the truthful guardrail — never claim 'audited'. Knowledge text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)