### PR TITLE
perf(ai): 1h prompt cache TTL + cost logging on Pip (cut ~$16/day API spend)

### DIFF
--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -5432,7 +5432,7 @@ async function callAnthropic(messages, extraSystemText) {
     {
       type: "text",
       text: SYSTEM_PROMPT,
-      cache_control: { type: "ephemeral" },
+      cache_control: { type: "ephemeral", ttl: "1h" },
     },
   ];
   if (extraSystemText) {
@@ -5447,6 +5447,7 @@ async function callAnthropic(messages, extraSystemText) {
         headers: {
           "x-api-key": API_KEY,
           "anthropic-version": "2023-06-01",
+          "anthropic-beta": "extended-cache-ttl-2025-04-11",
           "content-type": "application/json",
         },
         body: JSON.stringify({
@@ -5458,7 +5459,18 @@ async function callAnthropic(messages, extraSystemText) {
         }),
         signal: AbortSignal.timeout(45_000),
       });
-      if (res.ok) return res.json();
+      if (res.ok) {
+        const json = await res.json();
+        const u = json.usage;
+        if (u) {
+          console.log(
+            `[ai-support] api call ~$${estimateCostUsd(u).toFixed(4)} ` +
+            `(in=${u.input_tokens || 0} out=${u.output_tokens || 0} ` +
+            `cacheR=${u.cache_read_input_tokens || 0} cacheW=${u.cache_creation_input_tokens || 0})`,
+          );
+        }
+        return json;
+      }
       const errBody = await res.text();
       const err = new Error(`Anthropic API ${res.status}: ${errBody.slice(0, 200)}`);
       err.status = res.status;
@@ -5496,7 +5508,7 @@ async function callAnthropicStream(messages, extraSystemText, onTextDelta) {
     {
       type: "text",
       text: SYSTEM_PROMPT,
-      cache_control: { type: "ephemeral" },
+      cache_control: { type: "ephemeral", ttl: "1h" },
     },
   ];
   if (extraSystemText) {
@@ -5508,6 +5520,7 @@ async function callAnthropicStream(messages, extraSystemText, onTextDelta) {
     headers: {
       "x-api-key": API_KEY,
       "anthropic-version": "2023-06-01",
+      "anthropic-beta": "extended-cache-ttl-2025-04-11",
       "content-type": "application/json",
     },
     body: JSON.stringify({
@@ -5616,6 +5629,14 @@ async function callAnthropicStream(messages, extraSystemText, onTextDelta) {
 
   // Filter out any stray empty slots (defensive — shouldn't happen)
   response.content = response.content.filter(Boolean);
+  const u = response.usage;
+  if (u) {
+    console.log(
+      `[ai-support] api call (stream) ~$${estimateCostUsd(u).toFixed(4)} ` +
+      `(in=${u.input_tokens || 0} out=${u.output_tokens || 0} ` +
+      `cacheR=${u.cache_read_input_tokens || 0} cacheW=${u.cache_creation_input_tokens || 0})`,
+    );
+  }
   return response;
 }
 

--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -478,13 +478,14 @@ export async function answerGroupQuestion(question, opts = {}) {
       headers: {
         "x-api-key": API_KEY,
         "anthropic-version": "2023-06-01",
+        "anthropic-beta": "extended-cache-ttl-2025-04-11",
         "content-type": "application/json",
       },
       body: JSON.stringify({
         model: MODEL,
         max_tokens: MAX_TOKENS,
         system: [
-          { type: "text", text: GROUP_SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
+          { type: "text", text: GROUP_SYSTEM_PROMPT, cache_control: { type: "ephemeral", ttl: "1h" } },
           { type: "text", text: extraSystem },
           ...(pinnedSystem ? [{ type: "text", text: pinnedSystem }] : []),
         ],


### PR DESCRIPTION
## Why
The AI-support and community Pip system prompts (~50K tokens) were cached on the **default 5-minute** ephemeral TTL. On a sporadically-used community bot the cache expires between questions, so each conversation's first call **re-writes the full prompt at cache-write price** — across up to 8 tool iterations per question. This is the main driver of the ~$16/day Anthropic API spend.

It was also invisible to the in-app ledger: `getTodaySpendUsd()` counts only base input/output tokens (not cache read/write), so the $20/day cap never fired.

## What
- All 3 Sonnet call sites (`ai-support` non-stream + stream, `community-pip` group) → `cache_control: { ttl: "1h" }` + `extended-cache-ttl-2025-04-11` beta header. Cached prefix now survives across the hour.
- Accurate per-call cost logging via the existing `estimateCostUsd` (already accounts for cache read/write). Watch `cacheW` fall and `cacheR` rise post-deploy.

## Risk
**Behavior-neutral for users** — Pip's outputs are unchanged; only cache duration and observability change.

## Follow-up (not in this PR)
Wire cache tokens into `getTodaySpendUsd` so the daily spend cap reflects the real bill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)