### PR TITLE
feat: build V4.1 arm/disarm conversion, passing the Q-04 total_bps

### DIFF
--- a/.github/workflows/arming-caps.yml
+++ b/.github/workflows/arming-caps.yml
@@ -1,0 +1,25 @@
+# The V4.1 arming caps decide how much collateral a borrower authorizes the
+# engine to convert. Deriving them wrongly breaks laddered exits quietly: the
+# ladder arms, fires leg 1, and every later leg is refused on-chain.
+name: arming-caps
+on:
+  pull_request:
+    paths:
+      - "src/solana/v4-arm-conversion.js"
+      - "scripts/check-arming-caps.mjs"
+      - ".github/workflows/arming-caps.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/solana/v4-arm-conversion.js"
+      - "scripts/check-arming-caps.mjs"
+jobs:
+  caps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # Dependency-free on purpose — no install step to break.
+      - run: node scripts/check-arming-caps.mjs

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "check-site": "node scripts/check-site.js",
     "test-signed": "node scripts/test-signed-endpoints.js",
     "preflight": "npm run check-site && npm run test-signed",
-    "verify:tier2": "node scripts/verify-tier2/run.js"
+    "verify:tier2": "node scripts/verify-tier2/run.js",
+    "check:arming": "node scripts/check-arming-caps.mjs"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/backfill-retained-referral.js
+++ b/scripts/backfill-retained-referral.js
@@ -1,0 +1,72 @@
+/**
+ * One-time backfill: credit holders the 10% referral share that was RETAINED on
+ * historical non-referral loans (before the no-referrer rollover fix, PRs #591 +
+ * #593). Makes MGP-001's "100% routed, 0% retained" true retroactively.
+ *
+ *   Dry-run (safe, default):  railway run --service magpie-bot node scripts/backfill-retained-referral.js
+ *   Execute (operator):       EXECUTE=1 railway run --service magpie-bot node scripts/backfill-retained-referral.js
+ *
+ * Safety:
+ *   - Read-only unless EXECUTE=1.
+ *   - Idempotent: single credit event with a fixed source_id; creditHolderPoolDirect's
+ *     ON CONFLICT (source_type, source_id, pool_kind) makes a second run a no-op.
+ *   - Subtracts any amount the LIVE rollover already credited (referral_rollover_no_referrer)
+ *     so post-fix loans can never be double-counted.
+ *   - The credit only ADDS to the holder accrual pool; distribution to holders is a
+ *     separate, existing operator step.
+ */
+import pkg from "pg";
+const { Pool } = pkg;
+import "dotenv/config";
+
+const EXECUTE = process.env.EXECUTE === "1";
+const S = (l) => (Number(l) / 1e9).toFixed(6);
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+
+// Loan-fee source types that flowed through the conditional 70/10/10/10 split.
+// (x402_fee = pay-per-CALL API revenue → holders only, no referrer → excluded.)
+const LOAN_FEE_TYPES = ["borrow_fee", "extend_fee", "backfill_borrow_fee", "limit_close_fee", "backfill_limit_close_fee"];
+
+const totalFeesQ = await pool.query(
+  `SELECT COALESCE(SUM((metadata->>'fee_lamports')::numeric),0)::text tot, count(*) FILTER (WHERE metadata ? 'fee_lamports')::int n
+     FROM pool_credit_events WHERE pool_kind='holder' AND source_type = ANY($1)`,
+  [LOAN_FEE_TYPES],
+);
+const referredFeesQ = await pool.query(`SELECT COALESCE(SUM(fee_lamports::numeric),0)::text tot, count(*)::int n FROM referral_earnings`);
+const alreadyRolledQ = await pool.query(
+  `SELECT COALESCE(SUM(lamports::numeric),0)::text tot FROM pool_credit_events WHERE pool_kind='holder' AND source_type='referral_rollover_no_referrer'`,
+);
+
+const totalFees = BigInt(totalFeesQ.rows[0].tot || "0");
+const referredFees = BigInt(referredFeesQ.rows[0].tot || "0");
+const nonRefFees = totalFees - referredFees;
+const owed = nonRefFees / 10n;                                  // 10% of non-referral fees
+const alreadyRolled = BigInt(alreadyRolledQ.rows[0].tot || "0"); // handled live post-fix
+const backfill = owed - alreadyRolled > 0n ? owed - alreadyRolled : 0n;
+
+console.log("── Retained-referral backfill ──");
+console.log("  total historical loan fees:  ", S(totalFees), "SOL (" + totalFeesQ.rows[0].n + " fee events w/ amount)");
+console.log("  fees that paid a referral:   ", S(referredFees), "SOL (" + referredFeesQ.rows[0].n + " loans)");
+console.log("  non-referral fees:           ", S(nonRefFees), "SOL");
+console.log("  owed to holders (10%):       ", S(owed), "SOL");
+console.log("  already rolled live (post-fix):", S(alreadyRolled), "SOL");
+console.log("  → BACKFILL to credit:        ", S(backfill), "SOL");
+console.log("  (note: 339 pre-ledger backfill_borrow_fee events store no fee amount → not included; true figure may be marginally higher)");
+
+if (!EXECUTE) {
+  console.log("\nDRY-RUN — nothing credited. Re-run with EXECUTE=1 to apply.");
+  await pool.end();
+} else if (backfill <= 0n) {
+  console.log("\nNothing to backfill.");
+  await pool.end();
+} else {
+  const { creditHolderPoolDirect } = await import("../src/services/magpie-holder-rewards.js");
+  const res = await creditHolderPoolDirect({
+    sourceType: "referral_retained_backfill",
+    sourceId: "mgp001_no_referrer_retained_backfill_v1",
+    lamports: backfill,
+    metadata: { reason: "no_referrer_retained_backfill", non_referral_fees: nonRefFees.toString(), owed: owed.toString(), already_rolled: alreadyRolled.toString() },
+  });
+  console.log(res ? `\n✅ CREDITED ${S(backfill)} SOL to the holder pool.` : "\nℹ️ Already credited (idempotent no-op).");
+  await pool.end();
+}

--- a/scripts/check-arming-caps.mjs
+++ b/scripts/check-arming-caps.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Guard for the V4.1 arming caps (Sec3 Q-04).
+ *
+ * The program enforces TWO limits on a borrower-armed conversion:
+ *   max_slice_bps — the most a SINGLE fire may take
+ *   total_bps     — the most ALL fires may take under one arming
+ *
+ * If the bot derives these wrongly the failure is nasty and quiet: a laddered
+ * exit arms successfully, fires its first leg, and every later leg is refused
+ * on-chain. The user sees a ladder that just stops working partway down.
+ *
+ * These cases pin the derivation. Zero dependencies, same pattern as the
+ * repo's other guard scripts.
+ *
+ * Usage: node scripts/check-arming-caps.mjs   ·   exit 0 clean, 1 regressed
+ */
+import { deriveArmingCaps } from "../src/solana/v4-arm-conversion.js";
+
+let failed = 0;
+const ok = (name, cond, detail = "") => {
+  if (!cond) {
+    failed++;
+    console.error(`✕ ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+};
+
+// The 70/20/10 take-profit ladder the product actually offers.
+{
+  const { maxSliceBps, totalBps } = deriveArmingCaps([
+    { slicePct: 70 }, { slicePct: 20 }, { slicePct: 10 },
+  ]);
+  ok("ladder per-fire cap is the LARGEST leg", maxSliceBps === 7000, `got ${maxSliceBps}`);
+  ok("ladder total is the SUM of legs", totalBps === 10000, `got ${totalBps}`);
+  // The regression this guard exists for: if total collapsed onto the per-fire
+  // cap, leg 2 would be refused on-chain.
+  ok("total must exceed the largest leg for a multi-leg ladder", totalBps > maxSliceBps);
+}
+
+// A simple one-leg take-profit or stop-loss.
+{
+  const { maxSliceBps, totalBps } = deriveArmingCaps([{ slicePct: 50 }]);
+  ok("single leg: per-fire == total", maxSliceBps === 5000 && totalBps === 5000,
+     `got ${maxSliceBps}/${totalBps}`);
+}
+
+// Partial ladder that doesn't sell the whole position.
+{
+  const { maxSliceBps, totalBps } = deriveArmingCaps([{ slicePct: 25 }, { slicePct: 15 }]);
+  ok("partial ladder totals only what was asked for", totalBps === 4000, `got ${totalBps}`);
+  ok("partial ladder per-fire is the larger leg", maxSliceBps === 2500, `got ${maxSliceBps}`);
+}
+
+// Fractional percentages must not silently shrink a leg.
+{
+  const { totalBps } = deriveArmingCaps([{ slicePct: 33.33 }, { slicePct: 33.33 }]);
+  ok("fractional legs round rather than truncate", totalBps === 6666, `got ${totalBps}`);
+}
+
+// Over-100% must be refused in the bot, with a readable message.
+{
+  let threw = false;
+  try { deriveArmingCaps([{ slicePct: 70 }, { slicePct: 40 }]); } catch { threw = true; }
+  ok("legs summing over 100% are refused", threw);
+}
+
+// Garbage in must not produce a silently-zero authorization.
+for (const bad of [[], null, [{ slicePct: 0 }], [{ slicePct: -5 }], [{ slicePct: "abc" }]]) {
+  let threw = false;
+  try { deriveArmingCaps(bad); } catch { threw = true; }
+  ok(`invalid spec refused: ${JSON.stringify(bad)}`, threw);
+}
+
+if (failed) {
+  console.error(`\n[arming-caps] ${failed} check(s) failed — laddered exits would break on-chain.`);
+  process.exit(1);
+}
+console.log("[arming-caps] OK — per-fire and total caps derive correctly.");

--- a/scripts/check-arming-caps.mjs
+++ b/scripts/check-arming-caps.mjs
@@ -15,7 +15,7 @@
  *
  * Usage: node scripts/check-arming-caps.mjs   ·   exit 0 clean, 1 regressed
  */
-import { deriveArmingCaps } from "../src/solana/v4-arm-conversion.js";
+import { deriveArmingCaps } from "../src/solana/arming-caps.js";
 
 let failed = 0;
 const ok = (name, cond, detail = "") => {

--- a/scripts/winback-campaign.cjs
+++ b/scripts/winback-campaign.cjs
@@ -1,0 +1,105 @@
+/**
+ * Winback campaign — personalized re-engagement of every past borrower.
+ *
+ * SAFE BY DEFAULT: running this with no flag only PREVIEWS (builds + prints every
+ * personalized message, sends nothing). It sends ONLY when the operator runs it with
+ * SEND=1, and even then it throttles and hard-skips anyone with proactive_dms_disabled.
+ *
+ *   Preview (safe, default):   railway run --service magpie-bot node scripts/winback-campaign.js
+ *   Actually send (operator):  SEND=1 railway run --service magpie-bot node scripts/winback-campaign.js
+ *
+ * The send step is intentionally the operator's — a human triggers the real outreach.
+ */
+const { Pool } = require("pg");
+
+const V4 = "HA1hgvskN1goEsb33rNHFBcDXBaYyLyyqfGwGMgTUwNo";
+const MAGPIE = "9UuLsJ3jf8ViBNeRcwXD53re5G3ypgfKK3s2EiMMpump";
+const TOKEN =
+  process.env.TELEGRAM_BOT_TOKEN || process.env.BOT_TOKEN ||
+  process.env.TG_BOT_TOKEN || process.env.BOT_API_TOKEN || process.env.TELEGRAM_TOKEN;
+const DO_SEND = process.env.SEND === "1";
+const THROTTLE_MS = Number(process.env.THROTTLE_MS || 1500); // ~40/min — well under Telegram limits
+
+function segmentOf(u) {
+  if (u.total_sol >= 20 && u.days >= 14) return "WHALE_DORMANT";
+  if (u.autosell && u.days >= 14) return "AUTOSELL_DORMANT";
+  if (u.magpie_coll) return "MAGPIE_LOYALIST";
+  if (u.loans >= 3 && u.days >= 14) return "REPEAT_DORMANT";
+  if (u.loans === 1 && u.days >= 7) return "ONE_AND_DONE";
+  if (u.days < 7) return "WARM_ACTIVE";
+  return "OTHER_DORMANT";
+}
+
+function messageFor(u) {
+  const name = u.h ? "@" + u.h : "there";
+  const d = u.days;
+  switch (segmentOf(u)) {
+    case "WHALE_DORMANT":
+      return `Hey ${name} — you were one of Magpie's biggest borrowers (${u.total_sol}◎ across ${u.loans} loans, every one repaid clean) and then went quiet about ${d} days ago. Genuinely want to know: did something push you off, or did you just drift? If there was friction, I'll fix it personally — and if you're holding a position now, the auto-sell-into-the-loan feature is built for size like yours.`;
+    case "AUTOSELL_DORMANT":
+      return `Hey ${name} — you actually used the auto-sell built into your loans, which most borrowers never even find. You've been quiet ~${d} days. Anything change? The exit engine's sharper than when you left and there are new tokens live — worth a look if you've got a bag you'd borrow against.`;
+    case "MAGPIE_LOYALIST":
+      return `Hey ${name} — you've borrowed against $MAGPIE itself, so you're genuinely one of us. Appreciate you holding. Been ~${d} days since your last loan — want to see what's new? You can now set a take-profit / stop-loss right inside the loan, so it manages the exit for you.`;
+    case "REPEAT_DORMANT":
+      return `Hey ${name} — you were a regular (${u.loans} loans, all repaid) then went quiet ~${d} days ago. Curious what changed. Also — did you ever try auto-sell inside the loan? Set your exit up front and it repays itself. Feels built for how you used Magpie.`;
+    case "ONE_AND_DONE":
+      return `Hey ${name} — you borrowed on Magpie once a while back and never came back. Genuinely curious why: too small to matter, a one-time need, or did something not click? Would honestly value 30 seconds of feedback. And in case it helps — the thing most people miss is you can set an auto-sell right inside the loan.`;
+    case "WARM_ACTIVE":
+      return `Hey ${name} — glad you're active on Magpie. Quick one: are you using the auto-sell inside your loans yet? Set a take-profit / stop-loss up front and it exits + repays hands-off. Happy to walk you through it.`;
+    default:
+      return `Hey ${name} — been a bit since your last Magpie loan. Anything we could've done better? Also worth knowing: you can now set your take-profit / stop-loss right inside the loan so it manages itself. Want a quick look?`;
+  }
+}
+
+(async () => {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+  const r = await pool.query(
+    `select u.id, u.telegram_id, u.telegram_username h, u.proactive_dms_disabled optout,
+            count(l.*)::int loans, round((sum(l.loan_amount_lamports)/1e9)::numeric,1) total_sol,
+            bool_or(l.program_id=$1) autosell, bool_or(l.collateral_mint=$2) magpie_coll,
+            (now()::date - max(l.created_at)::date) days,
+            max(u.last_winback_nudge_at) recent_nudge
+     from users u join loans l on l.user_id=u.id group by 1,2,3,4`, [V4, MAGPIE]);
+
+  // reachable = has TG, not opted out, and NOT already nudged in the last 5 days (no double-tapping)
+  const cutoff = Date.now() - 5 * 24 * 3600 * 1000;
+  const reachable = r.rows.filter(
+    (u) => u.telegram_id && !u.optout && !(u.recent_nudge && new Date(u.recent_nudge).getTime() > cutoff)
+  );
+  const counts = {};
+  reachable.forEach((u) => (counts[segmentOf(u)] = (counts[segmentOf(u)] || 0) + 1));
+  console.log(`${DO_SEND ? "*** LIVE SEND ***" : "PREVIEW (no send)"} — ${reachable.length} reachable / ${r.rows.length} total borrowers`);
+  console.log("segments:", JSON.stringify(counts));
+
+  if (!DO_SEND) {
+    // preview: 1 sample message per segment
+    const seen = new Set();
+    for (const u of reachable) {
+      const s = segmentOf(u);
+      if (seen.has(s)) continue;
+      seen.add(s);
+      console.log(`\n[${s}] -> @${u.h}\n${messageFor(u)}`);
+    }
+    console.log(`\n(${reachable.length} messages ready. Re-run with SEND=1 to deliver.)`);
+    await pool.end();
+    return;
+  }
+
+  // LIVE SEND (operator-triggered). Throttled, opt-outs already filtered.
+  if (!TOKEN) { console.log("NO BOT TOKEN — aborting, nothing sent."); await pool.end(); return; }
+  let sent = 0, failed = 0;
+  for (const u of reachable) {
+    try {
+      const resp = await fetch(`https://api.telegram.org/bot${TOKEN}/sendMessage`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ chat_id: u.telegram_id, text: messageFor(u), disable_web_page_preview: true }),
+      });
+      const j = await resp.json();
+      if (j.ok) { sent++; await pool.query("update users set last_winback_nudge_at=now() where id=$1", [u.id]).catch(() => {}); }
+      else { failed++; console.log(`FAIL @${u.h}: ${j.description}`); }
+    } catch (e) { failed++; console.log(`ERR @${u.h}: ${e.message}`); }
+    await new Promise((res) => setTimeout(res, THROTTLE_MS));
+  }
+  console.log(`DONE — sent ${sent}, failed ${failed}`);
+  await pool.end();
+})().catch((e) => console.log("FATAL", e.message));

--- a/scripts/withdraw-from-pool.mjs
+++ b/scripts/withdraw-from-pool.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Withdraw SOL from a Magpie lending pool (V1/V3/V4) from the lender/depositor
+ * keypair, CHUNKED to dodge the on-chain u64 overflow in `withdraw`
+ * (`shares * deposited_amount` overflows u64 for large amounts → MathOverflow
+ * 6004). Each tx batches up to K sub-withdrawals (accounts are shared so many
+ * fit), each sized so chunk_shares * deposited_amount < U64_MAX/2. The position
+ * shrinks as we withdraw, so chunks grow and it converges fast. wSOL is
+ * accumulated per-tx then unwrapped to native SOL by a single close.
+ *
+ * SAFETY: run with --dry-run first (simulates tx#1 + projects the plan, moves
+ * nothing). Only run --execute once the dry-run shows sim err: null.
+ *
+ * Usage:
+ *   LENDER_PRIVATE_KEY=<bs58> | LENDER_KEYPAIR_PATH=<file> \
+ *   SOLANA_RPC_URL=<...> [WITHDRAW_IXS_PER_TX=10] \
+ *   node scripts/withdraw-from-pool.mjs <v1|v3|v4> <sol_amount> --dry-run|--execute
+ */
+import "dotenv/config";
+import { readFileSync, existsSync } from "node:fs";
+import {
+  Connection, Keypair, PublicKey, ComputeBudgetProgram, Transaction, sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID, NATIVE_MINT, getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountIdempotentInstruction, createCloseAccountInstruction,
+} from "@solana/spl-token";
+import bs58 from "bs58";
+import anchor from "@coral-xyz/anchor";
+const { AnchorProvider, BN, Program, Wallet } = anchor;
+
+const version = (process.argv[2] || "").toLowerCase();
+const amountSol = parseFloat(process.argv[3]);
+const dryRun = process.argv.includes("--dry-run");
+const execute = process.argv.includes("--execute");
+const K = Math.max(1, Number(process.env.WITHDRAW_IXS_PER_TX || 10));
+
+const MAP = {
+  v1: { idl: "./src/solana/idl/magpie_lending.json", pid: process.env.PROGRAM_ID || "4FEFPeMH68BbkrrZW2ak9wWXUS7JCkvXqBkGf5Bg6wmh" },
+  v3: { idl: "./src/solana/idl/magpie-v3.json", pid: process.env.PROGRAM_ID_V3 || "B8AwYzFmc3ZB5EWWVtJcJhJtEmKL78W5i3kZrL1uMCmP" },
+  v4: { idl: "./src/solana/idl/magpie-v4.json", pid: process.env.PROGRAM_ID_V4 || "HA1hgvskN1goEsb33rNHFBcDXBaYyLyyqfGwGMgTUwNo" },
+};
+if (!MAP[version] || !amountSol || amountSol <= 0) {
+  console.error("Usage: node scripts/withdraw-from-pool.mjs <v1|v3|v4> <sol_amount> --dry-run|--execute");
+  process.exit(1);
+}
+if (!dryRun && !execute) { console.error("Specify --dry-run (simulate) or --execute (real withdrawal)."); process.exit(1); }
+
+const { idl: idlPath, pid } = MAP[version];
+const RPC = process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com";
+function loadLender() {
+  const b58 = process.env.LENDER_PRIVATE_KEY;
+  if (b58) { const decode = bs58.decode || (bs58.default && bs58.default.decode); return Keypair.fromSecretKey(decode(b58)); }
+  const path = process.env.LENDER_KEYPAIR_PATH || "./lender-keypair.json";
+  if (!existsSync(path)) { console.error(`No LENDER_PRIVATE_KEY env and no keypair file at ${path}`); process.exit(1); }
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(readFileSync(path, "utf8"))));
+}
+const lender = loadLender();
+const connection = new Connection(RPC, "confirmed");
+const idl = JSON.parse(readFileSync(idlPath, "utf8")); idl.address = pid;
+const programId = new PublicKey(pid);
+const program = new Program(idl, new AnchorProvider(connection, new Wallet(lender), { commitment: "confirmed" }));
+
+const [pool] = PublicKey.findProgramAddressSync([Buffer.from("pool"), lender.publicKey.toBuffer()], programId);
+const [loanTokenVault] = PublicKey.findProgramAddressSync([Buffer.from("loan-token-vault"), pool.toBuffer()], programId);
+const [position] = PublicKey.findProgramAddressSync([Buffer.from("position"), pool.toBuffer(), lender.publicKey.toBuffer()], programId);
+const wsolAta = getAssociatedTokenAddressSync(NATIVE_MINT, lender.publicKey);
+
+const U64_MAX = 18_446_744_073_709_551_615n;
+const SAFE = U64_MAX / 2n; // 50% headroom under the overflow ceiling
+
+const p0 = await program.account.lendingPool.fetch(pool);
+const td = BigInt(p0.totalDeposits.toString());
+const ts = BigInt(p0.totalShares.toString());
+const pos0 = await program.account.depositorPosition.fetch(position);
+const myShares = BigInt(pos0.shares.toString());
+const dep0 = BigInt((pos0.depositedAmount ?? pos0.deposited_amount).toString());
+const vps = ts > 0n ? Number(td) / Number(ts) : 1;
+const targetLamports = BigInt(Math.floor(amountSol * 1e9));
+let targetShares = ts > 0n ? (targetLamports * ts) / td : targetLamports;
+if (targetShares > myShares) targetShares = myShares;
+
+console.log(`Withdraw ${version.toUpperCase()}${dryRun ? " [DRY RUN]" : ""}:`);
+console.log(`  depositor:   ${lender.publicKey.toBase58()}`);
+console.log(`  program:     ${pid}`);
+console.log(`  pool:        ${pool.toBase58()}`);
+console.log(`  your shares: ${(Number(myShares) / 1e9).toFixed(4)}  value/share ${vps.toFixed(6)}`);
+console.log(`  target:      ${amountSol} SOL  => burn ~${(Number(targetShares) / 1e9).toFixed(4)} shares  (K=${K} ix/tx)`);
+
+const cuUnits = Math.min(1_400_000, 120_000 + K * 100_000);
+async function withdrawIx(shares) {
+  return program.methods.withdraw(new BN(shares.toString())).accounts({
+    pool, loanTokenVault, position, depositorTokenAccount: wsolAta, depositor: lender.publicKey, tokenProgram: TOKEN_PROGRAM_ID,
+  }).instruction();
+}
+async function buildTx(chunks) {
+  const priorityMicroLamports = Number(process.env.WITHDRAW_PRIORITY_MICROLAMPORTS ?? 250_000);
+  const ixs = [
+    ComputeBudgetProgram.setComputeUnitLimit({ units: cuUnits }),
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityMicroLamports }), // priority fee so txs land in congestion
+    createAssociatedTokenAccountIdempotentInstruction(lender.publicKey, wsolAta, lender.publicKey, NATIVE_MINT),
+  ];
+  for (const c of chunks) ixs.push(await withdrawIx(c));
+  ixs.push(createCloseAccountInstruction(wsolAta, lender.publicKey, lender.publicKey));
+  const tx = new Transaction().add(...ixs);
+  tx.feePayer = lender.publicKey;
+  return tx;
+}
+function planChunks(depNow, remaining) {
+  const maxChunk = depNow > 0n ? SAFE / depNow : remaining;
+  const chunks = []; let rem = remaining;
+  for (let i = 0; i < K && rem > 0n; i++) { const c = maxChunk < rem ? maxChunk : rem; if (c <= 0n) break; chunks.push(c); rem -= c; }
+  return chunks;
+}
+
+if (dryRun) {
+  let depLocal = dep0, remaining = targetShares, txNo = 0, firstErr = null;
+  while (remaining > 0n && txNo < 300) {
+    const chunks = planChunks(depLocal, remaining);
+    if (!chunks.length) break;
+    const sum = chunks.reduce((a, b) => a + b, 0n);
+    txNo++;
+    if (txNo === 1) {
+      const tx = await buildTx(chunks);
+      tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+      const sim = await connection.simulateTransaction(tx);
+      firstErr = sim.value.err;
+      console.log(`  tx#1: ${chunks.length} chunks ~${(Number(sum) / 1e9 * vps).toFixed(3)} SOL, sim err: ${JSON.stringify(sim.value.err)}`);
+      if (sim.value.err) { console.log((sim.value.logs || []).slice(-8).join("\n")); process.exit(1); }
+    }
+    remaining -= sum; depLocal -= sum;
+  }
+  console.log(`\n[DRY RUN OK] ~${amountSol} SOL withdrawable across ~${txNo} transaction(s). Re-run with --execute.`);
+  process.exit(firstErr ? 1 : 0);
+}
+
+// ── EXECUTE ──
+let remaining = targetShares, txNo = 0; const sigs = [];
+while (remaining > 0n) {
+  const pos = await program.account.depositorPosition.fetch(position);
+  const dep = BigInt((pos.depositedAmount ?? pos.deposited_amount).toString());
+  const posShares = BigInt(pos.shares.toString());
+  if (posShares === 0n || dep === 0n) break;
+  const rem = remaining < posShares ? remaining : posShares;
+  const chunks = planChunks(dep, rem);
+  if (!chunks.length) break;
+  const sum = chunks.reduce((a, b) => a + b, 0n);
+  txNo++;
+  const tx = await buildTx(chunks);
+  const sig = await sendAndConfirmTransaction(connection, tx, [lender], { commitment: "confirmed", maxRetries: 3 });
+  sigs.push(sig);
+  console.log(`  tx#${txNo}: ${chunks.length} chunks ~${(Number(sum) / 1e9 * vps).toFixed(3)} SOL  ✓ ${sig.slice(0, 20)}…`);
+  remaining -= sum;
+  if (txNo > 80) { console.error("safety stop: >80 txs"); break; }
+}
+const pEnd = await program.account.lendingPool.fetch(pool);
+console.log(`\nDone — ${txNo} tx(s). ${version.toUpperCase()} pool now: ${(Number(pEnd.totalDeposits) / 1e9).toFixed(3)} SOL`);
+if (sigs.length) console.log(`  last tx: https://solscan.io/tx/${sigs[sigs.length - 1]}`);
+process.exit(0);

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ import { handleStats } from "./commands/stats.js";
 import { handleFeedback } from "./commands/feedback.js";
 import { handleCollectibleSubmissions } from "./commands/collectible-submissions.js";
 import { startCollectibleRetention } from "./services/collectible-retention.js";
+import { startSchemaContractMonitor } from "./services/schema-contract.js";
 import { handleHistory } from "./commands/history.js";
 import { handleSimulate } from "./commands/simulate.js";
 import { handleMe, registerMeCallbacks } from "./commands/me.js";
@@ -1003,6 +1004,12 @@ bot.start({
     // BEFORE any reduction, so retention can never destroy the demand history.
     // Daily; slow clock by design.
     setTimeout(() => startCollectibleRetention(), 240_000);
+    // SCHEMA CONTRACT — the site writes tables whose schema the bot owns, and
+    // nothing verified the two agreed. That gap let the collectible submission
+    // feature fail SILENTLY from the day it shipped (every INSERT rejected,
+    // caught by a best-effort try/catch, found only by chance). Declares the
+    // columns each writer depends on and alerts when one goes missing.
+    setTimeout(() => startSchemaContractMonitor(bot), 300_000);
     // $MAGPIE holder reward distributions — DISABLED as of MGP-001 (2026-06-10).
     // Distributions now flow through the governance autopilot (MGP-XXX) instead
     // of an automated bot-driven cadence. The auto-snapshotter previously created

--- a/src/services/schema-contract.js
+++ b/src/services/schema-contract.js
@@ -1,0 +1,151 @@
+/**
+ * Schema Contract Monitor — catches silent write failures caused by schema drift.
+ *
+ * WHY THIS EXISTS. On 2026-08-07 the collectible submission feature was found to
+ * have been broken since the day it shipped: the site wrote columns the table
+ * didn't have, every INSERT failed, and NOBODY KNEW. The write is wrapped in a
+ * best-effort try/catch — which is the right call for the user, because a
+ * storage problem shouldn't cost a collector their answer — but it means total
+ * feature failure is completely invisible. It was found by chance.
+ *
+ * The root cause is structural, not a one-off: the SITE writes these tables and
+ * the BOT owns their schema, and nothing verified the two agreed. Any future
+ * column rename, dropped migration, or half-applied deploy reintroduces exactly
+ * the same silent failure.
+ *
+ * So the contract is declared here explicitly. If a column the writer depends on
+ * goes missing, the operator hears about it in minutes instead of never.
+ *
+ * This deliberately checks SHAPE, not data. It answers "can the write succeed?",
+ * which is the question that was being silently answered "no".
+ */
+import { query } from "../db/pool.js";
+
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 4x/day — schema drift is a deploy-time event
+const ADMIN_TG_ID = process.env.ADMIN_TELEGRAM_ID;
+
+/**
+ * Columns each cross-boundary table MUST have for its writer to work.
+ *
+ * Keep this in step with the writer, not with the migration: the point is to
+ * detect the two disagreeing. If you add a column to an INSERT, add it here.
+ */
+const CONTRACTS = {
+  // Written by magpie-site /api/submit-collectible, schema owned by migration 097.
+  collectible_submissions: [
+    "wallet", "contact", "grader", "cert", "card", "card_set", "card_year",
+    "grade", "auto_grade", "platform", "verdict", "tier", "checks",
+    "next_steps", "gate_version", "status", "source", "ip_hash", "ua_hash",
+    "flags", "created_at",
+  ],
+  // Written by the retention job, schema owned by migration 098.
+  collectible_submission_daily: [
+    "day", "verdict", "tier", "platform", "submissions", "wallets", "updated_at",
+  ],
+};
+
+/** Indexes whose UNIQUENESS is load-bearing for correctness, either way. */
+const INDEX_EXPECTATIONS = [
+  {
+    table: "collectible_submissions",
+    index: "collectible_submissions_cert_idx",
+    unique: false,
+    why: "one row per attempt — a UNIQUE index here silently discards the duplicate-cert fraud signal",
+  },
+];
+
+let lastAlertKey = null;
+
+async function findDrift() {
+  const problems = [];
+
+  for (const [table, required] of Object.entries(CONTRACTS)) {
+    const { rows } = await query(
+      `SELECT column_name FROM information_schema.columns
+        WHERE table_schema = current_schema() AND table_name = $1`,
+      [table],
+    );
+
+    if (!rows.length) {
+      problems.push(`${table}: table is MISSING (migration not applied?)`);
+      continue;
+    }
+
+    const present = new Set(rows.map((r) => r.column_name));
+    const missing = required.filter((c) => !present.has(c));
+    if (missing.length) problems.push(`${table}: missing column(s) ${missing.join(", ")}`);
+  }
+
+  for (const exp of INDEX_EXPECTATIONS) {
+    const { rows } = await query(
+      `SELECT ix.indisunique AS uniq
+         FROM pg_index ix
+         JOIN pg_class i  ON i.oid = ix.indexrelid
+         JOIN pg_class t  ON t.oid = ix.indrelid
+         JOIN pg_namespace ns ON ns.oid = t.relnamespace
+        WHERE ns.nspname = current_schema() AND t.relname = $1 AND i.relname = $2`,
+      [exp.table, exp.index],
+    );
+    if (!rows.length) {
+      problems.push(`${exp.table}: index ${exp.index} is missing`);
+    } else if (rows[0].uniq !== exp.unique) {
+      problems.push(
+        `${exp.table}: index ${exp.index} is ${rows[0].uniq ? "UNIQUE" : "non-unique"}, expected ` +
+          `${exp.unique ? "UNIQUE" : "non-unique"} — ${exp.why}`,
+      );
+    }
+  }
+
+  return problems;
+}
+
+async function tick(bot) {
+  let problems;
+  try {
+    problems = await findDrift();
+  } catch (err) {
+    // The DB being unreachable is db-health's job to report, not ours.
+    console.warn("[schema-contract] check failed:", err.message?.slice(0, 160));
+    return;
+  }
+
+  if (!problems.length) {
+    if (lastAlertKey) {
+      console.log("[schema-contract] drift resolved");
+      if (bot && ADMIN_TG_ID) {
+        try {
+          await bot.api.sendMessage(ADMIN_TG_ID, "*Schema contract restored*\n\nAll declared columns and indexes are present again.", { parse_mode: "Markdown" });
+        } catch { /* non-critical */ }
+      }
+      lastAlertKey = null;
+    }
+    return;
+  }
+
+  console.error("[schema-contract] DRIFT:", problems.join(" | "));
+
+  // Alert on change, not on every tick — a persistent drift shouldn't spam.
+  const key = problems.join("|");
+  if (key === lastAlertKey) return;
+  lastAlertKey = key;
+
+  if (bot && ADMIN_TG_ID) {
+    try {
+      await bot.api.sendMessage(
+        ADMIN_TG_ID,
+        "*Schema contract broken*\n\n" +
+          problems.map((p) => `• ${p}`).join("\n") +
+          "\n\nWrites against this table are probably failing SILENTLY — the writer swallows DB errors so the user still gets a response. Check the latest migration actually applied.",
+        { parse_mode: "Markdown" },
+      );
+    } catch { /* non-critical */ }
+  }
+}
+
+export function startSchemaContractMonitor(bot, intervalMs = CHECK_INTERVAL_MS) {
+  tick(bot);
+  return setInterval(() => tick(bot), intervalMs);
+}
+
+/** Exported for the one-shot check script. */
+export { findDrift };

--- a/src/solana/arming-caps.js
+++ b/src/solana/arming-caps.js
@@ -1,0 +1,54 @@
+/**
+ * Derivation of the two V4.1 conversion caps (Sec3 Q-04).
+ *
+ * Deliberately in its own module with NO imports. The instruction builders need
+ * @solana/web3.js; this arithmetic does not, and keeping it separate means the
+ * guard script can verify it without installing anything — a check that can't
+ * be skipped because a lockfile broke is worth more than a tidier file tree.
+ *
+ *   max_slice_bps — the most a SINGLE fire may take
+ *   total_bps     — the most ALL fires may take under one arming
+ *
+ * A laddered exit fires several legs under one arming, so per-fire is the
+ * LARGEST leg and total is the SUM. Collapsing them would cap a ladder at its
+ * largest leg: a 70/20/10 take-profit ladder needs a 70% per-fire cap but 100%
+ * of total authorization, so leg 2 would be refused on-chain.
+ */
+
+const BPS_MAX = 10_000;
+
+/**
+ * @param {Array<{slicePct:number}>} legs one entry per ladder leg; a single
+ *        take-profit or stop-loss is just a one-leg ladder.
+ * @returns {{maxSliceBps:number, totalBps:number}}
+ */
+export function deriveArmingCaps(legs) {
+  if (!Array.isArray(legs) || legs.length === 0) {
+    throw new Error("arming: at least one leg is required");
+  }
+
+  const bps = legs.map((l, i) => {
+    const pct = Number(l?.slicePct);
+    if (!Number.isFinite(pct) || pct <= 0) {
+      throw new Error(`arming: leg ${i + 1} has a non-positive slice`);
+    }
+    // Percent → bps. Round rather than truncate so a leg can't quietly shrink.
+    return Math.round(pct * 100);
+  });
+
+  const totalBps = bps.reduce((a, b) => a + b, 0);
+  const maxSliceBps = Math.max(...bps);
+
+  if (totalBps > BPS_MAX) {
+    throw new Error(
+      `arming: legs sum to ${totalBps / 100}% — cannot exceed 100% of the original collateral`,
+    );
+  }
+  // Invariant the program also enforces; assert here so a bad spec fails in the
+  // bot with a readable message instead of as an opaque on-chain error.
+  if (maxSliceBps > totalBps) {
+    throw new Error("arming: per-fire cap cannot exceed the total authorization");
+  }
+
+  return { maxSliceBps, totalBps };
+}

--- a/src/solana/idl/magpie-v4-1.json
+++ b/src/solana/idl/magpie-v4-1.json
@@ -1,0 +1,3505 @@
+{
+  "address": "11111111111111111111111111111111",
+  "metadata": {
+    "name": "magpie_lending",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Magpie lending v4 \u2014 adds in-vault auto-sell conversion.",
+    "note": "V4.1 (UNDEPLOYED). address is a placeholder \u2014 resolve the real program id from PROGRAM_ID_V4_1 at runtime."
+  },
+  "instructions": [
+    {
+      "name": "add_collateral",
+      "docs": [
+        "Add more collateral to an active loan (no fee)."
+      ],
+      "discriminator": [
+        127,
+        82,
+        121,
+        42,
+        161,
+        176,
+        249,
+        206
+      ],
+      "accounts": [
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint \u2014 needed for transfer_checked (Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "borrower_collateral_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "admin_withdraw",
+      "docs": [
+        "Emergency admin withdrawal \u2014 transfer wSOL directly from vault to authority.",
+        "Only callable by the pool authority. Use this to recover funds that were",
+        "deposited outside the share-based deposit flow.",
+        "Emergency admin withdrawal \u2014 transfer wSOL directly from vault to",
+        "authority, BYPASSING share accounting. Intended use: recover funds",
+        "that were sent directly to the vault outside the share-based deposit",
+        "flow (misroutes, fee dust, etc.). The on-chain enforcement below",
+        "guarantees the admin can NEVER drain share-backed deposits, so LP",
+        "accounting can never silently break \u2014 a class of bug that bit V1/V2",
+        "(admin_withdraw had no on-chain excess-only guard, so a careless",
+        "--all drain would leave pool.total_deposits over-stated and lock",
+        "LPs out of subsequent withdraws)."
+      ],
+      "discriminator": [
+        160,
+        166,
+        147,
+        222,
+        46,
+        220,
+        75,
+        224
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority_token_account",
+          "docs": [
+            "Authority's wSOL token account to receive the funds."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "arm_conversion",
+      "docs": [
+        "[H-02 \u00b7 Sec3] BORROWER-signed: arm an auto-sell trigger on this loan.",
+        "This is the on-chain borrower CONSENT that gates",
+        "`convert_collateral_slice` \u2014 without an armed trigger (or an overdue",
+        "loan) the engine cannot move a single token of collateral. The borrower",
+        "chooses the price, direction (take-profit / stop-loss), and per-fire",
+        "slice cap; the off-chain engine merely executes what the borrower armed."
+      ],
+      "discriminator": [
+        30,
+        129,
+        77,
+        151,
+        228,
+        249,
+        182,
+        219
+      ],
+      "accounts": [
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "trigger_price",
+          "type": "u64"
+        },
+        {
+          "name": "direction",
+          "type": "u8"
+        },
+        {
+          "name": "max_slice_bps",
+          "type": "u16"
+        },
+        {
+          "name": "total_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "convert_collateral_slice",
+      "docs": [
+        "v4 \u2500\u2500 auto-sell a slice of SPL collateral and store the SOL in the",
+        "loan vault. The loan stays ACTIVE; principal, fee, and due_timestamp",
+        "are unchanged. Only the engine authority can call this. Pattern B",
+        "CPI: the caller provides the swap program + accounts in",
+        "`remaining_accounts` and the swap-instruction data via `swap_ix_data`;",
+        "this function invokes the swap and validates the SOL came back \u2265",
+        "min_sol_out. Aggregator-agnostic.",
+        "",
+        "State changes (atomic \u2014 all or none):",
+        "loan.current_collateral_amount -= slice_amount",
+        "loan.sol_proceeds_amount       += sol_received - protocol_fee",
+        "loan.auto_sells_fired          += 1",
+        "",
+        "The 1% protocol fee is skimmed in-program and sent to the fee",
+        "wallet (same wSOL ATA the borrow-side fee flows to). The slice",
+        "is expressed in basis points of the ORIGINAL collateral amount,",
+        "not the remaining \u2014 so \"70% / 20% / 10%\" ladders compose",
+        "arithmetically without per-leg drift.",
+        "",
+        "Safety guarantees:",
+        "- Only ENGINE_AUTHORITY may sign (constraint on ConvertCollateralSlice)",
+        "- slice_bps clamped to (0, 10_000]",
+        "- slice_amount clamped to remaining collateral",
+        "- SOL deposit verified against vault delta (not trusting the swap)",
+        "- min_sol_out enforced after the swap (slippage cap)",
+        "- Fee skim arithmetic uses u128 intermediate (no overflow)"
+      ],
+      "discriminator": [
+        253,
+        2,
+        10,
+        59,
+        245,
+        38,
+        24,
+        72
+      ],
+      "accounts": [
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint (for transfer_checked decimals + Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "docs": [
+            "SPL collateral vault \u2014 source of the slice being sold."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_proceeds_vault",
+          "docs": [
+            "wSOL vault \u2014 destination for swap proceeds. Initialized lazily so",
+            "loans that never auto-sell don't pay the rent overhead. Authority",
+            "is the collateral_vault PDA (program-signed via vault_seeds).",
+            "The mint MUST be native wSOL \u2014 checked by the constraint."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  45,
+                  112,
+                  114,
+                  111,
+                  99,
+                  101,
+                  101,
+                  100,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "engine_collateral_account",
+          "docs": [
+            "Engine's SPL ATA \u2014 receives the slice that the swap will then",
+            "consume. Owner must be the engine signer. Mint must match the",
+            "loan's collateral mint."
+          ],
+          "writable": true
+        },
+        {
+          "name": "fee_wallet",
+          "docs": [
+            "Fee wallet (same wSOL ATA the borrow-side fee flows to).",
+            "Wave 3 (2026-06-15): hardcoded `address` constraint closes the",
+            "V4 audit finding that a compromised engine key could route the",
+            "1% protocol skim to any TokenAccount. Now restricted to the",
+            "canonical Magpie fee wallet only."
+          ],
+          "writable": true,
+          "address": "3wk75XDABdEEec28c9ES6KdH2V9zh8h76Q8oTitEe4TE"
+        },
+        {
+          "name": "wsol_mint",
+          "docs": [
+            "wSOL mint (canonical pubkey So11111...). Used to gate the",
+            "sol_proceeds_vault init.",
+            "[I-01 \u00b7 Sec3] Pinned to the canonical Wrapped SOL mint."
+          ],
+          "address": "So11111111111111111111111111111111111111112"
+        },
+        {
+          "name": "engine",
+          "docs": [
+            "Engine authority \u2014 the ONLY pubkey allowed to call this.",
+            "Constraint compares against the hardcoded ENGINE_AUTHORITY",
+            "constant; this is the least-privilege seam."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "7GKdZ8n6nNc6oFpQMiPZxmiR1KRJgXuBSmuJF4u2BKrs"
+        },
+        {
+          "name": "price_history",
+          "docs": [
+            "V4.1 ANTI-DRAIN: price history PDA for the loan's collateral",
+            "mint. The program reads the latest sample to compute the oracle",
+            "floor on `min_sol_out`. The seeds must match the engine-managed",
+            "price feed for the collateral mint + pool."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan.collateral_mint",
+                "account": "Loan"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Pool reference for the price_history PDA derivation. Read-only.",
+            "[L-05 \u00b7 Sec3] Bind the pool to the loan's own pool. Without this, the",
+            "oracle floor could be computed from a DIFFERENT pool's price feed for the",
+            "same collateral mint (an attacker-initialized pool priced near zero),",
+            "letting the slice be sold near zero while still passing the floor check."
+          ]
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "slice_bps",
+          "type": "u16"
+        },
+        {
+          "name": "min_sol_out",
+          "type": "u64"
+        },
+        {
+          "name": "swap_ix_data",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "deposit",
+      "docs": [
+        "Deposit SOL-equivalent loan tokens into the pool and receive shares.",
+        "Shares = deposit_amount * total_shares / pool_value   (or 1:1 if first)"
+      ],
+      "discriminator": [
+        242,
+        35,
+        198,
+        137,
+        82,
+        225,
+        242,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor_token_account",
+          "writable": true
+        },
+        {
+          "name": "depositor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "disarm_conversion",
+      "docs": [
+        "[H-02 \u00b7 Sec3] BORROWER-signed: disarm the auto-sell trigger, returning",
+        "the loan to the \"engine cannot convert\" default."
+      ],
+      "discriminator": [
+        142,
+        236,
+        234,
+        163,
+        200,
+        137,
+        22,
+        31
+      ],
+      "accounts": [
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "extend_loan",
+      "docs": [
+        "Extend loan by its original duration, paying the tier fee again."
+      ],
+      "discriminator": [
+        2,
+        208,
+        222,
+        190,
+        109,
+        148,
+        247,
+        117
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "[M-01 \u00b7 Sec3] Collateral mint \u2014 supplies decimals for the on-chain",
+            "health check. Bound to the loan via `has_one = collateral_mint` above."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "price_history",
+          "docs": [
+            "[M-01 \u00b7 Sec3] Price feed for the on-chain collateral health check.",
+            "Pool-bound (same pattern as ConvertCollateralSlice, per L-05) so a",
+            "foreign pool's price feed can't be substituted. Read-only."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan.collateral_mint",
+                "account": "Loan"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "fee_wallet_token_account",
+          "docs": [
+            "Wave 5 C4 (2026-06-15): hardcoded `address` constraint closes",
+            "the audit finding \u2014 without it a borrower extending their V4",
+            "loan could pass own wSOL ATA and keep the 1% extension fee.",
+            "Now restricted to the canonical Magpie fee wallet only.",
+            "(Wave 3 added this to RequestLoan + ConvertCollateralSlice but",
+            "MISSED ExtendLoan \u2014 caught in the post-Wave-4 final audit.)"
+          ],
+          "writable": true,
+          "address": "3wk75XDABdEEec28c9ES6KdH2V9zh8h76Q8oTitEe4TE"
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "[M-01 \u00b7 Sec3] Pool authority co-signer \u2014 OPTIONAL. Required (and must",
+            "equal pool.authority) ONLY when the loan is not provably healthy",
+            "on-chain (stale price, or current LTV above the loan's LTV). A healthy",
+            "loan self-extends without it, so a malicious authority cannot grief a",
+            "healthy borrower toward liquidation by withholding a signature."
+          ],
+          "signer": true,
+          "optional": true
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_pool",
+      "docs": [
+        "Create a permissionless lending pool.  Anyone can call this once per",
+        "authority key, but the `protocol_fee_bps` determines how much of each",
+        "loan fee goes to the protocol vs the pool depositors."
+      ],
+      "discriminator": [
+        95,
+        180,
+        10,
+        172,
+        84,
+        174,
+        232,
+        40
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan_token_mint",
+          "docs": [
+            "[I-01 \u00b7 Sec3] The loan token must be the canonical Wrapped SOL mint."
+          ],
+          "address": "So11111111111111111111111111111111111111112"
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "protocol_fee_bps",
+          "type": "u16"
+        },
+        {
+          "name": "keeper_reward_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "initialize_price_feed",
+      "docs": [
+        "Initialize a price feed for a specific token mint.",
+        "Only the pool authority can create feeds for their pool.",
+        "v3: the PriceHistory ring buffer starts empty. Borrows are",
+        "refused until MIN_SAMPLES_FOR_TWAP samples accumulate AND",
+        "MIN_HISTORY_SECONDS of time has elapsed since the first sample."
+      ],
+      "discriminator": [
+        68,
+        180,
+        81,
+        20,
+        102,
+        213,
+        145,
+        233
+      ],
+      "accounts": [
+        {
+          "name": "pool"
+        },
+        {
+          "name": "mint",
+          "docs": [
+            "Accept both legacy Token and Token-2022 mints."
+          ]
+        },
+        {
+          "name": "price_feed",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "liquidate_loan",
+      "docs": [
+        "Liquidate an overdue loan. **Permissionless** \u2014 any wallet (keeper) can",
+        "call this. The keeper receives `keeper_reward_bps` of the seized",
+        "collateral as a bounty; the remainder goes to the pool authority for",
+        "off-chain swap and pool recovery."
+      ],
+      "discriminator": [
+        111,
+        249,
+        185,
+        54,
+        161,
+        147,
+        178,
+        24
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "docs": [
+            "[L-02 \u00b7 Sec3] Pool loan-token vault. Recovered wSOL proceeds are routed",
+            "back HERE and credited to LP equity, instead of being paid out to the",
+            "authority \u2014 so LPs recover the reconcilable portion of the debt on-chain",
+            "rather than taking a full write-off."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint \u2014 needed for transfer_checked (Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "keeper_collateral_account",
+          "docs": [
+            "Keeper's token account \u2014 receives the keeper bounty portion"
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority_collateral_account",
+          "docs": [
+            "Authority's token account \u2014 receives the remaining collateral"
+          ],
+          "writable": true
+        },
+        {
+          "name": "sol_proceeds_vault",
+          "docs": [
+            "v4 \u2014 sol_proceeds_vault holding accumulated SOL from auto-sells.",
+            "Same seeds + authority pattern as the SPL collateral vault.",
+            "Wave 5 C1 (2026-06-15): `init_if_needed` so V4 loans whose",
+            "auto-sell never fired can still be liquidated. Keeper pays the",
+            "small ATA rent (~0.002 SOL); recovered on the close path."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  45,
+                  112,
+                  114,
+                  111,
+                  99,
+                  101,
+                  101,
+                  100,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "keeper_loan_token_account",
+          "docs": [
+            "v4 \u2014 keeper's wSOL ATA for the SOL-pot bounty."
+          ],
+          "writable": true
+        },
+        {
+          "name": "authority_loan_token_account",
+          "docs": [
+            "v4 \u2014 authority's wSOL ATA for the SOL-pot residual."
+          ],
+          "writable": true
+        },
+        {
+          "name": "keeper",
+          "docs": [
+            "The keeper (liquidator) \u2014 permissionless, any wallet can sign"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "wsol_mint",
+          "docs": [
+            "wSOL mint \u2014 needed by the `init_if_needed` on sol_proceeds_vault.",
+            "[I-01 \u00b7 Sec3] Pinned to the canonical Wrapped SOL mint."
+          ],
+          "address": "So11111111111111111111111111111111111111112"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Wave 5 C1 \u2014 required by init_if_needed on sol_proceeds_vault."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "partial_repay",
+      "docs": [
+        "Partial repayment \u2014 reduce outstanding balance, collateral stays locked."
+      ],
+      "discriminator": [
+        142,
+        116,
+        46,
+        250,
+        227,
+        209,
+        60,
+        39
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "recover_liquidated_collateral",
+      "docs": [
+        "[L-02 \u00b7 Sec3] On-chain recovery of residual SPL collateral value.",
+        "`liquidate_loan` sends any unsold SPL collateral to the pool authority",
+        "for off-chain sale; before this instruction there was no on-chain path",
+        "to return the resulting value to LPs, so an off-chain SPL sale stayed",
+        "OUTSIDE the accounting used to price LP shares (LPs bore a full on-chain",
+        "write-off until a voluntary, unreconciled transfer). This instruction",
+        "deposits the recovered wSOL proceeds into the pool's loan_token_vault",
+        "and credits `total_deposits` WITHOUT minting shares \u2014 so the recovered",
+        "value accrues to EXISTING LP shares, linked on-chain to the liquidated",
+        "loan. Authority-only, and it only ever ADDS the authority's own tokens",
+        "to the pool."
+      ],
+      "discriminator": [
+        133,
+        10,
+        191,
+        76,
+        34,
+        180,
+        127,
+        192
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan",
+          "docs": [
+            "The liquidated loan this recovery is reconciled against. Bound to the",
+            "pool; must be in the Liquidated terminal state."
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "docs": [
+            "Pool's loan-token (wSOL) vault \u2014 destination for the recovered value."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Pool authority \u2014 the only signer allowed (checked == pool.authority)."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority_loan_token_account",
+          "docs": [
+            "Authority's wSOL source account holding the off-chain sale proceeds."
+          ],
+          "writable": true
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "repay_loan",
+      "docs": [
+        "Repay loan in full; collateral returned to borrower."
+      ],
+      "discriminator": [
+        224,
+        93,
+        144,
+        77,
+        61,
+        17,
+        137,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "collateral_mint",
+          "docs": [
+            "Collateral mint \u2014 needed for transfer_checked (Token-2022 compat)."
+          ],
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "borrower_collateral_account",
+          "writable": true
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "loan"
+          ]
+        },
+        {
+          "name": "sol_proceeds_vault",
+          "docs": [
+            "v4 \u2014 wSOL vault where auto-sell proceeds accumulate. Initialized",
+            "lazily on first convert_collateral_slice; here in repay it gets",
+            "drained back to the borrower along with any remaining SPL.",
+            "Authority = collateral_vault PDA (same seeds as the SPL vault),",
+            "so the program can sign for withdrawals using vault_seeds.",
+            "",
+            "Wave 5 C1 (2026-06-15): `init_if_needed` so V4 loans whose",
+            "auto-sell never fired (price never hit trigger) can still be",
+            "repaid. Without this, every never-fired V4 loan is unrepayable",
+            "\u2014 sol_proceeds_vault is only init'd lazily inside",
+            "convert_collateral_slice, so a loan that didn't auto-sell has",
+            "no vault account and Anchor fails with AccountNotInitialized",
+            "(3012) at repay time. wsol_mint param added below for the init.",
+            "Borrower pays the small ATA rent (~0.002 SOL); on close path",
+            "the rent is recovered."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  111,
+                  108,
+                  45,
+                  112,
+                  114,
+                  111,
+                  99,
+                  101,
+                  101,
+                  100,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "wsol_mint",
+          "docs": [
+            "wSOL mint (canonical pubkey So11111\u2026). Used to gate the",
+            "init_if_needed on sol_proceeds_vault. Read-only.",
+            "[I-01 \u00b7 Sec3] Pinned to the canonical Wrapped SOL mint."
+          ],
+          "address": "So11111111111111111111111111111111111111112"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "loan_token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Wave 5 C1 \u2014 needed because init_if_needed allocates a new",
+            "account, which requires the system_program to be passed."
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "request_and_fund_loan",
+      "docs": [
+        "Request and instantly fund a loan from the pool.",
+        "",
+        "`collateral_amount` \u2013 raw token units of collateral to lock.",
+        "`loan_option`       \u2013 tier 0/1/2 within the chosen category.",
+        "`collateral_value`  \u2013 oracle-supplied value in loan-token units.",
+        "`loan_id`           \u2013 unique nonce (e.g. unix-ms).",
+        "`category`          \u2013 0 = memecoin (30/25/20% LTV @ 2/3/7d),",
+        "1 = RWA stock/etf/metal (50/60/70% @ 7/15/30d).",
+        "The cosign authority is responsible for matching",
+        "this to the on-chain mint category \u2014 if a memecoin",
+        "borrow arrives with category=RWA the higher LTV",
+        "on a volatile mint becomes a default risk. The",
+        "authority signature gates that."
+      ],
+      "discriminator": [
+        21,
+        217,
+        199,
+        183,
+        6,
+        96,
+        200,
+        52
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "loan",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "borrower"
+              },
+              {
+                "kind": "arg",
+                "path": "loan_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "collateral_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  108,
+                  108,
+                  97,
+                  116,
+                  101,
+                  114,
+                  97,
+                  108,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "loan"
+              }
+            ]
+          }
+        },
+        {
+          "name": "collateral_mint"
+        },
+        {
+          "name": "borrower_collateral_account",
+          "writable": true
+        },
+        {
+          "name": "borrower_loan_token_account",
+          "writable": true
+        },
+        {
+          "name": "fee_wallet_token_account",
+          "docs": [
+            "Wave 3 (2026-06-15): hardcoded `address` constraint closes the",
+            "V4 audit finding that a borrower could pass their own wSOL ATA",
+            "here as fee_wallet and keep the 1% extension fee. Now restricted",
+            "to the canonical Magpie fee wallet only."
+          ],
+          "writable": true,
+          "address": "3wk75XDABdEEec28c9ES6KdH2V9zh8h76Q8oTitEe4TE"
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Pool authority must co-sign every borrow to attest the collateral value."
+          ],
+          "signer": true
+        },
+        {
+          "name": "price_feed",
+          "docs": [
+            "On-chain price attestation for the collateral mint. PDA seeds already",
+            "enforce mint+pool linkage so duplicate constraints removed."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "collateral_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Used for collateral vault init + collateral transfers. Accepts both",
+            "legacy SPL Token and Token-2022 mints."
+          ]
+        },
+        {
+          "name": "loan_token_program",
+          "docs": [
+            "Used for loan token (wSOL) transfers from pool vault. Always legacy."
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "collateral_amount",
+          "type": "u64"
+        },
+        {
+          "name": "loan_option",
+          "type": "u8"
+        },
+        {
+          "name": "collateral_value",
+          "type": "u64"
+        },
+        {
+          "name": "loan_id",
+          "type": "u64"
+        },
+        {
+          "name": "category",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "set_keeper_reward",
+      "docs": [
+        "Update keeper reward percentage (authority only)."
+      ],
+      "discriminator": [
+        72,
+        2,
+        226,
+        109,
+        200,
+        82,
+        237,
+        9
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "keeper_reward_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "set_paused",
+      "docs": [
+        "Pause / unpause new borrows (authority only)."
+      ],
+      "discriminator": [
+        91,
+        60,
+        125,
+        192,
+        176,
+        225,
+        166,
+        218
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "paused",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "update_price",
+      "docs": [
+        "Append a new price sample to the rolling history. Only the pool",
+        "authority can call this. The bot calls this on its attestor tick",
+        "(every 30-60s). Each call advances the ring buffer one slot.",
+        "",
+        "`confidence_bps` is accepted for IDL compatibility with v1/v2",
+        "but not stored \u2014 TWAP makes per-sample confidence less useful.",
+        "[Q-01 \u00b7 Sec3] Oracle confidence is INTENTIONALLY not used in v4 risk",
+        "checks. The `confidence_bps` argument is retained only for IDL",
+        "compatibility with earlier versions; it is neither stored nor emitted",
+        "(the PriceUpdated event hardcodes 0). v4 relies on the time-weighted",
+        "average price plus the spot-vs-TWAP pump gate for manipulation",
+        "resistance, which supersedes per-sample confidence: a single wide- or",
+        "bad-confidence print cannot move the TWAP, and the borrow path already",
+        "values collateral at the lower of spot and TWAP. Operators/integrators",
+        "should treat confidence as unused on v4 by design."
+      ],
+      "discriminator": [
+        61,
+        34,
+        117,
+        155,
+        75,
+        34,
+        123,
+        208
+      ],
+      "accounts": [
+        {
+          "name": "pool"
+        },
+        {
+          "name": "price_feed",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  105,
+                  99,
+                  101,
+                  95,
+                  118,
+                  51
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "price_feed.mint",
+                "account": "PriceHistory"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "pool"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "price_lamports",
+          "type": "u64"
+        },
+        {
+          "name": "_confidence_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "withdraw",
+      "docs": [
+        "Withdraw by burning shares. Receives proportional pool value."
+      ],
+      "discriminator": [
+        183,
+        18,
+        70,
+        156,
+        148,
+        109,
+        161,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "loan_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  108,
+                  111,
+                  97,
+                  110,
+                  45,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  45,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor_token_account",
+          "writable": true
+        },
+        {
+          "name": "depositor",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "shares",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "DepositorPosition",
+      "discriminator": [
+        27,
+        17,
+        217,
+        253,
+        51,
+        126,
+        101,
+        78
+      ]
+    },
+    {
+      "name": "LendingPool",
+      "discriminator": [
+        208,
+        40,
+        242,
+        82,
+        186,
+        18,
+        75,
+        36
+      ]
+    },
+    {
+      "name": "Loan",
+      "discriminator": [
+        20,
+        195,
+        70,
+        117,
+        165,
+        227,
+        182,
+        1
+      ]
+    },
+    {
+      "name": "PriceHistory",
+      "discriminator": [
+        38,
+        241,
+        40,
+        19,
+        42,
+        228,
+        93,
+        152
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "CollateralAdded",
+      "discriminator": [
+        172,
+        68,
+        58,
+        249,
+        157,
+        64,
+        74,
+        141
+      ]
+    },
+    {
+      "name": "CollateralConverted",
+      "discriminator": [
+        31,
+        54,
+        10,
+        182,
+        111,
+        73,
+        67,
+        210
+      ]
+    },
+    {
+      "name": "ConversionArmed",
+      "discriminator": [
+        248,
+        68,
+        76,
+        36,
+        132,
+        22,
+        41,
+        51
+      ]
+    },
+    {
+      "name": "ConversionDisarmed",
+      "discriminator": [
+        169,
+        228,
+        26,
+        79,
+        180,
+        100,
+        46,
+        243
+      ]
+    },
+    {
+      "name": "Deposited",
+      "discriminator": [
+        111,
+        141,
+        26,
+        45,
+        161,
+        35,
+        100,
+        57
+      ]
+    },
+    {
+      "name": "LiquidationRecovered",
+      "discriminator": [
+        191,
+        85,
+        150,
+        51,
+        91,
+        216,
+        43,
+        170
+      ]
+    },
+    {
+      "name": "LoanExtended",
+      "discriminator": [
+        146,
+        18,
+        190,
+        31,
+        50,
+        17,
+        133,
+        1
+      ]
+    },
+    {
+      "name": "LoanFunded",
+      "discriminator": [
+        94,
+        180,
+        111,
+        215,
+        102,
+        39,
+        198,
+        83
+      ]
+    },
+    {
+      "name": "LoanLiquidated",
+      "discriminator": [
+        1,
+        29,
+        28,
+        96,
+        66,
+        95,
+        8,
+        204
+      ]
+    },
+    {
+      "name": "LoanRepaid",
+      "discriminator": [
+        202,
+        183,
+        88,
+        60,
+        211,
+        54,
+        142,
+        243
+      ]
+    },
+    {
+      "name": "PartialRepayment",
+      "discriminator": [
+        168,
+        167,
+        24,
+        229,
+        107,
+        179,
+        36,
+        228
+      ]
+    },
+    {
+      "name": "PoolInitialized",
+      "discriminator": [
+        100,
+        118,
+        173,
+        87,
+        12,
+        198,
+        254,
+        229
+      ]
+    },
+    {
+      "name": "PriceFeedInitialized",
+      "discriminator": [
+        215,
+        208,
+        148,
+        233,
+        198,
+        216,
+        185,
+        183
+      ]
+    },
+    {
+      "name": "PriceUpdated",
+      "discriminator": [
+        154,
+        72,
+        87,
+        150,
+        246,
+        230,
+        23,
+        217
+      ]
+    },
+    {
+      "name": "Withdrawn",
+      "discriminator": [
+        20,
+        89,
+        223,
+        198,
+        194,
+        124,
+        219,
+        13
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidLoanOption",
+      "msg": "Invalid loan option. Must be 0, 1, or 2."
+    },
+    {
+      "code": 6001,
+      "name": "InvalidCollateralAmount",
+      "msg": "Invalid collateral amount."
+    },
+    {
+      "code": 6002,
+      "name": "InvalidCollateralValue",
+      "msg": "Invalid collateral value."
+    },
+    {
+      "code": 6003,
+      "name": "InvalidAmount",
+      "msg": "Invalid amount."
+    },
+    {
+      "code": 6004,
+      "name": "MathOverflow",
+      "msg": "Math overflow."
+    },
+    {
+      "code": 6005,
+      "name": "InsufficientLiquidity",
+      "msg": "Insufficient pool liquidity."
+    },
+    {
+      "code": 6006,
+      "name": "LoanNotActive",
+      "msg": "Loan is not active."
+    },
+    {
+      "code": 6007,
+      "name": "LoanNotDue",
+      "msg": "Loan is not yet due for liquidation."
+    },
+    {
+      "code": 6008,
+      "name": "Unauthorized",
+      "msg": "Unauthorized."
+    },
+    {
+      "code": 6009,
+      "name": "FeeTooHigh",
+      "msg": "Protocol fee too high (max 50%)."
+    },
+    {
+      "code": 6010,
+      "name": "InsufficientShares",
+      "msg": "Insufficient shares."
+    },
+    {
+      "code": 6011,
+      "name": "PoolPaused",
+      "msg": "Pool is paused."
+    },
+    {
+      "code": 6012,
+      "name": "KeeperRewardTooHigh",
+      "msg": "Keeper reward too high (max 20%)."
+    },
+    {
+      "code": 6013,
+      "name": "StalePriceAttestation",
+      "msg": "Price attestation is stale (older than 2 minutes)."
+    },
+    {
+      "code": 6014,
+      "name": "CollateralValueExceedsAttestation",
+      "msg": "Collateral value exceeds attested price beyond tolerance."
+    },
+    {
+      "code": 6015,
+      "name": "PriceMintMismatch",
+      "msg": "Price attestation mint does not match collateral mint."
+    },
+    {
+      "code": 6016,
+      "name": "TwapInsufficientHistory",
+      "msg": "TWAP requires more price history than is currently available."
+    },
+    {
+      "code": 6017,
+      "name": "PriceImpactPumpDetected",
+      "msg": "Spot price is too far above the TWAP \u2014 pump detected, refusing to lend."
+    },
+    {
+      "code": 6018,
+      "name": "PriceTimestampWentBackwards",
+      "msg": "Price sample timestamp went backwards \u2014 clock skew or replay."
+    },
+    {
+      "code": 6019,
+      "name": "InvalidCategory",
+      "msg": "Invalid category. Must be 0 (memecoin) or 1 (RWA)."
+    },
+    {
+      "code": 6020,
+      "name": "AdminWithdrawWouldDrainLpFunds",
+      "msg": "admin_withdraw refused: would drain share-backed LP deposits. Only excess (vault_balance - total_deposits) is admin-withdrawable."
+    },
+    {
+      "code": 6021,
+      "name": "InvalidSlice",
+      "msg": "slice_bps must be in (0, 10000]."
+    },
+    {
+      "code": 6022,
+      "name": "SliceTooSmall",
+      "msg": "Computed slice amount is zero \u2014 collateral too small for this slice_bps."
+    },
+    {
+      "code": 6023,
+      "name": "SliceExceedsRemaining",
+      "msg": "Slice exceeds remaining collateral. Some auto-sells already fired and reduced the pool."
+    },
+    {
+      "code": 6024,
+      "name": "SlippageExceeded",
+      "msg": "Swap returned less than min_sol_out. Slippage exceeded the cap you specified."
+    },
+    {
+      "code": 6025,
+      "name": "SwapMissing",
+      "msg": "convert_collateral_slice requires a swap program + accounts in remaining_accounts. Engine must pre-assemble the swap."
+    },
+    {
+      "code": 6026,
+      "name": "EngineUnauthorized",
+      "msg": "Only the designated engine authority can call convert_collateral_slice. Refusing."
+    },
+    {
+      "code": 6027,
+      "name": "InvalidFeeWallet",
+      "msg": "fee_wallet must equal MAGPIE_FEE_WALLET. The 1% protocol skim is hardcoded to the canonical Magpie fee wallet only."
+    },
+    {
+      "code": 6028,
+      "name": "MinOutBelowOracleFloor",
+      "msg": "min_sol_out is below the on-chain oracle floor. The program refuses fires that could drain collateral via under-priced swaps."
+    },
+    {
+      "code": 6029,
+      "name": "ConversionNotAuthorized",
+      "msg": "[H-02] Conversion not authorized: the loan is not overdue and has no borrower-armed trigger satisfied at the current price. A compromised engine cannot force-sell a healthy, un-armed loan."
+    },
+    {
+      "code": 6030,
+      "name": "InvalidTrigger",
+      "msg": "[H-02] Invalid auto-sell trigger: price must be > 0, direction must be 0 (take-profit) or 1 (stop-loss), and max_slice_bps must be in (0, 10000]."
+    },
+    {
+      "code": 6031,
+      "name": "ExtendRequiresAuthority",
+      "msg": "[M-01] Extension requires the pool authority to co-sign: the loan is not provably healthy on-chain (stale price or under-collateralized)."
+    },
+    {
+      "code": 6032,
+      "name": "PriceChangeExceedsBound",
+      "msg": "[M-04] Price update exceeds the per-update sanity bound (>100x move vs the previous sample). Rejected as a likely fat-finger/unit error; walk the price over multiple updates if the move is genuine."
+    },
+    {
+      "code": 6033,
+      "name": "LoanNotLiquidated",
+      "msg": "[L-02] Loan is not in the Liquidated state \u2014 recovery only applies to a liquidated loan."
+    },
+    {
+      "code": 6034,
+      "name": "SwapProgramNotAllowed",
+      "msg": "Swap program not in the V4.1 allowlist (Jupiter v6 + Orca Whirlpool). Refusing to invoke arbitrary programs as swap routers."
+    },
+    {
+      "code": 6035,
+      "name": "OracleEmpty",
+      "msg": "Oracle sample is empty for this collateral mint. Push at least one update_price sample before firing."
+    },
+    {
+      "code": 6036,
+      "name": "OracleStale",
+      "msg": "Oracle sample is older than MAX_ORACLE_AGE_SECONDS. Engine must push a fresh price sample before this fire."
+    },
+    {
+      "code": 6037,
+      "name": "OracleMintMismatch",
+      "msg": "price_history.mint does not match loan.collateral_mint. Wrong oracle account passed."
+    },
+    {
+      "code": 6038,
+      "name": "OraclePoolMismatch",
+      "msg": "price_history.pool does not match the pool account. Wrong oracle account passed."
+    },
+    {
+      "code": 6039,
+      "name": "UnsupportedCollateralExtension",
+      "msg": "[H-01] Collateral mint carries an unsupported Token-2022 extension (permanent-delegate / non-transferable). Refusing to custody it."
+    },
+    {
+      "code": 6040,
+      "name": "ZeroCollateralReceived",
+      "msg": "[H-01] Collateral vault received zero tokens after the transfer."
+    },
+    {
+      "code": 6041,
+      "name": "CollateralNotConsumed",
+      "msg": "[H-02] The collateral slice was not consumed as swap input \u2014 the engine account still holds it. Refusing."
+    },
+    {
+      "code": 6042,
+      "name": "PoolMismatch",
+      "msg": "[L-05] pool account does not match loan.pool. Wrong pool passed for the oracle floor."
+    },
+    {
+      "code": 6043,
+      "name": "UseRepayLoanForFinalPayment",
+      "msg": "[M-02] A partial repayment must leave a remainder. Use repay_loan for the final payment so collateral is returned and the loan is closed."
+    },
+    {
+      "code": 6044,
+      "name": "LoanFullyRepaid",
+      "msg": "[M-02] Loan has no outstanding debt and cannot be liquidated."
+    },
+    {
+      "code": 6045,
+      "name": "LoanOverdueForExtension",
+      "msg": "[Q-02] Loan is past due and can no longer be extended \u2014 it is liquidatable."
+    },
+    {
+      "code": 6046,
+      "name": "LoanOverdue",
+      "msg": "[H-02] Loan is past due \u2014 the conversion trigger no longer restricts the engine, so it can no longer be armed or disarmed."
+    },
+    {
+      "code": 6047,
+      "name": "PoolInsolvent",
+      "msg": "[L-07] Pool is insolvent (zero deposits, outstanding shares). New deposits are paused until recovery."
+    },
+    {
+      "code": 6048,
+      "name": "WrongWsolMint",
+      "msg": "[I-01] loan_token_mint / wsol_mint must be the canonical Wrapped SOL mint."
+    }
+  ],
+  "types": [
+    {
+      "name": "CollateralAdded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "new_total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollateralConverted",
+      "docs": [
+        "v4 \u2014 Emitted on every convert_collateral_slice call. Captures both",
+        "the gross (pre-fee) and net (post-fee) so off-chain accounting can",
+        "reconcile fee accrual without re-querying state."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "slice_bps",
+            "type": "u16"
+          },
+          {
+            "name": "slice_amount_sold",
+            "type": "u64"
+          },
+          {
+            "name": "sol_received_gross",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "net_sol_to_vault",
+            "type": "u64"
+          },
+          {
+            "name": "remaining_collateral",
+            "type": "u64"
+          },
+          {
+            "name": "total_sol_proceeds",
+            "type": "u64"
+          },
+          {
+            "name": "auto_sells_fired",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConversionArmed",
+      "docs": [
+        "[H-02 \u00b7 Sec3] Borrower armed an on-chain auto-sell trigger."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "trigger_price",
+            "type": "u64"
+          },
+          {
+            "name": "direction",
+            "type": "u8"
+          },
+          {
+            "name": "max_slice_bps",
+            "type": "u16"
+          },
+          {
+            "name": "total_bps",
+            "docs": [
+              "[Q-04] Total authorization across all fires under this arming."
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConversionDisarmed",
+      "docs": [
+        "[H-02 \u00b7 Sec3] Borrower disarmed the on-chain auto-sell trigger."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Deposited",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "depositor",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "shares",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositorPosition",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Depositor wallet"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "docs": [
+              "Which pool this position belongs to"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "shares",
+            "docs": [
+              "Pool shares held"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposited_amount",
+            "docs": [
+              "Cumulative amount deposited (for UI/analytics)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_deposit_ts",
+            "docs": [
+              "Last deposit timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LendingPool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "Pool creator / admin"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "loan_token_vault",
+            "docs": [
+              "PDA token account holding wSOL for loans"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "loan_token_mint",
+            "docs": [
+              "Mint of the loan token (wSOL)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee_bps",
+            "docs": [
+              "Protocol's cut of fees in basis points (e.g. 2000 = 20%)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "keeper_reward_bps",
+            "docs": [
+              "Keeper reward for liquidations in basis points (e.g. 500 = 5% of collateral)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "total_deposits",
+            "docs": [
+              "Total wSOL deposited by liquidity providers"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_shares",
+            "docs": [
+              "Total outstanding shares"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_borrowed",
+            "docs": [
+              "Total wSOL currently lent out"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_fees_earned",
+            "docs": [
+              "Cumulative fees earned"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "pending_fees",
+            "docs": [
+              "[L-03 \u00b7 Sec3] LP-retained fees (pool_cut) that are NOT yet withdrawable",
+              "because their originating loan is still outstanding. Held out of",
+              "total_deposits (LP share value) until the loan repays or liquidates, so",
+              "an LP cannot exit early with a fee whose loan later defaults."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_loans_issued",
+            "docs": [
+              "Cumulative loans issued"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_liquidations",
+            "docs": [
+              "Cumulative liquidations"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "paused",
+            "docs": [
+              "Whether new borrows are paused"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vault_bump",
+            "docs": [
+              "Vault PDA bump"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidationRecovered",
+      "docs": [
+        "[L-02 \u00b7 Sec3] Off-chain SPL-sale proceeds returned to LPs and credited to",
+        "pool.total_deposits (no new shares minted), reconciled to a liquidated loan."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Loan",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan_id",
+            "docs": [
+              "Unique identifier"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "borrower",
+            "docs": [
+              "Borrower's wallet"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "docs": [
+              "Pool this loan was issued from"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_mint",
+            "docs": [
+              "Collateral token mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_vault",
+            "docs": [
+              "PDA vault holding collateral"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_amount",
+            "docs": [
+              "Collateral amount locked (raw units)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "loan_amount",
+            "docs": [
+              "Net loan amount borrower received"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "repay_amount",
+            "docs": [
+              "Amount borrower must repay (decreases with partial repayments)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transaction_fee",
+            "docs": [
+              "Fee charged at origination"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "ltv_bps",
+            "docs": [
+              "LTV in basis points. Memecoin: 2000/2500/3000.",
+              "RWA: 5000/6000/7000. Tier resolved within the loan's category."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "duration_days",
+            "docs": [
+              "Loan duration in days"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "start_timestamp",
+            "docs": [
+              "When loan was funded"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "due_timestamp",
+            "docs": [
+              "When repayment is due"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Loan status"
+            ],
+            "type": {
+              "defined": {
+                "name": "LoanStatus"
+              }
+            }
+          },
+          {
+            "name": "collateral_value_at_start",
+            "docs": [
+              "Collateral value at loan creation (in loan token units)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump for loan account"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "vault_bump",
+            "docs": [
+              "PDA bump for collateral vault"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "category",
+            "docs": [
+              "Loan category (0 = memecoin, 1 = RWA). Used by extend_loan to",
+              "pick the right tier ladder without a round-trip to off-chain",
+              "metadata."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "current_collateral_amount",
+            "docs": [
+              "SPL collateral remaining in the vault. Equals collateral_amount",
+              "at borrow time, decreases as convert_collateral_slice fires.",
+              "Reaches 0 when the position is fully auto-sold. At repay /",
+              "liquidation time, whatever is here gets returned to the borrower",
+              "(alongside sol_proceeds_amount)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sol_proceeds_amount",
+            "docs": [
+              "SOL accumulated from auto-sells (in lamports, net of the 1%",
+              "protocol fee). Sits in a vault-owned wSOL token account whose",
+              "authority is the loan's collateral_vault PDA, so the engine",
+              "can credit it on conversions but only the borrower can claim it",
+              "(via repay) or the keeper can claim it (via liquidate)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "auto_sells_fired",
+            "docs": [
+              "Number of times convert_collateral_slice has fired against this",
+              "loan. Diagnostics only \u2014 no contract invariant depends on it."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "accrued_pool_fees",
+            "docs": [
+              "[L-03 \u00b7 Sec3] LP-retained fee (pool_cut) this loan has accrued at",
+              "origination + each extension. Held in pool.pending_fees while the loan is",
+              "active; realized into pool.total_deposits when the loan repays or",
+              "liquidates. Prevents LPs from withdrawing unearned fee before the loan",
+              "resolves."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "armed_trigger_price",
+            "docs": [
+              "Borrower-armed trigger price (lamports per WHOLE collateral token,",
+              "same unit as the price feed). `convert_collateral_slice` may fire",
+              "ONLY when the loan is overdue OR this trigger is armed (> 0) AND the",
+              "current price has reached it. A compromised engine cannot force-sell",
+              "a healthy, un-armed loan. 0 = disarmed."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "armed_trigger_direction",
+            "docs": [
+              "Direction of the armed trigger: 0 = take-profit (fire when spot price",
+              "RISES to >= armed_trigger_price \u2014 captures upside spikes), 1 =",
+              "stop-loss (fire when spot price FALLS to <= armed_trigger_price).",
+              "Ignored while disarmed."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "armed_max_slice_bps",
+            "docs": [
+              "Max slice (bps of ORIGINAL collateral) the engine may convert per fire",
+              "under the armed order. A single conversion cannot exceed this. The",
+              "engine still cannot exceed the remaining collateral. 0 while disarmed."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "armed_total_bps",
+            "docs": [
+              "[Q-04 \u00b7 Sec3] TOTAL bps of original collateral the engine may convert",
+              "across ALL fires under the current arming. This is deliberately separate",
+              "from `armed_max_slice_bps`: that one bounds a SINGLE fire, this one",
+              "bounds the aggregate. Collapsing the two would have capped a ladder at",
+              "its largest leg \u2014 a 70/20/10 take-profit ladder needs a 70% per-fire cap",
+              "but 100% of total authorization \u2014 so the product needs both numbers."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "armed_converted_bps",
+            "docs": [
+              "[Q-04 \u00b7 Sec3] Running total of slice_bps already converted under the",
+              "CURRENT armed trigger. Without it, the cap applied per call rather than",
+              "in aggregate, so the engine could drain a position in successive slices",
+              "while the trigger stayed satisfied \u2014 making the borrower's authorization",
+              "meaningless. Reset to 0 whenever the trigger is armed or disarmed."
+            ],
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanExtended",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_due_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "extension_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanFunded",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_amount",
+            "type": "u64"
+          },
+          {
+            "name": "loan_amount",
+            "type": "u64"
+          },
+          {
+            "name": "fee",
+            "type": "u64"
+          },
+          {
+            "name": "ltv_bps",
+            "type": "u16"
+          },
+          {
+            "name": "duration_days",
+            "type": "u8"
+          },
+          {
+            "name": "category",
+            "docs": [
+              "0 = memecoin, 1 = RWA. Off-chain indexers can filter loans",
+              "by category without joining against the off-chain mint table."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanLiquidated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "keeper",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_seized_spl",
+            "type": "u64"
+          },
+          {
+            "name": "proceeds_seized_wsol",
+            "type": "u64"
+          },
+          {
+            "name": "keeper_reward_spl",
+            "type": "u64"
+          },
+          {
+            "name": "keeper_reward_wsol",
+            "type": "u64"
+          },
+          {
+            "name": "authority_amount_spl",
+            "docs": [
+              "Unsold SPL collateral sent to the pool authority for off-chain sale",
+              "(later reconciled to LPs via recover_liquidated_collateral, L-02)."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lp_recovered_wsol",
+            "docs": [
+              "[I-02 \u00b7 Sec3] Recovered wSOL proceeds routed to the LP vault + credited",
+              "to pool.total_deposits (L-02). Renamed from `authority_amount_wsol`,",
+              "which was misleading \u2014 this value goes to the LP vault, NOT the authority."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "collateral_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan_token_mint",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanRepaid",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "repay_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LoanStatus",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Repaid"
+          },
+          {
+            "name": "Liquidated"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartialRepayment",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "loan",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "remaining",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee_bps",
+            "type": "u16"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceFeedInitialized",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceHistory",
+      "docs": [
+        "Rolling ring buffer of price samples per mint. Replaces the v2",
+        "`PriceHistory` single-spot design. TWAP is computed over the",
+        "samples within `TWAP_WINDOW_SECONDS`; samples outside the window",
+        "remain in the buffer (so we don't lose capacity) but are excluded",
+        "from the average.",
+        "",
+        "Updates are append-only at `head_index`, which wraps around. After",
+        "the buffer fills once, `count = PRICE_HISTORY_CAPACITY` and",
+        "`head_index` keeps advancing modulo capacity (oldest slot is",
+        "overwritten next). Order in the array is not chronological after",
+        "wrap \u2014 readers must use `head_index` + `count` to walk it."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "Token mint this history covers"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "docs": [
+              "Pool this history belongs to"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Authority allowed to append samples"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "head_index",
+            "docs": [
+              "Index of the slot that will receive the NEXT sample (wraps)."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "count",
+            "docs": [
+              "How many slots in `samples` are populated (caps at capacity)."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserved for future use / forces alignment."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "samples",
+            "docs": [
+              "Ring buffer of samples. Newest sample lives at",
+              "`samples[(head_index - 1 + capacity) % capacity]` when count > 0."
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "PriceSample"
+                  }
+                },
+                32
+              ]
+            }
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "PDA bump"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceSample",
+      "docs": [
+        "One sample in the rolling price history. Compact 16-byte layout."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "price_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PriceUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "price_lamports",
+            "type": "u64"
+          },
+          {
+            "name": "confidence_bps",
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Withdrawn",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "depositor",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "shares",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/solana/v4-arm-conversion.js
+++ b/src/solana/v4-arm-conversion.js
@@ -1,0 +1,121 @@
+/**
+ * V4.1 borrower-armed conversion triggers — `arm_conversion` / `disarm_conversion`.
+ *
+ * These instructions are the on-chain borrower CONSENT that gates
+ * `convert_collateral_slice` (Sec3 H-02). Without an armed trigger, or an
+ * overdue loan, the engine cannot move a single token of collateral.
+ *
+ * TWO CAPS, and getting the difference right is the whole job of this file
+ * (Sec3 Q-04):
+ *
+ *   max_slice_bps — the most a SINGLE fire may take
+ *   total_bps     — the most ALL fires may take under this arming
+ *
+ * A laddered exit fires several legs under one arming. If both numbers were set
+ * to the same value the ladder would die at its largest leg: a 70/20/10
+ * take-profit ladder needs a 70% per-fire cap but 100% of total authorization,
+ * so leg 2 would be refused on-chain. Hence `deriveArmingCaps` below —
+ * per-fire is the LARGEST leg, total is the SUM.
+ *
+ * ⚠️ V4.1 ONLY. These instructions DO NOT EXIST in the deployed V4 program
+ * (HA1hgvskN1go…), and V4.1 also changes the Loan account layout. Every entry
+ * point here refuses to build unless PROGRAM_ID_V4_1 is explicitly configured,
+ * so this can never be aimed at the live program by accident.
+ */
+import { PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+
+/** take-profit: fire when spot RISES to >= trigger. */
+export const DIRECTION_TAKE_PROFIT = 0;
+/** stop-loss: fire when spot FALLS to <= trigger. */
+export const DIRECTION_STOP_LOSS = 1;
+
+const BPS_MAX = 10_000;
+
+/**
+ * Turn an exit spec into the two on-chain caps.
+ *
+ * @param {Array<{slicePct:number}>} legs one entry per ladder leg; a single
+ *        take-profit or stop-loss is just a one-leg ladder.
+ * @returns {{maxSliceBps:number, totalBps:number}}
+ */
+export function deriveArmingCaps(legs) {
+  if (!Array.isArray(legs) || legs.length === 0) {
+    throw new Error("arming: at least one leg is required");
+  }
+
+  const bps = legs.map((l, i) => {
+    const pct = Number(l?.slicePct);
+    if (!Number.isFinite(pct) || pct <= 0) {
+      throw new Error(`arming: leg ${i + 1} has a non-positive slice`);
+    }
+    // Percent → bps. Round rather than truncate so a leg can't quietly shrink.
+    return Math.round(pct * 100);
+  });
+
+  const totalBps = bps.reduce((a, b) => a + b, 0);
+  const maxSliceBps = Math.max(...bps);
+
+  if (totalBps > BPS_MAX) {
+    throw new Error(
+      `arming: legs sum to ${totalBps / 100}% — cannot exceed 100% of the original collateral`,
+    );
+  }
+  // Invariant the program also enforces; assert here so a bad spec fails in the
+  // bot with a readable message instead of as an opaque on-chain error.
+  if (maxSliceBps > totalBps) {
+    throw new Error("arming: per-fire cap cannot exceed the total authorization");
+  }
+
+  return { maxSliceBps, totalBps };
+}
+
+function v41ProgramId() {
+  const raw = process.env.PROGRAM_ID_V4_1;
+  if (!raw) {
+    throw new Error(
+      "arm_conversion is V4.1-only and PROGRAM_ID_V4_1 is not set. " +
+        "Refusing to build — the deployed V4 program has no such instruction.",
+    );
+  }
+  return new PublicKey(raw);
+}
+
+/**
+ * Build an `arm_conversion` instruction.
+ *
+ * @param {import("@coral-xyz/anchor").Program} program V4.1 Anchor program
+ * @param {object} p
+ * @param {PublicKey} p.loan
+ * @param {PublicKey} p.borrower must sign
+ * @param {number|bigint} p.triggerPrice lamports per WHOLE collateral token
+ * @param {number} p.direction DIRECTION_TAKE_PROFIT | DIRECTION_STOP_LOSS
+ * @param {Array<{slicePct:number}>} p.legs the exit spec (1 leg = simple TP/SL)
+ */
+export async function buildArmConversionIx(program, { loan, borrower, triggerPrice, direction, legs }) {
+  const expected = v41ProgramId();
+  if (!program.programId.equals(expected)) {
+    throw new Error("arm_conversion: program is not the configured V4.1 program");
+  }
+  if (direction !== DIRECTION_TAKE_PROFIT && direction !== DIRECTION_STOP_LOSS) {
+    throw new Error("arm_conversion: direction must be 0 (take-profit) or 1 (stop-loss)");
+  }
+  const price = BigInt(triggerPrice);
+  if (price <= 0n) throw new Error("arm_conversion: trigger price must be > 0");
+
+  const { maxSliceBps, totalBps } = deriveArmingCaps(legs);
+
+  return program.methods
+    .armConversion(new BN(price.toString()), direction, maxSliceBps, totalBps)
+    .accounts({ loan, borrower })
+    .instruction();
+}
+
+/** Build a `disarm_conversion` instruction. Borrower must sign. */
+export async function buildDisarmConversionIx(program, { loan, borrower }) {
+  const expected = v41ProgramId();
+  if (!program.programId.equals(expected)) {
+    throw new Error("disarm_conversion: program is not the configured V4.1 program");
+  }
+  return program.methods.disarmConversion().accounts({ loan, borrower }).instruction();
+}

--- a/src/solana/v4-arm-conversion.js
+++ b/src/solana/v4-arm-conversion.js
@@ -24,51 +24,16 @@
  */
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
+import { deriveArmingCaps } from "./arming-caps.js";
+
+// The cap arithmetic lives in ./arming-caps.js — no web3 imports there, so
+// the CI guard can verify it without an install step.
+export { deriveArmingCaps };
 
 /** take-profit: fire when spot RISES to >= trigger. */
 export const DIRECTION_TAKE_PROFIT = 0;
 /** stop-loss: fire when spot FALLS to <= trigger. */
 export const DIRECTION_STOP_LOSS = 1;
-
-const BPS_MAX = 10_000;
-
-/**
- * Turn an exit spec into the two on-chain caps.
- *
- * @param {Array<{slicePct:number}>} legs one entry per ladder leg; a single
- *        take-profit or stop-loss is just a one-leg ladder.
- * @returns {{maxSliceBps:number, totalBps:number}}
- */
-export function deriveArmingCaps(legs) {
-  if (!Array.isArray(legs) || legs.length === 0) {
-    throw new Error("arming: at least one leg is required");
-  }
-
-  const bps = legs.map((l, i) => {
-    const pct = Number(l?.slicePct);
-    if (!Number.isFinite(pct) || pct <= 0) {
-      throw new Error(`arming: leg ${i + 1} has a non-positive slice`);
-    }
-    // Percent → bps. Round rather than truncate so a leg can't quietly shrink.
-    return Math.round(pct * 100);
-  });
-
-  const totalBps = bps.reduce((a, b) => a + b, 0);
-  const maxSliceBps = Math.max(...bps);
-
-  if (totalBps > BPS_MAX) {
-    throw new Error(
-      `arming: legs sum to ${totalBps / 100}% — cannot exceed 100% of the original collateral`,
-    );
-  }
-  // Invariant the program also enforces; assert here so a bad spec fails in the
-  // bot with a readable message instead of as an opaque on-chain error.
-  if (maxSliceBps > totalBps) {
-    throw new Error("arming: per-fire cap cannot exceed the total authorization");
-  }
-
-  return { maxSliceBps, totalBps };
-}
 
 function v41ProgramId() {
   const raw = process.env.PROGRAM_ID_V4_1;


### PR DESCRIPTION
Sec3 **Q-04** added a second cap to `arm_conversion`, so the bot has to supply it:

| arg | bounds |
|---|---|
| `max_slice_bps` | the most a **single** fire may take |
| `total_bps` | the most **all** fires may take under one arming |

## Why this is its own module
Deriving these wrongly fails **quietly, in the worst way**: a ladder arms fine, fires its first leg, and every later leg is refused on-chain. The user just sees a ladder that stopped working partway down.

So the derivation is explicit — **per-fire is the largest leg, total is the sum**. A 70/20/10 take-profit ladder arms as `(7000, 10000)` and all three legs fire. Collapsing the two numbers onto one would cap the ladder at its largest leg.

## Guarded, not assumed
`scripts/check-arming-caps.mjs` pins the derivation: the real 70/20/10 ladder, single-leg exits, partial ladders, fractional legs rounding rather than truncating, over-100% refused, and garbage specs refused rather than producing a silently-zero authorization.

**Verified the guard actually fails** — collapsing total onto the per-fire cap makes it exit 1 naming the broken cases:
```
✕ ladder total is the SUM of legs — got 7000
✕ total must exceed the largest leg for a multi-leg ladder
[arming-caps] 5 check(s) failed — laddered exits would break on-chain.
```
Dependency-free, wired into CI like the repo's other guards. `npm run check:arming` locally.

## Safety — nothing here touches live
These instructions **do not exist in the deployed V4 program**, and V4.1 also changes the `Loan` account layout. Every entry point **refuses to build unless `PROGRAM_ID_V4_1` is explicitly set**, and the bundled V4.1 IDL ships with a **zeroed address** so it can't be loaded and aimed at the live program by accident. The live borrow/exit path is untouched.

Wire-up into the borrow/exit flow comes with the coordinated new-id deploy, which is still operator-gated on Sec3 sign-off.