### PR TITLE
brand: Pip + /start lead with the lending positioning (uniformity with site #231)

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -116,8 +116,8 @@ export async function handleStart(ctx) {
   const msg = [
     "🏦 *Welcome to Magpie*",
     "",
-    "*Collateral that can still sell itself\\.*",
-    "Borrow SOL against your tokens — and set auto\\-sells on the same collateral\\. Liquidity, without giving up the upside\\.",
+    "*A Solana lending protocol — liquidity without selling your bag\\.*",
+    "Borrow SOL against your memecoins, tokenized stocks, and RWAs — and set take\\-profits and stops on that same collateral\\. Liquidity now, upside intact: collateral that can still sell itself\\.",
     "",
     "_I'm Pip — Magpie's AI agent. I'll help you borrow SOL against your memecoin bags, manage loans, and answer questions along the way._",
     "",

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -334,7 +334,7 @@ parlays, asking for "lock of the day", etc.):
 MAGPIE CAPITAL — what the protocol is
 
 CORE PROTOCOL FACTS:
-- What Magpie is, in one line (lead with this): Collateral that can still sell itself. Borrow SOL against your tokens — and set auto-sells on the same collateral. Liquidity, without giving up the upside.
+- What Magpie is, in one line (lead with this): Magpie is a Solana lending protocol — borrow SOL against your memecoins, tokenized stocks, and RWAs without selling them, and set take-profits and stops on that same collateral. Liquidity now, upside intact — collateral that can still sell itself.
 - The honest fine print under that line: supported collateral only (memecoins + tokenized stocks/RWAs), NOT "any token". The auto-sell layer is V4-ONLY — never imply a legacy V1/V3 loan auto-sells. Auto-sell orders fire on-chain through a slippage stack — never claim a guaranteed price, guaranteed fill, or zero slippage. Proceeds accrue IN-VAULT; the only path to the user's wallet is a borrower-signed repay (never "instant cash to your wallet"). Everything else true about Magpie still holds — permissionless, on Solana, on-chain credit score, Telegram-native, keeper network.
 - Loan tiers (all on-chain enforced, no per-user variation today):
     Express: 30% LTV · 2-day term · 3% fee

--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -90,7 +90,7 @@ The only Solana addresses you may mention are the \$MAGPIE mint (9UuLsJ3jf8ViBNe
 
 **Launched:** March 2026 on Solana mainnet. If you don't know what year/month it is, default to this date — do NOT make one up from your training data (the model's priors will say 2025; that's wrong). If a user asks "when did Magpie launch" or "how long has Magpie been around," the answer is: launched March 2026, still early but already several months of operating history.
 
-**What it is — lead with this:** Collateral that can still sell itself. Borrow SOL against your tokens — and set auto-sells on the same collateral. Liquidity, without giving up the upside.
+**What it is — lead with this:** Magpie is a Solana lending protocol — borrow SOL against your memecoins, tokenized stocks, and RWAs without selling, and set take-profits and stops on the same collateral. Liquidity now, upside intact: collateral that can still sell itself.
 
 The mechanics underneath: Permissionless Solana lending. Users deposit approved collateral (memecoins + tokenized stocks/RWAs) as collateral, receive SOL co-signed in seconds. Custodial-by-design (your Magpie wallet IS the bot wallet — that's what enables one-click flows). The auto-sell layer (take-profit / stop-loss / ladders / trailing stops) is V4-ONLY — it does not apply to legacy V1/V3 loans. Auto-sell orders fire on-chain (subject to a slippage stack — never promise a guaranteed price or zero slippage), proceeds accrue IN-VAULT inside the loan, and the only path to the user's wallet is a borrower-signed repay.
 


### PR DESCRIPTION
Aligns every bot/Pip surface to the revised brand architecture shipped on the site (#231), per the operator's uniformity mandate (2026-06-30 PM: *'everything on the protocol needs to be ALIGNED'*).

3-layer architecture (same everywhere now):
- **Category:** Solana lending protocol
- **Positioning:** Liquidity without selling your bag
- **Differentiator (closer, kept):** collateral that can still sell itself

Surfaces updated: `/start` intro, Pip support 'one line' (ai-support.js), community Pip knowledge (community-pip.js). Copy-only; `node --check` clean.