### PR TITLE
CHCAM funder bulletproofing — in-tick lender unwrap, self-healing gap monitor, ops /stats true picture

### DIFF
--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -4,6 +4,8 @@ import { lendingPoolPda, loanTokenVaultPda } from "../solana/pdas.js";
 import { connection } from "../solana/connection.js";
 import { query } from "../db/pool.js";
 import { getBurnSummary } from "../services/magpie-burns.js";
+import { isAdmin } from "../services/admin.js";
+import { getDistributionFunderStatus } from "../services/distribution-auto-funder.js";
 
 // Helper: fetch a single pool's on-chain snapshot for the /stats roll-up.
 // Pool layouts are identical between V1 and V2 across the fields we read
@@ -57,6 +59,40 @@ const RULE = "─".repeat(COL_WIDTH + 2);
 function fmtSol(lamports) {
   const n = Number(lamports) / 1e9;
   return Number.isFinite(n) ? n.toFixed(2) : "—";
+}
+
+// OPERATOR-ONLY: the autonomous rewards-funder true picture. The point (per the
+// operator) is that a transient lag must never READ as a shortfall — so this
+// shows CHCAM-spendable vs owed vs gap PLUS a plain-English verdict, so the
+// operator stops pre-funding phantoms. Wallet balances are operator-private, so
+// this block is gated to admins and never rendered in public /stats.
+function renderFunderHealth(fs) {
+  if (!fs) return [];
+  const fmt2 = (n) => (n == null || !Number.isFinite(n) ? "—" : n.toFixed(2));
+  const verdictLine = {
+    healthy:        "✓ healthy — CHCAM covers all owed",
+    catching_up:    "⏳ catching up — auto-funds ≤5m (transient, do NOT hand-fund)",
+    lender_limited: "⚠ lender-limited — real revenue lag; investigate, do NOT hand-fund",
+    paused:         "⏸ PAUSED — DIST_FUNDER_DISABLED is set",
+    unknown:        "… status unavailable (RPC)",
+  }[fs.verdict] || fs.verdict;
+
+  const out = [
+    ``,
+    `REWARDS FUNDER (autonomous · ops-only)`,
+    row("CHCAM spendable", `${fmt2(fs.distribution_spendable_sol)} SOL`),
+    row("Owed (holder+LP)", `${fmt2(fs.payable_owed_sol)} SOL`),
+  ];
+  // Only show the gap line when there actually is one — keeps the healthy
+  // readout terse.
+  if ((fs.current_gap_sol ?? 0) >= 0.005) {
+    out.push(row("Gap", `${fmt2(fs.current_gap_sol)} SOL`));
+    out.push(row("Lender available", `${fmt2(fs.lender_available_sol)} SOL`));
+  }
+  // The verdict can exceed the column width — render it on its own indented
+  // line rather than squeezing it into the two-column row().
+  out.push(`  ${verdictLine}`);
+  return out;
 }
 
 export async function handleStats(ctx) {
@@ -373,6 +409,17 @@ export async function handleStats(ctx) {
         return row(`#${idx + 1} ${date}`, `${amount} SOL → ${s.eligible_count} LPs`);
       });
 
+    // OPERATOR-ONLY: autonomous rewards-funder health. Best-effort — a funder
+    // read failure must never break /stats. Public callers never see this.
+    let funderLines = [];
+    if (isAdmin(ctx.from?.id)) {
+      try {
+        funderLines = renderFunderHealth(await getDistributionFunderStatus());
+      } catch (e) {
+        console.warn("[stats] funder-health read failed:", e.message);
+      }
+    }
+
     const codeLines = [
       RULE,
       `LOAN BOOK`,
@@ -401,6 +448,8 @@ export async function handleStats(ctx) {
       row("Referrers (10%)",       `${fmtSol(refAccrued.toString())} SOL`),
       row("Protocol reserve (10%)",`${fmtSol(reserveAccrued.toString())} SOL`),
       row("Total accruing",        `${fmtSol(totalAccrued.toString())} SOL`),
+      // OPERATOR-ONLY funder-health (empty array for everyone else).
+      ...funderLines,
       ``,
       // Prior-snapshots section only renders once at least one snapshot
       // has happened. Until then, hide the section entirely — operator

--- a/src/services/distribution-auto-funder.js
+++ b/src/services/distribution-auto-funder.js
@@ -155,6 +155,13 @@ const MAX_FUND_LAMPORTS = solToLamports(envNum("DIST_FUNDER_MAX_SOL", 8));
 // NOTHING and alert. Far above any legitimate weekly liability.
 const OWED_SANITY_CEILING_LAMPORTS = solToLamports(envNum("DIST_FUNDER_OWED_CEILING_SOL", 50));
 const TX_FEE_HEADROOM = 10_000n;
+// In-tick lender-wSOL unwrap floor — only unwrap the lender's fee wSOL ATA
+// when it holds at least this much (else the tx fee isn't worth it). Borrow
+// fees land as wSOL in the lender's OWN NATIVE_MINT ATA; the hourly
+// fee-wallet-sweeper normally unwraps them, but that up-to-1h lag is exactly
+// why CHCAM read "short" — the revenue was present, just wrapped + invisible
+// to the native-only funder. This funder unwraps in-tick when a gap needs it.
+const MIN_INTICK_UNWRAP_LAMPORTS = solToLamports(envNum("DIST_FUNDER_MIN_INTICK_UNWRAP_SOL", 0.05));
 
 const RPC_URL =
   process.env.SOLANA_RPC_URL ||
@@ -172,6 +179,7 @@ const DISTRIBUTION_PUBKEY = new PublicKey(
 
 let _timer = null;
 let _running = false; // in-process reentrancy guard
+let _lastTickStartedMs = 0; // for the kick's no-double-fund start floor
 
 // ─── Lender keypair (signs the lender→distribution transfer) ──────
 function loadLenderKeypair() {
@@ -305,10 +313,107 @@ async function unwrapDistributionWsol(connection) {
   }
 }
 
+// ─── In-tick: unwrap the LENDER's stranded fee wSOL → lender native ──
+// Root-cause latency fix. Borrow fees land as wSOL in the lender's OWN
+// NATIVE_MINT ATA. The hourly fee-wallet-sweeper unwraps them, but until it
+// runs (up to 1h) that revenue is wrapped + invisible to this native-only
+// funder, so CHCAM reads "short" even though the protocol HAS the money. When
+// a tick finds a gap the lender's native alone can't close, we unwrap the
+// lender's fee wSOL HERE so CHCAM tops up within the 5-min funder cadence
+// instead of waiting on the hourly sweeper.
+//
+// SAFETY: lender-OWN-wSOL → lender-OWN-native — no external destination, nets
+// the lender POSITIVE (so it never threatens the gas reserve). Runs under the
+// SHARED lender lock already held by tickInner (so it can't race the
+// fee-wallet-sweeper's close of the same ATA), is guard-simulated with the
+// close destination pinned to the lender, and is idempotent (close+reopen — if
+// the sweeper already unwrapped, the ATA reads empty and we skip). Audited to
+// fee_wallet_sweeps (reason 'funder_intick_unwrap') so the gap-monitor's "last
+// sweep" reflects it. Returns lamports unwrapped (0 on skip/error).
+async function unwrapLenderFeeWsol(bot, connection, lenderKp) {
+  const feeAta = await getAssociatedTokenAddress(NATIVE_MINT, lenderKp.publicKey, false, TOKEN_PROGRAM_ID);
+  let wsol = 0n;
+  try {
+    const acct = await getAccount(connection, feeAta, "confirmed", TOKEN_PROGRAM_ID);
+    wsol = acct.amount;
+  } catch {
+    return 0n; // no fee ATA / unreadable → nothing to unwrap
+  }
+  if (wsol < MIN_INTICK_UNWRAP_LAMPORTS) return 0n; // dust — not worth a tx fee
+
+  // Audit anchor (best-effort; the close is idempotent so a missing anchor is
+  // never a correctness problem — it just means one fewer paper-trail row).
+  let sweepId = null;
+  try {
+    const { rows: [a] } = await query(
+      `INSERT INTO fee_wallet_sweeps (source_pubkey, dest_pubkey, amount_lamports, status, reason)
+       VALUES ($1, $2, $3::numeric, 'planned', 'funder_intick_unwrap') RETURNING id`,
+      [feeAta.toBase58(), lenderKp.publicKey.toBase58(), wsol.toString()],
+    );
+    sweepId = a.id;
+  } catch { /* audit table optional — proceed */ }
+
+  try {
+    const tx = new Transaction();
+    tx.add(createCloseAccountInstruction(feeAta, lenderKp.publicKey, lenderKp.publicKey, [], TOKEN_PROGRAM_ID));
+    tx.add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        lenderKp.publicKey, feeAta, lenderKp.publicKey, NATIVE_MINT, TOKEN_PROGRAM_ID,
+      ),
+    );
+    const { blockhash, lastValidBlockHeight } = await withFailover((c) => c.getLatestBlockhash("confirmed"));
+    tx.recentBlockhash = blockhash;
+    tx.feePayer = lenderKp.publicKey;
+    const guard = await runPrivilegedSign({
+      service: "distribution-auto-funder:intick-unwrap",
+      tx,
+      signers: [lenderKp],
+      // The close NETS the lender POSITIVE (wSOL + close rent in; reopen rent +
+      // tx fee out). Declare the fee ATA's full token decrease + a tiny lender
+      // SOL fee headroom; pin the close destination to the lender itself.
+      allowedDeltas: [
+        { pubkey: feeAta, kind: "token", mint: NATIVE_MINT, maxDecrease: wsol },
+        { pubkey: lenderKp.publicKey, kind: "sol", maxDecrease: 10_000n },
+      ],
+      allowedCloseDestinations: [lenderKp.publicKey],
+    });
+    const sig = await withFailover((c) => c.sendRawTransaction(tx.serialize(), { skipPreflight: false }));
+    await withFailover((c) => c.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed"));
+    await recordPrivilegedSignResult({ auditId: guard.auditId, status: "confirmed", txSig: sig });
+    if (sweepId) {
+      await query(
+        `UPDATE fee_wallet_sweeps SET status = 'confirmed', tx_signature = $2, updated_at = NOW() WHERE id = $1`,
+        [sweepId, sig],
+      ).catch(() => {});
+    }
+    console.log(`[dist-funder] in-tick unwrapped ${fmt(wsol)} lender wSOL → native (sig ${sig.slice(0, 12)}…)`);
+    return wsol;
+  } catch (err) {
+    if (sweepId) {
+      await query(
+        `UPDATE fee_wallet_sweeps SET status = 'failed', err = $2, updated_at = NOW() WHERE id = $1`,
+        [sweepId, err.message?.slice(0, 200)],
+      ).catch(() => {});
+    }
+    console.warn(`[dist-funder] in-tick lender unwrap skipped: ${err.message?.slice(0, 120)}`);
+    return 0n;
+  }
+}
+
 // ─── One tick ─────────────────────────────────────────────────────
-async function tick(bot) {
+async function tick(bot, opts = {}) {
   if (_running) return; // in-process reentrancy guard
+  // NO-DOUBLE-FUND START FLOOR: never START two ticks closer than the interval
+  // floor (3 min > a blockhash's ~90s validity). The scheduled timer is
+  // already 5 min so it never trips this; the guard exists for event KICKS,
+  // which could otherwise fire a tick seconds after a funding broadcast —
+  // before the prior tx lands — and double-fund. Gating tick START preserves
+  // the no-double-fund invariant for EVERY trigger, not just the timer.
+  if (opts.source === "kick" && Date.now() - _lastTickStartedMs < INTERVAL_FLOOR_MS) {
+    return; // too soon after the last tick — the scheduled tick covers it
+  }
   _running = true;
+  _lastTickStartedMs = Date.now();
   try {
     if (isDisabled()) {
       await record({ outcome: "skip_disabled", notes: "DIST_FUNDER_DISABLED set" });
@@ -377,25 +482,8 @@ async function tickInner(bot) {
     return;
   }
 
-  // 5. What the lender can safely provide right now — via the shared helper,
-  //    which subtracts the canonical 5-SOL reserve AND every UNCONFIRMED
-  //    in-flight lender spend (so a sibling service's in-flight tx can't push
-  //    4JSS below the gas floor). Fails CLOSED (0) if the read is uncertain.
-  const lenderAvail = await availableLenderNative(connection);
-  if (lenderAvail < MIN_FUND_LAMPORTS) {
-    await record({ ...baseRow, outcome: "skip_lender_low",
-      notes: `lenderAvail=${fmt(lenderAvail)} < min; gap=${fmt(gap)} unmet` });
-    await alertLenderLow(bot, { gap, lenderNative, owed: payableOwed });
-    return;
-  }
-
-  // 6. fundAmount = min(gap, lenderAvail, HARD CEILING). The ceiling is the
-  //    real bound — independent of `owed` — so no counter value can move more
-  //    than MAX_FUND per tick even if everything else is wrong.
-  let fundAmount = gap;
-  if (lenderAvail < fundAmount) fundAmount = lenderAvail;
-  if (MAX_FUND_LAMPORTS < fundAmount) fundAmount = MAX_FUND_LAMPORTS;
-
+  // 5. Load the lender key now — needed both for the in-tick wSOL unwrap and
+  //    the funding transfer.
   let lenderKp;
   try {
     lenderKp = loadLenderKeypair();
@@ -409,6 +497,40 @@ async function tickInner(bot) {
       error: `lender key ${lenderKp.publicKey.toBase58().slice(0, 10)}… ≠ ${LENDER_PUBKEY.toBase58().slice(0, 10)}…` });
     return;
   }
+
+  // 6. What the lender can safely provide right now — via the shared helper,
+  //    which subtracts the canonical 5-SOL reserve AND every UNCONFIRMED
+  //    in-flight lender spend (so a sibling service's in-flight tx can't push
+  //    4JSS below the gas floor). Fails CLOSED (0) if the read is uncertain.
+  let lenderAvail = await availableLenderNative(connection);
+
+  // 6b. IN-TICK LENDER wSOL UNWRAP — if the lender's NATIVE alone can't close
+  //     the gap, the missing revenue is most likely sitting as wSOL in the
+  //     lender's fee ATA that the hourly sweeper hasn't unwrapped yet. Unwrap
+  //     it NOW (under the shared lock we already hold) so CHCAM tops up this
+  //     5-min cadence instead of waiting ≤1h. Fires ONLY when actually needed
+  //     (lender native can't cover the gap) and the wSOL is material.
+  if (lenderAvail < gap) {
+    const unwrapped = await unwrapLenderFeeWsol(bot, connection, lenderKp).catch(() => 0n);
+    if (unwrapped > 0n) {
+      lenderAvail = await availableLenderNative(connection); // re-read post-unwrap
+      baseRow.lenderNative = BigInt(await withFailover((c) => c.getBalance(LENDER_PUBKEY, "confirmed")));
+    }
+  }
+
+  if (lenderAvail < MIN_FUND_LAMPORTS) {
+    await record({ ...baseRow, outcome: "skip_lender_low",
+      notes: `lenderAvail=${fmt(lenderAvail)} < min; gap=${fmt(gap)} unmet (after in-tick unwrap attempt)` });
+    await alertLenderLow(bot, { gap, lenderNative: baseRow.lenderNative, owed: payableOwed });
+    return;
+  }
+
+  // 7. fundAmount = min(gap, lenderAvail, HARD CEILING). The ceiling is the
+  //    real bound — independent of `owed` — so no counter value can move more
+  //    than MAX_FUND per tick even if everything else is wrong.
+  let fundAmount = gap;
+  if (lenderAvail < fundAmount) fundAmount = lenderAvail;
+  if (MAX_FUND_LAMPORTS < fundAmount) fundAmount = MAX_FUND_LAMPORTS;
 
   try {
     assertAllowedDestination("distribution-auto-funder", DISTRIBUTION_PUBKEY);
@@ -572,6 +694,29 @@ export function stopDistributionAutoFunder() {
   if (_timer) { clearInterval(_timer); _timer = null; }
 }
 
+/**
+ * Event-driven nudge — fire an immediate, out-of-band funder tick (e.g. the
+ * gap-monitor's self-heal when it spots a gap between scheduled ticks). This
+ * is what turns the funder from "every 5 min" into "tops up within seconds of
+ * a detected gap" without coupling to the hot loan/fee-accrual path.
+ *
+ * FULLY SAFE TO CALL FROM ANYWHERE, AT ANY RATE:
+ *   • fire-and-forget — never awaits, never throws into the caller.
+ *   • the tick-start floor in tick() guarantees a kick can NEVER run a tick
+ *     within INTERVAL_FLOOR_MS (3 min) of the prior one, so the no-double-fund
+ *     invariant holds no matter how often this is called.
+ *   • the in-process reentrancy guard + shared lender lock still serialize it
+ *     against the scheduled tick and every other lender-spending service.
+ */
+export function kickDistributionFunder(bot, reason = "kick") {
+  if (isDisabled()) return;
+  setTimeout(() => {
+    tick(bot, { source: "kick" }).catch((e) =>
+      console.warn(`[dist-funder] kick(${reason}) tick: ${e.message?.slice(0, 140)}`),
+    );
+  }, 0);
+}
+
 // ─── Status (for admin command / observability) ───────────────────
 export async function getDistributionFunderStatus() {
   const connection = new Connection(RPC_URL, "confirmed");
@@ -580,9 +725,13 @@ export async function getDistributionFunderStatus() {
   const { holderOwed, lpOwed, protocolOwed, payableOwed } = await readPayableOwed().catch(() => ({
     holderOwed: 0n, lpOwed: 0n, protocolOwed: 0n, payableOwed: 0n,
   }));
-  const [distNative, lenderNative, recent] = await Promise.all([
+  const [distNative, distWsol, lenderNative, lenderAvail, recent] = await Promise.all([
     connection.getBalance(DISTRIBUTION_PUBKEY, "confirmed").then(BigInt).catch(() => null),
+    getAssociatedTokenAddress(NATIVE_MINT, DISTRIBUTION_PUBKEY, false, TOKEN_PROGRAM_ID)
+      .then((ata) => getAccount(connection, ata, "confirmed", TOKEN_PROGRAM_ID))
+      .then((a) => a.amount).catch(() => 0n),
     connection.getBalance(LENDER_PUBKEY, "confirmed").then(BigInt).catch(() => null),
+    availableLenderNative(connection).catch(() => null),
     query(
       `SELECT id, outcome, initiated_at, funded_lamports::text AS funded,
               gap_lamports::text AS gap, tx_signature, notes, error_message
@@ -591,17 +740,42 @@ export async function getDistributionFunderStatus() {
     ).catch(() => ({ rows: [] })),
   ]);
   const target = payableOwed + SAFETY_RESERVE_LAMPORTS;
+  // CHCAM "spendable" = native + any wSOL (the funder unwraps CHCAM's own wSOL
+  // in-tick, so it's effectively spendable). Gap is measured against native —
+  // the conservative figure the funder actually targets.
+  const spendable = distNative == null ? null : distNative + distWsol;
+  const gapLamports = distNative == null ? null : (target > distNative ? target - distNative : 0n);
+
+  // VERDICT — the whole point of surfacing this: a transient lag must NOT read
+  // as a "shortfall" the operator hand-funds. Classify it honestly:
+  //   • paused        — funder disabled
+  //   • healthy       — CHCAM already covers owed+reserve
+  //   • catching_up   — a gap exists BUT the lender can cover it → the funder
+  //                     auto-tops-up within ~5 min; do NOT hand-fund.
+  //   • lender_limited— a gap exists AND the lender can't cover it → real fee
+  //                     revenue is below the accrued obligation; investigate,
+  //                     still do NOT hand-fund.
+  let verdict = "unknown";
+  if (isDisabled()) verdict = "paused";
+  else if (gapLamports == null) verdict = "unknown";
+  else if (gapLamports < MIN_FUND_LAMPORTS) verdict = "healthy";
+  else if (lenderAvail != null && lenderAvail >= gapLamports) verdict = "catching_up";
+  else verdict = "lender_limited";
+
   return {
     disabled: isDisabled(),
     interval_min: INTERVAL_MS / 60_000,
+    verdict,
     payable_owed_sol: Number(payableOwed) / LAMPORTS_PER_SOL,
     holder_owed_sol: Number(holderOwed) / LAMPORTS_PER_SOL,
     lp_owed_sol: Number(lpOwed) / LAMPORTS_PER_SOL,
     protocol_reserve_owed_sol: Number(protocolOwed) / LAMPORTS_PER_SOL, // excluded from gap
     distribution_native_sol: distNative == null ? null : Number(distNative) / LAMPORTS_PER_SOL,
+    distribution_wsol_sol: Number(distWsol) / LAMPORTS_PER_SOL,
+    distribution_spendable_sol: spendable == null ? null : Number(spendable) / LAMPORTS_PER_SOL,
     lender_native_sol: lenderNative == null ? null : Number(lenderNative) / LAMPORTS_PER_SOL,
-    current_gap_sol:
-      distNative == null ? null : Math.max(0, Number(target - distNative) / LAMPORTS_PER_SOL),
+    lender_available_sol: lenderAvail == null ? null : Number(lenderAvail) / LAMPORTS_PER_SOL,
+    current_gap_sol: gapLamports == null ? null : Number(gapLamports) / LAMPORTS_PER_SOL,
     lender_reserve_sol: Number(LENDER_RESERVE_LAMPORTS) / LAMPORTS_PER_SOL,
     per_tick_ceiling_sol: Number(MAX_FUND_LAMPORTS) / LAMPORTS_PER_SOL,
     recent: recent.rows,

--- a/src/services/distribution-gap-monitor.js
+++ b/src/services/distribution-gap-monitor.js
@@ -45,6 +45,8 @@ import { query } from "../db/pool.js";
 import { notifyAdmin } from "./admin-notify.js";
 import { withFailover } from "../solana/connection.js";
 import { readPayableOwed } from "./distribution-owed.js";
+import { kickDistributionFunder } from "./distribution-auto-funder.js";
+import { availableLenderNative } from "./lender-reserve.js";
 
 const INTERVAL_MS = Number(
   process.env.DIST_GAP_MONITOR_INTERVAL_MS || 10 * 60 * 1000, // 10 min
@@ -64,6 +66,16 @@ const P0_THROTTLE_MS = 0;                  // P0: every tick, no throttle
 let _lastAlert = { warn: 0, alert: 0, p0: 0 };
 let _lastP0DeficitLamports = 0n;
 let _timer = null;
+
+// PERSISTENCE GATE — the hardening. A gap on a SINGLE reading is almost always
+// transient: fees just accrued as wSOL, or the funder simply hasn't run since
+// the last accrual. Alarming on that trains the operator to hand-fund phantoms.
+// So on EVERY gap reading we first KICK the funder (self-heal — it in-tick
+// unwraps lender wSOL + tops CHCAM up), and only DM the operator once the gap
+// PERSISTS across this many consecutive readings (i.e. the funder demonstrably
+// could NOT close it → a real, durable shortfall worth a human). Env-tunable.
+const PERSIST_TICKS = Math.max(1, Number(process.env.DIST_GAP_PERSIST_TICKS || 2));
+let _consecutiveGapTicks = 0;
 
 export function startDistributionGapMonitor(bot) {
   if (_timer) return;
@@ -112,7 +124,12 @@ async function runOnce(bot) {
   const gap = required > distSpendable ? required - distSpendable : 0n;
 
   if (gap === 0n) {
-    // healthy — log occasionally so the operator can see the watcher is alive
+    // healthy — reset the persistence counter and log occasionally so the
+    // operator can see the watcher is alive.
+    if (_consecutiveGapTicks > 0) {
+      console.log(`[dist-gap] gap CLEARED after ${_consecutiveGapTicks} tick(s) — back to healthy`);
+    }
+    _consecutiveGapTicks = 0;
     if (Math.random() < 0.05) {
       console.log(
         `[dist-gap] healthy — distributor ${(Number(distBalance) / 1e9).toFixed(4)} ≥ required ${(Number(required) / 1e9).toFixed(4)} SOL`,
@@ -121,15 +138,53 @@ async function runOnce(bot) {
     return;
   }
 
+  // A GAP EXISTS. STEP 1 — SELF-HEAL FIRST: kick the auto-funder immediately
+  // (it in-tick unwraps any lender wSOL + funds CHCAM). A transient gap closes
+  // here and is NEVER alarmed. This is what makes the gap monitor a healer, not
+  // just a smoke detector.
+  kickDistributionFunder(bot, "gap-monitor");
+  _consecutiveGapTicks += 1;
+
+  // STEP 2 — PERSISTENCE GATE: only escalate to the operator once the gap has
+  // survived PERSIST_TICKS consecutive readings, i.e. the funder kick could NOT
+  // close it. A single transient reading never pages anyone.
+  if (_consecutiveGapTicks < PERSIST_TICKS) {
+    console.log(
+      `[dist-gap] gap=${(Number(gap) / 1e9).toFixed(4)} SOL seen (${_consecutiveGapTicks}/${PERSIST_TICKS}) — ` +
+        `kicked funder to self-heal; deferring alarm until persistent`,
+    );
+    return;
+  }
+
   // Categorize level.
   const ONE_SOL = 1_000_000_000n;
   const FIVE_SOL = 5_000_000_000n;
   const level = gap >= FIVE_SOL ? "p0" : gap >= ONE_SOL ? "alert" : "warn";
 
-  // Throttle per level.
+  // STEP 3 — THE RIGHT ACTION: a PERSISTENT gap means the funder couldn't close
+  // it. WHY it couldn't determines what the operator should do, so read the
+  // lender's available native and classify:
+  //   • lender CAN cover  → the funder/sweeper is stuck (disabled, key, RPC),
+  //     NOT a money problem. Action: investigate the funder. Do NOT hand-fund.
+  //   • lender CANNOT cover → protocol fee revenue is genuinely below the
+  //     accrued obligation right now. Action: investigate accrual/over-credit.
+  //     Still do NOT hand-fund (the auto-funder catches up on the next inflow).
+  let lenderAvail = null;
+  try { lenderAvail = await availableLenderNative(connection); } catch { /* unknown */ }
+  const lenderCanCover = lenderAvail != null && lenderAvail >= gap;
+  const actionLine = lenderCanCover
+    ? `→ The lender CAN cover this (${(Number(lenderAvail) / 1e9).toFixed(4)} SOL available) — so the FUNDER is stuck, not your wallet. ` +
+      `Check DIST_FUNDER_DISABLED, the lender key, and recent distribution_funding_events. *Do NOT hand-fund.*`
+    : `→ The lender CANNOT cover this${lenderAvail != null ? ` (only ${(Number(lenderAvail) / 1e9).toFixed(4)} SOL available)` : ""} — ` +
+      `real fee revenue is below the accrued obligation right now. *Do NOT add personal funds*; investigate accrual/over-credit. The funder tops up on the next inflow.`;
+
+  // Throttle per level (persistence already gated the first alarm). P0 keeps
+  // its no-throttle behavior so a genuine, persistent P0 pages every tick until
+  // closed (operator mandate 2026-06-19).
   const lastTs = _lastAlert[level] || 0;
-  if (Date.now() - lastTs < ALERT_THROTTLE_MS) {
-    console.log(`[dist-gap] ${level.toUpperCase()} gap=${(Number(gap) / 1e9).toFixed(4)} SOL — DM throttled`);
+  const throttleMs = level === "p0" ? P0_THROTTLE_MS : ALERT_THROTTLE_MS;
+  if (Date.now() - lastTs < throttleMs) {
+    console.log(`[dist-gap] ${level.toUpperCase()} gap=${(Number(gap) / 1e9).toFixed(4)} SOL (persistent ${_consecutiveGapTicks}) — DM throttled`);
     return;
   }
 
@@ -149,7 +204,10 @@ async function runOnce(bot) {
 
   const emoji = { warn: "⚠️", alert: "🟠", p0: "🚨" }[level];
   const dmText =
-    `${emoji} Distribution wallet GAP detected (${level.toUpperCase()})\n` +
+    `${emoji} Distribution wallet PERSISTENT gap (${level.toUpperCase()})\n` +
+    `\n` +
+    `Survived ${_consecutiveGapTicks} consecutive checks (~${Math.round((_consecutiveGapTicks * INTERVAL_MS) / 60_000)} min) ` +
+    `despite an auto-funder kick each time — so this is NOT a transient lag.\n` +
     `\n` +
     `Payable owed (holder+LP): ${(Number(totalOwed) / 1e9).toFixed(4)} SOL\n` +
     `  - magpie_holder_pool: ${(Number(holderOwed) / 1e9).toFixed(4)} SOL\n` +
@@ -161,14 +219,16 @@ async function runOnce(bot) {
     `\n` +
     `*DEFICIT: ${(Number(gap) / 1e9).toFixed(4)} SOL*\n` +
     `\n` +
+    `${actionLine}\n` +
+    `\n` +
     `Sweeper status:\n` +
     `  - Last successful sweep: ${lastSweepStr}\n` +
     `  - Planned-but-unresolved: ${planned}\n` +
     `  - Failed (24h): ${failed}\n` +
     `\n` +
     (level === "p0"
-      ? `*Next holder distribution will SKIP unless funded.*`
-      : `Next distribution may be at risk if the sweeper can't close the gap before snapshot.`);
+      ? `*Next holder distribution will SKIP unless this clears.*`
+      : `Next distribution may be at risk if this doesn't clear before snapshot.`);
 
   try {
     await notifyAdmin(bot, dmText, { parse_mode: "Markdown" });


### PR DESCRIPTION
## Why
The CHCAM "shortfalls" that kept forcing manual funding were **transient, not real**. Accrued fees land as **wSOL in the lender's fee ATA** and sit there for up to **1h** (the hourly `fee-wallet-sweeper`) before the 5-min *native-only* funder can even see them — so `/stats` showed `owed > CHCAM-native` and read like a deficit when the money was right there, just wrapped. The earlier diagnosis confirmed the counters reconcile to the lamport. These three no-regret changes make the autonomous funder self-evidently correct so it never needs watching.

## What

### 1. `/stats` true picture (operator-only)
- New ops-gated **REWARDS FUNDER** block: CHCAM-spendable vs owed vs gap + a plain-English **verdict** (`healthy` / `catching-up` / `lender-limited` / `paused`).
- A transient lag now reads *"catching up — auto-funds ≤5m, do NOT hand-fund"* instead of looking like a shortfall → **you stop pre-funding phantoms**.
- Gated by `isAdmin()`; wallet balances never appear in **public** `/stats`. Best-effort — a funder read failure never breaks `/stats`.
- `getDistributionFunderStatus()` returns `verdict` + spendable + lender headroom (purely additive).

### 2. In-tick lender-wSOL unwrap + event-driven self-heal
- When a funder tick finds a gap the lender's native alone can't close, it now **unwraps the lender's fee wSOL in-tick** (lender-own-wSOL → lender-own-native, idempotent close+reopen, under the shared lender lock already held, guard-simulated with the close destination pinned to the lender, audited to `fee_wallet_sweeps`). **Accrual → CHCAM latency drops from ≤1h to ≤5min.**
- New `kickDistributionFunder()` — fire-and-forget out-of-band nudge. A new **tick-start floor** (`INTERVAL_FLOOR_MS`) guarantees a kick can **never** run a tick within the no-double-fund window, so it's safe to call at any rate.

### 3. Gap-monitor hardening — alarm only on a REAL, persistent shortfall
- On every gap reading the monitor now **kicks the funder first (self-heal)**, and only DMs once the gap survives `DIST_GAP_PERSIST_TICKS` consecutive readings (default **2**) — a single transient reading never pages.
- **The right action**: a persistent gap is classified by lender headroom — *lender-can-cover* ⇒ the funder is stuck (investigate it, do **not** hand-fund); *lender-cannot-cover* ⇒ real revenue lag (investigate accrual, still do **not** hand-fund). P0 keeps its no-throttle once genuinely persistent.

## Safety
- **Zero** change to any user loan/collateral path. The fee-accrual path (`creditHolderPoolDirect`/`accrueToHolderPool`, inside the loan try/catch) is deliberately **not** touched — the event-driven hook runs through the gap-monitor, off the hot path.
- Money movement is unchanged in shape: still lender-own-wSOL unwrap + the single allowlisted `lender → CHCAM` transfer, both guard-simulated (`runPrivilegedSign`).
- No-double-fund invariant preserved (tick-start floor applies to every trigger).
- Pool credits remain idempotent (untouched).
- `node --check` clean on all three files; no circular import; no new deps.

## Env (all optional, sensible defaults)
- `DIST_FUNDER_MIN_INTICK_UNWRAP_SOL` (default 0.05) — floor below which in-tick lender unwrap is skipped as dust.
- `DIST_GAP_PERSIST_TICKS` (default 2) — consecutive gap readings before the monitor pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)