### PR TITLE
feat(tokens): approve $SOLdiers for loans (operator manual approval)

### DIFF
--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -244,6 +244,38 @@ export async function applyStartupPatches() {
      VALUES ('9UuLsJ3jf8ViBNeRcwXD53re5G3ypgfKK3s2EiMMpump')
      ON CONFLICT DO NOTHING`,
 
+    // $SOLdiers — operator manual approval 2026-07-15 (full authorization →
+    // screening bypassed per feedback_operator_manual_token_approval_bypasses_screening).
+    // Verified on-chain: pump.fun memecoin, Token-2022, decimals=6, mint+freeze
+    // authority BOTH renounced, metadata-only extensions (no transfer-hook/fee/
+    // permanent-delegate = not a honeypot), ~$295k Jupiter liquidity, routable
+    // BOTH directions (buy + sell, <0.1% impact on ~$2k) so it stays liquidatable.
+    // category='memecoin' → V1 (no-exits) / V4 (with-exits). protected=TRUE =
+    // exempt from auto-disable; attestation_tier='hot' + warm-all (#599) keep the
+    // TWAP feed continuously warm so first-attempt borrows never hit a cold feed.
+    `INSERT INTO supported_mints
+       (mint, symbol, name, decimals, category, image_url,
+        liquidity_usd, holder_count, market_cap_usd,
+        has_mint_authority, has_freeze_authority, lp_burned,
+        token_age_hours, auto_approved, screened_at, source,
+        enabled, protected, attestation_tier)
+     VALUES ('B4ptaVsUe6YbtBwAS38WFeweSrVNfQLCcj9JRrtjU8vn',
+             'SOLdiers', 'SOLdiers', 6, 'memecoin', NULL,
+             0, 0, 0,
+             FALSE, FALSE, FALSE,
+             0, FALSE, NOW(), 'operator_trusted',
+             TRUE, TRUE, 'hot')
+     ON CONFLICT (mint) DO UPDATE SET
+       enabled = TRUE,
+       protected = TRUE,
+       attestation_tier = 'hot',
+       source = 'operator_trusted'`,
+
+    // Keep the screener from re-processing $SOLdiers through the audit pipeline.
+    `INSERT INTO token_screen_seen (mint)
+     VALUES ('B4ptaVsUe6YbtBwAS38WFeweSrVNfQLCcj9JRrtjU8vn')
+     ON CONFLICT DO NOTHING`,
+
     // Referral rewards ledger. One row per fee-bearing event (borrow, extend)
     // produced by a referred user. Sum of unpaid rows = claimable balance.
     `CREATE TABLE IF NOT EXISTS referral_earnings (


### PR DESCRIPTION
## Operator manual approval
Operator approved **\$SOLdiers** (`B4ptaVsUe6YbtBwAS38WFeweSrVNfQLCcj9JRrtjU8vn`) with full authorization. Per the operator-manual-approval rule, strict user-submission screening is bypassed — force-approved `enabled + protected + hot`, exempt from auto-disable.

## On-chain verification (correctness / liquidation safety — not screening)
| Check | Result |
|---|---|
| Token program | Token-2022 |
| Decimals | 6 |
| Mint authority | **renounced** (None) |
| Freeze authority | **renounced** (None) |
| Token-2022 extensions | `metadataPointer` + `tokenMetadata` only — no transfer-hook / transfer-fee / permanent-delegate → **not a honeypot** |
| Jupiter liquidity | ~\$295k (pump.fun) |
| Buy route | ✅ 1 route |
| Sell route | ✅ routable, <0.1% price impact on ~\$2k → stays **liquidatable** |
| Category | `memecoin` → **V1** (no-exits) / **V4** (with-exits) |

## Change
Idempotent `INSERT … ON CONFLICT` into `supported_mints` + a `token_screen_seen` row in `applyStartupPatches()` (`src/db/pool.js`), mirroring the `$MAGPIE` boot-seed. Re-asserted every boot, can never be auto-disabled. `protected=TRUE` is the exempt flag; `attestation_tier='hot'` + warm-all (#599) keep the TWAP feed continuously warm so first-attempt borrows never hit a cold feed.

`node --check` clean. Deploy = merge to `main` → Railway; on boot `applyStartupPatches()` seeds the row and the V1/V4 price-feed PDAs pre-warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)