### PR TITLE
oracle hardening (low-risk): rwa auto-disable race + drift-buffer env clamp

### DIFF
--- a/src/api/safe-collateral-value.js
+++ b/src/api/safe-collateral-value.js
@@ -61,8 +61,22 @@ const MAX_PRICE_STALENESS_SECONDS = 110; // under the program's 120s wall
 // (strictly safer for the protocol — it can never over-value collateral); the
 // cost is a few % of borrowing power, which is the right trade for ZERO
 // rejections. Tune via env without a redeploy.
-const HEADROOM_MEMECOIN_BPS = Number(process.env.SAFE_HEADROOM_MEMECOIN_BPS) || 500; // 5% — memecoins are volatile
-const HEADROOM_RWA_BPS = Number(process.env.SAFE_HEADROOM_RWA_BPS) || 200; // 2% — RWAs/stocks (TWAP-smoothed, can still gap)
+// Clamp the drift-headroom env overrides to a safe band. The buffer only
+// ever REDUCES borrowing power (SCALE − headroom), so a misconfigured value
+// must not be able to (a) collapse the buffer to ~0 (a tiny positive like
+// `=1` → 0.01%, re-opening quote→execution drift rejections/over-valuation)
+// or (b) INVERT it (a negative value would make the multiplier > 1 and
+// inflate collateral value — a security-relevant misconfig). NaN/0/negative
+// fall back to the default; valid values are bounded to [0.5%, 50%].
+const MIN_HEADROOM_BPS = 50; // never let the buffer collapse below 0.5%
+const MAX_HEADROOM_BPS = 5000; // never exceed 50%
+function parseHeadroomBps(envVal, def) {
+  const n = Number(envVal);
+  if (!Number.isFinite(n) || n <= 0) return def;
+  return Math.min(Math.max(n, MIN_HEADROOM_BPS), MAX_HEADROOM_BPS);
+}
+const HEADROOM_MEMECOIN_BPS = parseHeadroomBps(process.env.SAFE_HEADROOM_MEMECOIN_BPS, 500); // 5% — memecoins are volatile
+const HEADROOM_RWA_BPS = parseHeadroomBps(process.env.SAFE_HEADROOM_RWA_BPS, 200); // 2% — RWAs/stocks (TWAP-smoothed, can still gap)
 const HEADROOM_DEFAULT_BPS = HEADROOM_MEMECOIN_BPS; // unknown category → widest (safest) buffer
 // Everything that isn't an RWA/stock/commodity class is treated as memecoin-volatile.
 const RWA_CATEGORIES = new Set([

--- a/src/services/token-health.js
+++ b/src/services/token-health.js
@@ -192,7 +192,7 @@ async function tick(bot) {
     `SELECT mint, symbol, has_mint_authority, health_strikes, category
      FROM supported_mints
      WHERE enabled = TRUE AND (protected IS NOT TRUE)
-       AND (category NOT IN ('stock','etf','metal') OR category IS NULL)`,
+       AND (category NOT IN ('stock','rwa','etf','metal') OR category IS NULL)`,
   );
 
   if (tokens.length === 0) return;


### PR DESCRIPTION
Two **safe, no-tradeoff** hardenings from the oracle audit. Default behavior unchanged — both only constrain a misconfig / close a race. Recommended to merge.

**1. `token-health.js` — RWA auto-disable race (LOW).** The auto-disable candidate filter excluded `('stock','etf','metal')` but not `'rwa'`, while the stocks-rwa-protection-sentinel protects `('stock','rwa','etf','metal')`. A freshly-added `category='rwa'` mint inserted `protected=FALSE` in the ≤5-min window before the sentinel's next sweep could be auto-disabled/striked. Adding `'rwa'` matches the sentinel and closes the window deterministically. Aligns with the always-hot+protected mandate.

**2. `safe-collateral-value.js` — drift-buffer env clamp (LOW).** `SAFE_HEADROOM_*_BPS` were parsed as `Number(env) || default` with no bounds. A tiny positive (`=1`) collapses the drift buffer to ~0.01%; a **negative** value parses truthy and **inverts** the buffer (multiplier > 1 → inflates collateral value — a security-relevant misconfig). Now clamped to `[0.5%, 50%]`; NaN/0/negative → default. The buffer only ever reduces borrowing power, so this just removes a footgun.

`node --check` clean. Leak-scanned. Part of the oracle-audit follow-up (companion to the gauntlet-bypass PR #619; the higher-stakes cross-source pricing fix is pending a design decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)