### PR TITLE
security: catch letter-spaced role-word impersonators ("D E V")

### DIFF
--- a/src/services/community-moderation.js
+++ b/src/services/community-moderation.js
@@ -688,6 +688,18 @@ export function isBareRoleWordImpersonation(user) {
   for (const raw of [user.username || "", user.first_name || "", user.last_name || "", combined]) {
     if (!raw) continue;
     const folded = foldConfusables(normalizeUnicode(raw)).toLowerCase();
+    // (b) LETTER-/PUNCTUATION-SPACED evasion: the whole name with ALL
+    // separators removed IS a single role word — "D E V" → "dev",
+    // "A.D.M.I.N" → "admin", "s u p p o r t" → "support", "d_e_v" → "dev".
+    // Checked FIRST and regardless of token count: the token-based check (a)
+    // below misses this because each spaced letter becomes its own non-role
+    // token, and a spaced-out word can exceed the 4-token "not a sentence"
+    // guard ("A D M I N" = 5 tokens). A legit name only trips this if it
+    // collapses to an EXACT staff-role word (e.g. "Devon" → "devon" does
+    // NOT), and the appeal path (/appeal) covers the rare edge.
+    const despaced = folded.replace(/[^a-z0-9]/g, "");
+    if (despaced && BARE_ROLE_WORDS.has(despaced)) return true;
+    // (a) every token is itself a role word ("Dev", "Dev Team", "Admin Support").
     const toks = folded.split(/[^a-z0-9]+/).filter(Boolean);
     if (!toks.length || toks.length > 4) continue;      // 1–4 tokens; a sentence isn't a name
     if (toks.every((t) => BARE_ROLE_WORDS.has(t))) return true;


### PR DESCRIPTION
## Incident
A scammer named **"D E V"** got into the Magpie community and posted — the impersonation filter missed it.

## Root cause
`isBareRoleWordImpersonation` split the name on separators into tokens `['d','e','v']` and checked each against `BARE_ROLE_WORDS`. None matched, and the **despaced** form (`'dev'`, which IS a role word) was never checked in this function — only the brand patterns get the despaced variant. The `>4-token` "not a sentence" guard made it worse: **"A D M I N" (5 tokens) skipped the check entirely.**

## Fix
Before the token check, also test the whole name with **all separators removed** against `BARE_ROLE_WORDS`, regardless of token count:
`"D E V"→dev`, `"A.D.M.I.N"→admin`, `"s u p p o r t"→support`, `"d_e_v"→dev`. Defeats the space-out-the-letters bypass.

## Verified (standalone test)
- **Now banned:** `D E V`, `A D M I N`, `S U P P O R T`, `d_e_v`, `A.D.M.I.N`, `m o d`, split first/last `D`/`E V`, fullwidth `Ｄ Ｅ Ｖ`, plus existing `Dev` / `Magpie Support`.
- **Not flagged (no new false-positive):** `Devon`, `CryptoDev`, `Andrew`, `Owen`, `alice`.

## Permanence + retroactive
Impersonator bans are already **permanent** (`banChatMember`, no `until_date`) and fire **on join** (handler L186) and **on every message** (L425). `/scan-impersonators` sweeps existing members retroactively. This PR only fixes the *detection* gap so all three enforce.

Note: role-word-prefixed names (e.g. "Dev Dan") are aggressively flagged with the `/appeal` safety valve, per the zero-impersonation directive. `node --check` clean; leak-scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)