### PR TITLE
screener: add $BOT (RoboStrategy xStock) as operator-trusted stock — V3+V4

### DIFF
--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -1081,6 +1081,47 @@ export async function applyStartupPatches() {
      VALUES ('SNDKbwMUQvZhnLnxLduradgLHG5KrPuKwpnrkkGRhfH')
      ON CONFLICT DO NOTHING`,
 
+    // $BOT — RoboStrategy tokenized stock (Backpack Securities, Token-2022),
+    // operator-trusted MANUAL approval with FULL approval (2026-07-02).
+    // Identical profile to $SNDK/$MU: category='stock' so it (a) shows in the
+    // site's Tokenized Stocks column, (b) routes to V3 (no-exit) + V4 (with-exit)
+    // per chooseProgramId RWA routing, (c) is force-kept hot+protected by the
+    // stocks-rwa-protection-sentinel so it can NEVER be auto-disabled and its
+    // V3/V4 price_feed PDAs stay pre-warmed (hot tier keeps the 8-sample TWAP
+    // window filled — required for the V3/V4 TWAP gate on low-liquidity xStocks).
+    // decimals=6 + Token-2022 owner + name "RoboStrategy - Backpack Securities" +
+    // symbol BOT verified on-chain; Jupiter prices it (~$36.46) so the attestor
+    // fills the TWAP window. mint+freeze authority held by Backpack (same as
+    // $SNDK/$DRAM). ON CONFLICT re-asserts symbol/name/category/enabled/protected/
+    // hot on EVERY boot, so no health watcher / screener can take it off or
+    // mis-categorize it.
+    `INSERT INTO supported_mints
+       (mint, symbol, name, decimals, category, image_url,
+        liquidity_usd, holder_count, market_cap_usd,
+        has_mint_authority, has_freeze_authority, lp_burned,
+        token_age_hours, auto_approved, screened_at, source,
+        enabled, protected, attestation_tier)
+     VALUES ('BoTx8y9ynfdxf5ZjWtCoBVkff52qKA82ysaLU8ZM6d8T',
+             'BOT', 'RoboStrategy', 6, 'stock', NULL,
+             0, 0, 0,
+             TRUE, TRUE, FALSE,
+             0, FALSE, NOW(), 'operator_trusted',
+             TRUE, TRUE, 'hot')
+     ON CONFLICT (mint) DO UPDATE SET
+       symbol = 'BOT',
+       name = 'RoboStrategy',
+       category = 'stock',
+       decimals = 6,
+       enabled = TRUE,
+       protected = TRUE,
+       attestation_tier = 'hot',
+       source = 'operator_trusted'`,
+
+    // Keep the screener from ever re-processing $BOT (operator-trusted, exempt).
+    `INSERT INTO token_screen_seen (mint)
+     VALUES ('BoTx8y9ynfdxf5ZjWtCoBVkff52qKA82ysaLU8ZM6d8T')
+     ON CONFLICT DO NOTHING`,
+
     // $QUEST — operator-trusted MANUAL approval (full approval 2026-06-23).
     // pump.fun memecoin (Token-2022, mint + freeze authority both renounced,
     // decimals=6, verified on-chain). category='memecoin' → routes V1 (no-exit) +


### PR DESCRIPTION
Operator FULL approval. Adds $BOT (RoboStrategy, Backpack Securities tokenized stock, CA `BoTx8y9ynfdxf5ZjWtCoBVkff52qKA82ysaLU8ZM6d8T`) as an operator-trusted `category='stock'` mint → eligible for V3 + V4 loans, hot+protected, screener-exempt, re-asserted every boot. Verified on-chain (Token-2022, decimals 6) + Jupiter-priced (~$36.46) so TWAP attestation fills. Mirrors $SNDK/$DRAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)