### PR TITLE
db: heal the submissions table, persist demand, and apply the retention clock

### DIFF
--- a/migrations/097_collectible_submissions.sql
+++ b/migrations/097_collectible_submissions.sql
@@ -1,77 +1,123 @@
--- migration 097: collectible submissions — the durable record behind the
--- public vetting gate at magpie.capital/collectibles#submit.
+-- migration 097: collectible submissions — durable record behind the vetting
+-- gate at magpie.capital/collectibles#submit.
 --
--- Design notes, because the shape here is deliberate:
+-- ⚠️ THIS MIGRATION HEALS A TABLE THAT ALREADY EXISTS IN PRODUCTION.
 --
---  1. ONE ROW PER ATTEMPT. We do NOT upsert on (grader, cert). If the same
---     slab is submitted twice we want both rows — a cert appearing under two
---     different wallets is a real fraud signal (someone claiming a card they
---     don't hold), and collapsing it would destroy the evidence. Dedupe is a
---     read-time concern, not a write-time one.
+-- The first version of the site route created this table itself with an inline
+-- CREATE TABLE. That was off-pattern, and it left production holding a DIFFERENT
+-- shape to the one intended here: no wallet/checks/next_steps/gate_version/
+-- status/flags columns, a legacy `year` and `detail` column, and — worst — a
+-- UNIQUE index on (grader, cert).
 --
---  2. THE FULL CHECK TRAIL IS STORED. `checks` holds every gate stage and its
---     outcome, and `gate_version` records which revision of the gate produced
---     it. Without the version, a verdict stops being interpretable the moment
---     the gate changes — and this table is meant to stay meaningful for years.
+-- Two things follow, and both are why this file is ALTER-based rather than a
+-- plain CREATE:
 --
---  3. MACHINE VERDICT AND HUMAN STATUS ARE SEPARATE COLUMNS. `verdict` is what
---     the deterministic gate returned and is never edited. `status` is the
---     human/licensed-data lifecycle on top of it. Overwriting the machine
---     verdict with a human decision would make the two impossible to audit
---     against each other.
+--   1. `CREATE TABLE IF NOT EXISTS` silently no-ops against the legacy table, so
+--      every column below has to be added explicitly or the site's INSERT keeps
+--      failing (it does — the route swallows DB errors so the collector still
+--      gets an answer, which is right, but it means the breakage was silent).
 --
---  4. NO RAW PII BEYOND WHAT THE USER TYPED. We store a SALTED HASH of the IP
---     and user-agent for abuse detection, never the raw values. `contact` is
---     optional and user-supplied. Nothing here is served publicly — the site
---     only ever returns a caller their OWN rows, and only the public columns.
+--   2. The legacy UNIQUE index directly contradicts the design: we keep ONE ROW
+--      PER ATTEMPT and never upsert on (grader, cert), because the same cert
+--      appearing under two different wallets is a fraud signal and collapsing it
+--      destroys the evidence. With a UNIQUE index in place the second attempt
+--      would error instead of being recorded. It is dropped and recreated
+--      non-unique below.
 --
---  5. INTERNAL-ONLY COLUMNS are marked below. reviewer_note, ip_hash,
---     ua_hash and flags must never leave the protocol.
+-- Design notes for the shape itself:
+--   - The full check trail is stored alongside `gate_version`. Without the
+--     version a verdict stops being interpretable the moment the gate changes,
+--     and this table is meant to stay meaningful for years.
+--   - Machine `verdict` and human `status` are SEPARATE columns. `verdict` is
+--     never edited, so the two can always be audited against each other.
+--   - No raw PII: `ip_hash`/`ua_hash` are salted hashes, never the raw values.
+--   - INTERNAL ONLY, never served to a user: reviewer_note, ip_hash, ua_hash,
+--     flags.
+
+-- Fresh environments get the whole thing in one shot.
 CREATE TABLE IF NOT EXISTS collectible_submissions (
   id            BIGSERIAL PRIMARY KEY,
-
-  -- ── who (all optional; a collector can check a card anonymously) ──
-  wallet        TEXT,          -- connected Solana wallet, base58
-  telegram_id   BIGINT,        -- set when a submission arrives via the bot
-  contact       TEXT,          -- user-supplied handle/email, optional
-
-  -- ── what was submitted ──
+  wallet        TEXT,
+  telegram_id   BIGINT,
+  contact       TEXT,
   grader        TEXT NOT NULL,
   cert          TEXT NOT NULL,
   card          TEXT NOT NULL,
   card_set      TEXT,
   card_year     TEXT,
-  grade         TEXT,          -- kept as text: "10", "9.5", or empty for autos
+  grade         TEXT,
   auto_grade    TEXT,
-  platform      TEXT,          -- vaulting platform, empty = not vaulted yet
-
-  -- ── what the deterministic gate decided (never edited) ──
-  verdict       TEXT NOT NULL, -- DECLINED | NEEDS_VAULTING | CANDIDATE_REVIEW | PROVISIONAL_TIER_A | PROVISIONAL_TIER_B
-  tier          TEXT,          -- A | B | NULL
+  platform      TEXT,
+  verdict       TEXT NOT NULL,
+  tier          TEXT,
   checks        JSONB NOT NULL DEFAULT '[]'::jsonb,
   next_steps    JSONB NOT NULL DEFAULT '[]'::jsonb,
   gate_version  TEXT NOT NULL DEFAULT 'v1',
-
-  -- ── human / licensed-data lifecycle on top of the machine verdict ──
-  status        TEXT NOT NULL DEFAULT 'submitted', -- submitted | in_review | approved | rejected | withdrawn
+  status        TEXT NOT NULL DEFAULT 'submitted',
   reviewed_at   TIMESTAMPTZ,
-  reviewer_note TEXT,          -- INTERNAL ONLY — never served to a user
-
-  -- ── provenance + abuse signals (INTERNAL ONLY) ──
+  reviewer_note TEXT,
   source        TEXT NOT NULL DEFAULT 'site',
-  ip_hash       TEXT,          -- salted hash, never the raw address
+  ip_hash       TEXT,
   ua_hash       TEXT,
   flags         JSONB NOT NULL DEFAULT '{}'::jsonb,
-
   created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- A collector opening their dashboard: "show me my submissions, newest first."
+-- Heal the legacy shape. Every one of these is a no-op where the column already
+-- exists, so this is safe on both fresh and legacy databases.
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS wallet        TEXT;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS telegram_id   BIGINT;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS card_year     TEXT;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS checks        JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS next_steps    JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS gate_version  TEXT NOT NULL DEFAULT 'v1';
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS status        TEXT NOT NULL DEFAULT 'submitted';
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS reviewed_at   TIMESTAMPTZ;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS reviewer_note TEXT;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS source        TEXT NOT NULL DEFAULT 'site';
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS ip_hash       TEXT;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS ua_hash       TEXT;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS flags         JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE collectible_submissions ADD COLUMN IF NOT EXISTS updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Carry the legacy columns across before they go. `detail` held {checks, next}.
+-- The information_schema guards MUST be qualified with current_schema(): without
+-- it they match a same-named table in ANY schema, so a re-run reports the legacy
+-- column as still present and then fails updating a column that's already gone.
+-- Caught by running this migration three times in a scratch schema.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+              WHERE table_schema = current_schema()
+                AND table_name = 'collectible_submissions' AND column_name = 'year') THEN
+    EXECUTE 'UPDATE collectible_submissions SET card_year = year WHERE card_year IS NULL AND year IS NOT NULL';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+              WHERE table_schema = current_schema()
+                AND table_name = 'collectible_submissions' AND column_name = 'detail') THEN
+    EXECUTE $q$
+      UPDATE collectible_submissions
+         SET checks     = COALESCE(detail->'checks', '[]'::jsonb),
+             next_steps = COALESCE(detail->'next',   '[]'::jsonb)
+       WHERE detail IS NOT NULL
+         AND checks = '[]'::jsonb
+    $q$;
+  END IF;
+END $$;
+
+ALTER TABLE collectible_submissions DROP COLUMN IF EXISTS year;
+ALTER TABLE collectible_submissions DROP COLUMN IF EXISTS detail;
+
+-- The legacy UNIQUE index has to go: one row per attempt is the whole point.
+DROP INDEX IF EXISTS collectible_submissions_cert_idx;
+
+-- A collector opening their dashboard: "my submissions, newest first."
 CREATE INDEX IF NOT EXISTS collectible_submissions_wallet_idx
   ON collectible_submissions (wallet, created_at DESC);
 
--- Cert collision detection — the fraud signal in note 1.
+-- Cert collision detection — deliberately NOT unique.
 CREATE INDEX IF NOT EXISTS collectible_submissions_cert_idx
   ON collectible_submissions (grader, cert);
 
@@ -79,14 +125,16 @@ CREATE INDEX IF NOT EXISTS collectible_submissions_cert_idx
 CREATE INDEX IF NOT EXISTS collectible_submissions_status_idx
   ON collectible_submissions (status, created_at DESC);
 
--- Demand analytics: what are collectors actually asking for, and what are we
--- turning away? The declines are the more valuable half — they map the edge of
--- the book and tell us which categories to underwrite next.
+-- Demand analytics: what collectors ask for, and what we turn away. The
+-- declines are the more valuable half — they map the edge of the book.
 CREATE INDEX IF NOT EXISTS collectible_submissions_verdict_idx
   ON collectible_submissions (verdict, created_at DESC);
 
--- INTERNAL analytics view. Aggregate only, no PII, safe to hand to the
--- operator or a future data room without exposing any individual submitter.
+-- INTERNAL analytics view. Aggregate only, no PII, safe to hand to the operator
+-- or a future data room without exposing any individual submitter.
+-- NOTE: this reads live rows, so it changes as retention reduces them. The
+-- DURABLE demand history is `collectible_submission_daily` (migration 098),
+-- which the retention job writes before it reduces anything.
 CREATE OR REPLACE VIEW collectible_submission_demand AS
 SELECT
   date_trunc('day', created_at)                       AS day,

--- a/migrations/098_collectible_submission_rollup.sql
+++ b/migrations/098_collectible_submission_rollup.sql
@@ -1,0 +1,47 @@
+-- migration 098: persist the collectible submission demand rollup.
+--
+-- WHY THIS EXISTS, and it's the whole point:
+--
+-- Migration 097 exposed demand through `collectible_submission_demand`, a VIEW
+-- over the base table. The retention policy (design repo doc 05) then says
+-- declined submissions are reduced after 24 months.
+--
+-- Those two facts are in direct conflict. A view computes from the rows that
+-- still exist, so the moment retention deletes an old declined row, that day's
+-- demand history silently changes underneath us — and the declines are the
+-- MORE valuable half of the signal, because they map the edge of the book.
+-- Retention would have been quietly destroying the asset it was written to
+-- protect.
+--
+-- So the aggregate has to be a real table that the retention job writes to
+-- BEFORE it reduces anything. Rows are ephemeral; the demand history is not.
+CREATE TABLE IF NOT EXISTS collectible_submission_daily (
+  day          DATE   NOT NULL,
+  verdict      TEXT   NOT NULL,
+  tier         TEXT   NOT NULL DEFAULT '-',
+  platform     TEXT   NOT NULL DEFAULT 'not vaulted',
+  submissions  INTEGER NOT NULL DEFAULT 0,
+  wallets      INTEGER NOT NULL DEFAULT 0,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (day, verdict, tier, platform)
+);
+
+CREATE INDEX IF NOT EXISTS collectible_submission_daily_day_idx
+  ON collectible_submission_daily (day DESC);
+
+-- Backfill from whatever is currently in the base table, so the rollup starts
+-- complete rather than from today. Safe to re-run.
+INSERT INTO collectible_submission_daily (day, verdict, tier, platform, submissions, wallets)
+SELECT
+  date_trunc('day', created_at)::date,
+  verdict,
+  COALESCE(NULLIF(tier, ''), '-'),
+  COALESCE(NULLIF(platform, ''), 'not vaulted'),
+  COUNT(*),
+  COUNT(DISTINCT wallet) FILTER (WHERE wallet IS NOT NULL AND wallet <> '')
+FROM collectible_submissions
+GROUP BY 1, 2, 3, 4
+ON CONFLICT (day, verdict, tier, platform) DO UPDATE
+  SET submissions = EXCLUDED.submissions,
+      wallets     = EXCLUDED.wallets,
+      updated_at  = NOW();

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,7 @@ import { handleMagpie } from "./commands/magpie.js";
 import { handleStats } from "./commands/stats.js";
 import { handleFeedback } from "./commands/feedback.js";
 import { handleCollectibleSubmissions } from "./commands/collectible-submissions.js";
+import { startCollectibleRetention } from "./services/collectible-retention.js";
 import { handleHistory } from "./commands/history.js";
 import { handleSimulate } from "./commands/simulate.js";
 import { handleMe, registerMeCallbacks } from "./commands/me.js";
@@ -995,6 +996,13 @@ bot.start({
     // Auto-disables enabled RWAs that degrade or get paused by the issuer.
     // Delayed start to avoid bunching with other startup workers.
     setTimeout(() => startRwaScreener(bot), 180_000);
+    // COLLECTIBLE SUBMISSION RETENTION — applies the data-retention clock from
+    // the design repo (doc 05): rolls demand into the persisted aggregate, then
+    // redacts stale contacts, clears old provenance hashes, and reduces aged
+    // declines to the aggregate row that already represents them. Rollup runs
+    // BEFORE any reduction, so retention can never destroy the demand history.
+    // Daily; slow clock by design.
+    setTimeout(() => startCollectibleRetention(), 240_000);
     // $MAGPIE holder reward distributions — DISABLED as of MGP-001 (2026-06-10).
     // Distributions now flow through the governance autopilot (MGP-XXX) instead
     // of an automated bot-driven cadence. The auto-snapshotter previously created

--- a/src/services/collectible-retention.js
+++ b/src/services/collectible-retention.js
@@ -1,0 +1,122 @@
+/**
+ * Collectible submission retention — applies the clock from the design repo's
+ * data-retention policy (doc 05).
+ *
+ * Holding submission data forever is not "keeping the asset", it is
+ * accumulating liability with a decreasing half-life of usefulness. The value
+ * lives in the demand signal, which survives aggregation; the identifying
+ * detail is what creates the risk, and it decays fast.
+ *
+ * ORDER MATTERS. The rollup is written BEFORE anything is reduced. The demand
+ * history is a real table (migration 098) precisely because it must outlive the
+ * rows it was computed from — reducing first would destroy the signal retention
+ * exists to protect, and the declines are the more valuable half of it.
+ *
+ * Every step is idempotent, so a crashed or double-run tick is harmless.
+ */
+import { query } from "../db/pool.js";
+
+/** Doc 05. Changing a number here means changing it there in the same PR. */
+export const RETENTION = {
+  contactMonths: 12, // user-supplied handle/email — to reply, not to market to
+  provenanceDays: 90, // ip/ua hashes — abuse correlation is short-horizon
+  declineMonths: 24, // declined rows reduce to their aggregate row
+};
+
+/**
+ * Roll every day present in the base table into the persisted aggregate.
+ * Recomputes rather than incrementing, so it is safe to run any number of
+ * times and self-heals if a tick was missed.
+ */
+async function rollUpDemand() {
+  const { rowCount } = await query(
+    `INSERT INTO collectible_submission_daily
+       (day, verdict, tier, platform, submissions, wallets)
+     SELECT date_trunc('day', created_at)::date,
+            verdict,
+            COALESCE(NULLIF(tier, ''), '-'),
+            COALESCE(NULLIF(platform, ''), 'not vaulted'),
+            COUNT(*),
+            COUNT(DISTINCT wallet) FILTER (WHERE wallet IS NOT NULL AND wallet <> '')
+       FROM collectible_submissions
+      GROUP BY 1, 2, 3, 4
+     ON CONFLICT (day, verdict, tier, platform) DO UPDATE
+       SET submissions = EXCLUDED.submissions,
+           wallets     = EXCLUDED.wallets,
+           updated_at  = NOW()`,
+  );
+  return rowCount ?? 0;
+}
+
+/** The only free-text PII we hold. It exists to answer a submission. */
+async function redactStaleContacts() {
+  const { rowCount } = await query(
+    `UPDATE collectible_submissions
+        SET contact = NULL, updated_at = NOW()
+      WHERE contact IS NOT NULL
+        AND GREATEST(created_at, COALESCE(reviewed_at, created_at))
+            < NOW() - INTERVAL '${RETENTION.contactMonths} months'`,
+  );
+  return rowCount ?? 0;
+}
+
+async function dropStaleProvenance() {
+  const { rowCount } = await query(
+    `UPDATE collectible_submissions
+        SET ip_hash = NULL, ua_hash = NULL, updated_at = NOW()
+      WHERE (ip_hash IS NOT NULL OR ua_hash IS NOT NULL)
+        AND created_at < NOW() - INTERVAL '${RETENTION.provenanceDays} days'`,
+  );
+  return rowCount ?? 0;
+}
+
+/**
+ * Reduce old declines to the aggregate row that already represents them.
+ *
+ * Guarded on the rollup actually containing that day — if the aggregate write
+ * failed, we must not delete the rows it was supposed to preserve. Deletion is
+ * destructive by design: a row that survives in an export is not deleted, so
+ * any export pipeline has to apply this same clock.
+ */
+async function reduceOldDeclines() {
+  const { rowCount } = await query(
+    `DELETE FROM collectible_submissions s
+      WHERE s.verdict = 'DECLINED'
+        AND s.created_at < NOW() - INTERVAL '${RETENTION.declineMonths} months'
+        AND EXISTS (
+          SELECT 1 FROM collectible_submission_daily d
+           WHERE d.day = date_trunc('day', s.created_at)::date
+             AND d.verdict = s.verdict
+        )`,
+  );
+  return rowCount ?? 0;
+}
+
+export async function runCollectibleRetention() {
+  // Rollup first, always. See the note at the top of this file.
+  const rolled = await rollUpDemand();
+  const contacts = await redactStaleContacts();
+  const provenance = await dropStaleProvenance();
+  const declines = await reduceOldDeclines();
+
+  if (contacts || provenance || declines) {
+    console.log(
+      `[collectible-retention] rollup=${rolled} contacts_redacted=${contacts} ` +
+        `provenance_cleared=${provenance} declines_reduced=${declines}`,
+    );
+  }
+  return { rolled, contacts, provenance, declines };
+}
+
+/**
+ * Daily tick. Deliberately not more often: this is a slow clock, and a tighter
+ * loop would add write pressure for no benefit.
+ */
+export function startCollectibleRetention(intervalMs = 24 * 60 * 60 * 1000) {
+  const tick = () =>
+    runCollectibleRetention().catch((e) =>
+      console.warn("[collectible-retention] tick failed:", e.message?.slice(0, 160)),
+    );
+  tick();
+  return setInterval(tick, intervalMs);
+}


### PR DESCRIPTION
## The bug — found by checking production rather than assuming
**097 had not been applied yet, and would have failed when it ran.**

The first version of the site route created `collectible_submissions` itself with an inline `CREATE TABLE`. Production is therefore holding the **legacy shape**: no `wallet`/`checks`/`next_steps`/`gate_version`/`status`/`flags`, a legacy `year` and `detail`, and a **UNIQUE index on `(grader, cert)`**.

Consequences — all silent, because the route swallows DB errors so the collector still gets an answer:
- **every submission INSERT was failing** → nothing was being recorded
- the dashboard `GET` selects `card_year`/`checks`/`next_steps`/`status` → failed → **"Your collectibles" could never show anything**
- 097's `CREATE TABLE IF NOT EXISTS` would no-op against the legacy table, then its wallet index would **error on a column that doesn't exist**, breaking the migration run

And the UNIQUE index **directly contradicts the design**: we keep one row per attempt precisely because the same cert under two different wallets is a fraud signal. With it in place the second attempt errored instead of being recorded — *the evidence was being thrown away.*

097 is **rewritten rather than patched by a 099**, because it has never been applied in any environment. It now ALTERs the legacy shape into the intended one, carries `year` → `card_year` and `detail` → `checks`/`next_steps`, and drops/recreates the cert index non-unique.

## Demand history had to become a real table (098)
`collectible_submission_demand` was a **view**. Retention reduces old declines. A view computes from surviving rows — so **retention would have silently rewritten demand history as it ran**, and the declines are the *more valuable half* of that signal. The aggregate is now a real table the retention job writes **before** it reduces anything.

## The retention job
Applies the doc-05 clock daily: roll up demand → redact contacts after 12 months → clear provenance hashes after 90 days → reduce declines to their aggregate row after 24 months. The delete is **guarded on the rollup actually containing that day**, so a failed aggregate write can never cost us the rows it was meant to preserve. Every step idempotent.

## Verification
Ran against a **byte-exact replica of production's legacy shape**, inside a transaction that was rolled back:
```
columns healed (26, legacy year/detail gone)
legacy row migrated -> card_year "1999", checks [...], next_steps ["step"]
indexes: ... collectible_submissions_cert_idx   (no longer UNIQUE)
duplicate cert now recorded, rows = 2
rollup rows backfilled = 1
```
Then run **three times** to prove idempotency — which caught a real bug: the `information_schema` guards matched a same-named table in **any** schema, so a re-run tried to read a column it had already dropped. Now qualified with `current_schema()`.