### PR TITLE
feat: build the V4.1 account lists, so deploy day is mechanical

### DIFF
--- a/.github/workflows/v41-accounts.yml
+++ b/.github/workflows/v41-accounts.yml
@@ -1,0 +1,27 @@
+# V4.1 changes several account lists. A missing account fails on-chain with
+# AccountNotEnoughKeys and takes the instruction with it — exactly how V4
+# launch day went. This pins the IDL delta against what the call sites build.
+name: v41-accounts
+on:
+  pull_request:
+    paths:
+      - "src/solana/idl/magpie-v4*.json"
+      - "src/services/keeper.js"
+      - "src/services/loans.js"
+      - "src/api/agent-manage.js"
+      - "scripts/check-v41-accounts.mjs"
+      - ".github/workflows/v41-accounts.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/solana/idl/magpie-v4*.json"
+      - "scripts/check-v41-accounts.mjs"
+jobs:
+  accounts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: node scripts/check-v41-accounts.mjs

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "preflight": "npm run check-site && npm run test-signed",
     "verify:tier2": "node scripts/verify-tier2/run.js",
     "check:arming": "node scripts/check-arming-caps.mjs",
-    "check:idl": "node scripts/check-idl-routing.mjs"
+    "check:idl": "node scripts/check-idl-routing.mjs",
+    "check:v41": "node scripts/check-v41-accounts.mjs"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/check-v41-accounts.mjs
+++ b/scripts/check-v41-accounts.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Guard: the V4.1 account-list deltas we build for must match the IDL.
+ *
+ * A missing account surfaces on-chain as `AccountNotEnoughKeys` and takes the
+ * instruction with it. That is exactly how V4 launch day went — the code
+ * comments in keeper.js record it: "Without these, every V4 overdue loan fails
+ * with AccountNotEnoughKeys and stays uncollected." An extra or mis-ordered
+ * account fails just as hard.
+ *
+ * So rather than trusting that someone re-reads the IDL after each audit round,
+ * this pins the delta. If Sec3's next round adds an account to any of these
+ * instructions, this fails and names it — instead of the deploy discovering it.
+ *
+ * Dependency-free (reads the IDL JSON and the call sites as text), so it runs
+ * in CI with no install step, like the repo's other guards.
+ *
+ * Usage: node scripts/check-v41-accounts.mjs   ·   exit 0 clean, 1 drifted
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(dir, "..");
+const idl = (f) => JSON.parse(readFileSync(path.join(root, "src", "solana", "idl", f), "utf8"));
+const v4 = idl("magpie-v4.json");
+const v41 = idl("magpie-v4-1.json");
+
+let failed = 0;
+const fail = (m) => { failed++; console.error(`✕ ${m}`); };
+
+const accounts = (i, name) => {
+  const ix = i.instructions.find((x) => x.name === name);
+  return ix ? ix.accounts.map((a) => a.name) : null;
+};
+
+/**
+ * The deltas we have built for. Keep this in step with the call sites — it is
+ * the whole point of the guard.
+ */
+const EXPECTED_DELTA = {
+  extend_loan: ["collateral_mint", "price_history", "authority"],
+  liquidate_loan: ["loan_token_vault"],
+  convert_collateral_slice: ["price_history", "pool"],
+};
+
+for (const [ixName, expected] of Object.entries(EXPECTED_DELTA)) {
+  const a = accounts(v4, ixName);
+  const b = accounts(v41, ixName);
+  if (!a || !b) { fail(`${ixName}: missing from one of the IDLs`); continue; }
+  const added = b.filter((n) => !a.includes(n));
+  const removed = a.filter((n) => !b.includes(n));
+  if (removed.length) {
+    fail(`${ixName}: V4.1 REMOVED account(s) ${removed.join(", ")} — call sites will pass a key the program no longer wants`);
+  }
+  if (JSON.stringify(added) !== JSON.stringify(expected)) {
+    fail(`${ixName}: account delta is [${added.join(", ")}], expected [${expected.join(", ")}] — a call site needs updating, or this guard does`);
+  } else {
+    console.log(`  ${ixName}: +${added.join(", ")}`);
+  }
+}
+
+/**
+ * The call sites must actually supply the REQUIRED additions. `authority` on
+ * extend_loan is optional by design (a provably-healthy loan self-extends), so
+ * it is deliberately excluded from this check.
+ */
+const REQUIRED_AT_CALLSITE = {
+  "src/services/loans.js": ["collateralMint", "priceHistory"],
+  "src/api/agent-manage.js": ["collateralMint", "priceHistory"],
+  "src/services/keeper.js": ["loanTokenVault"],
+};
+
+for (const [file, keys] of Object.entries(REQUIRED_AT_CALLSITE)) {
+  const src = readFileSync(path.join(root, file), "utf8");
+  if (!src.includes("PROGRAM_ID_V4_1")) {
+    fail(`${file}: builds a V4-family instruction but never checks PROGRAM_ID_V4_1`);
+    continue;
+  }
+  for (const k of keys) {
+    // Must be ASSIGNED into the accounts object, not merely mentioned. A bare
+    // substring match passes on unrelated identifiers (`loanTokenVaultPda`),
+    // which made an earlier version of this guard unable to fail.
+    const assigned = new RegExp(`\\.\\s*${k}\\s*=|\\b${k}\\s*:`).test(src);
+    if (!assigned) fail(`${file}: never assigns '${k}' into the V4.1 account list`);
+  }
+}
+
+/**
+ * convert_collateral_slice is NOT built in this repo (the engine assembles it).
+ * Recorded so nobody hunts for a call site that doesn't exist — and so this
+ * fails loudly if one is ever added without the V4.1 accounts.
+ */
+const buildsConvert = ["src/services", "src/api"].some((d) => {
+  try {
+    return readFileSync(path.join(root, d, "keeper.js"), "utf8").includes(".convertCollateralSlice(");
+  } catch { return false; }
+});
+if (buildsConvert) {
+  fail("a call site now builds convertCollateralSlice — it needs price_history + pool for V4.1");
+}
+
+if (failed) {
+  console.error(`\n[v41-accounts] ${failed} problem(s) — a V4.1 instruction would fail with AccountNotEnoughKeys.`);
+  process.exit(1);
+}
+console.log("[v41-accounts] OK — IDL deltas match what the call sites build.");

--- a/src/api/agent-manage.js
+++ b/src/api/agent-manage.js
@@ -38,7 +38,7 @@ import BN from "bn.js";
 import { query } from "../db/pool.js";
 import { connection, withFailover } from "../solana/connection.js";
 import { getDynamicPriorityFee } from "../solana/priority-fee.js";
-import { chooseProgramIdForLoan, getProgramForSigner } from "../solana/program.js";
+import { chooseProgramIdForLoan, getProgramForSigner, PROGRAM_ID_V4_1 } from "../solana/program.js";
 import { rejectIfSiteDisabled } from "../services/site-global.js";
 import { rejectIfLocked } from "../services/site-lock.js";
 import {
@@ -207,6 +207,20 @@ export async function handleAgentBuildExtend(req) {
       createCloseAccountInstruction(borrowerWsolAta, borrowerPk, borrowerPk, [], loanTokenProgram),
     ];
 
+    // V4.1 (Sec3 M-01): extend_loan re-checks collateral health on-chain and so
+    // additionally takes collateral_mint + price_history. `authority` is an
+    // OPTIONAL signer; we deliberately don't pass it, so an unhealthy loan
+    // fails loudly instead of being silently co-signed into an extension.
+    // Inert until PROGRAM_ID_V4_1 is set after a signed-off deploy.
+    const v41ExtendAccounts = {};
+    if (PROGRAM_ID_V4_1 && programId.equals(PROGRAM_ID_V4_1)) {
+      const { priceFeedPda } = await import("../solana/pdas.js");
+      const extendCollateralMint = new PublicKey(loan.collateral_mint);
+      const [priceHistoryPda] = priceFeedPda(extendCollateralMint, lendingPool, programId);
+      v41ExtendAccounts.collateralMint = extendCollateralMint;
+      v41ExtendAccounts.priceHistory = priceHistoryPda;
+    }
+
     const ix = await program.methods
       .extendLoan()
       .accounts({
@@ -217,6 +231,7 @@ export async function handleAgentBuildExtend(req) {
         feeWalletTokenAccount: feeWalletWsolAta,
         borrower: borrowerPk,
         loanTokenProgram,
+        ...v41ExtendAccounts,
       })
       .preInstructions(preIxs).postInstructions(postIxs).instruction();
 

--- a/src/services/keeper.js
+++ b/src/services/keeper.js
@@ -38,6 +38,7 @@ import {
   PROGRAM_ID_V2,
   PROGRAM_ID_V3,
   PROGRAM_ID_V4,
+  PROGRAM_ID_V4_1,
 } from "../solana/program.js";
 import { lendingPoolPda } from "../solana/pdas.js";
 import { readFileSync } from "node:fs";
@@ -151,12 +152,18 @@ async function liquidateLoan(program, keeper, loan, pool) {
   // SOL in sol_proceeds_vault). Without these, every V4 overdue loan
   // fails with AccountNotEnoughKeys and stays uncollected.
   const isV4 = PROGRAM_ID_V4 && program.programId.equals(PROGRAM_ID_V4);
+  // V4.1 (Sec3 L-02): liquidate_loan additionally takes loan_token_vault,
+  // because wSOL recovered at liquidation now routes back to the LPs instead
+  // of the authority. V4.1 is a SUPERSET of V4's list here, so it reuses the
+  // V4 block below and only adds the one account. Inert until the operator
+  // sets PROGRAM_ID_V4_1 after a signed-off deploy.
+  const isV41 = PROGRAM_ID_V4_1 && program.programId.equals(PROGRAM_ID_V4_1);
   let v4ExtraAccounts = {};
   let preIxs = [
     ComputeBudgetProgram.setComputeUnitPrice({ microLamports: await getDynamicPriorityFee({ label: "liquidation" }) }),
     ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }),
   ];
-  if (isV4) {
+  if (isV4 || isV41) {
     const { NATIVE_MINT } = await import("@solana/spl-token");
     const { getAssociatedTokenAddressSync, createAssociatedTokenAccountIdempotentInstruction } =
       await import("@solana/spl-token");
@@ -186,6 +193,15 @@ async function liquidateLoan(program, keeper, loan, pool) {
       systemProgram: SystemProgram.programId,
       rent: SYSVAR_RENT_PUBKEY,
     };
+    if (isV41) {
+      // [L-02] Recovered wSOL goes to the pool's loan-token vault (the LPs),
+      // not the authority. Same PDA the pool itself uses.
+      const [loanTokenVaultPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from("loan-token-vault"), loanData.pool.toBuffer()],
+        program.programId,
+      );
+      v4ExtraAccounts.loanTokenVault = loanTokenVaultPda;
+    }
     // Create the wSOL ATAs idempotently — keeper pays.
     preIxs.push(
       createAssociatedTokenAccountIdempotentInstruction(

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -26,6 +26,7 @@ import {
   getProgramForSigner,
   PROGRAM_ID,
   PROGRAM_ID_V4,
+  PROGRAM_ID_V4_1,
   chooseProgramIdForCategory,
   chooseProgramId,
   assertProgramMatchesCategory,
@@ -1216,6 +1217,20 @@ export async function executeExtendLoan({ userId, loanDbRow }) {
     ),
   ];
 
+  // V4.1 (Sec3 M-01): extend_loan re-checks collateral health on-chain, so it
+  // additionally takes collateral_mint + price_history. `authority` is an
+  // OPTIONAL signer — a provably-healthy loan self-extends without it. We do
+  // NOT pass it: an unhealthy loan should fail loudly rather than be silently
+  // co-signed into an extension. Inert until PROGRAM_ID_V4_1 is set.
+  const v41ExtendAccounts = {};
+  if (PROGRAM_ID_V4_1 && programId.equals(PROGRAM_ID_V4_1)) {
+    const { priceFeedPda } = await import("../solana/pdas.js");
+    const extendCollateralMint = new PublicKey(loanDbRow.collateral_mint);
+    const [priceHistoryPda] = priceFeedPda(extendCollateralMint, lendingPool, programId);
+    v41ExtendAccounts.collateralMint = extendCollateralMint;
+    v41ExtendAccounts.priceHistory = priceHistoryPda;
+  }
+
   const sig = await program.methods
     .extendLoan()
     .accounts({
@@ -1226,6 +1241,7 @@ export async function executeExtendLoan({ userId, loanDbRow }) {
       feeWalletTokenAccount: feeWalletWsolAta,
       borrower: borrower.publicKey,
       loanTokenProgram,
+      ...v41ExtendAccounts,
     })
     .preInstructions(preIxs)
     .postInstructions(postIxs)

--- a/src/solana/pdas.js
+++ b/src/solana/pdas.js
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
-import { PROGRAM_ID, PROGRAM_ID_V3, PROGRAM_ID_V4 } from "./program.js";
+import { PROGRAM_ID, PROGRAM_ID_V3, PROGRAM_ID_V4, PROGRAM_ID_V4_1 } from "./program.js";
 
 // All PDA derivations accept an optional `programId` so v1 and v2 callers
 // can share these functions. Defaulting to v1's PROGRAM_ID keeps every
@@ -49,9 +49,15 @@ export function priceFeedPda(mintPubkey, poolPubkey, programId = PROGRAM_ID) {
   // PriceHistory layout, just a different program ID. Falling through
   // to the "price" default surfaces as "Account state mismatch" on
   // every V4 borrow (same audit bug class as the V3 launch day).
+  //
+  // V4.1 (post-Sec3) keeps the SAME "price_v3" seed — verified against the
+  // program's own `seeds = [b"price_v3", ...]` constraints. Omitting it here
+  // would fall through to the v1/v2 "price" prefix and reproduce the exact
+  // launch-day failure described above, on every V4.1 borrow and extend.
   const isV3 = PROGRAM_ID_V3 && programId.equals(PROGRAM_ID_V3);
   const isV4 = PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4);
-  const seedPrefix = (isV3 || isV4) ? "price_v3" : "price";
+  const isV41 = PROGRAM_ID_V4_1 && programId.equals(PROGRAM_ID_V4_1);
+  const seedPrefix = (isV3 || isV4 || isV41) ? "price_v3" : "price";
   return PublicKey.findProgramAddressSync(
     [Buffer.from(seedPrefix), mintPubkey.toBuffer(), poolPubkey.toBuffer()],
     programId,


### PR DESCRIPTION
V4.1 changes three account lists. A missing account fails on-chain with `AccountNotEnoughKeys` and takes the instruction with it — **which is exactly how V4 launch day went**, as `keeper.js`'s own comment records:

> *"Without these, every V4 overdue loan fails with AccountNotEnoughKeys and stays uncollected."*

### Wired, each conditional on `PROGRAM_ID_V4_1`
| instruction | added | why |
|---|---|---|
| `liquidate_loan` | `loan_token_vault` | L-02 — recovered wSOL routes back to the **LPs**, not the authority |
| `extend_loan` ×2 sites | `collateral_mint`, `price_history` | M-01 — the on-chain health re-check |

`authority` on `extend_loan` is an **optional signer and we deliberately don't pass it**: a provably-healthy loan self-extends, and an unhealthy one should **fail loudly rather than be silently co-signed** into an extension.

### A latent trap this turned up
`priceFeedPda` only mapped V3 and V4 to the `"price_v3"` seed — V4.1 would have fallen through to the v1/v2 `"price"` prefix and **broken every V4.1 borrow and extend**. That's the same failure the function's own comment documents from *both* V3 and V4 launch days. Verified against the program's actual `seeds = [b"price_v3", ...]` constraints rather than assumed.

### New guard (`npm run check:v41`)
Pins the IDL account deltas against what the call sites build — so if Sec3's next round adds an account, we hear it from CI instead of from a deploy. It also fails if a call site ever starts building `convertCollateralSlice` without the V4.1 accounts (nothing does today; the engine assembles that one).

**The guard was initially unable to fail** — a bare substring match was satisfied by the unrelated identifier `loanTokenVaultPda`. Tightened to require the key be *assigned* into the accounts object, then re-verified by deleting the assignment and watching it exit 1.

### Inert today
`PROGRAM_ID_V4_1` is unset, so every branch is false and V1/V3/V4 flows are byte-identical.