### PR TITLE
security: run systemic anti-exploit gates on null-userId cosign borrows (REVIEW — do not auto-merge)

### DIFF
--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -330,7 +330,15 @@ const TWAP_MIN_SAMPLES = Math.max(
  */
 export async function preBorrowAntiExploitCheck(opts) {
   const { userId, collateralMint, proposedLoanLamports, walletPubkey } = opts;
-  if (!userId || !collateralMint) return null; // can't check without inputs — fail open
+  // We need a collateral mint to run ANY gate. We do NOT require a userId:
+  // the SYSTEMIC gates below (per-token exposure cap, TWAP-pump, liquidity
+  // floor, pool-% cap, imported-wallet cooldown) are keyed on the mint /
+  // wallet, not the user, and MUST run for every borrow — including the
+  // public cosign path, where an un-onboarded wallet resolves to a null
+  // userId (the site uses the non-creating resolver on purpose, to avoid a
+  // loan-misattribution bug). Only the per-USER gates (rapid-fire,
+  // new-account) are gated on `userId` below.
+  if (!collateralMint) return null; // can't check anything without a mint
 
   // Exempt-wallet check — bypasses ONLY the wallet/account profile gates
   // below. All systemic gates (TWAP, pool floor, per-token cap, rapid-fire,
@@ -464,8 +472,9 @@ export async function preBorrowAntiExploitCheck(opts) {
     }
 
 
-    // 1. RAPID_FIRE — refuse a new borrow within N seconds of the last one
-    if (RAPID_FIRE_SECONDS > 0) {
+    // 1. RAPID_FIRE — refuse a new borrow within N seconds of the last one.
+    // Per-USER gate — only runs when we resolved a userId.
+    if (userId && RAPID_FIRE_SECONDS > 0) {
       const { rows } = await query(
         `SELECT EXTRACT(EPOCH FROM (NOW() - MAX(start_timestamp)))::int AS seconds_ago
            FROM loans WHERE user_id = $1`,
@@ -485,7 +494,9 @@ export async function preBorrowAntiExploitCheck(opts) {
     // Exempt wallets bypass entirely. Protocol-owned mints (e.g.
     // $MAGPIE) also bypass — the operator can't flash-pump
     // themselves, and we want day-one utility on the gov token.
-    if (!isExempt
+    // Per-USER gate — only runs when we resolved a userId.
+    if (userId
+        && !isExempt
         && !NEW_ACCOUNT_EXEMPT_MINTS.has(String(collateralMint))
         && NEW_ACCOUNT_AGE_HOURS > 0
         && NEW_ACCOUNT_MAX_LAMPORTS > 0n) {


### PR DESCRIPTION
> ⚠️ **Security fix — for review. Please do not merge until reviewed.** Confirmed by reading the live control flow.

## The bug (HIGH)
`/api/v1/cosign-borrow` (public POST, accepts an attacker-built partial tx) resolves the borrower with the **non-creating** wallet resolver at `cosign-borrow.js:1429` — intentionally, because creating a row here caused a loan-misattribution bug (V3 loan 720). For a wallet with **no DB row**, that yields `userId = null`, which was passed to `preBorrowAntiExploitCheck({ userId: null, ... })`. Its first line was:

```js
if (!userId || !collateralMint) return null; // fail open
```

So a `null` userId **short-circuited the entire gauntlet** — skipping the **per-token exposure cap, liquidity floor, pool-% cap, and TWAP-pump gate**. An un-onboarded wallet could therefore bypass every systemic borrow limit, re-opening the thin-pool flash-pump surface (the `$FATHER` class). *(Agent and TG paths carry a userId and were unaffected.)*

This compounds with a separate pricing finding (cross-source guard can collapse to single-source DexScreener under Jupiter backoff) — together they form a credible pool-drain path. That pricing fix is a **separate PR**.

## The fix
Only a `collateralMint` is needed to run the **systemic** gates (keyed on mint/wallet, not user). So:
- Early-return now requires only `collateralMint`.
- The **per-USER** checks — rapid-fire (§1) and new-account cap (§2), the only two that query by `user_id` — are gated on `if (userId && …)`.
- Per-token cap, imported-wallet cooldown, TWAP-pump, liquidity floor, and pool-% cap now run for **every** borrow, including the null-userId cosign path.

## Why it's safe
- **Registered wallets: behavior unchanged** (userId present → every gate runs exactly as before).
- **Unregistered wallets** are now subject to the same systemic limits as everyone else — which only ever **block** a thin-pool/pumped/over-cap borrow (the intended behavior). Adequately-liquid tokens with headroom pass.
- All gates keep their existing **fail-open on infra error** and **operator-trusted/protected exemption**.
- `node --check` clean; leak-scanned.

## Not included
No JS unit-test harness exists for bot services (only Anchor/TS program tests) — a regression test asserting "systemic gates run when userId is null" would need a DB-mock harness this repo doesn't have yet. Flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)