### PR TITLE
borrow: harden warm-tier readiness so #554's cost cut can never fail a loan

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -1450,6 +1450,26 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
             borrowProgramId.toBase58() === process.env.PROGRAM_ID_V3);
 
         if (usesTwapGate) {
+          // Register TRANSIENT INTEREST first: a warm-tier idle memecoin is
+          // excluded from continuous attestation, and the 300s TWAP span is a
+          // TIME requirement (no amount of rapid attesting shortcuts it — that
+          // just wraps the 32-slot buffer). So put this mint into the continuous
+          // (~30s-cadence) attest loop for ~10 min so its span keeps building
+          // through this warm AND the user's retry. Same two-track mechanism as
+          // the site's hot-on-select beacon. Fire-and-forget; never blocks.
+          try {
+            const { requestMintWarm } = await import("../services/v4-feed-readiness.js");
+            requestMintWarm(mintStr);
+          } catch {}
+          try {
+            await query(
+              `INSERT INTO mint_warming_intents (mint, requested_by, expires_at)
+                 VALUES ($1, 'cosign-jit-warm', NOW() + INTERVAL '10 minutes')
+               ON CONFLICT (mint) DO UPDATE
+                 SET expires_at = NOW() + INTERVAL '10 minutes'`,
+              [mintStr],
+            );
+          } catch {}
           // Program's TWAP gate needs >= 8 samples within 300s OR
           // `TwapInsufficientHistory` (Anchor 6016 / 0x1780) rejects
           // the borrow. The single-shot freshness attest below is
@@ -1482,15 +1502,23 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
                 `CRIT [cosign-borrow] JIT TWAP warmer TIMED OUT — user hit TwapInsufficientHistory on borrow. prog=${borrowProgramId.toBase58().slice(0, 8)} mint=${mintStr.slice(0, 12)} inWindow=${warm.inWindow}/8 waited=${warm.waitedMs}ms attests=${warm.attests} reason=${warm.reason}`,
               );
             } catch {}
+            // Accurate, honest retry hint. secondsToReady (from ensureV4TwapReady)
+            // is dominated by the 300s span requirement for a stone-cold feed —
+            // don't promise "30s" when it's really a few minutes. The mint is
+            // now in the continuous loop (transient interest above), so the span
+            // WILL build and the retry lands.
+            const secs = Math.min(300, Math.max(15, warm.secondsToReady ?? 30));
             return {
               status: 503,
               body: {
                 error:
-                  "Price oracle is warming up for this token (we need a few more samples in the rolling 5-min window). This usually clears in 30–45 seconds — please tap Borrow again.",
+                  secs > 60
+                    ? `Price oracle is warming up for this token — it needs about ${Math.ceil(secs / 60)} more minute(s) of price history in the rolling 5-min window. We've queued it to warm; please tap Borrow again shortly.`
+                    : "Price oracle is warming up for this token (a few more samples in the rolling 5-min window). This usually clears in 30–45 seconds — please tap Borrow again.",
                 oracle_warming: true,
                 in_window: warm.inWindow,
                 required_in_window: 8,
-                retry_after_seconds: 30,
+                retry_after_seconds: secs,
               },
             };
           }
@@ -1934,6 +1962,28 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
     })();
     const detail = [message, code, logs, stringified].filter(Boolean).join(" :: ").slice(0, 600) || "unknown_submission_error";
     console.error("[cosign-borrow] SUBMISSION_FAILED:", stringified, "logs:", logs);
+    // CLASS-ELIMINATING (borrow-conversion mandate): a broadcast-TIME TWAP /
+    // price error — e.g. the oldest in-window sample ages past the on-chain
+    // 300s edge in the gap between the pre-broadcast sim passing and confirm —
+    // must NEVER surface raw. Pip/x402 surfaces don't run translateTxError, so
+    // a raw "custom program error: 0x1780" would leak to a real borrower.
+    // Classify send/confirm the SAME way the sim path (~1738-1768) does, BEFORE
+    // building the raw "Submission failed" body, so no surface can ever get it.
+    if (/StalePriceAttestation|"Custom":\s*6013\b|0x177d/i.test(detail)) {
+      recordBorrowFailure("stale_price_attestation");
+      _recordBorrowConversionFailure(_convCtx, "stale_price_attestation_broadcast", { detail: detail?.slice(0, 220) });
+      return { status: 503, body: { error: "Oracle is finalizing — please tap Borrow again in 20–30 seconds.", oracle_warming: true, retry_after_seconds: 25, detail } };
+    }
+    if (/TwapInsufficientHistory|"Custom":\s*6016\b|0x1780/i.test(detail)) {
+      recordBorrowFailure("twap_insufficient_history");
+      _recordBorrowConversionFailure(_convCtx, "twap_insufficient_history_broadcast", { detail: detail?.slice(0, 220) });
+      return { status: 503, body: { error: "Oracle is finalizing — please tap Borrow again in 20–30 seconds.", oracle_warming: true, retry_after_seconds: 25, detail } };
+    }
+    if (/CollateralValueExceedsAttestation|"Custom":\s*6014\b|0x177e/i.test(detail)) {
+      recordBorrowFailure("collateral_value_exceeds");
+      _recordBorrowConversionFailure(_convCtx, "collateral_value_exceeds_broadcast", { detail: detail?.slice(0, 220) });
+      return { status: 503, body: { error: "Price moved while you were signing. Please tap Borrow again to get a fresh quote.", price_moved: true, retry_after_seconds: 3, detail } };
+    }
     return {
       status: 500,
       body: { error: `Submission failed: ${detail}`, detail, message, code, logs },

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -257,43 +257,67 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
       await new Promise((r) => setTimeout(r, 1000));
       continue;
     }
-    if (status.inWindow >= REQUIRED_IN_WINDOW) {
+    // The on-chain V3/V4 TWAP gate requires BOTH >= MIN_SAMPLES in-window AND
+    // >= MIN_HISTORY_SECONDS (300s) of span since the oldest in-window sample
+    // (magpie-lending-v3 lib.rs). Checking the COUNT alone false-readies a
+    // stone-cold feed (10 samples fired in 15s → count ok, span 15s → the chain
+    // REJECTS at broadcast). So require the span too: "ready" here now means
+    // "will pass on-chain", which is what closes the sign-then-fail path.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const spanSec = status.oldestInWindowTs != null ? nowSec - status.oldestInWindowTs : 0;
+    if (status.inWindow >= REQUIRED_IN_WINDOW && spanSec >= WINDOW_SEC) {
       return {
         ok: true,
         inWindow: status.inWindow,
+        spanSec,
         waitedMs: Date.now() - START,
         attests,
         programId: programId.toBase58().slice(0, 8),
       };
     }
-    // Need more samples — fire one attest and wait briefly so the
-    // tx finalizes (confirmed) before the next iteration measures.
-    try {
-      await attestPrice(mintStr, decimals, undefined, programId);
-      attests++;
-    } catch (e) {
-      lastErr = e.message?.slice(0, 100);
-      // If this fails because the feed PDA wasn't actually initialized,
-      // re-init and try again. AccountNotInitialized → 3012/0xbc4.
-      if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(lastErr)) {
-        try {
-          await initializePriceFeed(mintStr, programId);
-        } catch (e2) {
-          lastErr = `init-then-attest failed: ${e2.message?.slice(0, 80)}`;
+    // Fire an attest ONLY when we're short on SAMPLES. Once the window is
+    // populated (count met) but the SPAN is still < 300s, firing more would
+    // wrap the 32-slot circular buffer and keep the oldest in-window sample
+    // recent — so the span could NEVER reach 300s and the feed would never
+    // become borrowable. When count is met, just WAIT for the span to age
+    // (the transient-interest continuous attestor the caller registers keeps
+    // the feed fresh at the ~30s cadence that lets span grow naturally).
+    if (status.inWindow < REQUIRED_IN_WINDOW) {
+      try {
+        await attestPrice(mintStr, decimals, undefined, programId);
+        attests++;
+      } catch (e) {
+        lastErr = e.message?.slice(0, 100);
+        // If this fails because the feed PDA wasn't actually initialized,
+        // re-init and try again. AccountNotInitialized → 3012/0xbc4.
+        if (/AccountNotInitialized|account.*does not exist|0xbc4|3012/i.test(lastErr)) {
+          try {
+            await initializePriceFeed(mintStr, programId);
+          } catch (e2) {
+            lastErr = `init-then-attest failed: ${e2.message?.slice(0, 80)}`;
+          }
         }
       }
     }
     await new Promise((r) => setTimeout(r, SPACING_MS));
   }
 
-  // Timed out — return current state so caller can surface a good message.
+  // Timed out — return current state + an ACCURATE seconds-to-ready so the
+  // caller surfaces a truthful "warming, retry in ~N s" (not a flat 30s that
+  // bounces a genuinely-cold feed for minutes). secondsToReady is dominated by
+  // the 300s span requirement for a cold feed.
   const final = await getV4TwapSampleCount(mintStr, WINDOW_SEC, programId);
+  const finalNowSec = Math.floor(Date.now() / 1000);
+  const finalSpanSec = final?.oldestInWindowTs != null ? finalNowSec - final.oldestInWindowTs : 0;
+  const countShort = (final?.inWindow ?? 0) < REQUIRED_IN_WINDOW;
   return {
     ok: false,
     inWindow: final?.inWindow ?? 0,
+    spanSec: finalSpanSec,
+    secondsToReady: Math.max(5, WINDOW_SEC - finalSpanSec),
     waitedMs: Date.now() - START,
     attests,
-    reason: lastErr || "timeout",
+    reason: lastErr || (countShort ? "timeout" : "span_warming"),
   };
 }
 


### PR DESCRIPTION
Adversarial audit of #554 (warming idle memecoins) found the cost cut could let a cold-feed borrow hit a hard error. Three class-eliminating fixes so every loan either succeeds or shows a clean, accurate 'warming, retry' wait: **(1)** broadcast-time TWAP classifier (no raw 0x1780/0x177d ever reaches Pip/x402), **(2)** span-aware readiness (match the on-chain 300s span gate; stop rapid-firing that wraps the buffer; accurate retry hint), **(3)** transient interest (register requestMintWarm + mint_warming_intents so a warm idle memecoin keeps warming through the retry). Cost savings preserved. `node --check` clean. Site companions coming: proxy timeout 30s→95s + PipActionCard translateTxError.