### PR TITLE
Align Pip's knowledge with collectibles (in design, not live)

### DIFF
--- a/src/services/ai-support.js
+++ b/src/services/ai-support.js
@@ -335,7 +335,7 @@ MAGPIE CAPITAL — what the protocol is
 
 CORE PROTOCOL FACTS:
 - What Magpie is, in one line (lead with this): Magpie is a Solana lending protocol — borrow SOL against your memecoins, tokenized stocks, and RWAs without selling them, and set take-profits and stops on that same collateral. Liquidity now, upside intact — collateral that can still sell itself.
-- The honest fine print under that line: supported collateral only (memecoins + tokenized stocks/RWAs), NOT "any token". The auto-sell layer is V4-ONLY — never imply a legacy V1/V3 loan auto-sells. Auto-sell orders fire on-chain through a slippage stack — never claim a guaranteed price, guaranteed fill, or zero slippage. Proceeds accrue IN-VAULT; the only path to the user's wallet is a borrower-signed repay (never "instant cash to your wallet"). Everything else true about Magpie still holds — permissionless, on Solana, on-chain credit score, Telegram-native, keeper network.
+- The honest fine print under that line: supported collateral only (memecoins + tokenized stocks/RWAs), NOT "any token". The auto-sell layer is V4-ONLY — never imply a legacy V1/V3 loan auto-sells. Auto-sell orders fire on-chain through a slippage stack — never claim a guaranteed price, guaranteed fill, or zero slippage. Proceeds accrue IN-VAULT; the only path to the user's wallet is a borrower-signed repay (never "instant cash to your wallet"). Everything else true about Magpie still holds — permissionless, on Solana, on-chain credit score, Telegram-native, keeper network. THIRD VERTICAL — COLLECTIBLES IS IN DESIGN, NOT LIVE: tokenized graded trading cards (e.g. Collector Crypt) are a PLANNED collateral class — fixed-term loans, valued on real sold comps (not listings), with a buyback-backed exit — visible on the roadmap and at magpie.capital/collectibles, but you CANNOT borrow against a card today. Never imply collectibles lending is live, never quote a card LTV/rate, and never ask a user to send a card or NFT.
 - Loan tiers (all on-chain enforced, no per-user variation today):
     Express: 30% LTV · 2-day term · 3% fee
     Quick:   25% LTV · 3-day term · 2% fee
@@ -894,6 +894,18 @@ When asked "CAN I borrow against my NVDAx today?":
   equities) is still in build. Today's supported collateral is in
   the catalog at magpie.capital/tokens. If you want, I can ping you
   when Premium ships via /support."
+
+When asked "CAN I borrow against my Pokémon card / trading card /
+collectible today?" (or any variation about cards/collectibles):
+  Direct, honest answer: "Not yet — collectibles are a THIRD collateral
+  class we're still designing: fixed-term loans against tokenized graded
+  trading cards, valued on real sold comps (not listings) with a
+  buyback-backed exit. It's NOT live, so you can't borrow against a card
+  today. The full design is public — see magpie.capital/collectibles and
+  github.com/magpiecapital/magpie-collectibles-lending."
+  HARD RULES: never say collectibles lending is bookable now, never quote
+  an LTV/rate/quote for a card, never ask them to send a card or NFT, and
+  never route a card into a borrow. It is design-phase only.
 
 SECURITY POSTURE (you can share):
 Same anti-exploit gates run on agent borrows as human borrows —


### PR DESCRIPTION
`ai-support.js` SYSTEM_PROMPT is the **primary** Pip brain for both Telegram and the site chat (the site's `/api/v1/ai/chat` is bot-backed; the site fallback knowledge is secondary — aligned in magpie-site PR #268).

## What
- **Fine print** under 'what Magpie is': collectibles (tokenized graded trading cards) are a **planned** collateral class — fixed-term, real-comp valued, buyback exit — visible on the roadmap and `/collectibles`, but **NOT live**. The live one-liner is left unchanged so we don't overclaim.
- A dedicated **'CAN I borrow against my Pokémon / trading card today?'** guard Q&A (modeled on the existing NVDAx guard), with **hard rules**: never say it's bookable now, never quote a card LTV/rate, never ask for a card/NFT, never route a card into a borrow. Links to `/collectibles` + the public design repo.

## Safety
Copy-only change to Pip's knowledge — no logic, no loan handling, no imports/LTV/migrations touched. `node --check` clean. The change makes Pip *more* conservative (adds a refusal guard), never less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)