### PR TITLE
Approve $CARDS (Collector Crypt) for lending — operator manual approval

### DIFF
--- a/scripts/add-cards-token.js
+++ b/scripts/add-cards-token.js
@@ -1,0 +1,121 @@
+/**
+ * One-shot: approve $CARDS (Collector Crypt) for lending — enabled=TRUE,
+ * protected=TRUE, attestation_tier='hot'.
+ *
+ * Operator manual approval 2026-07-31 (full green light → screening bypassed per
+ * feedback_operator_manual_token_approval_bypasses_screening):
+ *   "We need $CARDS approved for lending on our platform ASAP … I give it the
+ *    full green light: CARDSccUMFKoPRZxt5vt3ksUbxEFEcnZ3H2pd3dKxYjp"
+ *
+ * Verified on-chain / on markets before approval:
+ *   - Classic SPL mint (Tokenkeg…), decimals=6.
+ *   - mint authority + freeze authority BOTH renounced (fixed supply, no freeze).
+ *   - ~$2.5M Raydium (CLMM) + Meteora liquidity, ~$1M 24h volume, price ~$0.15.
+ *   - Jupiter-routable to USDC (~0.002% impact on ~$150 sell) → stays liquidatable,
+ *     so it satisfies "collateral that can still sell itself".
+ *
+ * category='memecoin' (a volatile, DEX-priced platform token — NOT a stable
+ * tokenized-stock, so standard memecoin LTV, routes V1 no-exit / V4 with-exit).
+ * protected=TRUE = exempt from the hourly token-health auto-disable.
+ * attestation_tier='hot' = TWAP feed kept continuously warm so first-attempt
+ * borrows never hit a cold feed. Same profile as $SOLdiers / $BP.
+ *
+ * Idempotent: re-running refreshes metadata + re-applies the flags.
+ *
+ * Usage:
+ *   railway run --service magpie-bot node scripts/add-cards-token.js
+ */
+import "dotenv/config";
+
+const CARDS_MINT = "CARDSccUMFKoPRZxt5vt3ksUbxEFEcnZ3H2pd3dKxYjp";
+
+async function main() {
+  const { query } = await import("../src/db/pool.js");
+
+  let symbol = "CARDS";
+  let name = "Collector Crypt";
+  let decimals = 6;
+  let imageUrl = null;
+  let liquidityUsd = 0;
+  let volume24h = 0;
+  let marketCap = 0;
+
+  try {
+    const res = await fetch(`https://api.dexscreener.com/tokens/v1/solana/${CARDS_MINT}`);
+    if (res.ok) {
+      const pairs = await res.json();
+      if (Array.isArray(pairs) && pairs.length > 0) {
+        const best = pairs.reduce((b, p) =>
+          (p.liquidity?.usd ?? 0) > (b.liquidity?.usd ?? 0) ? p : b,
+        );
+        symbol = best.baseToken?.symbol?.toUpperCase() || symbol;
+        name = best.baseToken?.name || name;
+        imageUrl = best.info?.imageUrl || null;
+        liquidityUsd = best.liquidity?.usd ?? 0;
+        volume24h = best.volume?.h24 ?? 0;
+        marketCap = best.marketCap ?? best.fdv ?? 0;
+      }
+    }
+  } catch (err) {
+    console.warn("DexScreener lookup failed, using defaults:", err.message);
+  }
+
+  try {
+    const { PublicKey } = await import("@solana/web3.js");
+    const { connection } = await import("../src/solana/connection.js");
+    const info = await connection.getAccountInfo(new PublicKey(CARDS_MINT));
+    if (info?.data?.length >= 45) decimals = info.data.readUInt8(44);
+  } catch (err) {
+    console.warn("On-chain decimals lookup failed, using default:", err.message);
+  }
+
+  console.log(`Approving ${symbol} (${CARDS_MINT}):`);
+  console.log(`  name: ${name}`);
+  console.log(`  decimals: ${decimals}`);
+  console.log(`  liquidity: $${Math.floor(liquidityUsd).toLocaleString()}  vol24h: $${Math.floor(volume24h).toLocaleString()}`);
+  console.log(`  category: memecoin · enabled: TRUE · protected: TRUE · attestation_tier: hot`);
+  console.log();
+
+  await query(
+    `INSERT INTO supported_mints
+       (mint, symbol, name, decimals, category, image_url,
+        liquidity_usd, holder_count, market_cap_usd,
+        has_mint_authority, has_freeze_authority, lp_burned,
+        token_age_hours, auto_approved, screened_at, source,
+        enabled, protected, attestation_tier)
+     VALUES ($1, $2, $3, $4, 'memecoin', $5,
+             $6, 0, $7,
+             FALSE, FALSE, FALSE,
+             0, FALSE, NOW(), 'operator_approved',
+             TRUE, TRUE, 'hot')
+     ON CONFLICT (mint) DO UPDATE SET
+       symbol = EXCLUDED.symbol,
+       name = COALESCE(EXCLUDED.name, supported_mints.name),
+       decimals = EXCLUDED.decimals,
+       image_url = COALESCE(EXCLUDED.image_url, supported_mints.image_url),
+       liquidity_usd = EXCLUDED.liquidity_usd,
+       market_cap_usd = EXCLUDED.market_cap_usd,
+       category = 'memecoin',
+       source = 'operator_approved',
+       enabled = TRUE,
+       protected = TRUE,
+       attestation_tier = 'hot'`,
+    [CARDS_MINT, symbol, name, decimals, imageUrl, liquidityUsd, marketCap],
+  );
+
+  await query(
+    `INSERT INTO token_screen_seen (mint) VALUES ($1) ON CONFLICT DO NOTHING`,
+    [CARDS_MINT],
+  );
+
+  const { rows } = await query(
+    `SELECT mint, symbol, decimals, category, enabled, protected, attestation_tier, source
+       FROM supported_mints WHERE mint = $1`,
+    [CARDS_MINT],
+  );
+  console.log("Verified in DB:");
+  console.log(rows[0]);
+  process.exit(0);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/src/db/pool.js
+++ b/src/db/pool.js
@@ -276,6 +276,38 @@ export async function applyStartupPatches() {
      VALUES ('B4ptaVsUe6YbtBwAS38WFeweSrVNfQLCcj9JRrtjU8vn')
      ON CONFLICT DO NOTHING`,
 
+    // $CARDS (Collector Crypt) — operator manual approval 2026-07-31 (full green
+    // light → screening bypassed per feedback_operator_manual_token_approval_bypasses_screening).
+    // Verified on-chain: classic SPL mint, decimals=6, mint+freeze authority BOTH
+    // renounced (fixed supply, no freeze); ~$2.5M Raydium (CLMM) + Meteora liquidity,
+    // ~$1M 24h volume, price ~$0.15; Jupiter-routable to USDC (~0.002% impact) so it
+    // stays liquidatable ("collateral that can still sell itself"). It's a volatile,
+    // DEX-priced platform token — NOT a stable tokenized-stock — so category='memecoin'
+    // (standard LTV, V1 no-exit / V4 with-exit), NOT an RWA category. protected=TRUE =
+    // exempt from auto-disable; attestation_tier='hot' keeps the TWAP feed warm.
+    `INSERT INTO supported_mints
+       (mint, symbol, name, decimals, category, image_url,
+        liquidity_usd, holder_count, market_cap_usd,
+        has_mint_authority, has_freeze_authority, lp_burned,
+        token_age_hours, auto_approved, screened_at, source,
+        enabled, protected, attestation_tier)
+     VALUES ('CARDSccUMFKoPRZxt5vt3ksUbxEFEcnZ3H2pd3dKxYjp',
+             'CARDS', 'Collector Crypt', 6, 'memecoin', NULL,
+             0, 0, 0,
+             FALSE, FALSE, FALSE,
+             0, FALSE, NOW(), 'operator_approved',
+             TRUE, TRUE, 'hot')
+     ON CONFLICT (mint) DO UPDATE SET
+       enabled = TRUE,
+       protected = TRUE,
+       attestation_tier = 'hot',
+       source = 'operator_approved'`,
+
+    // Keep the screener from re-processing $CARDS through the audit pipeline.
+    `INSERT INTO token_screen_seen (mint)
+     VALUES ('CARDSccUMFKoPRZxt5vt3ksUbxEFEcnZ3H2pd3dKxYjp')
+     ON CONFLICT DO NOTHING`,
+
     // Referral rewards ledger. One row per fee-bearing event (borrow, extend)
     // produced by a referred user. Sum of unpaid rows = claimable balance.
     `CREATE TABLE IF NOT EXISTS referral_earnings (


### PR DESCRIPTION
Operator gave $CARDS the full green light (2026-07-31) for lending on Magpie.
Mint: `CARDSccUMFKoPRZxt5vt3ksUbxEFEcnZ3H2pd3dKxYjp`

**Already applied live** to prod DB via `railway run … scripts/add-cards-token.js` — this PR makes it durable in the boot seed.

**Verified before approval**
- Classic SPL mint, decimals=6, **mint + freeze authority both renounced** (fixed supply, no freeze).
- **~$2.5M** Raydium (CLMM) + Meteora liquidity, **~$1M** 24h volume, price ~$0.15.
- **Jupiter-routable** CARDS→USDC (~0.002% impact) → stays liquidatable ("collateral that can still sell itself").

**Config:** `category='memecoin'` (a volatile, DEX-priced platform token — NOT a stable tokenized-stock, so standard LTV, routes V1 no-exit / V4 with-exit), `enabled + protected + attestation_tier='hot'`. Same profile as \$SOLdiers / \$BP.

**Changes**
- `src/db/pool.js`: add \$CARDS to the operator-approved boot seed (idempotent).
- `scripts/add-cards-token.js`: one-shot apply script.

Confirmed live: appears in `/api/v1/tokens`; DB row shows enabled/protected/hot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)