### PR TITLE
feedback: durable storage of captured replies + /feedback command

### DIFF
--- a/migrations/095_user_feedback.sql
+++ b/migrations/095_user_feedback.sql
@@ -1,0 +1,15 @@
+-- migration 095: captured user feedback / DM replies.
+--
+-- When a user DMs the bot a plain conversational message that matches no command
+-- — feedback, a question, or a reply to a winback/outreach DM — the fallback
+-- handler now stores it here (in addition to forwarding it to the operator) so
+-- replies are durable, searchable, and aggregatable instead of scrolling past in
+-- a DM. Powers the operator-only /feedback command.
+CREATE TABLE IF NOT EXISTS user_feedback (
+  id                BIGSERIAL PRIMARY KEY,
+  telegram_id       BIGINT,
+  telegram_username TEXT,
+  message           TEXT NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS user_feedback_recent_idx ON user_feedback (created_at DESC);

--- a/src/commands/fallback.js
+++ b/src/commands/fallback.js
@@ -3,6 +3,7 @@
  * Maps common phrases to the right command, or shows a helpful nudge.
  */
 import { InlineKeyboard } from "grammy";
+import { query } from "../db/pool.js";
 
 // Keyword → { handler, label } mapping
 // Order matters — first match wins
@@ -334,6 +335,12 @@ export async function handleFallback(ctx) {
         try { await ctx.api.sendMessage(op, note); } catch { /* best-effort per operator */ }
       }
     }
+    // Durable store so replies are searchable/aggregatable (powers /feedback),
+    // not just a forwarded DM. Best-effort — never blocks the user's reply.
+    await query(
+      `INSERT INTO user_feedback (telegram_id, telegram_username, message) VALUES ($1, $2, $3)`,
+      [ctx.from?.id ?? null, ctx.from?.username ?? null, text],
+    ).catch(() => {});
     console.log(`[reply-capture] from ${ctx.from?.id} (@${ctx.from?.username || "?"}): ${text.slice(0, 200)}`);
   } catch { /* capture must never break the user's reply */ }
 

--- a/src/commands/feedback.js
+++ b/src/commands/feedback.js
@@ -1,0 +1,44 @@
+/**
+ * /feedback — operator-only review of captured user replies.
+ *
+ * Every plain conversational DM that matches no command is stored in
+ * user_feedback by the fallback handler (see fallback.js reply-capture). This
+ * command surfaces the most recent ones so the operator can read what users —
+ * especially winback-campaign responders — actually said, in one place, instead
+ * of scrolling through forwarded DMs.
+ */
+import { isAdmin } from "../services/admin.js";
+import { query } from "../db/pool.js";
+
+export async function handleFeedback(ctx) {
+  if (!isAdmin(ctx.from?.id)) {
+    await ctx.reply("This command is operator-only.");
+    return;
+  }
+  let rows;
+  try {
+    ({ rows } = await query(
+      `SELECT telegram_username, telegram_id, message, created_at
+         FROM user_feedback
+        ORDER BY created_at DESC
+        LIMIT 25`,
+    ));
+  } catch (e) {
+    await ctx.reply(`Couldn't load feedback: ${e.message}`);
+    return;
+  }
+  if (!rows.length) {
+    await ctx.reply("No feedback captured yet. Replies to bot DMs will show up here.");
+    return;
+  }
+  const lines = rows.map((r) => {
+    const who = r.telegram_username ? "@" + r.telegram_username : `id ${r.telegram_id}`;
+    const when = new Date(r.created_at).toISOString().slice(5, 16).replace("T", " ");
+    const msg = String(r.message).replace(/\s+/g, " ").slice(0, 220);
+    return `• ${when} — ${who}\n  ${msg}`;
+  });
+  await ctx.reply(
+    `📝 Recent feedback (${rows.length} shown, newest first):\n\n${lines.join("\n\n")}`,
+    { disable_web_page_preview: true },
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,7 @@ import { handleHelp } from "./commands/help.js";
 import { handleCommunity } from "./commands/community.js";
 import { handleMagpie } from "./commands/magpie.js";
 import { handleStats } from "./commands/stats.js";
+import { handleFeedback } from "./commands/feedback.js";
 import { handleHistory } from "./commands/history.js";
 import { handleSimulate } from "./commands/simulate.js";
 import { handleMe, registerMeCallbacks } from "./commands/me.js";
@@ -585,6 +586,7 @@ bot.command("crosspost", handleCommunityCrosspost);
 // via OPERATOR_TG_IDS env var. /gov-pause is the master kill switch.
 bot.command("gov-pause", handleGovPause);
 bot.command("gov_pause", handleGovPause);   // underscore alias (TG strips dashes inconsistently on some clients)
+bot.command("feedback", handleFeedback);    // operator-only: review captured user replies (see fallback reply-capture)
 bot.command("gov-resume", handleGovResume);
 bot.command("gov_resume", handleGovResume);
 bot.command("gov-status", handleGovStatus);


### PR DESCRIPTION
Follow-up to #589 (reply forwarding). Persists every captured reply to a new user_feedback table and adds an operator-only /feedback command to review them, so responses to the winback campaign are durable + searchable, not just forwarded DMs.

- migrations/095_user_feedback.sql (auto-applied on boot)
- fallback.js: INSERT alongside the operator forward (best-effort)
- /feedback: operator-only recent-feedback review

Additive; command routing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)