### PR TITLE
fix(holder-rewards): stop excluding legitimate 0-SOL holders from distributions

### DIFF
--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -575,9 +575,31 @@ export async function snapshotMagpieHolders() {
   // would otherwise siphon ~14% of every distribution to non-holders
   // (e.g. PumpSwap AMM, Token-2022 protocol accounts, etc).
   //
+  // BUT: a holder whose native SOL balance is 0 has NO on-chain account
+  // (getAccountInfo → null), and a null account looks identical whether
+  // it's a drained real wallet or an unfunded PDA. Excluding all nulls
+  // (the pre-2026-07-16 behaviour) silently dropped legitimate 0-SOL
+  // holders from every round — e.g. a wallet holding millions of $MAGPIE
+  // but zero SOL would receive nothing, then get re-included the moment
+  // it happened to hold a little SOL at snapshot time. The reliable
+  // discriminator: real user wallets are ON-curve ed25519 addresses;
+  // program-derived addresses (the AMM/vault/bonding-curve accounts we
+  // must never pay) are OFF-curve by construction. So for a null account
+  // we keep it iff it's on-curve — a 0-SOL wallet can still receive SOL,
+  // and the payout itself creates its account. Funded accounts still get
+  // the strict System-Program owner check (an on-curve keypair account
+  // reassigned to a program is caught here by its non-System owner).
+  //
   // Batch fetch (100 per call) keeps RPC cost minimal even with thousands
   // of holders.
   const SystemProgramId = SystemProgram.programId.toBase58();
+  const isOnCurveAddress = (addr) => {
+    try {
+      return PublicKey.isOnCurve(new PublicKey(addr).toBytes());
+    } catch {
+      return false; // unparseable → treat as non-wallet, exclude
+    }
+  };
   const allOwners = Array.from(byOwner.keys());
   const BATCH = 100;
   for (let i = 0; i < allOwners.length; i += BATCH) {
@@ -587,16 +609,24 @@ export async function snapshotMagpieHolders() {
     try {
       infos = await connection.getMultipleAccountsInfo(pubkeys, { commitment: "confirmed" });
     } catch (err) {
-      console.error("[holder-rewards] account-owner lookup failed (keeping conservatively, excluding all in batch):", err.message);
-      // Conservative: if we can't verify, exclude rather than risk paying to PDAs.
-      for (const o of batch) byOwner.delete(o);
+      // RPC lookup failed — we can't read owners. Don't silently drop
+      // legitimate holders over a transient blip: fall back to the
+      // on-curve test, which still excludes every off-curve PDA (the
+      // actual siphon threat) while keeping real wallets in the round.
+      console.error("[holder-rewards] account-owner lookup failed — falling back to on-curve filter for this batch:", err.message);
+      for (const o of batch) {
+        if (!isOnCurveAddress(o)) byOwner.delete(o);
+      }
       continue;
     }
     for (let j = 0; j < batch.length; j++) {
       const info = infos[j];
-      // No account info → owner doesn't exist (could be a PDA never funded);
-      // OR owner is a contract — exclude to be safe.
-      if (!info || info.owner?.toBase58() !== SystemProgramId) {
+      if (!info) {
+        // Unfunded/null account: keep on-curve real wallets (0-SOL
+        // holders can still be paid), drop off-curve unfunded PDAs.
+        if (!isOnCurveAddress(batch[j])) byOwner.delete(batch[j]);
+      } else if (info.owner?.toBase58() !== SystemProgramId) {
+        // Funded account owned by a program → contract/PDA, never pay.
         byOwner.delete(batch[j]);
       }
     }


### PR DESCRIPTION
## Problem

A legitimate holder (`4RYeGEYhwNZu1PSAxBGAgW6quwH5pSrEUWePzY2cHz65`, ~11.25M \$MAGPIE) received **nothing** in the **July 15** distribution (event #5) — and also missed #3 (Jun 29) — despite being paid in #2 (Jun 19) and #4 (Jul 7).

**Root cause:** the anti-PDA safety filter in `snapshotMagpieHolders()` (`src/services/magpie-holder-rewards.js`) excludes any holder whose native account is `null` or not owned by the System Program, to stop AMM/vault/bonding-curve PDAs from siphoning ~14% of each pool. But a real user wallet **drained to 0 SOL has no on-chain account** (`getAccountInfo → null`) and is indistinguishable from an unfunded PDA under that check. So the wallet was excluded exactly in the rounds where it held 0 SOL at snapshot time — even while holding millions of \$MAGPIE.

Pattern matches the data precisely:

| Round | Date | Native SOL at snapshot | Result |
|---|---|---|---|
| #2 | Jun 19 | funded | paid 0.0996 SOL |
| #3 | Jun 29 | 0 | **excluded** |
| #4 | Jul 7 | funded | paid 0.0516 SOL |
| #5 | Jul 15 | 0 | **excluded** (missed ~0.139 SOL) |

## Fix

For a `null` account, keep it **iff the address is on-curve**. Real ed25519 wallets are on-curve; program-derived addresses (the accounts we must never pay) are **off-curve by construction**, so siphon protection is fully intact. Funded accounts keep the strict System-Program owner check. Also hardens the RPC-failure path: instead of dropping the whole batch on a transient lookup error (same silent-drop class), it falls back to the on-curve filter.

## Verification

- `4RYeGEYh…` (holds ~11.25M \$MAGPIE, 0 SOL, `isOnCurve = true`) → **included** under the fix.
- An off-curve unfunded PDA → **still excluded** (siphon protection intact).
- `node --check` clean.

## Follow-up (not in this PR)

- **Remediation:** re-run the #5 (and #3) enumeration to list every on-curve 0-SOL holder wrongly excluded and prepare a retroactive top-up plan (operator-executed from the distributor key). Holder count dropped 1667→1594 between #4 and #5 — some of that gap is likely this same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)