### PR TITLE
fix(borrow): screeners aggregate liquidity across all pools (completes the $ANSEM cached-floor class fix)

### DIFF
--- a/src/services/rwa-screener.js
+++ b/src/services/rwa-screener.js
@@ -579,11 +579,18 @@ async function tick(bot) {
         continue;
       }
       const top = pairs.sort((a, b) => (b.liquidity?.usd || 0) - (a.liquidity?.usd || 0))[0];
+      // AGGREGATE liquidity across ALL of this mint's pools — a sell/liquidation
+      // routes via Jupiter across every pool, so the cached liquidity_usd the
+      // borrow gate floors against must be TOTAL depth, not the single largest
+      // pool. (Single-pool under-read wrongly blocked a borrow on a multi-pool
+      // token — $ANSEM, 2026-06-30.) Price/symbol/name stay from the top pool
+      // (those are per-pair, not summed).
+      const aggLiquidityUsd = pairs.reduce((s, p) => s + (Number(p.liquidity?.usd) || 0), 0);
       const probed = {
         mint: row.mint,
         symbol: top.baseToken?.symbol || row.symbol,
         name: top.baseToken?.name || row.symbol,
-        liquidity: top.liquidity?.usd || 0,
+        liquidity: aggLiquidityUsd,
         volume24h: top.volume?.h24 || 0,
         priceUsd: parseFloat(top.priceUsd) || 0,
       };

--- a/src/services/token-screener.js
+++ b/src/services/token-screener.js
@@ -529,20 +529,39 @@ async function getMarketData(mints) {
       const addr = p.baseToken?.address;
       if (!addr) continue;
 
-      const liq = p.liquidity?.usd ?? 0;
+      const liq = Number(p.liquidity?.usd) || 0;
       const existing = result.get(addr);
-      if (existing && (existing.liquidity ?? 0) >= liq) continue;
-
-      result.set(addr, {
-        symbol: p.baseToken?.symbol || "???",
-        name: p.baseToken?.name || p.baseToken?.symbol || "Unknown",
-        price: p.priceUsd ? parseFloat(p.priceUsd) : null,
-        liquidity: liq,
-        volume24h: p.volume?.h24 ?? 0,
-        marketCap: p.marketCap ?? p.fdv ?? 0,
-        pairCreatedAt: p.pairCreatedAt ?? null,
-        imageUrl: p.info?.imageUrl ?? null,
-      });
+      if (!existing) {
+        result.set(addr, {
+          symbol: p.baseToken?.symbol || "???",
+          name: p.baseToken?.name || p.baseToken?.symbol || "Unknown",
+          price: p.priceUsd ? parseFloat(p.priceUsd) : null,
+          // AGGREGATE: liquidity is the SUM across ALL of this token's pools (a
+          // sell routes via Jupiter across every pool). Single-pool under-read
+          // wrongly blocked a borrow on a multi-pool token ($ANSEM 2026-06-30);
+          // the cached liquidity_usd the borrow gate floors against must be the
+          // TOTAL depth. Price/symbol/metadata come from the LARGEST pool.
+          liquidity: liq,
+          _topPoolLiq: liq,
+          volume24h: p.volume?.h24 ?? 0,
+          marketCap: p.marketCap ?? p.fdv ?? 0,
+          pairCreatedAt: p.pairCreatedAt ?? null,
+          imageUrl: p.info?.imageUrl ?? null,
+        });
+      } else {
+        existing.liquidity += liq; // sum every pool for this token
+        if (liq > (existing._topPoolLiq ?? 0)) {
+          // larger pool → take its price + metadata as the representative
+          existing._topPoolLiq = liq;
+          existing.symbol = p.baseToken?.symbol || existing.symbol;
+          existing.name = p.baseToken?.name || existing.name;
+          existing.price = p.priceUsd ? parseFloat(p.priceUsd) : existing.price;
+          existing.volume24h = p.volume?.h24 ?? existing.volume24h;
+          existing.marketCap = p.marketCap ?? p.fdv ?? existing.marketCap;
+          existing.pairCreatedAt = p.pairCreatedAt ?? existing.pairCreatedAt;
+          existing.imageUrl = p.info?.imageUrl ?? existing.imageUrl;
+        }
+      }
     }
   }
   return result;


### PR DESCRIPTION
Companion to #547. Makes cached supported_mints.liquidity_usd an AGGREGATE across all pools (not single largest) in rwa-screener + token-screener. End-to-end, live + cached liquidity used by the borrow gate are now total cross-pool depth → a liquidity misread can never wrongly block a legit borrow on any token. node --check clean; metadata still from largest pool; thin-in-all-sources still refused.