### PR TITLE
funding hardening (clean batch): gap-monitor net-owed + LP forgo + boot discipline

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ import { startApiServer } from "./api/server.js";
 import { initGovernanceSchema } from "./api/governance-api.js";
 import { setSecurityAlertBot } from "./services/security-alerts.js";
 import { setLenderAlarmBot } from "./api/lender-alarm-webhook.js";
-import { setNotifyBot } from "./services/admin-notify.js";
+import { setNotifyBot, notifyAdmin } from "./services/admin-notify.js";
 import { startDailyOpsReport } from "./services/daily-ops-report.js";
 import { startX402DailyDigest } from "./services/x402-daily-digest.js";
 import { startUsedNoncesCleaner } from "./services/used-nonces-cleaner.js";
@@ -179,6 +179,7 @@ import { startAutoProtect } from "./services/auto-protect.js";
 import { startFeeWalletSweeper } from "./services/fee-wallet-sweeper.js";
 import { startDistributionGapMonitor } from "./services/distribution-gap-monitor.js";
 import { startDistributionAutoFunder } from "./services/distribution-auto-funder.js";
+import { assertDistributorKeyDiscipline } from "./services/distributor-keypair.js";
 import { startPendingArmRetryWatcher } from "./services/pending-arm-retry-watcher.js";
 import { startAiConversationDigest } from "./services/ai-conversation-digest.js";
 import { startTicketAgingWatcher } from "./services/ticket-aging-watcher.js";
@@ -1125,6 +1126,24 @@ bot.start({
     // Eliminates manual funding. Operator-mandated 2026-06-28.
     // See src/services/distribution-auto-funder.js +
     // memory feedback_distribution_wallet_must_be_auto_funded.
+    // Boot-time custody discipline: the bot MUST run in lender-fallback mode —
+    // it must NEVER hold CHCAM's private key (off-Railway custody minimizes
+    // blast radius; distributions are operator-initiated LOCAL ops). CRIT-log +
+    // admin-alert (NOT a hard throw, so a misconfig can never block boot /
+    // loan execution — the #1 priority) if REWARDS_DISTRIBUTOR_PRIVATE_KEY is
+    // ever set or the pubkey drifts from the canonical CHCAM.
+    try {
+      const disc = assertDistributorKeyDiscipline({ hard: false });
+      if (!disc.ok) {
+        notifyAdmin(
+          bot,
+          `🚨 *Distributor key discipline violated*\n${disc.issues.join("\n")}\n\nThe bot must NOT hold CHCAM's key. Unset REWARDS_DISTRIBUTOR_PRIVATE_KEY on Railway.`,
+          { parse_mode: "Markdown" },
+        ).catch(() => {});
+      }
+    } catch (e) {
+      console.error("[boot] distributor key-discipline check failed:", e.message);
+    }
     setTimeout(() => startDistributionAutoFunder(bot), 135_000);
     // Pending-arm retry watcher — Tier-2 architectural fix for the
     // arm-race failure class. When arm-core's 30s phase-1 polling

--- a/src/services/distribution-gap-monitor.js
+++ b/src/services/distribution-gap-monitor.js
@@ -40,8 +40,11 @@
  * Mandated by [[feedback_distribution_wallet_must_be_auto_funded]].
  */
 import { Connection, PublicKey } from "@solana/web3.js";
+import { NATIVE_MINT, TOKEN_PROGRAM_ID, getAssociatedTokenAddress, getAccount } from "@solana/spl-token";
 import { query } from "../db/pool.js";
 import { notifyAdmin } from "./admin-notify.js";
+import { withFailover } from "../solana/connection.js";
+import { readPayableOwed } from "./distribution-owed.js";
 
 const INTERVAL_MS = Number(
   process.env.DIST_GAP_MONITOR_INTERVAL_MS || 10 * 60 * 1000, // 10 min
@@ -83,36 +86,30 @@ export function startDistributionGapMonitor(bot) {
 }
 
 async function runOnce(bot) {
-  // 1. Read DB notional totals.
-  const { rows: holderRows } = await query(
-    `SELECT COALESCE(accrued_lamports, 0)::numeric AS amt FROM magpie_holder_pool WHERE id = 1`,
-  );
-  const { rows: lpRows } = await query(
-    `SELECT COALESCE(accrued_lamports, 0)::numeric AS amt FROM lp_loyalty_pool WHERE id = 1`,
-  ).catch(() => ({ rows: [] }));
-  const { rows: protocolRows } = await query(
-    `SELECT COALESCE(accrued_lamports, 0)::numeric AS amt FROM protocol_reserve_pool WHERE id = 1`,
-  ).catch(() => ({ rows: [] }));
+  // 1. PAYABLE owed via the ONE canonical helper (holder + LP third-party-NET;
+  //    protocol reserve excluded) — the SAME source the funder + /stats use, so
+  //    the monitored gap matches the displayed + funded numbers exactly.
+  const { holderOwed, lpOwed, protocolOwed, payableOwed } = await readPayableOwed();
+  const totalOwed = payableOwed;
 
-  const holderOwed = BigInt(holderRows[0]?.amt || 0);
-  const lpOwed = BigInt(lpRows[0]?.amt || 0);
-  const protocolOwed = BigInt(protocolRows[0]?.amt || 0);
-  // PAYABLE owed = holder + lp only. protocol_reserve_pool has NO auto-payout
-  // path from the distribution wallet and is never decremented, so including
-  // it would inflate the gap forever (over-report a deficit that the
-  // distribution wallet should not actually hold SOL for). Keep protocolOwed
-  // for the breakdown display only. Matches distribution-auto-funder.js.
-  const totalOwed = holderOwed + lpOwed;
-
-  // 2. Read distributor on-chain balance.
+  // 2. Read distributor on-chain balances via failover. Surface wSOL too: with
+  //    the native-only-sink design CHCAM shouldn't hold wSOL, but if any is
+  //    present it's spendable-after-unwrap, so it should not read as a native
+  //    P0 deficit.
   const connection = new Connection(RPC_URL, "confirmed");
-  const distBalance = BigInt(
-    await connection.getBalance(new PublicKey(DISTRIBUTION_WALLET_PUBKEY), "confirmed"),
-  );
+  const distPk = new PublicKey(DISTRIBUTION_WALLET_PUBKEY);
+  const distBalance = BigInt(await withFailover((c) => c.getBalance(distPk, "confirmed")));
+  let distWsol = 0n;
+  try {
+    const ata = await getAssociatedTokenAddress(NATIVE_MINT, distPk, false, TOKEN_PROGRAM_ID);
+    const acct = await getAccount(connection, ata, "confirmed", TOKEN_PROGRAM_ID);
+    distWsol = acct.amount;
+  } catch { /* no wSOL ATA */ }
 
-  // 3. Compute the gap.
+  // 3. Compute the gap against spendable native + any wSOL (unwrappable).
   const required = totalOwed + SAFETY_RESERVE_LAMPORTS;
-  const gap = required > distBalance ? required - distBalance : 0n;
+  const distSpendable = distBalance + distWsol;
+  const gap = required > distSpendable ? required - distSpendable : 0n;
 
   if (gap === 0n) {
     // healthy — log occasionally so the operator can see the watcher is alive
@@ -158,7 +155,8 @@ async function runOnce(bot) {
     `  - magpie_holder_pool: ${(Number(holderOwed) / 1e9).toFixed(4)} SOL\n` +
     `  - lp_loyalty_pool: ${(Number(lpOwed) / 1e9).toFixed(4)} SOL\n` +
     `  - protocol_reserve_pool: ${(Number(protocolOwed) / 1e9).toFixed(4)} SOL (excluded — no auto-payout)\n` +
-    `Distributor on-chain: ${(Number(distBalance) / 1e9).toFixed(4)} SOL\n` +
+    `Distributor on-chain: ${(Number(distBalance) / 1e9).toFixed(4)} SOL native` +
+    (distWsol > 0n ? ` + ${(Number(distWsol) / 1e9).toFixed(4)} wSOL (unwrappable, counted as spendable)` : "") + `\n` +
     `Required (owed + 0.1 reserve): ${(Number(required) / 1e9).toFixed(4)} SOL\n` +
     `\n` +
     `*DEFICIT: ${(Number(gap) / 1e9).toFixed(4)} SOL*\n` +

--- a/src/services/liquidation-distribution-watcher.js
+++ b/src/services/liquidation-distribution-watcher.js
@@ -60,13 +60,9 @@
  *   LIQUIDATION_DISTRIBUTION_TICK_MS    — default 90_000 (1.5 min)
  */
 import { query } from "../db/pool.js";
-import { PublicKey, Keypair, SystemProgram, Transaction } from "@solana/web3.js";
+import { PublicKey, Keypair, SystemProgram, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
 import bs58 from "bs58";
-import { connection, withFailover } from "../solana/connection.js";
-import { withLenderSpendLock } from "./lender-spend-lock.js";
-import { availableLenderNative } from "./lender-reserve.js";
-import { runPrivilegedSign, recordPrivilegedSignResult } from "./privileged-sign-guard.js";
-import { assertAllowedDestination } from "./privileged-destinations.js";
+import { connection } from "../solana/connection.js";
 
 const TICK_MS = Number(process.env.LIQUIDATION_DISTRIBUTION_TICK_MS) || 90_000;
 const FIRST_TICK_DELAY_MS = 180_000; // wait 3 min after boot so other services init
@@ -175,16 +171,14 @@ async function distributeOne(row) {
   // the gate that makes the rest of distributeOne atomic-on-failure.
   if (REWARDS_DISTRIBUTOR_PUBKEY && transferAmount > 0n) {
     try {
-      // Reserve-safe pre-flight via the shared helper: subtracts the canonical
-      // 5-SOL gas reserve AND every unconfirmed in-flight lender spend, so a
-      // liquidation burst can't drain 4JSS below the gas floor (was 0.01 SOL).
-      // Fails CLOSED (0) on an uncertain read.
-      const avail = await availableLenderNative(connection);
-      if (avail < transferAmount) {
+      const lenderBal = BigInt(await connection.getBalance(
+        getLenderKeypairForTransfer()?.publicKey,
+      ));
+      if (lenderBal < transferAmount + LENDER_RESERVE_LAMPORTS) {
         console.warn(
-          `[liq-distribute] loan ${row.loan_id} skipped — lender spendable ` +
-          `${(Number(avail) / 1e9).toFixed(4)} SOL < transfer ` +
-          `${(Number(transferAmount) / 1e9).toFixed(4)} SOL (5-SOL gas reserve protected). Will retry next tick.`,
+          `[liq-distribute] loan ${row.loan_id} skipped — lender balance ` +
+          `${(Number(lenderBal) / 1e9).toFixed(4)} SOL < required ` +
+          `${(Number(transferAmount + LENDER_RESERVE_LAMPORTS) / 1e9).toFixed(4)} SOL. Will retry next tick.`,
         );
         return { ok: false, reason: "lender_balance_too_low" };
       }
@@ -232,61 +226,28 @@ async function distributeOne(row) {
     if (!lender) {
       errors.push("on_chain_transfer: LENDER_PRIVATE_KEY missing");
     } else {
-      // Serialize on the ONE shared lender-spend lock (with the funder +
-      // fee-sweeper), route through the privileged-sign guard + destination
-      // allowlist, and re-check spendable INSIDE the lock so a sibling spend
-      // can't push 4JSS below the 5-SOL gas reserve.
-      const locked = await withLenderSpendLock(async () => {
-        const avail = await availableLenderNative(connection);
-        if (avail < transferAmount) {
-          return { err: `reserve: spendable ${(Number(avail) / 1e9).toFixed(4)} < transfer ${(Number(transferAmount) / 1e9).toFixed(4)}` };
-        }
-        try {
-          assertAllowedDestination("liquidation-distribution-watcher", REWARDS_DISTRIBUTOR_PUBKEY);
-        } catch (e) {
-          return { err: e.message?.slice(0, 100) };
-        }
-        const { blockhash, lastValidBlockHeight } = await withFailover((c) => c.getLatestBlockhash("confirmed"));
-        // BigInt precision: bounded by a single liquidation's proceeds (≪ 2^53).
-        const tx = new Transaction({ feePayer: lender.publicKey, blockhash, lastValidBlockHeight }).add(
+      try {
+        const tx = new Transaction().add(
           SystemProgram.transfer({
             fromPubkey: lender.publicKey,
             toPubkey: REWARDS_DISTRIBUTOR_PUBKEY,
+            // BigInt precision: SOL amounts here are bounded by the
+            // sale_proceeds of a single liquidation (max ~10s of SOL
+            // realistically), comfortably under 2^53. Number() is safe.
             lamports: Number(transferAmount),
           }),
         );
-        let auditId = null;
-        try {
-          const guard = await runPrivilegedSign({
-            service: "liquidation-distribution-watcher",
-            tx,
-            signers: [lender],
-            allowedDeltas: [{ pubkey: lender.publicKey, kind: "sol", maxDecrease: transferAmount + 10_000n }],
-          });
-          auditId = guard.auditId;
-          const sig = await withFailover((c) => c.sendRawTransaction(tx.serialize(), { skipPreflight: false }));
-          await recordPrivilegedSignResult({ auditId, status: "broadcast", txSig: sig });
-          await withFailover((c) => c.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed"));
-          await recordPrivilegedSignResult({ auditId, status: "confirmed", txSig: sig });
-          return { sig };
-        } catch (e) {
-          if (auditId) {
-            try { await recordPrivilegedSignResult({ auditId, status: "failed", error: e.message?.slice(0, 160) }); } catch {}
-          }
-          return { err: e.message?.slice(0, 100) };
-        }
-      });
-      if (locked.skipped) {
-        errors.push("on_chain_transfer: shared lender lock held — retry next tick");
-      } else if (locked.result?.err) {
-        errors.push(`on_chain_transfer: ${locked.result.err}`);
-      } else {
-        transferSig = locked.result?.sig || null;
+        transferSig = await sendAndConfirmTransaction(connection, tx, [lender], {
+          commitment: "confirmed",
+          maxRetries: 3,
+        });
         console.log(
           `[liq-distribute] loan ${row.loan_id} on-chain move: ` +
           `${(Number(transferAmount) / 1e9).toFixed(4)} SOL → ` +
-          `${REWARDS_DISTRIBUTOR_PUBKEY.toBase58().slice(0, 8)}…  sig=${transferSig?.slice(0, 24)}…`,
+          `${REWARDS_DISTRIBUTOR_PUBKEY.toBase58().slice(0, 8)}…  sig=${transferSig.slice(0, 24)}…`,
         );
+      } catch (err) {
+        errors.push(`on_chain_transfer: ${err.message?.slice(0, 80)}`);
       }
     }
   }

--- a/src/services/liquidation-distribution-watcher.js
+++ b/src/services/liquidation-distribution-watcher.js
@@ -60,9 +60,13 @@
  *   LIQUIDATION_DISTRIBUTION_TICK_MS    — default 90_000 (1.5 min)
  */
 import { query } from "../db/pool.js";
-import { PublicKey, Keypair, SystemProgram, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+import { PublicKey, Keypair, SystemProgram, Transaction } from "@solana/web3.js";
 import bs58 from "bs58";
-import { connection } from "../solana/connection.js";
+import { connection, withFailover } from "../solana/connection.js";
+import { withLenderSpendLock } from "./lender-spend-lock.js";
+import { availableLenderNative } from "./lender-reserve.js";
+import { runPrivilegedSign, recordPrivilegedSignResult } from "./privileged-sign-guard.js";
+import { assertAllowedDestination } from "./privileged-destinations.js";
 
 const TICK_MS = Number(process.env.LIQUIDATION_DISTRIBUTION_TICK_MS) || 90_000;
 const FIRST_TICK_DELAY_MS = 180_000; // wait 3 min after boot so other services init
@@ -171,14 +175,16 @@ async function distributeOne(row) {
   // the gate that makes the rest of distributeOne atomic-on-failure.
   if (REWARDS_DISTRIBUTOR_PUBKEY && transferAmount > 0n) {
     try {
-      const lenderBal = BigInt(await connection.getBalance(
-        getLenderKeypairForTransfer()?.publicKey,
-      ));
-      if (lenderBal < transferAmount + LENDER_RESERVE_LAMPORTS) {
+      // Reserve-safe pre-flight via the shared helper: subtracts the canonical
+      // 5-SOL gas reserve AND every unconfirmed in-flight lender spend, so a
+      // liquidation burst can't drain 4JSS below the gas floor (was 0.01 SOL).
+      // Fails CLOSED (0) on an uncertain read.
+      const avail = await availableLenderNative(connection);
+      if (avail < transferAmount) {
         console.warn(
-          `[liq-distribute] loan ${row.loan_id} skipped — lender balance ` +
-          `${(Number(lenderBal) / 1e9).toFixed(4)} SOL < required ` +
-          `${(Number(transferAmount + LENDER_RESERVE_LAMPORTS) / 1e9).toFixed(4)} SOL. Will retry next tick.`,
+          `[liq-distribute] loan ${row.loan_id} skipped — lender spendable ` +
+          `${(Number(avail) / 1e9).toFixed(4)} SOL < transfer ` +
+          `${(Number(transferAmount) / 1e9).toFixed(4)} SOL (5-SOL gas reserve protected). Will retry next tick.`,
         );
         return { ok: false, reason: "lender_balance_too_low" };
       }
@@ -226,28 +232,61 @@ async function distributeOne(row) {
     if (!lender) {
       errors.push("on_chain_transfer: LENDER_PRIVATE_KEY missing");
     } else {
-      try {
-        const tx = new Transaction().add(
+      // Serialize on the ONE shared lender-spend lock (with the funder +
+      // fee-sweeper), route through the privileged-sign guard + destination
+      // allowlist, and re-check spendable INSIDE the lock so a sibling spend
+      // can't push 4JSS below the 5-SOL gas reserve.
+      const locked = await withLenderSpendLock(async () => {
+        const avail = await availableLenderNative(connection);
+        if (avail < transferAmount) {
+          return { err: `reserve: spendable ${(Number(avail) / 1e9).toFixed(4)} < transfer ${(Number(transferAmount) / 1e9).toFixed(4)}` };
+        }
+        try {
+          assertAllowedDestination("liquidation-distribution-watcher", REWARDS_DISTRIBUTOR_PUBKEY);
+        } catch (e) {
+          return { err: e.message?.slice(0, 100) };
+        }
+        const { blockhash, lastValidBlockHeight } = await withFailover((c) => c.getLatestBlockhash("confirmed"));
+        // BigInt precision: bounded by a single liquidation's proceeds (≪ 2^53).
+        const tx = new Transaction({ feePayer: lender.publicKey, blockhash, lastValidBlockHeight }).add(
           SystemProgram.transfer({
             fromPubkey: lender.publicKey,
             toPubkey: REWARDS_DISTRIBUTOR_PUBKEY,
-            // BigInt precision: SOL amounts here are bounded by the
-            // sale_proceeds of a single liquidation (max ~10s of SOL
-            // realistically), comfortably under 2^53. Number() is safe.
             lamports: Number(transferAmount),
           }),
         );
-        transferSig = await sendAndConfirmTransaction(connection, tx, [lender], {
-          commitment: "confirmed",
-          maxRetries: 3,
-        });
+        let auditId = null;
+        try {
+          const guard = await runPrivilegedSign({
+            service: "liquidation-distribution-watcher",
+            tx,
+            signers: [lender],
+            allowedDeltas: [{ pubkey: lender.publicKey, kind: "sol", maxDecrease: transferAmount + 10_000n }],
+          });
+          auditId = guard.auditId;
+          const sig = await withFailover((c) => c.sendRawTransaction(tx.serialize(), { skipPreflight: false }));
+          await recordPrivilegedSignResult({ auditId, status: "broadcast", txSig: sig });
+          await withFailover((c) => c.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed"));
+          await recordPrivilegedSignResult({ auditId, status: "confirmed", txSig: sig });
+          return { sig };
+        } catch (e) {
+          if (auditId) {
+            try { await recordPrivilegedSignResult({ auditId, status: "failed", error: e.message?.slice(0, 160) }); } catch {}
+          }
+          return { err: e.message?.slice(0, 100) };
+        }
+      });
+      if (locked.skipped) {
+        errors.push("on_chain_transfer: shared lender lock held — retry next tick");
+      } else if (locked.result?.err) {
+        errors.push(`on_chain_transfer: ${locked.result.err}`);
+      } else {
+        transferSig = locked.result?.sig || null;
         console.log(
           `[liq-distribute] loan ${row.loan_id} on-chain move: ` +
           `${(Number(transferAmount) / 1e9).toFixed(4)} SOL → ` +
-          `${REWARDS_DISTRIBUTOR_PUBKEY.toBase58().slice(0, 8)}…  sig=${transferSig.slice(0, 24)}…`,
+          `${REWARDS_DISTRIBUTOR_PUBKEY.toBase58().slice(0, 8)}…  sig=${transferSig?.slice(0, 24)}…`,
         );
-      } catch (err) {
-        errors.push(`on_chain_transfer: ${err.message?.slice(0, 80)}`);
       }
     }
   }

--- a/src/services/lp-loyalty.js
+++ b/src/services/lp-loyalty.js
@@ -498,12 +498,17 @@ export async function snapshotAndDistributeLpLoyalty() {
     const nextDelay = pickNextDistributionDelay();
     await client.query(
       `UPDATE lp_loyalty_pool
-          SET accrued_lamports = accrued_lamports - $1::numeric,
+          SET accrued_lamports = GREATEST(0, accrued_lamports - $1::numeric),
               last_distribution_at = NOW(),
               next_distribution_at = NOW() + ($2 || ' milliseconds')::interval,
               updated_at = NOW()
         WHERE id = 1`,
-      [allocatedSum.toString(), Math.floor(nextDelay).toString()],
+      // Decrement by the FULL snapshotted pool, NOT just the third-party
+      // allocatedSum: the operator-exempt slice is FORGONE on distribution so
+      // the LP "rewards snapshot" resets to ~0 (like the holder pool) instead
+      // of carrying the exempt slice forward as a phantom figure. Only accruals
+      // that landed AFTER the snapshot (concurrent borrow fees) carry forward.
+      [pool.toString(), Math.floor(nextDelay).toString()],
     );
 
     await client.query("COMMIT");


### PR DESCRIPTION
Completes the autonomous-funding rollout (remaining audit steps). **Held for adversarial audit.**

- **liquidation-distribution-watcher** — lender→CHCAM transfer now under `withLenderSpendLock`, sized by `availableLenderNative` (5-SOL reserve, was 0.01), via `runPrivilegedSign` + allowlist. Lock-skip/insufficient reverts the claim.
- **gap-monitor** — `readPayableOwed` (net LP) so monitored==funded==displayed; `withFailover` getBalance; surfaces wSOL so it isn't a false native P0.
- **lp-loyalty** — decrement the FULL snapshotted pool (forgo operator-exempt slice) so the LP snapshot resets to ~0 like the holder pool.
- **index.js boot** — `assertDistributorKeyDiscipline` (CRIT-log + alert, **not** a hard throw — never blocks boot/loan execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)