### PR TITLE
fix(v4-arm): auto-recover single-arm borrow race (never strand on 'Signing…')

### DIFF
--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -914,6 +914,12 @@ async function _handleSiteLimitCloseArmImpl(req) {
   }
 
   // ── Shared arm ──
+  // Envelope context so arm-core can queue the arm to pending_arms if the
+  // borrow is still finalizing (loan not committed / not yet active) — the
+  // retry-watcher then completes it with NO re-sign. Fixes the stuck
+  // "Signing…" that forced repeated clicks (feedback_v4_every_arm_must_succeed).
+  const envelopeIssuedAtMs = auth.fields?.IssuedAt ? Date.parse(auth.fields.IssuedAt) : NaN;
+  const intentIdFromReq = Number(fields.IntentId);
   const armed = await armOrder({
     userId,
     source: "site",
@@ -927,7 +933,30 @@ async function _handleSiteLimitCloseArmImpl(req) {
     expiresAt,
     slicePct: slicePctApplied,
     armNote: `armed via site (${trailingDistanceBps != null ? `TRAILING-SL ${trailingDistanceBps/100}%` : (isSl ? "SL" : "TP")}${slicePctApplied < 10000 ? ` slice=${(slicePctApplied/100).toFixed(0)}%` : ""}) by ${auth.signerPubkey.slice(0, 8)}…`,
+    intentId: Number.isInteger(intentIdFromReq) ? intentIdFromReq : null,
+    envelope: Number.isFinite(envelopeIssuedAtMs)
+      ? { signer_pubkey: auth.signerPubkey, wallet: auth.signerPubkey, envelope_issued_at_ms: envelopeIssuedAtMs }
+      : null,
   });
+  // Borrow-finalization race: arm was queued for background auto-completion.
+  // Return 202 so the dashboard shows "queued — arms automatically" instead of
+  // a stuck spinner; the user does NOT re-sign.
+  if (armed.ok && armed.pending) {
+    return {
+      status: 202,
+      body: {
+        ok: true,
+        pending: true,
+        pending_arm_id: armed.pending_arm_id,
+        retry_in_ms: armed.retry_in_ms ?? 10_000,
+        envelope_expires_at_ms: armed.envelope_expires_at_ms ?? null,
+        loan_id: fields.LoanId,
+        trigger_kind: triggerKind,
+        trigger_value_micro: triggerValueMicro.toString(),
+        detail: armed.detail || "Auto-sell queued — arms automatically once your loan finishes setting up.",
+      },
+    };
+  }
   if (!armed.ok) {
     return {
       status: 409,

--- a/src/services/limit-close-arm-core.js
+++ b/src/services/limit-close-arm-core.js
@@ -312,7 +312,10 @@ export async function armOrder(args) {
   // hides automatically once the intent is no longer 'pending'.
   // Best-effort — a reconciliation failure must NOT mask the real
   // arm result.
-  if (result.ok && args.intentId != null) {
+  // NB: a queued (result.pending === true) arm is ok:true but NOT armed yet —
+  // leave its intent 'pending' so the recovery banner keeps showing "queued"
+  // until the watcher actually arms it (then the watcher/reconcile marks armed).
+  if (result.ok && result.pending !== true && args.intentId != null) {
     try {
       await query(
         `UPDATE arm_intents
@@ -379,6 +382,15 @@ async function armOrderImpl({
   // notifications either (none happen in armOrder anyway today,
   // but the contract holds).
   dryRun = false,
+  // Signed-envelope context (site/agent single arms). When the loan isn't
+  // yet committed OR still finalizing (borrow→active race), we persist the
+  // arm to the pending_arms queue so the retry-watcher REPLAYS it with the
+  // user's still-valid signature — NO re-sign. Mirrors armOrderBatchImpl.
+  // The batch path already does this for ladders; single arms were the gap
+  // that stranded users on a stuck "Signing…" (feedback_v4_every_arm_must_succeed).
+  envelope = null,        // { signer_pubkey, wallet, envelope_issued_at_ms }
+  skipPendingQueue = false, // watcher replay sets this so it can't self-requeue
+  intentId = null,        // arm_intents row id to link for banner clear
 }) {
   // ── Shape validation ─────────────────────────────────────────
   if (!VALID_TRIGGER_KINDS.has(triggerKind)) {
@@ -501,7 +513,59 @@ async function armOrderImpl({
     if (Date.now() >= LOAN_LOOKUP_DEADLINE_MS) break;
     await new Promise((r) => setTimeout(r, LOAN_LOOKUP_INTERVAL_MS));
   }
+  // Borrow-finalization race recovery: persist the signed arm to pending_arms
+  // so the retry-watcher replays it (NO re-sign) the instant the loan commits
+  // AND goes active. Returns a pending result the caller surfaces as "queued";
+  // returns null when queuing isn't possible (no envelope / stale / insert fail)
+  // so the hard-fail path below still runs.
+  const tryQueuePendingArm = async () => {
+    if (!envelope || skipPendingQueue) return null;
+    const issuedAtMs = Number(envelope.envelope_issued_at_ms);
+    if (!Number.isFinite(issuedAtMs) || issuedAtMs <= 0) return null;
+    const ENVELOPE_FRESH_MS = 5 * 60 * 1000;
+    // Need >30s of freshness left so the 10s watcher gets ≥1 replay attempt.
+    if (Date.now() - issuedAtMs >= ENVELOPE_FRESH_MS - 30_000) return null;
+    try {
+      // 1-leg batch, in the exact shape armOrderBatch (the watcher's replay
+      // entrypoint) parses. Trigger value is already resolved (fixed strike).
+      const leg = {
+        direction: triggerDirection,
+        kind: triggerKind,
+        valueMicro: String(triggerValueMicro),
+        sliceBps: slicePct,
+        slippageBps,
+        expiresAt: expiresAt || null,
+        trailingDistanceBps: trailingDistanceBps ?? null,
+      };
+      const pending = await persistPendingArm({
+        userId,
+        signerPubkey: envelope.signer_pubkey || null,
+        wallet: envelope.wallet || envelope.signer_pubkey || null,
+        loanIdChain: String(loanIdChain),
+        legs: [leg],
+        intentIds: intentId != null ? [intentId] : null,
+        source,
+        armNotePrefix: null,
+        envelopeIssuedAtMs: issuedAtMs,
+      });
+      return {
+        ok: true,
+        pending: true,
+        pending_arm_id: pending.id,
+        envelope_expires_at_ms: issuedAtMs + ENVELOPE_FRESH_MS,
+        retry_in_ms: 10_000,
+        detail: "Your loan is still finishing setup — the auto-sell is queued and arms automatically in a few seconds. No need to sign again.",
+      };
+    } catch (qErr) {
+      console.warn(`[arm-core single] pending_arms insert failed: ${qErr.message?.slice(0, 160)} — falling back to hard-fail`);
+      return null;
+    }
+  };
+
   if (!loan) {
+    // Tier-2 recovery: queue for the watcher before the hard-fail path.
+    const queued = await tryQueuePendingArm();
+    if (queued) return queued;
     // Tier-1 defense: admin DM on first occurrence per
     // feedback_loan_830_full_postmortem_and_defenses.md.
     try {
@@ -520,6 +584,14 @@ async function armOrderImpl({
     return { ok: false, error: "loan_not_found_for_user" };
   }
   if (loan.status !== "active") {
+    // A loan that exists but is still FINALIZING (not yet 'active') is the
+    // same race — queue it. Only for non-terminal statuses: a genuinely
+    // repaid/liquidated/closed loan will never become active, so hard-fail.
+    const TERMINAL = new Set(["repaid", "liquidated", "cancelled", "closed", "defaulted", "refunded"]);
+    if (!TERMINAL.has(String(loan.status).toLowerCase())) {
+      const queued = await tryQueuePendingArm();
+      if (queued) return queued;
+    }
     return { ok: false, error: "loan_not_active", detail: loan.status };
   }
   if (BigInt(loan.owed) < MIN_LOAN_LAMPORTS) {

--- a/src/services/pending-arm-retry-watcher.js
+++ b/src/services/pending-arm-retry-watcher.js
@@ -368,12 +368,21 @@ async function retryFreshRows(bot) {
 
     // If the error is anything OTHER than the race itself, it's not
     // going to fix itself — mark failed and DM. Examples:
-    // loan_not_active, collateral_not_enabled, exits_require_v4_loan.
+    // collateral_not_enabled, exits_require_v4_loan.
     const TRANSIENT_ERRORS = new Set([
       "loan_not_found_for_user",
       "watcher_exception",
     ]);
-    if (!TRANSIENT_ERRORS.has(result.error)) {
+    // loan_not_active is transient ONLY while the loan is still FINALIZING
+    // (borrow committed the row but hasn't flipped to 'active' yet). Once it's
+    // active a replay succeeds; a TERMINAL status (repaid/liquidated/…) never
+    // will → hard-fail. result.detail carries the loan status string.
+    const TERMINAL_LOAN_STATUSES = new Set(["repaid", "liquidated", "cancelled", "closed", "defaulted", "refunded"]);
+    const isFinalizingRace =
+      result.error === "loan_not_active" &&
+      typeof result.detail === "string" &&
+      !TERMINAL_LOAN_STATUSES.has(result.detail.trim().toLowerCase());
+    if (!TRANSIENT_ERRORS.has(result.error) && !isFinalizingRace) {
       try {
         await query(
           `UPDATE pending_arms


### PR DESCRIPTION
Single (non-ladder) V4 arms hit `loan_not_found`/`loan_not_active` when the borrow was still finalizing, hard-failed, and forced a fresh wallet signature per retry — a user could click 'Sell at $X mc' repeatedly for minutes before it armed (operator hit this on a THREE loan: order armed only after ~310s + 3 clicks).

**Fix:** `armOrderImpl` now mirrors the ladder path — on the borrow-finalization race it persists the already-signed arm to `pending_arms` so the retry-watcher replays it with **no re-sign**. The watcher treats a *finalizing* `loan_not_active` as transient (terminal statuses still hard-fail). The site /arm endpoint passes envelope context + returns 202 pending so the dashboard shows 'Arming…' not a stuck spinner. `armOrder` no longer marks the intent 'armed' on a pending result.

Bot-only; frontend already renders `pending_arms` as 'Arming…'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)