### PR TITLE
feat: route V4.1 accounts to their own IDL, before they can be misread

### DIFF
--- a/.github/workflows/idl-routing.yml
+++ b/.github/workflows/idl-routing.yml
@@ -1,0 +1,29 @@
+# V4.1 accounts must never be decoded with the V4 IDL. The layouts diverge and
+# Anchor does NOT throw on the mismatch — it reads later fields at the wrong
+# offset, which means wrong collateral and debt in repay math, silently.
+name: idl-routing
+on:
+  pull_request:
+    paths:
+      - "src/solana/program.js"
+      - "src/solana/idl/magpie-v4.json"
+      - "src/solana/idl/magpie-v4-1.json"
+      - "scripts/check-idl-routing.mjs"
+      - ".github/workflows/idl-routing.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/solana/program.js"
+      - "src/solana/idl/magpie-v4-1.json"
+      - "scripts/check-idl-routing.mjs"
+jobs:
+  routing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # Dependency-free by design, like the repo's other guards — no install
+      # step to break.
+      - run: node scripts/check-idl-routing.mjs

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test-signed": "node scripts/test-signed-endpoints.js",
     "preflight": "npm run check-site && npm run test-signed",
     "verify:tier2": "node scripts/verify-tier2/run.js",
-    "check:arming": "node scripts/check-arming-caps.mjs"
+    "check:arming": "node scripts/check-arming-caps.mjs",
+    "check:idl": "node scripts/check-idl-routing.mjs"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/check-idl-routing.mjs
+++ b/scripts/check-idl-routing.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Guard: V4.1 accounts must never be decoded with the V4 IDL.
+ *
+ * V4.1 deploys at a NEW program id and its account layouts diverge from V4 —
+ * Loan appends accrued_pool_fees plus five borrower-armed trigger fields, and
+ * LendingPool appends pending_fees.
+ *
+ * Decoding a V4.1 account with the V4 IDL DOES NOT THROW. Anchor reads every
+ * field past the divergence at the wrong offset, so the failure looks like
+ * plausible-but-wrong collateral and debt numbers — which feed repay math.
+ * That is funds-adjacent, not cosmetic, and it is silent.
+ *
+ * This is the same class of bug the repo already hit twice (V2 fee_wallet
+ * 2026-06-12, V3 Loan size 2026-06-14), which is why the routing exists at all.
+ *
+ * Dependency-free on purpose, like the repo's other guards: it reads the IDL
+ * JSON directly and checks the routing order in source, so it runs in CI with
+ * no install step.
+ *
+ * Usage: node scripts/check-idl-routing.mjs   ·   exit 0 clean, 1 regressed
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const idlDir = path.join(dir, "..", "src", "solana", "idl");
+const v4 = JSON.parse(readFileSync(path.join(idlDir, "magpie-v4.json"), "utf8"));
+const v41 = JSON.parse(readFileSync(path.join(idlDir, "magpie-v4-1.json"), "utf8"));
+const programSrc = readFileSync(path.join(dir, "..", "src", "solana", "program.js"), "utf8");
+
+let failed = 0;
+const fail = (msg) => { failed++; console.error(`✕ ${msg}`); };
+
+const fields = (idl, name) => {
+  const t = (idl.types || []).find((x) => x.name === name);
+  return t ? t.type.fields.map((f) => f.name) : null;
+};
+
+// 1. The hazard must actually exist — if the layouts ever converge, this guard
+//    is obsolete and should be reconsidered rather than silently passing.
+for (const acct of ["Loan", "LendingPool"]) {
+  const a = fields(v4, acct);
+  const b = fields(v41, acct);
+  if (!a || !b) { fail(`${acct} missing from one of the IDLs`); continue; }
+  if (JSON.stringify(a) === JSON.stringify(b)) {
+    fail(`${acct} layouts are identical across V4 and V4.1 — routing may no longer be needed; re-check before deleting it`);
+    continue;
+  }
+  const diverge = a.findIndex((f, i) => b[i] !== f);
+  const at = diverge === -1 ? a.length : diverge;
+  console.log(`  ${acct}: layouts diverge at field index ${at} (V4 has ${a.length} fields, V4.1 has ${b.length}) — wrong IDL = wrong values, silently`);
+}
+
+// 2. They must be genuinely different interfaces.
+const ix = (idl) => new Set(idl.instructions.map((i) => i.name));
+const only41 = [...ix(v41)].filter((n) => !ix(v4).has(n));
+if (!only41.includes("arm_conversion")) {
+  fail("V4.1 IDL has no arm_conversion — wrong file committed?");
+}
+if (ix(v4).has("arm_conversion")) {
+  fail("the DEPLOYED V4 IDL contains arm_conversion — it must not; that instruction is V4.1-only");
+}
+
+// 3. The V4.1 branch must be checked BEFORE V4 in every IDL-selection chain.
+//    Appending it after V4 would still compile and still look right in review,
+//    but V4 would win for a V4.1 program id and we'd be back to silent
+//    mis-deserialization.
+const chains = [...programSrc.matchAll(/let useIdl = idl;([\s\S]*?)return new Program/g)];
+if (chains.length === 0) fail("could not find any IDL-selection chain in program.js");
+chains.forEach((m, i) => {
+  const body = m[1];
+  const p41 = body.indexOf("PROGRAM_ID_V4_1");
+  const p4 = body.indexOf("PROGRAM_ID_V4 ");
+  if (p41 === -1) fail(`IDL-selection chain #${i + 1} does not handle PROGRAM_ID_V4_1`);
+  else if (p4 !== -1 && p41 > p4) {
+    fail(`IDL-selection chain #${i + 1} checks V4 before V4.1 — a V4.1 program id would decode with the V4 IDL`);
+  }
+});
+
+// 4. The shipped V4.1 IDL must not carry a real address; the id comes from env.
+if (v41.address !== "11111111111111111111111111111111") {
+  fail(`V4.1 IDL address is ${v41.address} — it must stay the 111…111 placeholder so it can't be aimed at a live program; the real id comes from PROGRAM_ID_V4_1`);
+}
+
+if (failed) {
+  console.error(`\n[idl-routing] ${failed} check(s) failed — V4.1 accounts could be decoded with the V4 layout.`);
+  process.exit(1);
+}
+console.log(`[idl-routing] OK — V4.1 routes to its own IDL in ${chains.length} selection chain(s).`);

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -56,6 +56,22 @@ function getV4Idl() {
   return _idlV4;
 }
 
+// V4.1 IDL — the post-Sec3 remediation build. It deploys at a NEW program id,
+// and its account layouts DIVERGE from V4: Loan appends accrued_pool_fees plus
+// the five borrower-armed trigger fields, and LendingPool appends pending_fees.
+//
+// This is the same hazard the V3 comment above describes, and it is the reason
+// this loader exists rather than reusing getV4Idl(): decoding a V4.1 Loan with
+// the V4 IDL does NOT throw, it reads every field past the divergence at the
+// wrong offset. That means wrong collateral and wrong debt in repay math —
+// funds-adjacent, not cosmetic.
+const idlPathV41 = path.join(__dirname, "idl", "magpie-v4-1.json");
+let _idlV41 = null;
+function getV41Idl() {
+  if (!_idlV41) _idlV41 = JSON.parse(readFileSync(idlPathV41, "utf8"));
+  return _idlV41;
+}
+
 export const PROGRAM_ID = new PublicKey(
   process.env.PROGRAM_ID || idl.address,
 );
@@ -102,6 +118,12 @@ const ROUTE_RWA_TO_V3 = process.env.ROUTE_RWA_TO_V3 === "true";
 // because each loan row stores its own program_id.
 export const PROGRAM_ID_V4 = process.env.PROGRAM_ID_V4
   ? new PublicKey(process.env.PROGRAM_ID_V4)
+  : null;
+
+// V4.1 — undeployed as of 2026-08-07. Stays null until the operator sets the
+// env after a signed-off deploy, so nothing can route to it accidentally.
+export const PROGRAM_ID_V4_1 = process.env.PROGRAM_ID_V4_1
+  ? new PublicKey(process.env.PROGRAM_ID_V4_1)
   : null;
 const ROUTE_MEMECOINS_TO_V4 = process.env.ROUTE_MEMECOINS_TO_V4 === "true";
 const ROUTE_RWA_TO_V4 = process.env.ROUTE_RWA_TO_V4 === "true";
@@ -302,7 +324,11 @@ export function getReadOnlyProgram(programId = PROGRAM_ID) {
   // divergence — caught the missing V2 fee_wallet during 2026-06-12
   // and the V3 Loan size mismatch during 2026-06-14.
   let useIdl = idl;
-  if (PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4)) {
+  if (PROGRAM_ID_V4_1 && programId.equals(PROGRAM_ID_V4_1)) {
+    // Checked BEFORE V4: the two are different programs with different Loan
+    // layouts, and V4 must never be the fallback for a V4.1 account.
+    useIdl = getV41Idl();
+  } else if (PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4)) {
     useIdl = getV4Idl();
   } else if (PROGRAM_ID_V3 && programId.equals(PROGRAM_ID_V3)) {
     useIdl = getV3Idl();
@@ -328,7 +354,11 @@ export function getProgramForSigner(signerKeypair, programId = PROGRAM_ID) {
   // 2026-06-14 on the SPCX TG borrow path. Mirrors the same IDL
   // selection getReadOnlyProgram does above.
   let useIdl = idl;
-  if (PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4)) {
+  if (PROGRAM_ID_V4_1 && programId.equals(PROGRAM_ID_V4_1)) {
+    // Checked BEFORE V4: the two are different programs with different Loan
+    // layouts, and V4 must never be the fallback for a V4.1 account.
+    useIdl = getV41Idl();
+  } else if (PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4)) {
     useIdl = getV4Idl();
   } else if (PROGRAM_ID_V3 && programId.equals(PROGRAM_ID_V3)) {
     useIdl = getV3Idl();


### PR DESCRIPTION
V4.1 deploys at a new program id with **different account layouts**. Decoding a V4.1 account with the V4 IDL **does not throw** — Anchor reads every field past the divergence at the wrong offset, so it surfaces as plausible-but-wrong collateral and debt, which feed **repay math**. Silent and funds-adjacent.

This repo has already been bitten twice by exactly this (V2 `fee_wallet` on 2026-06-12, V3 `Loan` size on 2026-06-14) — which is why the routing exists at all. V4.1 just needed the same treatment **before its first loan exists**, rather than being left as a deploy-day checklist item.

### Checking the IDLs made it worse than expected
| account | change | consequence under the V4 layout |
|---|---|---|
| `Loan` | 6 fields **appended** | only the new tail misreads |
| `LendingPool` | `pending_fees` **inserted at index 9** | `total_loans_issued`, `total_liquidations`, **`paused`**, **`bump`**, **`vault_bump`** all shift |

A misread `paused` flips a pool's operational state in our view; a misread `vault_bump` **breaks PDA derivation outright**. That's the one that makes this a blocker rather than a nice-to-have.

### The guard checks order, not just presence
The V4.1 branch is checked **before** V4 in both selection chains. Appending it after would compile, review fine, and quietly hand V4.1 ids to the V4 IDL. So `check-idl-routing.mjs` verifies the ordering — and I confirmed it fails when flipped:
```
✕ IDL-selection chain #1 checks V4 before V4.1 — a V4.1 program id would decode with the V4 IDL
✕ IDL-selection chain #2 checks V4 before V4.1 — ...
exit 1
```
It also fails if the layouts ever converge (guard would be obsolete — worth a human look, not a silent pass), and if the shipped V4.1 IDL ever carries a real address instead of the `111…111` placeholder.

Dependency-free, like the repo's other guards. `npm run check:idl`.

### Nothing routes anywhere new today
`PROGRAM_ID_V4_1` is unset, so the branch is **inert** and existing V4/V3/V1 flows are untouched.