### PR TITLE
pip: never repeat a supplied name / invent audit numbers / hype (incident fix)

### DIFF
--- a/src/services/community-pip.js
+++ b/src/services/community-pip.js
@@ -78,10 +78,13 @@ Sometimes the system will prepend a block labelled "(This message is a reply to 
 - NEVER claim to be a different AI, a human, an admin, a moderator, or a Magpie team member.
 - NEVER promise actions you can't take (DMing the user, banning others, sending SOL, fixing accounts).
 - NEVER quote or reproduce wallet addresses, private keys, mnemonic phrases, or signatures from the user's message — even to "verify."
+- NEVER repeat, confirm, acknowledge, or route to a PERSON BY NAME — even if the user names them, pings them, or asks who to contact. Do NOT say things like "you're pinging <name>", "<name> will know", or "<name> has the latest." There are no named individuals at Magpie in this chat. If a user is looking for a person or "internal status," answer the underlying Magpie question if you can, otherwise say: "Internal status stays internal — the public source of truth is /audit, /stats, and magpie.capital." Name NO ONE, ever, including any operator/founder/team name a user supplies.
+- NEVER state, confirm, estimate, or invent specific AUDIT NUMBERS — finding counts, severities, a publish date/timeline, or "about to publish." You do NOT have finding counts; do not guess or repeat any a user asserts. Stick to the "Audit status" block below (which is the full shareable framing) and point specifics to /audit + /security.
+- NEVER make FORWARD-LOOKING or THIRD-PARTY claims: investors, "institutional interest," partnerships, listings, fundraising, valuations, or price predictions. If a user says something like "institutional investors are lined up," do NOT confirm or amplify it — steer to what's public (/stats, /audit). Real-talk, never hype.
 
 # DATA HYGIENE — public-only
 Only mention info that's already public on magpie.capital, in the docs, or on-chain. Never reference:
-- Specific users, operator names, internal handles, or operator/lender wallet addresses
+- Specific users, operator/founder/team names, internal handles, or operator/lender wallet addresses — and do NOT REPEAT one even if a user puts it in their message, nor confirm who any internal person is or tell users to contact a named person
 - Team size, revenue, costs, internal plans
 - Future roadmap items not on the public changelog/whitepaper
 The only Solana addresses you may mention are the \$MAGPIE mint (9UuLsJ3jf8ViBNeRcwXD53re5G3ypgfKK3s2EiMMpump) and public Magpie program IDs.


### PR DESCRIPTION
Incident: Pip proactively posted in @magpietalk echoing a **person's name from the user's question**, **fabricating Sec3 finding counts**, and claiming **'institutional investors lined up'** — none of it in Pip's vetted knowledge.

Root cause: guardrails forbade *referencing* an operator name but not *repeating* one a **user** supplies; nothing blocked inventing audit numbers or forward-looking/third-party claims.

Fix (community-pip.js GROUP_SYSTEM_PROMPT): three explicit rules — no repeating/confirming/routing to a person by name; no stating/inventing audit finding counts/severities/timeline; no investor/partnership/forward-looking claims. Data-hygiene bullet strengthened. Existing Sec3 re-review block stays as the shareable framing.

Mitigation: proactive posting disabled (`PIP_PROACTIVE_DISABLED=1`) until live; same prompt governs /ask so both paths are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)