### PR TITLE
security: admission control on cosign-borrow (availability) — REVIEW, do not auto-merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "verify:tier2": "node scripts/verify-tier2/run.js",
     "check:arming": "node scripts/check-arming-caps.mjs",
     "check:idl": "node scripts/check-idl-routing.mjs",
-    "check:v41": "node scripts/check-v41-accounts.mjs"
+    "check:v41": "node scripts/check-v41-accounts.mjs",
+    "check:cosign-admission": "node scripts/check-cosign-admission.mjs"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/check-cosign-admission.mjs
+++ b/scripts/check-cosign-admission.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Guard for cosign admission control.
+ *
+ * The worst outcome here is NOT "a flood got through" — it is "a slot leaked
+ * and real borrows are permanently refused". A counter that climbs and never
+ * comes back down would take the borrow path down harder than any flood, so
+ * the release paths are tested first and hardest.
+ */
+import { admitCosign, getCosignAdmissionStats } from "../src/middleware/cosign-admission.js";
+
+let failed = 0;
+const check = (name, cond) => {
+  if (!cond) { failed++; console.error(`✕ ${name}`); } else console.log(`✓ ${name}`);
+};
+const reqFrom = (ip) => new Request("https://x/y", { headers: ip ? { "x-forwarded-for": ip } : {} });
+
+// ── release correctness: the failure that would break borrows ──────────────
+{
+  const before = getCosignAdmissionStats().inflight;
+  const a = admitCosign(reqFrom("1.1.1.1"));
+  check("admitted under capacity", a.ok === true);
+  check("in-flight rises while held", getCosignAdmissionStats().inflight === before + 1);
+  a.release();
+  check("release() returns the slot", getCosignAdmissionStats().inflight === before);
+  a.release(); a.release();
+  check("release() is idempotent — a double release cannot corrupt the count",
+    getCosignAdmissionStats().inflight === before);
+}
+{
+  // A handler that THROWS must not leak a slot — this is the real-world path.
+  const before = getCosignAdmissionStats().inflight;
+  const adm = admitCosign(reqFrom("1.1.1.2"));
+  try {
+    try { throw new Error("handler blew up"); } finally { adm.release(); }
+  } catch { /* expected */ }
+  check("a throwing handler still releases its slot", getCosignAdmissionStats().inflight === before);
+}
+
+// ── fail-open ──────────────────────────────────────────────────────────────
+{
+  const a = admitCosign({});                     // malformed request object
+  check("malformed request fails OPEN (admitted)", a.ok === true);
+  a.release();
+  const b = admitCosign(reqFrom(null));          // no client IP
+  check("unattributable request is admitted, not punished", b.ok === true);
+  b.release();
+}
+
+// ── the in-flight cap ──────────────────────────────────────────────────────
+{
+  const held = [];
+  for (let i = 0; i < 12; i++) {
+    const a = admitCosign(reqFrom(`10.0.0.${i}`));
+    if (a.ok) held.push(a);
+  }
+  check("12 concurrent are admitted", held.length === 12);
+  const over = admitCosign(reqFrom("10.0.1.1"));
+  check("the 13th concurrent is refused", over.ok === false);
+  check("refusal is 503", over.ok === false && over.response.status === 503);
+  check("refusal is explicitly RETRYABLE with a retry_after",
+    over.ok === false && over.response.body.retryable === true && over.response.body.retry_after_seconds > 0);
+  check("refusal states nothing was signed",
+    over.ok === false && /not submitted|nothing was signed/i.test(over.response.body.detail));
+  held.forEach((h) => h.release());
+  check("all slots return after release", getCosignAdmissionStats().inflight === 0);
+  const after = admitCosign(reqFrom("10.0.1.2"));
+  check("service recovers and admits again once drained", after.ok === true);
+  after.release();
+}
+
+// ── per-IP rate limiting, and that it cannot starve another borrower ───────
+{
+  const ip = "203.0.113.5";
+  let refused = 0;
+  for (let i = 0; i < 20; i++) {
+    const a = admitCosign(reqFrom(ip));
+    if (a.ok) a.release(); else refused++;
+  }
+  check("a single IP hammering is eventually rate-limited", refused > 0);
+  const other = admitCosign(reqFrom("203.0.113.6"));
+  check("a DIFFERENT borrower is unaffected by that abuser", other.ok === true);
+  if (other.ok) other.release();
+  check("in-flight is back to zero — no leak across the whole run",
+    getCosignAdmissionStats().inflight === 0);
+}
+
+if (failed) { console.error(`\n[cosign-admission] ${failed} check(s) failed.`); process.exit(1); }
+console.log("\n[cosign-admission] OK — bounds a flood, never leaks a slot, always fails open.");

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -60,6 +60,7 @@ async function writeJson(req, res, status, headers, body) {
 }
 import { getHeartbeats, getStartedAt } from "../lib/heartbeat.js";
 import { handleCosignBorrow } from "./cosign-borrow.js";
+import { admitCosign } from "../middleware/cosign-admission.js";
 import { handleAgentBuildBorrow } from "./agent.js";
 import { handleAgentBuildRepay } from "./agent-repay.js";
 import {
@@ -2327,9 +2328,24 @@ async function router(req, res) {
       case "/api/v1/lp-loyalty":
         result = await handleLpLoyalty(req, url);
         break;
-      case "/api/v1/cosign-borrow":
-        result = await handleCosignBorrow(req);
+      case "/api/v1/cosign-borrow": {
+        // Admission control (availability, not security — the handler's
+        // discriminator allowlist is what keeps this safe to expose). The path
+        // is unauthenticated and a single request can hold ~95s while a cold
+        // V4 feed TWAP-warms, so an unbounded flood starves REAL borrows.
+        // Fails OPEN; every rejection is explicitly retryable.
+        const adm = admitCosign(req);
+        if (!adm.ok) {
+          result = adm.response;
+          break;
+        }
+        try {
+          result = await handleCosignBorrow(req);
+        } finally {
+          adm.release();
+        }
         break;
+      }
       case "/api/v1/agent/build-borrow":
         result = await handleAgentBuildBorrow(req);
         break;

--- a/src/middleware/cosign-admission.js
+++ b/src/middleware/cosign-admission.js
@@ -1,0 +1,163 @@
+/**
+ * Admission control for /api/v1/cosign-borrow — the privileged, unauthenticated,
+ * expensive path that leads to the lender signer.
+ *
+ * WHY. The endpoint's SECURITY is already strong: the handler enforces a strict
+ * instruction-discriminator allowlist, so it will only ever sign
+ * `request_and_fund_loan` and rejects anything else. There is deliberately no
+ * API-key gate, because any user's browser has to be able to call it.
+ *
+ * What is NOT protected is AVAILABILITY. The endpoint is unauthenticated,
+ * unthrottled, and a single request can occupy up to ~95 seconds while a cold
+ * V4 feed TWAP-warms. Nothing stops anyone opening many concurrent requests and
+ * saturating the service — and when this endpoint is saturated, REAL BORROWS
+ * FAIL. That is the protocol's first mandate, so the availability of this path
+ * matters more than almost anything else on the service.
+ *
+ * WHY CONCURRENCY, NOT JUST RATE. Rate limiting alone does not fix this: a cap
+ * of 20/min still permits 20 simultaneous 95-second requests. The scarce
+ * resource here is in-flight slots, so that is what is bounded.
+ *
+ * WHY IN-MEMORY IS THE RIGHT TOOL HERE (and was not on the site). The bot is a
+ * single long-running Railway process, so one in-memory counter sees every
+ * request. The same approach on the Vercel site was MEASURED useless — 70
+ * sequential requests passed a 60/min limit untouched, because each serverless
+ * instance keeps its own counter. Put the limiter where the process is durable.
+ *
+ * DESIGN PRIORITY — in this order:
+ *   1. NEVER BLOCK A REAL BORROWER. Ceilings are far above any plausible real
+ *      load, every rejection is explicitly RETRYABLE with a retry_after, and
+ *      any internal error FAILS OPEN (admits the request).
+ *   2. Bound the damage a flood can do.
+ *
+ * Env overrides (operator can widen instantly without a code change):
+ *   COSIGN_MAX_INFLIGHT   default 12
+ *   COSIGN_BURST          default 10
+ *   COSIGN_REFILL_PER_SEC default 0.5
+ */
+
+const num = (v, d) => {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : d;
+};
+
+const MAX_INFLIGHT = num(process.env.COSIGN_MAX_INFLIGHT, 12);
+const BURST = num(process.env.COSIGN_BURST, 10);
+const REFILL_PER_SEC = num(process.env.COSIGN_REFILL_PER_SEC, 0.5);
+
+/** Per-IP token buckets. Same shape as src/middleware/rate-limit.js. */
+const buckets = new Map();
+const MAX_KEYS = 20_000;
+
+let inflight = 0;
+
+/** Observability — surfaced by getCosignAdmissionStats() for /health. */
+const stats = { admitted: 0, rejectedInflight: 0, rejectedRate: 0, peakInflight: 0 };
+
+function clientIp(req) {
+  try {
+    const xff = req.headers?.get?.("x-forwarded-for") || req.headers?.["x-forwarded-for"];
+    if (xff) {
+      const first = String(xff).split(",")[0]?.trim();
+      if (first) return first;
+    }
+    const real = req.headers?.get?.("x-real-ip") || req.headers?.["x-real-ip"];
+    return real ? String(real).trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function takeToken(ip) {
+  const now = Date.now();
+  let b = buckets.get(ip);
+  if (!b) {
+    if (buckets.size >= MAX_KEYS) {
+      // Drop buckets that have fully refilled — they carry no state worth keeping.
+      for (const [k, v] of buckets) {
+        if (v.tokens + ((now - v.last) / 1000) * REFILL_PER_SEC >= BURST) buckets.delete(k);
+      }
+      if (buckets.size >= MAX_KEYS) buckets.clear();
+    }
+    b = { tokens: BURST, last: now };
+    buckets.set(ip, b);
+  } else {
+    b.tokens = Math.min(BURST, b.tokens + ((now - b.last) / 1000) * REFILL_PER_SEC);
+    b.last = now;
+  }
+  if (b.tokens < 1) return false;
+  b.tokens -= 1;
+  return true;
+}
+
+/**
+ * Decide whether to admit a cosign request.
+ *
+ * @returns {{ ok: true, release: () => void } | { ok: false, response: object }}
+ *   On admission the caller MUST invoke release() in a finally block.
+ *   On rejection, `response` is a ready `{ status, body }` for the dispatcher.
+ */
+export function admitCosign(req) {
+  try {
+    if (inflight >= MAX_INFLIGHT) {
+      stats.rejectedInflight++;
+      return {
+        ok: false,
+        response: {
+          status: 503,
+          body: {
+            error: "cosign_busy",
+            detail:
+              "The co-signer is at capacity right now. This is temporary and safe to retry — " +
+              "your transaction was not submitted and nothing was signed.",
+            retry_after_seconds: 5,
+            retryable: true,
+          },
+        },
+      };
+    }
+
+    const ip = clientIp(req);
+    // An unattributable request is admitted: we cannot fairly throttle what we
+    // cannot identify, and refusing it would punish a real borrower behind a
+    // proxy that strips headers. The in-flight cap above still bounds the flood.
+    if (ip && !takeToken(ip)) {
+      stats.rejectedRate++;
+      return {
+        ok: false,
+        response: {
+          status: 429,
+          body: {
+            error: "cosign_rate_limited",
+            detail:
+              "Too many co-sign attempts from this address in a short window. " +
+              "Wait a few seconds and retry — nothing was signed.",
+            retry_after_seconds: 6,
+            retryable: true,
+          },
+        },
+      };
+    }
+
+    inflight++;
+    stats.admitted++;
+    if (inflight > stats.peakInflight) stats.peakInflight = inflight;
+    let released = false;
+    return {
+      ok: true,
+      release: () => {
+        if (released) return; // idempotent — a double-release must not corrupt the count
+        released = true;
+        inflight = Math.max(0, inflight - 1);
+      },
+    };
+  } catch {
+    // FAIL OPEN. A bug in admission control must never be the reason a borrow
+    // fails. Returns a no-op release so the caller's finally block is safe.
+    return { ok: true, release: () => {} };
+  }
+}
+
+export function getCosignAdmissionStats() {
+  return { ...stats, inflight, maxInflight: MAX_INFLIGHT, burst: BURST };
+}


### PR DESCRIPTION
⚠️ **Merging this redeploys the live borrow path.** Left unmerged deliberately, per the standing rule: no redeploy without an explicit OK.

## The gap

`/api/v1/cosign-borrow`'s **security is already strong** — the handler's strict instruction-discriminator allowlist means it will only ever sign `request_and_fund_loan` and rejects anything else. That's precisely why it can safely have no API-key gate.

Its **availability is unprotected.** The endpoint is unauthenticated, unthrottled, and a single request can occupy **~95 seconds** while a cold V4 feed TWAP-warms. Nothing stops anyone opening many concurrent requests and saturating the service — and **when this endpoint is saturated, real borrows fail.** That's the protocol's first mandate.

## Why concurrency, not just rate

A rate cap of 20/min still permits **20 simultaneous 95-second requests**. The scarce resource is in-flight slots, so that's what this bounds — with a generous per-IP token bucket on top.

## Why in-memory is right *here*

The bot is a **single long-running Railway process**, so one counter sees every request. The same approach on the Vercel site was **measured useless** (site #316): 70 sequential requests sailed through a 60/min limit because each serverless instance keeps its own counter. *Put the limiter where the process is durable.*

## Design priority, in order

1. **Never block a real borrower** — ceilings far above plausible load; every rejection is explicitly retryable with a `retry_after` and states that **nothing was signed**; any internal error **fails open**.
2. Bound what a flood can do.

Defaults are env-overridable so you can widen instantly with no code change: `COSIGN_MAX_INFLIGHT=12`, `COSIGN_BURST=10`, `COSIGN_REFILL_PER_SEC=0.5`.

## Verified — 17 checks

The worst outcome here isn't "a flood got through", it's **"a slot leaked and borrows are permanently refused"** — that would take the borrow path down harder than any flood. So the release paths are tested first and hardest:

- `release()` returns the slot, and is **idempotent** (a double release can't corrupt the count)
- **A throwing handler still releases its slot** — the dispatcher uses `try/finally`
- Malformed request **and** unattributable (no-IP) request are both **admitted**
- One abuser **cannot starve a different borrower**
- Service **recovers** and admits again once drained
- In-flight is back to **zero** at the end of the whole run — no leak anywhere

All existing guards still pass: `check-arming-caps`, `check-idl-routing`, `check-v4-bp`, `check-v41-accounts`, `check-shared-imports`. `node --check` clean.

## To deploy

Merge when you're ready for the redeploy. If you'd rather stage it, set `COSIGN_MAX_INFLIGHT` very high on Railway first — the code path then admits everything while you watch `getCosignAdmissionStats()`.