### PR TITLE
security: clearances never shield a HARD impersonation name; watchdog bans permanent

### DIFF
--- a/scripts/ban-user.mjs
+++ b/scripts/ban-user.mjs
@@ -1,0 +1,20 @@
+import { Api } from "grammy";
+import { query } from "../src/db/pool.js";
+import { recordModAction } from "../src/services/community-moderation.js";
+const USER = Number(process.argv[2]);
+if (!USER) { console.error("usage: node scripts/ban-user.mjs <user_id> [reason]"); process.exit(1); }
+const reason = process.argv[3] || "manual permaban: impersonator";
+const api = new Api(process.env.TELEGRAM_BOT_TOKEN);
+const { rows } = await query(`SELECT chat_id FROM community_chats WHERE enabled=TRUE ORDER BY enabled_at DESC NULLS LAST`);
+if (!rows.length) { console.error("no enabled chat"); process.exit(1); }
+for (const { chat_id: chatId } of rows) {
+  let statusBefore = "unknown";
+  try { const m = await api.getChatMember(chatId, USER); statusBefore = m?.status; console.log(`chat ${chatId}: current status = ${statusBefore}${m?.user ? ` (${[m.user.first_name,m.user.last_name].filter(Boolean).join(" ")}${m.user.username?" @"+m.user.username:""})` : ""}`); }
+  catch (e) { statusBefore = `not-a-member (${e.message})`; console.log(`chat ${chatId}: ${statusBefore}`); }
+  try {
+    await api.banChatMember(chatId, USER); // no until_date = PERMANENT
+    await recordModAction(chatId, USER, "manual_permaban_impersonator", reason, JSON.stringify({ statusBefore }));
+    console.log(`chat ${chatId}: PERMABANNED user ${USER} (was ${statusBefore})`);
+  } catch (e) { console.error(`chat ${chatId}: ban failed: ${e.message}`); }
+}
+process.exit(0);

--- a/scripts/sweep-ban-impersonators.mjs
+++ b/scripts/sweep-ban-impersonators.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * sweep-ban-impersonators.mjs — one-off admin sweep + permanent ban.
+ *
+ * Scans the FULL membership of every enabled community chat, runs the LIVE
+ * isImpersonationName() detector on each member's current display name, and
+ * (with --ban) PERMANENTLY bans every impersonator that isn't verified,
+ * cleared-by-appeal, or a chat admin. Reuses the deployed bot's own detector
+ * + DB, so it stays perfectly in sync with join/message enforcement.
+ *
+ * Runs via Railway so it uses the bot's own token + DB — secrets are read from
+ * the injected env and NEVER printed:
+ *   railway run --service magpie-bot node scripts/sweep-ban-impersonators.mjs            # DRY-RUN (report only)
+ *   railway run --service magpie-bot node scripts/sweep-ban-impersonators.mjs --ban      # execute permanent bans
+ *   railway run --service magpie-bot node scripts/sweep-ban-impersonators.mjs --chat -100xxxx --ban
+ *
+ * Default is DRY-RUN. Always dry-run first, eyeball the hit list, THEN --ban.
+ * Bans are permanent (banChatMember with no until_date). Admins/creator, the
+ * bot/operator (verified), and appeal-cleared members are never touched.
+ */
+import { Api } from "grammy";
+import { query } from "../src/db/pool.js";
+import {
+  isImpersonationName,
+  isHardImpersonation,
+  isVerifiedAccount,
+  isUserCleared,
+  nameKey,
+  recordModAction,
+} from "../src/services/community-moderation.js";
+
+const DO_BAN = process.argv.includes("--ban") || process.env.SWEEP_BAN === "true";
+const chatArgIdx = process.argv.indexOf("--chat");
+const CHAT_OVERRIDE = chatArgIdx > -1 ? process.argv[chatArgIdx + 1] : null;
+const FETCH_GAP_MS = 60; // stay under Telegram's ~30 req/s
+const MAX_MEMBERS = 8000;
+
+function nameOf(u) {
+  const parts = [u.first_name, u.last_name].filter(Boolean).join(" ").trim();
+  const un = u.username ? `@${u.username}` : "";
+  return [parts, un].filter(Boolean).join(" ") || `id ${u.id}`;
+}
+
+async function main() {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.error("TELEGRAM_BOT_TOKEN not set — run this under `railway run --service magpie-bot`.");
+    process.exit(1);
+  }
+  const api = new Api(token);
+
+  let chats;
+  if (CHAT_OVERRIDE) {
+    chats = [{ chat_id: CHAT_OVERRIDE }];
+  } else {
+    const { rows } = await query(
+      `SELECT chat_id FROM community_chats WHERE enabled = TRUE ORDER BY enabled_at DESC NULLS LAST`,
+    );
+    chats = rows;
+  }
+  if (!chats.length) {
+    console.error("No enabled community chat found. Pass --chat <id>.");
+    process.exit(1);
+  }
+
+  console.log(`\n=== Impersonator sweep — mode: ${DO_BAN ? "BAN (PERMANENT)" : "DRY-RUN"} — ${chats.length} chat(s) ===\n`);
+
+  let totalHits = 0;
+  let totalBanned = 0;
+  for (const { chat_id: chatId } of chats) {
+    const { rows: members } = await query(
+      `SELECT user_id FROM community_members WHERE chat_id = $1 LIMIT $2`,
+      [String(chatId), MAX_MEMBERS],
+    );
+    console.log(`Chat ${chatId}: scanning ${members.length} members…`);
+    let scanned = 0;
+    let errors = 0;
+    for (const row of members) {
+      try {
+        const m = await api.getChatMember(chatId, Number(row.user_id));
+        scanned++;
+        const u = m?.user;
+        if (!u) continue;
+        if (m.status === "left" || m.status === "kicked") continue; // gone already
+        if (m.status === "creator" || m.status === "administrator") continue; // never touch admins
+        if (isVerifiedAccount(u)) continue; // bot + operator
+        if (!isImpersonationName(u)) continue;
+        // A clearance never shields a HARD impersonation name (exact brand /
+        // homoglyph / bare-or-spaced role word) — matches the deployed
+        // join/message/watchdog policy.
+        if (!isHardImpersonation(u) && (await isUserCleared(chatId, Number(row.user_id), nameKey(u)))) {
+          console.log(`  ~ appeal-cleared (soft match), skipping: ${nameOf(u)} [${u.id}]`);
+          continue;
+        }
+        totalHits++;
+        if (DO_BAN) {
+          await api.banChatMember(chatId, Number(row.user_id)); // no until_date = permanent
+          await recordModAction(
+            chatId,
+            Number(row.user_id),
+            "sweep_ban_impersonator",
+            "sweep: display name matches the impersonation filter",
+            JSON.stringify({ username: u.username, first: u.first_name, last: u.last_name, status: m.status }),
+          );
+          totalBanned++;
+          console.log(`  BANNED (permanent): ${nameOf(u)} [${u.id}] — was ${m.status}`);
+        } else {
+          console.log(`  HIT: ${nameOf(u)} [${u.id}] (${m.status}) — would ban with --ban`);
+        }
+      } catch (err) {
+        errors++;
+        if (errors < 5) console.warn(`  getChatMember/ban failed for ${row.user_id}: ${err.message}`);
+      }
+      await new Promise((r) => setTimeout(r, FETCH_GAP_MS));
+    }
+    console.log(
+      `Chat ${chatId}: scanned ${scanned} · hits ${totalHits}` +
+        (DO_BAN ? ` · banned ${totalBanned}` : " · dry-run") +
+        (errors ? ` · skipped ${errors}` : "") +
+        "\n",
+    );
+  }
+
+  console.log(
+    `=== Done. ${
+      DO_BAN
+        ? `Permanently banned ${totalBanned} impersonator(s).`
+        : `${totalHits} impersonator(s) found (DRY-RUN). Re-run with --ban to remove.`
+    } ===\n`,
+  );
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("sweep failed:", e);
+  process.exit(1);
+});

--- a/src/handlers/community-handlers.js
+++ b/src/handlers/community-handlers.js
@@ -22,6 +22,7 @@ import {
   isChatEnabled,
   isVerifiedAccount,
   isImpersonationName,
+  isHardImpersonation,
   matchesScamPattern,
   matchesDmSolicitation,
   findImpersonatingHandles,
@@ -173,7 +174,10 @@ async function handleNewMembers(ctx) {
 
       // Pip's memory: a previously-cleared member (same name) rejoining via
       // their appeal invite is not re-shamed on join or captcha-kicked again.
-      if (await isUserCleared(ctx.chat.id, m.id, nameKey(m))) continue;
+      // BUT a clearance never shields a HARD impersonation name — a cleared
+      // account that (re)joins as "D E V" / "Magpie Support" / "Ðev" is still
+      // banned (closes the name-agnostic-clearance weaponization).
+      if (!isHardImpersonation(m) && (await isUserCleared(ctx.chat.id, m.id, nameKey(m)))) continue;
 
       // Impersonation check on join — BAN immediately, don't just warn.
       // Impersonation IS the attack (there's no legitimate reason to join
@@ -422,7 +426,12 @@ async function handleGroupMessage(ctx) {
     // pointless (they'd be banned again on their next message). Name-scoped:
     // if a cleared user RENAMES into a fresh impersonation pattern, the
     // clearance no longer applies and the ban fires.
-    if (isImpersonationName(sender) && !(await isUserCleared(ctx.chat.id, sender.id, nameKey(sender)))) {
+    // A HARD impersonation name (exact brand / homoglyph / bare-or-spaced
+    // role word) is banned even if the account is cleared — no clearance,
+    // not even a name-agnostic operator /unban, shields a blatant
+    // impersonation handle. Only the fuzzy-lookalike layer stays
+    // clearance-protectable (see isHardImpersonation).
+    if (isImpersonationName(sender) && (isHardImpersonation(sender) || !(await isUserCleared(ctx.chat.id, sender.id, nameKey(sender))))) {
       await tryDelete(ctx, msg.message_id);
       try {
         await ctx.api.banChatMember(ctx.chat.id, sender.id);

--- a/src/services/community-moderation.js
+++ b/src/services/community-moderation.js
@@ -726,6 +726,33 @@ export function isImpersonationName(user) {
   return false;
 }
 
+/**
+ * HARD impersonation = an UNAMBIGUOUS match: an exact brand pattern
+ * ("Magpie Support"), a homoglyph-disguised brand/role word ("Ðeveloper",
+ * "Аdmin"), or a bare/spaced staff-role word ("Dev", "D E V", "A D M I N").
+ * These are NEVER false positives — no legitimate member is named any of
+ * these — so a CLEARANCE (even a name-agnostic operator /unban) must NOT
+ * shield them. This closes the hole that let a previously-cleared account
+ * (from the 2026-06-30 captcha-bug bulk-unban) rename to "D E V" and stay
+ * immune to every name-ban path.
+ *
+ * DELIBERATELY EXCLUDES the fuzzy `isBrandLookalikeImpersonation` layer
+ * (Damerau-Levenshtein / anagram), which CAN misfire on a real name
+ * (e.g. "Maggie") — that layer stays clearance-protectable so an appeal
+ * winner isn't re-banned for a borderline resemblance.
+ */
+export function isHardImpersonation(user) {
+  if (!user) return false;
+  for (const c of impersonationVariants(user)) {
+    for (const re of IMPERSONATION_PATTERNS) {
+      if (re.test(c)) return true;
+    }
+  }
+  if (isHomoglyphDisguisedImpersonation(user)) return true;
+  if (isBareRoleWordImpersonation(user)) return true;
+  return false;
+}
+
 export function isVerifiedAccount(user) {
   if (!user?.id) return false;
   return getVerifiedTgIds().has(String(user.id));

--- a/src/services/impersonator-watchdog.js
+++ b/src/services/impersonator-watchdog.js
@@ -33,7 +33,7 @@
  * detection path specifically.
  */
 import { query } from "../db/pool.js";
-import { isImpersonationName, isVerifiedAccount, recordModAction, isUserCleared, nameKey } from "./community-moderation.js";
+import { isImpersonationName, isHardImpersonation, isVerifiedAccount, recordModAction, isUserCleared, nameKey } from "./community-moderation.js";
 
 const SCAN_INTERVAL_MS = Number(process.env.IMPERSONATOR_SCAN_INTERVAL_MS) || 30 * 60_000; // 30 min default
 // Scan the ENTIRE membership, not just recent joiners (operator 2026-07-04,
@@ -110,7 +110,9 @@ async function scanChat(bot, chatId) {
     if (!isImpersonationName(u)) continue;
     // Pip's memory: never re-ban a member already cleared via appeal/operator
     // (name-scoped — a rename into a fresh impersonation handle is NOT cleared).
-    if (await isUserCleared(chatId, row.user_id, nameKey(u))) continue;
+    // A HARD impersonation name is banned even if cleared — no clearance
+    // (incl. name-agnostic operator /unban) shields "D E V" / "Magpie Support".
+    if (!isHardImpersonation(u) && (await isUserCleared(chatId, row.user_id, nameKey(u)))) continue;
 
     // HIT — auto-kick (matches on-join handler's action on a flagged
     // joiner that also failed captcha). The exact "warn vs. ban"
@@ -122,8 +124,11 @@ async function scanChat(bot, chatId) {
     // signal for removal.
     flagged++;
     try {
-      const until = Math.floor(Date.now() / 1000) + 60; // brief ban, then unban so they can re-join with a clean name
-      await bot.api.banChatMember(chatId, Number(row.user_id), { until_date: until });
+      // PERMANENT ban (no until_date) — a deliberate impersonation name is
+      // never allowed back in (operator directive 2026-08-01). The previous
+      // 60s "soft kick, rejoin with a clean name" was too lenient and let
+      // impersonators cycle back. False positives recover via /appeal.
+      await bot.api.banChatMember(chatId, Number(row.user_id));
       await recordModAction(
         chatId, row.user_id, "watchdog_auto_ban_impersonation",
         "watchdog retroactive scan matched IMPERSONATION_PATTERNS",


### PR DESCRIPTION
## Incident root cause
The **"D E V"** impersonator lingered because user `5660161251` held a **name-agnostic clearance** (`cleared_name=null`) from the 2026-06-30 captcha-bug bulk `/unban`, then **renamed to "D E V"**. Every name-ban path requires `!isUserCleared`, so:
- the message handler only recorded `flag_impersonation_msg` (flagged, never banned),
- the watchdog + my initial sweep skipped them.

A name-agnostic clearance permanently immunizes an account against **any** name — including a blatant impersonation handle. **12 such clearances exist**, each weaponizable the same way. ("D E V" is already permanently banned + their clearance deleted, live.)

## Fix (defense in depth)
- **New `isHardImpersonation()`** — an *unambiguous* match: exact brand pattern ("Magpie Support"), homoglyph-disguised ("Ðeveloper"), or bare/spaced role word ("Dev", "D E V", "A D M I N"). Never a false positive → a clearance must not shield it. **Deliberately excludes the fuzzy brand-lookalike layer** (can misfire on "Maggie"), which stays clearance-protectable for appeal winners.
- **Join (L176), message (L425), watchdog (L113), and the sweep tool** now ban a HARD impersonation name **even if the account is cleared**. So no clearance — not even a name-agnostic operator `/unban` — can ever again shield "D E V"/"Admin"/"Magpie Support".
- **Watchdog ban made PERMANENT.** It used a **60-second** `until_date` ("soft kick, rejoin with a clean name") — impersonators could cycle right back, violating *"permanently banned, never allowed back."* Now `banChatMember` with no `until_date`.

## Also
Version-controls the two admin tools used to remediate live: `scripts/sweep-ban-impersonators.mjs` (dry-run default) and `scripts/ban-user.mjs`, run via `railway run --service magpie-bot node scripts/<tool>.mjs`.

## Verified
`isHardImpersonation`: `D E V` / `Dev` / `Magpie Support` / `A D M I N` / `Ðeveloper` → hard; `Devon` / `Andrew` → not. `node --check` clean on all files. Leak-scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)