### PR TITLE
fix(anti-exploit): exempt trusted/protected tokens from borrow liquidity floor ($MAGPIE lendable)

### DIFF
--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -343,6 +343,13 @@ export async function preBorrowAntiExploitCheck(opts) {
   }
 
   try {
+    // Operator-trust flag for THIS collateral, loaded once from
+    // supported_mints below and consulted by the liquidity gate (section 3).
+    // protected=TRUE (our own $MAGPIE, manually-approved tokens, stocks/RWAs)
+    // OR source='operator_trusted' ⇒ the operator has explicitly vetted this
+    // token, so it is exempt from the thin-pool liquidity floor + pool-% cap.
+    let tokenIsTrusted = false;
+
     // 0. PER_TOKEN_CAP — refuse if total open loans against this mint
     // already exceed the cap. Four-step cap resolution:
     //   1. supported_mints.max_open_lamports override (operator-set):
@@ -373,7 +380,7 @@ export async function preBorrowAntiExploitCheck(opts) {
       const { rows: capRows } = await query(
         `SELECT sm.max_open_lamports, sm.liquidity_usd, sm.holder_count, sm.token_age_hours,
                 sm.top10_holder_pct, sm.has_mint_authority, sm.has_freeze_authority, sm.lp_burned,
-                sm.symbol, sm.market_cap_usd,
+                sm.symbol, sm.market_cap_usd, sm.protected, sm.source,
                 pt.max_open_lamports::text AS pt_cap,
                 pt.enabled AS pt_enabled,
                 pt.symbol AS pt_symbol
@@ -383,6 +390,8 @@ export async function preBorrowAntiExploitCheck(opts) {
         [String(collateralMint)],
       );
       const mintRow = capRows[0];
+      tokenIsTrusted =
+        mintRow?.protected === true || mintRow?.source === "operator_trusted";
       const override = mintRow?.max_open_lamports;
       const ptCap = mintRow?.pt_enabled === true && mintRow?.pt_cap != null
         ? BigInt(String(mintRow.pt_cap))
@@ -550,6 +559,24 @@ export async function preBorrowAntiExploitCheck(opts) {
     //    screener's cached supported_mints.liquidity_usd and take the GREATER.
     //    A token thin in BOTH sources is still blocked (rug/thin-pool guard
     //    intact); a token deep in EITHER source is never blocked.
+    //
+    //    EXEMPTION: operator-trusted / protected tokens (our own $MAGPIE,
+    //    manually-approved tokens, stocks/RWAs) skip the floor + pool-% cap
+    //    entirely — the operator has explicitly vetted them, so the thin-pool
+    //    heuristic must NEVER block lending against approved/own collateral
+    //    (feedback_operator_manual_token_approval_bypasses_screening,
+    //    feedback_manual_token_adds_are_protected_exempt). This gate is the
+    //    single borrow-time chokepoint for site + TG + x402, so exempting
+    //    here fixes it across the whole protocol. Price-manipulation defenses
+    //    (cross-source price + attestation cap + the TWAP-pump gate above)
+    //    still apply to these tokens — we drop only the pool-SIZE heuristic.
+    if (tokenIsTrusted) {
+      console.log(
+        `[anti-exploit] trusted/protected collateral ${String(collateralMint).slice(0, 8)}… ` +
+        `— exempt from liquidity floor + pool-% cap (operator-vetted).`,
+      );
+      return null;
+    }
     const liqLive = await fetchLiveLiquidityUsd(collateralMint);
     let liqCached = 0;
     try {


### PR DESCRIPTION
## Problem
Borrowing against **$MAGPIE** (our own protocol token) was blocked:
> Deposit failed: This token's current pool liquidity ($41,320) is below the minimum ($50,000) required to borrow against.

I verified $MAGPIE's real liquidity — **~$41.5k aggregate across 5 pools** (largest $39,979). The aggregate read is already correct (the #547/#548 fix); $MAGPIE genuinely sits under the $50k thin-pool floor. The floor just **shouldn't apply to a token the operator has explicitly vetted** — per the operator-manual-approval mandate, `protected=TRUE` tokens bypass auto-screen criteria *including low liquidity*.

## Fix (one shared chokepoint = "across the protocol")
`preBorrowAntiExploitCheck` is the single borrow-time gate for **site** (`cosign-borrow.js`), **TG** (`borrow.js`), and **x402** (`agent.js`). Exempting here covers all three at once:
- load `sm.protected` + `sm.source` in the existing per-token-cap query
- `tokenIsTrusted = protected === true || source === 'operator_trusted'`
- section 3 early-returns (allow) for trusted tokens, skipping **only** the pool-SIZE heuristic (liquidity floor + pool-% cap)

## Scope is deliberately narrow (security preserved)
Trusted tokens still pass through **every other gate**: cross-source price check, attestation cap, TWAP-pump gate, per-token exposure cap, rapid-fire / new-account / imported-wallet caps. We drop **only** the thin-pool size heuristic that wrongly blocked our own/approved collateral.

## Who this covers
| Token class | `protected` | Effect |
|---|---|---|
| $MAGPIE | TRUE | ✅ exempt — lendable at any pool size |
| Manually-approved ($SOLdiers, $MU, $SNDK, $BOT…) | TRUE | ✅ exempt (matches manual-approval mandate) |
| Stocks / RWAs | TRUE | ✅ exempt (thin on-chain LP, backed 1:1) |
| **User-submitted tokens** | **not protected** | ⛔ floor still fully applies |

## Note
This does not touch the **per-token exposure cap** (`max_open_lamports`) — that's a separate concentration knob you control per token. Say the word if you want $MAGPIE's set to unlimited too.

`node --check` clean. Deploy = merge to `main` → Railway; effective on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)