### PR TITLE
fix(borrow): rebroadcast cosigned tx — stop borrows getting stuck on 'Landing your transaction'

### DIFF
--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -2011,10 +2011,15 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
   let signature;
   try {
     const raw = tx.serialize();
-    signature = await sendAndConfirmRawTransaction(connection, raw, {
+    // Robust submit: rebroadcast the fully-signed tx every ~2s and poll to
+    // confirmation, instead of sending once and blocking on blockhash expiry.
+    // Fixes borrows stuck on "Landing your transaction…" during congestion.
+    // (Externally-signed → we can't re-sign, so this helper never re-signs; it
+    // gives up only once the blockhash can no longer land the tx = no dup loan.)
+    const { sendSignedRawWithRebroadcast } = await import("../solana/tx-send.js");
+    signature = await sendSignedRawWithRebroadcast(connection, raw, {
       commitment: "confirmed",
-      skipPreflight: false,
-      maxRetries: 3,
+      blockhash: tx.recentBlockhash,
     });
   } catch (e) {
     // Surface every possible field on the error object — message can be
@@ -2050,6 +2055,14 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
       recordBorrowFailure("collateral_value_exceeds");
       _recordBorrowConversionFailure(_convCtx, "collateral_value_exceeds_broadcast", { detail: detail?.slice(0, 220) });
       return { status: 503, body: { error: "Price moved while you were signing. Please tap Borrow again to get a fresh quote.", price_moved: true, retry_after_seconds: 3, detail } };
+    }
+    // Congestion give-up: the tx didn't land before its blockhash expired. This
+    // is SAFE to retry — the blockhash is dead, so no duplicate loan can form —
+    // and it must surface as a clean, retryable message, never a raw error.
+    if (e && e.expiredTimeout === true) {
+      recordBorrowFailure("congestion_timeout");
+      _recordBorrowConversionFailure(_convCtx, "congestion_timeout", { detail: detail?.slice(0, 220) });
+      return { status: 503, body: { error: "Solana is congested — your transaction didn't land in time and expired safely (no funds moved). Please tap Borrow again.", congested: true, retry_after_seconds: 3, detail } };
     }
     return {
       status: 500,

--- a/src/solana/tx-send.js
+++ b/src/solana/tx-send.js
@@ -142,3 +142,113 @@ async function confirmWithRebroadcast(connection, o) {
   }
   return "expired";
 }
+
+/**
+ * Robust send-and-confirm for an ALREADY-fully-signed raw transaction whose
+ * signers we do NOT hold (e.g. cosign-borrow: user-signed + lender-cosigned).
+ *
+ * WHY (2026-07-31): cosign-borrow submitted the fully-signed borrow with a bare
+ * `sendAndConfirmRawTransaction`, which SENDS ONCE and then blocks on the
+ * blockhash's expiry (~60-90s) via `confirmTransaction`. Under congestion the tx
+ * is dropped and never re-broadcast, so the user sits on "Landing your
+ * transaction…" for a minute and then it fails. This helper re-broadcasts the
+ * SAME raw tx every couple seconds (a Solana tx pays its fee once, so resending
+ * is free) and polls `getSignatureStatuses(searchTransactionHistory)` to
+ * confirmation — the same rebroadcast pattern the protocol's own txs use, but
+ * WITHOUT re-signing (we can't; the user's key is client-side).
+ *
+ * SAFETY (no duplicate loans): we only give up once the tx can NEVER land —
+ * confirmed, on-chain error, or the blockhash is no longer valid
+ * (`isBlockhashValid` = false) — so a retryable error we return can't produce a
+ * second loan on the same blockhash.
+ *
+ * @param {import("@solana/web3.js").Connection} connection
+ * @param {Buffer|Uint8Array} raw  serialized, fully-signed tx
+ * @param {object} [opts]
+ * @param {string} [opts.blockhash]  the tx's recentBlockhash — gates the safe give-up
+ * @param {"processed"|"confirmed"|"finalized"} [opts.commitment]  default "confirmed"
+ * @param {number} [opts.rebroadcastIntervalMs]  default 2000
+ * @param {number} [opts.hardTimeoutMs]  absolute cap (> blockhash validity), default 95000
+ * @returns {Promise<string>} confirmed signature
+ * @throws Error — an on-chain failure carries `.logs`/`.txErr` for classification;
+ *   a give-up carries `.expiredTimeout = true` (safe to retry: the tx is dead).
+ */
+export async function sendSignedRawWithRebroadcast(connection, raw, opts = {}) {
+  const {
+    blockhash,
+    commitment = "confirmed",
+    rebroadcastIntervalMs = 2_000,
+    hardTimeoutMs = 95_000,
+  } = opts;
+
+  const isConfirmed = (level) =>
+    level === "finalized" ||
+    (commitment === "confirmed" && (level === "confirmed" || level === "finalized")) ||
+    (commitment === "processed" && !!level);
+
+  // Initial send WITH preflight so an immediate program error (e.g. a price /
+  // TWAP revert) throws right here with logs — preserving the exact
+  // classification the old sendAndConfirmRawTransaction path relied on.
+  const signature = await connection.sendRawTransaction(raw, {
+    skipPreflight: false,
+    preflightCommitment: commitment,
+    maxRetries: 5,
+  });
+
+  const deadline = Date.now() + hardTimeoutMs;
+  let lastRebroadcast = Date.now();
+
+  while (Date.now() < deadline) {
+    const { value } = await connection.getSignatureStatuses([signature], {
+      searchTransactionHistory: true,
+    });
+    const st = value?.[0];
+    if (st) {
+      if (st.err) {
+        let logs = [];
+        try {
+          const t = await connection.getTransaction(signature, {
+            commitment: "confirmed",
+            maxSupportedTransactionVersion: 0,
+          });
+          logs = t?.meta?.logMessages || [];
+        } catch { /* best-effort log fetch for classification */ }
+        const e = new Error(`transaction failed on-chain: ${JSON.stringify(st.err)}`);
+        e.txErr = st.err;
+        e.logs = logs;
+        throw e;
+      }
+      if (isConfirmed(st.confirmationStatus)) return signature;
+    }
+
+    // Safe give-up: stop only once this blockhash can no longer land the tx,
+    // so returning a retryable error can never cause a duplicate loan.
+    if (blockhash) {
+      try {
+        const v = await connection.isBlockhashValid(blockhash, { commitment });
+        if (v && v.value === false) break;
+      } catch { /* RPC lacks isBlockhashValid — fall through to hard timeout */ }
+    }
+
+    if (Date.now() - lastRebroadcast >= rebroadcastIntervalMs) {
+      try {
+        await connection.sendRawTransaction(raw, { skipPreflight: true, maxRetries: 5 });
+      } catch { /* transient send error — keep polling */ }
+      lastRebroadcast = Date.now();
+    }
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+
+  // Final status check to avoid the race where it landed just as we gave up.
+  try {
+    const { value } = await connection.getSignatureStatuses([signature], {
+      searchTransactionHistory: true,
+    });
+    const st = value?.[0];
+    if (st && !st.err && isConfirmed(st.confirmationStatus)) return signature;
+  } catch { /* ignore */ }
+
+  const e = new Error(`not confirmed before blockhash expiry (sig ${signature})`);
+  e.expiredTimeout = true;
+  throw e;
+}


### PR DESCRIPTION
## P0 — users report \$MAGPIE borrows stuck/slow on **"Landing your transaction…"**

**Root cause:** `cosign-borrow` submits the fully-signed borrow with a bare
`sendAndConfirmRawTransaction` → it **sends once** and then blocks on the blockhash's
expiry (~60–90s) via `confirmTransaction`. Under congestion the tx is dropped and
**never re-broadcast**, so the user sits on "Landing your transaction…" for a minute
and it fails. Loan execution is the #1 priority — unacceptable.

**Fix:** add `sendSignedRawWithRebroadcast()` (for externally-signed txs — we can't
re-sign the user's key) that **rebroadcasts the same raw tx every ~2s** and polls
`getSignatureStatuses(searchTransactionHistory)` to confirmation — the same
rebroadcast pattern the protocol's own txs already use (`confirmWithRebroadcast`).
`cosign-borrow` now uses it. Initial send keeps preflight so immediate program
errors (stale-price / TWAP / collateral) still throw with logs and classify exactly
as before.

**Safety (no duplicate loans):** gives up **only** once the tx can never land —
confirmed, on-chain error, or `isBlockhashValid = false` — so the new retryable
"Solana is congested — expired safely, tap Borrow again" 503 cannot create a second
loan on the same blockhash.

Files: `src/solana/tx-send.js` (+helper), `src/api/cosign-borrow.js` (use it + retryable-timeout class). Syntax-checked; leak-scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)