### PR TITLE
rewards: no-referrer rollover on the auto-sell (limit_close) fee path too

### DIFF
--- a/src/services/limit-close-fee-accrual-watcher.js
+++ b/src/services/limit-close-fee-accrual-watcher.js
@@ -67,11 +67,13 @@ async function tick() {
     { accrueToHolderPool },
     { accrueToLpLoyaltyPool },
     { accrueToProtocolReserve },
+    { rollUnreferredShareToHolders },
   ] = await Promise.all([
     import("./referral-rewards.js"),
     import("./magpie-holder-rewards.js"),
     import("./lp-loyalty.js"),
     import("./protocol-reserve.js"),
+    import("./loans.js"),
   ]);
 
   let accruedCount = 0;
@@ -112,6 +114,10 @@ async function tick() {
       } catch (err) {
         console.warn(`[limit-close-accrual] holder accrual failed for order ${row.id}:`, err.message);
       }
+      // No-referrer rollover — same 0%-retained guarantee as the borrow/extend
+      // fee paths: if the borrower has no referrer, the unpaid 10% rolls into
+      // holders (→80/10/10) instead of being retained. No-op if referred.
+      await rollUnreferredShareToHolders({ refereeUserId: row.user_id, feeLamports, sourceId: `lc_order_${row.id}` });
       try {
         await accrueToLpLoyaltyPool(feeLamports, { sourceType: "limit_close_fee", sourceId: `lc_order_${row.id}` });
       } catch (err) {

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -581,7 +581,7 @@ async function _executeRepayImpl({ userId, loanDbRow }) {
  * exists (their 10% was already accrued). Idempotent via creditHolderPoolDirect's
  * ON CONFLICT (source_type, source_id, pool_kind).
  */
-async function rollUnreferredShareToHolders({ refereeUserId, feeLamports, sourceId }) {
+export async function rollUnreferredShareToHolders({ refereeUserId, feeLamports, sourceId }) {
   const fee = BigInt(feeLamports);
   if (fee <= 0n || !refereeUserId || !sourceId) return;
   try {


### PR DESCRIPTION
Completes #591. The auto-sell fee path (limit-close-fee-accrual-watcher) does the same 70/10/10/10 split with a conditional referral but was missing the no-referrer rollover — so it retained 10% on non-referral auto-sell fees. Exported rollUnreferredShareToHolders and wired it in. Now every fee path (borrow/extend/auto-sell) routes 100%, nothing retained.