### PR TITLE
reply-capture: forward user DM replies to operator instead of dropping them

### DIFF
--- a/src/commands/fallback.js
+++ b/src/commands/fallback.js
@@ -316,14 +316,34 @@ export async function handleFallback(ctx) {
     }
   }
 
-  // No match — show helpful suggestions
+  // ── Reply capture ──────────────────────────────────────────────
+  // A plain conversational message that matched no command is almost always a
+  // REAL reply — feedback, a question, a response to an outreach/winback DM.
+  // Historically this hit a canned "I'm not sure what you mean" and was LOST.
+  // Now: forward it to the operator(s) so a human actually sees it and can
+  // respond, and acknowledge the user warmly instead of robotically.
+  try {
+    const ops = (process.env.OPERATOR_TG_IDS || "")
+      .split(",").map((s) => s.trim()).filter(Boolean);
+    if (ops.length) {
+      const u = ctx.from || {};
+      const who = u.username ? "@" + u.username : (u.first_name || "user");
+      const back = u.username ? "@" + u.username : `tg://user?id=${u.id}`;
+      const note = `💬 User reply — ${who} (id ${u.id})\n\n"${text}"\n\n↳ reply to them: ${back}`;
+      for (const op of ops) {
+        try { await ctx.api.sendMessage(op, note); } catch { /* best-effort per operator */ }
+      }
+    }
+    console.log(`[reply-capture] from ${ctx.from?.id} (@${ctx.from?.username || "?"}): ${text.slice(0, 200)}`);
+  } catch { /* capture must never break the user's reply */ }
+
   const kb = new InlineKeyboard()
     .text("💰 Borrow", "start:borrow")
     .text("📋 Wallet", "fallback:deposit")
     .text("📖 Help", "fallback:help");
 
   await ctx.reply(
-    "I'm not sure what you mean. Here are some things I can help with:",
+    "Got it — thanks for the message. A human on the Magpie team sees this and will follow up. In the meantime, here's what I can help with right now:",
     { reply_markup: kb },
   );
 }


### PR DESCRIPTION
Plain conversational DMs that match no command (feedback, winback replies, questions) used to hit a canned fallback and vanish. Now forwarded to OPERATOR_TG_IDS with the sender handle + reply-to link, and the user gets a warm ack. Additive only; command routing unchanged; guarded so capture can't break the reply path.

Motivation: just sent 89 winback DMs asking past borrowers why they left — this ensures their replies actually reach a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)