### PR TITLE
rewards copy uniformity: fix all stale referral 5% + LP 2% -> 10%

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -54,7 +54,7 @@ export async function handleHelp(ctx) {
     "/risk <symbol> — AI risk assessment for a token",
     "",
     "*Earn*",
-    "/refer — earn 5% of friends' loan fees (lifetime, paid in SOL)",
+    "/refer — earn 10% of friends' loan fees (lifetime, paid in SOL)",
     "/holders — $MAGPIE holders earn 70% of all fees pro-rata (weekly distribution)",
     "",
     "*Marketplace*",

--- a/src/commands/me.js
+++ b/src/commands/me.js
@@ -65,12 +65,12 @@ function mePipCoachLine({
     if (solBalance > lamports(0.5)) {
       return `${(solBalance/1e9).toFixed(2)} SOL idle. Consider /lend for ~80% of fees pro-rata, or /borrow if you have a bag to put to work.`;
     }
-    return `Track record looks clean. /borrow when you're ready, or /refer to earn 5% of friends' loan fees lifetime.`;
+    return `Track record looks clean. /borrow when you're ready, or /refer to earn 10% of friends' loan fees lifetime.`;
   }
 
   // Default: healthy general
   if (referredCount === 0 && repaidCount > 0) {
-    return `You've got the playbook down. /refer earns you 5% of every loan fee your friends pay, in SOL, lifetime.`;
+    return `You've got the playbook down. /refer earns you 10% of every loan fee your friends pay, in SOL, lifetime.`;
   }
   return null;
 }

--- a/src/commands/refer.js
+++ b/src/commands/refer.js
@@ -2,7 +2,7 @@
  * /refer — show the user's referral code, share link, lifetime earnings,
  * and a button to claim their accrued SOL payout.
  *
- * Economics: 5% of every loan fee from users they bring in. Sourced from
+ * Economics: 10% of every loan fee from users they bring in. Sourced from
  * the protocol's share — LPs are unaffected. Paid out in SOL on demand.
  */
 import { InlineKeyboard } from "grammy";

--- a/src/commands/share.js
+++ b/src/commands/share.js
@@ -105,7 +105,7 @@ export async function handleShare(ctx) {
     card.text,
     "```",
     "",
-    "_Sharing gives you credit for anyone who joins via your link. 5% of their lifetime fees ↑ to you._",
+    "_Sharing gives you credit for anyone who joins via your link. 10% of their lifetime fees ↑ to you._",
   ].join("\n");
 
   await ctx.reply(preview, {

--- a/src/index.js
+++ b/src/index.js
@@ -726,7 +726,7 @@ async function registerBotCommands() {
       { command: "supported", description: "Approved collateral tokens" },
       { command: "credit", description: "Your credit score + points" },
       { command: "history", description: "Loan history" },
-      { command: "refer", description: "Earn 5% of friends' loan fees" },
+      { command: "refer", description: "Earn 10% of friends' loan fees" },
       { command: "share", description: "Flex your loan / streak on Twitter" },
       { command: "holders", description: "$MAGPIE holder rewards" },
       { command: "distributions", description: "Your full distribution history" },
@@ -1000,7 +1000,7 @@ bot.start({
     // permanently off; if a future MGP proposal restores automated distributions,
     // re-enable this line as part of that proposal's ratified implementation.
     // setTimeout(() => startHolderDistributor(bot), 90_000);
-    // LP Loyalty distributor — rewards long-term LPs from 2% of fees
+    // LP Loyalty distributor — rewards long-term LPs from 10% of fees
     setTimeout(() => startLpLoyaltyDistributor(), 120_000);
     // Loan reconciler — proactively syncs DB state with on-chain truth
     // every 5 min. Catches partial-repay/extend/liquidation drift.

--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -353,8 +353,8 @@ CORE PROTOCOL FACTS:
 - Defaulted-loan profit (2026-06-14 policy): when a non-$MAGPIE collateralized loan defaults, the protocol seizes + sells the collateral. The NET PROFIT (sale proceeds minus principal lent) goes 70/10/10/10 to holders / LP loyalty / referrer / protocol reserve — same split as the fee-side accrual. If the borrower had no referrer, the 10% referrer slice rolls back into the holder slice (so holders effectively get 80%). When $MAGPIE is the collateral, the seized $MAGPIE is burned by the operator instead. Live counts: /stats "DEFAULTED-LOAN PROFIT" section, magpie.capital/stats "defaultedLoanProfit" field. Explain this when users ask "what happens when someone defaults" or "where does the seized collateral go".
 - Credit score: 300-850 on-chain oracle (program BBYtty9s...). Today same loan terms for all tiers — tier perks are reputation signals, not modified rates (program upgrade planned)
 - $MAGPIE token: mint 9UuLsJ3jf8ViBNeRcwXD53re5G3ypgfKK3s2EiMMpump, Token-2022. Holders get pro-rata SOL from the 70% pool, distributed automatically every random 5-10d (snapshot timing is private — don't reveal it)
-- Referrals: every user has a 6-char code. Share link format: https://t.me/magpie_capital_bot?start=CODE. 5% lifetime cut on referred-user fees
-- LP Loyalty: 2% pool, time-weighted (shares × seconds held). Auto-paid in SOL on random 5-10d window
+- Referrals: every user has a 6-char code. Share link format: https://t.me/magpie_capital_bot?start=CODE. 10% lifetime cut on referred-user fees
+- LP Loyalty: 10% pool, time-weighted (shares × seconds held). Auto-paid in SOL on random 5-10d window
 - Liquidations: sub-1.5% lifetime liquidation rate (short terms + low LTV + token-health watcher). For an exact current count, point users at /liquidations (live from on-chain data) — do NOT hardcode "zero ever" as that became false on 2026-06-07
 - Governance v0 (shipped 2026-06-09): $MAGPIE holders get real signal on protocol direction via off-chain signal voting. Operator commits to honor passing Tier A votes within 14 days. Tier A scope: collateral add/remove, tier LTV ±5pp, tier fees ±0.5pp, holder share 5-15%, distribution cadence 3-14d, non-binding signal polls. Out of scope (Tier B, operator discretion): retroactive loan changes, on-chain safety config, founder identity, treasury structure, supply, x402 pricing. (MGP-003 clarification: that was a one-time BINDING vote to ALLOCATE the pre-existing locked Streamflow tranche (~5% of supply) — NOT a change to the immutable mint authority or fixed total supply, which stay out of scope.) Mechanics: 1 token = 1 vote, weight based on $MAGPIE balance at proposal activation. Binary parameter votes: 3-day window / 5% quorum / 60% pass; multi-choice allocation votes (e.g. MGP-003): 5-day window / 7.5% quorum / >40% plurality. Aggregate tallies published at vote close; per-wallet choices are not. Public surfaces: magpie.capital/governance, /api/v1/governance, GOVERNANCE.md, docs/#governance. Discussion in @magpietalk
 - MGP-003 — Option C "Build" WON + EXECUTED on-chain 2026-07-01: holders voted on the July 1, 2026 Streamflow unlock (~5% of supply, 50,494,118 $MAGPIE). Binding plurality winner: Option C — Build a 24-month locked Growth Treasury (C 62.53% of cast · D 33.48% · A 3.55% · B 0.42%; participation 19.55%; quorum 7.5% + plurality >40% both cleared). EXECUTED 2026-07-01 into a 2-of-3 hardware-key Squads multi-sig Growth Treasury (48h timelock, autonomous/no-admin-key, separate from operational funds; multisig 5tSPCUX7Vc4nFyE5WBMzf2ZrEjgaqBm85gmqizVFh2gz, vault EE12mvJR5itRMMiiYXAnUgJtduBnyxK4B78MqgfrHnp7): a working tranche of 15,494,117.598940 $MAGPIE deposited to the treasury vault, deployable ONLY on five pre-declared categories (deep $MAGPIE liquidity Raydium/Meteora; partner integrations + x402 grants; third-party audits with public reports; 1:1 matched community LP top-ups; 30-day-noticed incentive campaigns) + a reserve tranche of ~34.83M $MAGPIE (35M minus Streamflow's ~0.5% fee) locked on-chain via a non-cancelable Streamflow Token-Lock until 2028-07-01, unlocking to the treasury wallet then. NO burn — total supply UNCHANGED (~995.6M; mint authority renounced). HONEST FRAMING: only the ~35M reserve is chain-frozen; the ~15.5M working tranche is constrained (5 categories + 48h timelock), NOT frozen — NEVER say "all 50M locked." Every treasury spend posts to magpie.capital/distributions with an on-chain receipt. "Did MGP-003 burn?" → No (that was Option D, which lost). NEVER say "audited" — external audits are IN PROGRESS with multiple top firms.
@@ -575,7 +575,7 @@ specific numbers — use them. Frame: "borrowing costs X SOL vs selling's
 
 SHARING + REFERRALS:
 - /share generates a Twitter/X share card the user can fire in one tap
-- Every share carries their referral code → they earn 5% of any new
+- Every share carries their referral code → they earn 10% of any new
   user's lifetime fees
 - After /borrow and /repay success messages, share buttons are appended
   automatically
@@ -1151,7 +1151,7 @@ REFERRING A FRIEND:
 1. /refer to see your code + share link
 2. Send the link to your friend
 3. They tap it → bot opens → they /start (referral auto-attaches)
-4. You earn 5% of every fee they pay, for life
+4. You earn 10% of every fee they pay, for life
 5. Claim accrued via /refer when it's worth a tx
 
 UNLOCKING TRUSTED TIER (5 SOL/loan, 10 SOL outstanding):

--- a/src/services/community-public-cmds.js
+++ b/src/services/community-public-cmds.js
@@ -616,13 +616,13 @@ export async function handleCommunityRefer(ctx) {
   const text = [
     `🤝 *Magpie referral program*`,
     ``,
-    `Refer a friend → earn *5% of every loan fee they ever pay*. Lifetime. Paid in SOL.`,
+    `Refer a friend → earn *10% of every loan fee they ever pay*. Lifetime. Paid in SOL.`,
     ``,
     `*How it works*`,
     `• DM @magpie\\_capital\\_bot and run /refer`,
     `• You get a unique link — share it`,
     `• Anyone who starts the bot through your link is linked to you forever`,
-    `• 5% of every fee they pay is airdropped to your wallet automatically`,
+    `• 10% of every fee they pay is airdropped to your wallet automatically`,
     ``,
     `*No cap, no claim, no signup* — just hold the wallet that originated the link.`,
   ].join("\n");
@@ -950,7 +950,7 @@ export async function handleCommunityApy(ctx) {
       RULE,
       "```",
       ``,
-      `_Rough estimate — assumes the 10% LP loyalty share of every loan fee (≈ 2% avg) flows to LPs per MGP-001, annualized over 30 days. Actual yield depends on borrow demand. Past performance is not a guarantee of future returns._`,
+      `_Rough estimate — assumes the 10% LP loyalty share of every loan fee flows to LPs per MGP-001, annualized over 30 days. Actual yield depends on borrow demand. Past performance is not a guarantee of future returns._`,
       ``,
       `Deposit at [magpie.capital/earn](${SITE_URL}/earn). See /lend for how it works.`,
     ].join("\n");

--- a/src/services/lender-balance-watcher.js
+++ b/src/services/lender-balance-watcher.js
@@ -3,7 +3,7 @@
  *
  * The lender wallet funds three things:
  *   1. Protocol operations (price attestations, ATA rents)
- *   2. Referral payouts (5% of fees → referrers on claim)
+ *   2. Referral payouts (10% of fees → referrers on claim)
  *   3. Holder reward distributions ($MAGPIE holders, LP loyalty)
  *
  * If it drains overnight without warning, holder/referral payouts


### PR DESCRIPTION
Follow-up to #591. Split is 70/10/10/10 (verified live in governance_config = 100%). Removes all pre-MGP-001 stale copy: referral **5%->10%** (/refer, /help, /me, /share, community messages, ai-support) and LP loyalty **2%->10%** (distributor comment, ai-support, LP-yield estimate). Copy/comments only, no logic change. Governance/supply '5%' refs left as-is (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)