### PR TITLE
Security: close 4 adversarially-verified audit findings

### DIFF
--- a/src/commands/repay.js
+++ b/src/commands/repay.js
@@ -34,6 +34,7 @@ export async function handleRepay(ctx) {
      FROM loans l
      LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
      WHERE l.status = 'active'
+       AND COALESCE(l.suspended, FALSE) = FALSE
        AND (l.user_id = $1
             OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $1))
      ORDER BY l.due_timestamp ASC`,
@@ -126,6 +127,7 @@ export function registerRepayCallbacks(bot) {
        FROM loans l
        LEFT JOIN supported_mints sm ON sm.mint = l.collateral_mint
        WHERE l.id = $1 AND l.status = 'active'
+         AND COALESCE(l.suspended, FALSE) = FALSE
          AND (l.user_id = $2
               OR l.borrower_wallet IN (SELECT public_key FROM wallets WHERE user_id = $2))`,
       [loanDbId, user.id],

--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,10 @@ const DM_ONLY_COMMANDS = new Set([
   "topup", "extend", "lock", "autoprotect", "protect", "tp", "sl",
   "export", "exportdata", "import", "wallet", "wallets", "switchwallet",
   "signedhistory", "me", "positions", "loans", "history",
+  // Agent-delegation commands are account-scoped (they authorize a delegate to
+  // act on the caller's wallet) — NEVER let them run in a public group, where a
+  // copy-pasted /agent_authorize could silently grant an attacker's key access.
+  "agent_authorize", "agent_revoke", "agent_list",
 ]);
 bot.use(async (ctx, next) => {
   const text = ctx.message?.text || "";

--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -522,6 +522,16 @@ export async function preBorrowAntiExploitCheck(opts) {
                 `Borrows refused until price settles (a few minutes).`,
             };
           }
+        } else {
+          // No trailing samples → the pump gate can't run and this borrow has
+          // NO off-chain pump protection (fail-open). Brief for a just-enabled
+          // mint, but if it persists the mint isn't being snapshotted — surface
+          // it loudly so a systematic gap can't hide. The on-chain V3/V4 TWAP is
+          // the backstop here (V1 has none). See price-snapshotter coverage.
+          console.warn(
+            `[anti-exploit] TWAP pump-gate SKIPPED for ${String(collateralMint).slice(0, 8)}… ` +
+            `— no trailing snapshots (fail-open); on-chain TWAP is the only remaining pump guard.`,
+          );
         }
       } catch (err) {
         // fail open — TWAP is one defense layer, not a single point of failure

--- a/src/services/price-snapshotter.js
+++ b/src/services/price-snapshotter.js
@@ -26,9 +26,18 @@ const PRUNE_AFTER_HOURS = Math.max(
   1,
   Number(process.env.PRICE_SNAPSHOT_PRUNE_HOURS) || 24,
 );
+// Must cover EVERY eligible mint each tick. The old default of 50 (with
+// `ORDER BY mint LIMIT 50` and no rotation) silently dropped every mint past
+// the 50th alphabetically — ~124 of 174 eligible mints never got a snapshot,
+// which PERMANENTLY fail-opened the off-chain TWAP pump-guard for them
+// (getTrailingPriceStats needs >=5 samples in a 30-min window; anti-exploit.js
+// skips the check when it returns null). A mint also needs a snapshot roughly
+// every <=6 min to accumulate 5 samples in the window, so partial rotation is
+// not enough — we snapshot the WHOLE eligible set every tick. High ceiling is
+// a runaway backstop, not a working limit; run() logs if it's ever hit.
 const MAX_MINTS_PER_TICK = Math.max(
   1,
-  Number(process.env.PRICE_SNAPSHOT_MAX_MINTS_PER_TICK) || 50,
+  Number(process.env.PRICE_SNAPSHOT_MAX_MINTS_PER_TICK) || 1000,
 );
 
 const DISABLED = process.env.PRICE_SNAPSHOTTER_DISABLED === "true";
@@ -45,6 +54,15 @@ async function fetchMintsToSnapshot() {
       LIMIT $1`,
     [MAX_MINTS_PER_TICK],
   );
+  if (rows.length >= MAX_MINTS_PER_TICK) {
+    // Truncation would silently re-disable the off-chain TWAP guard for the
+    // dropped mints — surface it loudly instead of failing open in the dark.
+    console.warn(
+      `[price-snapshotter] eligible mints hit the ${MAX_MINTS_PER_TICK} cap — ` +
+      `mints past the cap get NO snapshots (off-chain TWAP fail-opens for them). ` +
+      `Raise PRICE_SNAPSHOT_MAX_MINTS_PER_TICK.`,
+    );
+  }
   return rows.map((r) => r.mint);
 }
 


### PR DESCRIPTION
From a 6-surface adversarial audit (23 agents; each finding independently refuted before surviving). **7 confirmed, 10 dismissed as already-guarded.** This ships the 4 clear, low-risk fixes.

| # | Sev | Fix |
|---|-----|-----|
| 1 | MED→(root of a HIGH) | `price-snapshotter.js`: cap 50→1000 so **all ~174 eligible mints** get price samples. Old `LIMIT 50`/no-rotation left ~124 mints (incl. MANLET) with zero snapshots → the off-chain TWAP pump-gate **fail-opened permanently** for them. |
| 2 | (defense-in-depth) | `anti-exploit.js`: WARN when the TWAP gate is skipped for want of samples (kept fail-open — never block a legit borrow; on-chain TWAP backstops). |
| 5/6 | HIGH | `repay.js`: TG `/repay` didn't filter **suspended** loans → an exploit-locked borrower could repay via Telegram and buy back seized collateral / dodge liquidation. Added `AND COALESCE(l.suspended,FALSE)=FALSE` to both queries (matches the agent API). |
| 7 | HIGH | `index.js`: `agent_authorize/revoke/list` are account-scoped delegation cmds but weren't DM-only → a copy-pasted `/agent_authorize` in the public group could grant an attacker's key access. Added to `DM_ONLY_COMMANDS`. |

**Deferred (careful standalone — not rushed into this PR):**
- **#3 (HIGH)** cosign-borrow stale-snapshot valuation could lend against a pumped stale price when *all* live pricing fails — touches the borrow-pricing path; the snapshotter fix already shrinks its window.
- **#4 (HIGH)** on-chain **V1 has no TWAP**; memecoins routed to V1 rely solely on the (now-restored) off-chain guard. Real fix = route memecoins to V3/V4 (on-chain TWAP) via `ROUTE_MEMECOINS_TO_V3` — an **operator env decision** + routing review, not a silent code flip.

**Dismissed (verified already-guarded):** borrower `Signer` enforced by the Solana runtime; x402 per-call + accrual ceilings; nonce 5-min freshness precedes the nonce check; trusted-holder owner-resolution guarded by Solana's account model; x402 release idempotency; +5 more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)