### PR TITLE
ops: /submissions — operator review queue for collectible submissions

### DIFF
--- a/migrations/097_collectible_submissions.sql
+++ b/migrations/097_collectible_submissions.sql
@@ -1,0 +1,99 @@
+-- migration 097: collectible submissions — the durable record behind the
+-- public vetting gate at magpie.capital/collectibles#submit.
+--
+-- Design notes, because the shape here is deliberate:
+--
+--  1. ONE ROW PER ATTEMPT. We do NOT upsert on (grader, cert). If the same
+--     slab is submitted twice we want both rows — a cert appearing under two
+--     different wallets is a real fraud signal (someone claiming a card they
+--     don't hold), and collapsing it would destroy the evidence. Dedupe is a
+--     read-time concern, not a write-time one.
+--
+--  2. THE FULL CHECK TRAIL IS STORED. `checks` holds every gate stage and its
+--     outcome, and `gate_version` records which revision of the gate produced
+--     it. Without the version, a verdict stops being interpretable the moment
+--     the gate changes — and this table is meant to stay meaningful for years.
+--
+--  3. MACHINE VERDICT AND HUMAN STATUS ARE SEPARATE COLUMNS. `verdict` is what
+--     the deterministic gate returned and is never edited. `status` is the
+--     human/licensed-data lifecycle on top of it. Overwriting the machine
+--     verdict with a human decision would make the two impossible to audit
+--     against each other.
+--
+--  4. NO RAW PII BEYOND WHAT THE USER TYPED. We store a SALTED HASH of the IP
+--     and user-agent for abuse detection, never the raw values. `contact` is
+--     optional and user-supplied. Nothing here is served publicly — the site
+--     only ever returns a caller their OWN rows, and only the public columns.
+--
+--  5. INTERNAL-ONLY COLUMNS are marked below. reviewer_note, ip_hash,
+--     ua_hash and flags must never leave the protocol.
+CREATE TABLE IF NOT EXISTS collectible_submissions (
+  id            BIGSERIAL PRIMARY KEY,
+
+  -- ── who (all optional; a collector can check a card anonymously) ──
+  wallet        TEXT,          -- connected Solana wallet, base58
+  telegram_id   BIGINT,        -- set when a submission arrives via the bot
+  contact       TEXT,          -- user-supplied handle/email, optional
+
+  -- ── what was submitted ──
+  grader        TEXT NOT NULL,
+  cert          TEXT NOT NULL,
+  card          TEXT NOT NULL,
+  card_set      TEXT,
+  card_year     TEXT,
+  grade         TEXT,          -- kept as text: "10", "9.5", or empty for autos
+  auto_grade    TEXT,
+  platform      TEXT,          -- vaulting platform, empty = not vaulted yet
+
+  -- ── what the deterministic gate decided (never edited) ──
+  verdict       TEXT NOT NULL, -- DECLINED | NEEDS_VAULTING | CANDIDATE_REVIEW | PROVISIONAL_TIER_A | PROVISIONAL_TIER_B
+  tier          TEXT,          -- A | B | NULL
+  checks        JSONB NOT NULL DEFAULT '[]'::jsonb,
+  next_steps    JSONB NOT NULL DEFAULT '[]'::jsonb,
+  gate_version  TEXT NOT NULL DEFAULT 'v1',
+
+  -- ── human / licensed-data lifecycle on top of the machine verdict ──
+  status        TEXT NOT NULL DEFAULT 'submitted', -- submitted | in_review | approved | rejected | withdrawn
+  reviewed_at   TIMESTAMPTZ,
+  reviewer_note TEXT,          -- INTERNAL ONLY — never served to a user
+
+  -- ── provenance + abuse signals (INTERNAL ONLY) ──
+  source        TEXT NOT NULL DEFAULT 'site',
+  ip_hash       TEXT,          -- salted hash, never the raw address
+  ua_hash       TEXT,
+  flags         JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- A collector opening their dashboard: "show me my submissions, newest first."
+CREATE INDEX IF NOT EXISTS collectible_submissions_wallet_idx
+  ON collectible_submissions (wallet, created_at DESC);
+
+-- Cert collision detection — the fraud signal in note 1.
+CREATE INDEX IF NOT EXISTS collectible_submissions_cert_idx
+  ON collectible_submissions (grader, cert);
+
+-- Operator review queue.
+CREATE INDEX IF NOT EXISTS collectible_submissions_status_idx
+  ON collectible_submissions (status, created_at DESC);
+
+-- Demand analytics: what are collectors actually asking for, and what are we
+-- turning away? The declines are the more valuable half — they map the edge of
+-- the book and tell us which categories to underwrite next.
+CREATE INDEX IF NOT EXISTS collectible_submissions_verdict_idx
+  ON collectible_submissions (verdict, created_at DESC);
+
+-- INTERNAL analytics view. Aggregate only, no PII, safe to hand to the
+-- operator or a future data room without exposing any individual submitter.
+CREATE OR REPLACE VIEW collectible_submission_demand AS
+SELECT
+  date_trunc('day', created_at)                       AS day,
+  verdict,
+  COALESCE(tier, '-')                                 AS tier,
+  COALESCE(NULLIF(platform, ''), 'not vaulted')       AS platform,
+  COUNT(*)                                            AS submissions,
+  COUNT(DISTINCT wallet) FILTER (WHERE wallet IS NOT NULL AND wallet <> '') AS wallets
+FROM collectible_submissions
+GROUP BY 1, 2, 3, 4;

--- a/src/commands/collectible-submissions.js
+++ b/src/commands/collectible-submissions.js
@@ -1,0 +1,191 @@
+/**
+ * /submissions — operator-only review queue for collectible submissions.
+ *
+ * The public gate at magpie.capital/collectibles#submit does the triage it can
+ * do from a form and records the result. It deliberately CANNOT approve a card
+ * for a loan: the liquidity proof needs realized multi-venue sold data, and the
+ * cert still has to be checked against the grader's own records. That last mile
+ * is a human decision, and this command is where it gets made.
+ *
+ * Usage:
+ *   /submissions                  — the queue, newest first
+ *   /submissions <id>             — full detail, including internal flags
+ *   /submissions review  <id> …   — mark as being worked on
+ *   /submissions approve <id> …   — approved as collateral-eligible
+ *   /submissions reject  <id> …   — rejected, with the reason
+ *
+ * The machine verdict is NEVER overwritten — approving sets `status`, and the
+ * gate's original `verdict` stays exactly as it was so the two can be audited
+ * against each other later.
+ */
+import { isAdmin } from "../services/admin.js";
+import { query } from "../db/pool.js";
+
+const STATUSES = { review: "in_review", approve: "approved", reject: "rejected" };
+
+/** Telegram truncates long messages; keep the queue readable. */
+const QUEUE_LIMIT = 15;
+
+function when(ts) {
+  return new Date(ts).toISOString().slice(5, 16).replace("T", " ");
+}
+
+function describe(r) {
+  return [
+    r.card,
+    r.card_set,
+    r.card_year,
+    `${r.grader} ${r.cert}`,
+    r.grade ? `grade ${r.grade}` : null,
+    r.auto_grade ? `auto ${r.auto_grade}` : null,
+    r.platform || "not vaulted",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+/** The signals that decide whether this is worth a human's time. */
+function riskLine(flags) {
+  const f = flags || {};
+  const bits = [];
+  if (f.ownership === "proven") bits.push("✅ holds it on-chain");
+  else if (f.ownership === "mismatch") bits.push("⚠️ does NOT hold it");
+  if (f.cert_claimed_by_other_wallet) bits.push("⚠️ cert claimed by another wallet");
+  else if (f.cert_seen_before) bits.push("↺ cert seen before");
+  return bits.length ? bits.join(" · ") : null;
+}
+
+async function showQueue(ctx) {
+  const { rows } = await query(
+    `SELECT id, card, card_set, card_year, grader, cert, grade, auto_grade,
+            platform, verdict, tier, status, flags, created_at
+       FROM collectible_submissions
+      WHERE status IN ('submitted', 'in_review')
+        AND verdict <> 'DECLINED'
+      ORDER BY created_at DESC
+      LIMIT ${QUEUE_LIMIT}`,
+  );
+
+  if (!rows.length) {
+    await ctx.reply(
+      "No collectible submissions waiting.\n\n" +
+        "Declines are filtered out — they need no decision. Use /submissions <id> to open any single one.",
+    );
+    return;
+  }
+
+  const lines = rows.map((r) => {
+    const risk = riskLine(r.flags);
+    return (
+      `#${r.id} · ${when(r.created_at)} · ${r.status}\n` +
+      `  ${describe(r)}\n` +
+      `  gate: ${r.verdict}${r.tier ? ` (Tier ${r.tier})` : ""}` +
+      (risk ? `\n  ${risk}` : "")
+    );
+  });
+
+  await ctx.reply(
+    `🃏 Collectible submissions awaiting a decision (${rows.length}):\n\n` +
+      lines.join("\n\n") +
+      "\n\n/submissions <id> for detail · approve|reject|review <id> <note>",
+    { disable_web_page_preview: true },
+  );
+}
+
+async function showOne(ctx, id) {
+  const { rows } = await query(
+    `SELECT * FROM collectible_submissions WHERE id = $1`,
+    [id],
+  );
+  const r = rows[0];
+  if (!r) {
+    await ctx.reply(`No submission #${id}.`);
+    return;
+  }
+
+  const checks = (r.checks || [])
+    .map((c) => `  ${c.pass === true ? "✓" : c.pass === false ? "✕" : "…"} ${c.name} — ${c.detail}`)
+    .join("\n");
+
+  const risk = riskLine(r.flags);
+
+  await ctx.reply(
+    [
+      `🃏 Submission #${r.id} · ${when(r.created_at)}`,
+      "",
+      describe(r),
+      "",
+      `Gate verdict: ${r.verdict}${r.tier ? ` (Tier ${r.tier})` : ""}  [${r.gate_version}]`,
+      `Status: ${r.status}${r.reviewed_at ? ` · reviewed ${when(r.reviewed_at)}` : ""}`,
+      r.reviewer_note ? `Note: ${r.reviewer_note}` : "",
+      risk ? `Signals: ${risk}` : "",
+      r.wallet ? `Wallet: ${r.wallet}` : "Wallet: not connected",
+      r.contact ? `Contact: ${r.contact}` : "",
+      "",
+      "Checks:",
+      checks || "  (none recorded)",
+      "",
+      "Before approving: cert verified with the grader, and a real multi-venue sold record.",
+    ]
+      .filter((l) => l !== "")
+      .join("\n"),
+    { disable_web_page_preview: true },
+  );
+}
+
+async function setStatus(ctx, action, id, note) {
+  const status = STATUSES[action];
+  const { rows } = await query(
+    `UPDATE collectible_submissions
+        SET status = $1,
+            reviewer_note = COALESCE(NULLIF($2, ''), reviewer_note),
+            reviewed_at = NOW(),
+            updated_at = NOW()
+      WHERE id = $3
+      RETURNING id, card, verdict, status`,
+    [status, note || "", id],
+  );
+  const r = rows[0];
+  if (!r) {
+    await ctx.reply(`No submission #${id}.`);
+    return;
+  }
+  await ctx.reply(
+    `#${r.id} → ${r.status}\n${r.card}\n\n` +
+      `Gate verdict is unchanged (${r.verdict}) — it's kept so the machine and human calls stay auditable against each other.`,
+  );
+}
+
+export async function handleCollectibleSubmissions(ctx) {
+  if (!isAdmin(ctx.from?.id)) {
+    await ctx.reply("This command is operator-only.");
+    return;
+  }
+
+  const parts = String(ctx.message?.text || "").trim().split(/\s+/).slice(1);
+  const first = (parts[0] || "").toLowerCase();
+
+  try {
+    if (!first) return await showQueue(ctx);
+
+    if (/^\d+$/.test(first)) return await showOne(ctx, Number(first));
+
+    if (first in STATUSES) {
+      const id = Number(parts[1]);
+      if (!Number.isInteger(id)) {
+        await ctx.reply(`Usage: /submissions ${first} <id> [note]`);
+        return;
+      }
+      return await setStatus(ctx, first, id, parts.slice(2).join(" ").slice(0, 500));
+    }
+
+    await ctx.reply(
+      "Usage:\n" +
+        "/submissions — the queue\n" +
+        "/submissions <id> — detail\n" +
+        "/submissions review|approve|reject <id> [note]",
+    );
+  } catch (e) {
+    await ctx.reply(`Couldn't load submissions: ${e.message}`);
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ import { handleCommunity } from "./commands/community.js";
 import { handleMagpie } from "./commands/magpie.js";
 import { handleStats } from "./commands/stats.js";
 import { handleFeedback } from "./commands/feedback.js";
+import { handleCollectibleSubmissions } from "./commands/collectible-submissions.js";
 import { handleHistory } from "./commands/history.js";
 import { handleSimulate } from "./commands/simulate.js";
 import { handleMe, registerMeCallbacks } from "./commands/me.js";
@@ -588,6 +589,7 @@ bot.command("crosspost", handleCommunityCrosspost);
 bot.command("gov-pause", handleGovPause);
 bot.command("gov_pause", handleGovPause);   // underscore alias (TG strips dashes inconsistently on some clients)
 bot.command("feedback", handleFeedback);    // operator-only: review captured user replies (see fallback reply-capture)
+bot.command("submissions", handleCollectibleSubmissions); // operator-only: collectible submission review queue
 bot.command("gov-resume", handleGovResume);
 bot.command("gov_resume", handleGovResume);
 bot.command("gov-status", handleGovStatus);


### PR DESCRIPTION
The public gate records a verdict and pings Telegram, but there was **no way to act on one**. Submissions accumulated with nothing to move them forward — an intake with no outbox.

```
/submissions                                    the queue, newest first
/submissions <id>                               full detail, incl. internal signals
/submissions review|approve|reject <id> [note]  the decision
```

The queue **hides declines** (they need no decision) and leads with the signals that decide whether something is worth a human's time: whether the wallet **holds the card on-chain**, and whether the cert has been **claimed by a different wallet** before.

### The machine verdict is never overwritten
Approving sets `status` and leaves `verdict` exactly as the gate returned it, so the automated call and the human call stay auditable against each other — which is the whole reason they're separate columns in migration 097. The reply says so explicitly, so nobody later assumes approving edited the verdict.

The detail view ends with the reminder that approval still requires **the cert verified against the grader** and **a real multi-venue sold record** — neither of which this command checks for you.