### PR TITLE
pip: fix @magpie_capital_bot rendering in the 'Two Magpies' post

### DIFF
--- a/src/services/community-proactive.js
+++ b/src/services/community-proactive.js
@@ -723,7 +723,7 @@ const VIBE_ROTATORS = [
   // 8. Safety reminder (rotates with the four-handle trust line)
   () => `🛡 Quick reminder: Magpie has *exactly four* official accounts. Anyone else claiming to be us is a scammer. Verify at magpie.capital/links.`,
   // 9. Two-surface reminder
-  () => `📲 Two Magpies: *@magpie\\_capital\\_bot* (your private wallet) and *@magpietalk* (this community). No DM support. No airdrops. No surprises.`,
+  () => `📲 Two Magpies: \`@magpie_capital_bot\` (your private wallet) and \`@magpietalk\` (this community). No DM support. No airdrops. No surprises.`,
   // 10. Lifetime repaid milestone
   (s) => `✅ *${s.repaid}* loans repaid lifetime. Zero LP losses. Every flow on-chain.`,
 ];


### PR DESCRIPTION
Operator-flagged: Pip's 'Two Magpies' vibe post rendered `@magpie\_capital\_bot` with literal backslashes. Cause: the string escaped underscores as `\_` but is sent with legacy `parse_mode: 'Markdown'`, which doesn't unescape backslashes (only MarkdownV2 does). Fixed by wrapping both handles in inline-code backticks — renders clean monospace `@magpie_capital_bot` / `@magpietalk` in legacy Markdown. Only occurrence of this pattern in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)