### PR TITLE
brand: 'Collateral that can still sell itself.' slogan rollout (copy-only)

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -116,6 +116,9 @@ export async function handleStart(ctx) {
   const msg = [
     "🏦 *Welcome to Magpie*",
     "",
+    "*Collateral that can still sell itself\\.*",
+    "Borrow SOL against your tokens — and set auto\\-sells on the same collateral\\. Liquidity, without giving up the upside\\.",
+    "",
     "_I'm Pip — Magpie's AI agent. I'll help you borrow SOL against your memecoin bags, manage loans, and answer questions along the way._",
     "",
     ...walletSection,

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -334,6 +334,8 @@ parlays, asking for "lock of the day", etc.):
 MAGPIE CAPITAL — what the protocol is
 
 CORE PROTOCOL FACTS:
+- What Magpie is, in one line (lead with this): Collateral that can still sell itself. Borrow SOL against your tokens — and set auto-sells on the same collateral. Liquidity, without giving up the upside.
+- The honest fine print under that line: supported collateral only (memecoins + tokenized stocks/RWAs), NOT "any token". The auto-sell layer is V4-ONLY — never imply a legacy V1/V3 loan auto-sells. Auto-sell orders fire on-chain through a slippage stack — never claim a guaranteed price, guaranteed fill, or zero slippage. Proceeds accrue IN-VAULT; the only path to the user's wallet is a borrower-signed repay (never "instant cash to your wallet"). Everything else true about Magpie still holds — permissionless, on Solana, on-chain credit score, Telegram-native, keeper network.
 - Loan tiers (all on-chain enforced, no per-user variation today):
     Express: 30% LTV · 2-day term · 3% fee
     Quick:   25% LTV · 3-day term · 2% fee
@@ -1930,7 +1932,7 @@ When a user says "I tried to set a take-profit and nothing happened" / "the ladd
 
 8. **Operator (admin) asking "is V4 healthy"** — call \`report_v4_health\`. Lead with the verdict ("HEALTHY" / "READY — no fires yet" / "DEGRADED — investigate"), then summarize active loans + 24h fires + any sol_proceeds_vault probe failures. If DEGRADED, point at the failing loan IDs and suggest /v4-status for the full report.
 
-9. **"What's a V4 loan?" / "What's the difference between V3 and V4?"** — V4 is the in-vault auto-sell program. On V4, when a ladder leg fires, the engine sells that slice of collateral inside the loan and the SOL accumulates in a per-loan vault (sol_proceeds_vault). The loan STAYS active. The user only sees the proceeds when they repay (or get liquidated). This is fundamentally different from V1/V3 which closed the loan on each fire and sent SOL directly to the wallet. V4 lets a single ladder cleanly scale out across multiple price levels without re-borrowing fees.
+9. **"What's a V4 loan?" / "What's the difference between V3 and V4?"** — V4 is the in-vault auto-sell program. Canonical one-liner for how the auto-sell works: "Take-profit, stop-loss, ladders, trailing stops — they fire on-chain into your loan's vault, the loan stays open, and proceeds reach your wallet only when you repay." On V4, when a ladder leg fires, the engine sells that slice of collateral inside the loan and the SOL accumulates in a per-loan vault (sol_proceeds_vault). The loan STAYS active. The user only sees the proceeds when they repay (or get liquidated). This is fundamentally different from V1/V3 which closed the loan on each fire and sent SOL directly to the wallet. V4 lets a single ladder cleanly scale out across multiple price levels without re-borrowing fees.
 
 10. **First-time user asking "how do I get a take-profit?"** — walk them through it: "Three steps. (1) Borrow against your token from the dashboard (magpie.capital/dashboard) or TG /borrow. (2) BEFORE you sign the borrow tx, set your ladder in the pre-borrow exit picker — pick a preset or build a custom one. (3) Sign the borrow tx + one Phantom envelope per ladder leg. After signing, the engine watches prices 24/7 and sells each leg automatically when its strike hits." Emphasize that exits work on V4 — the bot routes there automatically when an exit is attached.
 

--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -90,7 +90,9 @@ The only Solana addresses you may mention are the \$MAGPIE mint (9UuLsJ3jf8ViBNe
 
 **Launched:** March 2026 on Solana mainnet. If you don't know what year/month it is, default to this date — do NOT make one up from your training data (the model's priors will say 2025; that's wrong). If a user asks "when did Magpie launch" or "how long has Magpie been around," the answer is: launched March 2026, still early but already several months of operating history.
 
-**What it is:** Permissionless Solana lending. Users deposit approved tokens as collateral, receive SOL co-signed in seconds. Custodial-by-design (your Magpie wallet IS the bot wallet — that's what enables one-click flows).
+**What it is — lead with this:** Collateral that can still sell itself. Borrow SOL against your tokens — and set auto-sells on the same collateral. Liquidity, without giving up the upside.
+
+The mechanics underneath: Permissionless Solana lending. Users deposit approved collateral (memecoins + tokenized stocks/RWAs) as collateral, receive SOL co-signed in seconds. Custodial-by-design (your Magpie wallet IS the bot wallet — that's what enables one-click flows). The auto-sell layer (take-profit / stop-loss / ladders / trailing stops) is V4-ONLY — it does not apply to legacy V1/V3 loans. Auto-sell orders fire on-chain (subject to a slippage stack — never promise a guaranteed price or zero slippage), proceeds accrue IN-VAULT inside the loan, and the only path to the user's wallet is a borrower-signed repay.
 
 **Loan tiers — depends on what's being collateralized.**
 
@@ -152,6 +154,8 @@ A dedicated RWA collateral pool for tokenized US equities ($NVDAx, $COINx, $TSLA
 
 **V4 in-vault auto-sells (LIVE 2026-06-15 — IMPORTANT NEW MODEL):**
 V4 is a parallel lending program at HA1hgvskN1goEsb33rNHFBcDXBaYyLyyqfGwGMgTUwNo that handles a fundamentally different auto-sell model. When a user opens a borrow AND attaches an auto-sell (take-profit / stop-loss / bracket / ladder) in the SAME flow, the loan automatically routes to V4. Plain borrows (no exit attached) continue to use V1 (memecoin) or V3 (RWA).
+
+How the auto-sell actually works (the canonical explainer): Take-profit, stop-loss, ladders, trailing stops — they fire on-chain into your loan's vault, the loan stays open, and proceeds reach your wallet only when you repay.
 
 What's different about V4: when an auto-sell fires, the collateral converts to SOL but the SOL STAYS INSIDE the loan vault — it does NOT go to the user's wallet. The loan stays Active. The user decides when to /repay to claim the mix (remaining collateral + accumulated SOL). This gives users tax-timing control, repay-when-ready freedom, and brokerage-style stop semantics on-chain.
 


### PR DESCRIPTION
**Copy-only, review-gated.** No logic changes, no dependency changes — only system-prompt / welcome-message copy. Leads every "what is Magpie" surface in the Telegram bot with the canonical brand slogan, while preserving all existing true facts.

## Canonical copy (byte-identical across surfaces)
- **SLOGAN:** `Collateral that can still sell itself.`
- **EXPLAINER:** `Borrow SOL against your tokens — and set auto-sells on the same collateral. Liquidity, without giving up the upside.`
- **MECHANIC:** `Take-profit, stop-loss, ladders, trailing stops — they fire on-chain into your loan's vault, the loan stays open, and proceeds reach your wallet only when you repay.`

## Files changed

### `src/services/community-pip.js` (Pip's public group "what is Magpie" knowledge)
- **`# PROTOCOL FACTS` → "What it is" block** — before: opened with `**What it is:** Permissionless Solana lending. Users deposit approved tokens as collateral…`; after: now leads with the SLOGAN + EXPLAINER, then keeps the full existing mechanics paragraph (permissionless / Solana / custodial-by-design) plus truthfulness guardrails inline (supported collateral only = memecoins + tokenized stocks/RWAs; auto-sell is V4-ONLY; fires on-chain through a slippage stack, no guaranteed price; proceeds accrue in-vault; only path to wallet is a borrower-signed repay).
- **V4 in-vault auto-sells block** — added the MECHANIC line as the canonical "how the auto-sell works" explainer, immediately before the existing "What's different about V4" paragraph (unchanged).

### `src/services/ai-support.js` (Pip's DM/support Magpie description)
- **`CORE PROTOCOL FACTS:` header** — added two lead bullets: (1) the SLOGAN + EXPLAINER as the one-line "what Magpie is"; (2) the truthfulness fine print (supported collateral only, V4-only auto-sell, slippage stack / no guaranteed fill, in-vault proceeds / borrower-signed repay, and a reminder that all other true facts still hold — permissionless, Solana, on-chain credit score, Telegram-native, keeper network). Existing tier/fee/etc. facts untouched.
- **Item 9 "What's a V4 loan?" explainer** — inserted the MECHANIC line verbatim as the canonical one-liner for how the auto-sell works; the rest of the explanation is unchanged.

### `src/commands/start.js` (`/start` welcome copy)
- **`handleStart` welcome `msg` array** — added the SLOGAN (bold) + EXPLAINER as the lead, directly under `🏦 *Welcome to Magpie*` and above the existing Pip intro line (unchanged). Telegram MarkdownV2 escaping applied (`\.`, `\-`) so the rendered text is byte-identical to the canonical strings.

## Truthfulness guardrails honored
- Auto-sell framed as **V4-only**; no implication that legacy V1/V3 loans auto-sell.
- No guaranteed profit / guaranteed fill / zero slippage — "auto-sell orders that fire on-chain," slippage stack noted.
- Proceeds accrue **in-vault**; only path to wallet is a borrower-signed repay (never "instant cash").
- "Supported collateral only" (memecoins + tokenized stocks/RWAs), not "any token."
- All pre-existing true claims (permissionless, Solana, on-chain credit score, Telegram-native, keeper network) preserved — slogan ADDED as the lead, nothing accurate deleted.

## Verification
- `node --check` passes on all three edited `.js` files.
- No `build`/`typecheck`/`lint`/`test` script exists in `package.json` (plain Node ESM); syntax check is the applicable gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
