### PR TITLE
fix: stop counting non-attempts as failed borrows — REVIEW, do not auto-merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "check:arming": "node scripts/check-arming-caps.mjs",
     "check:idl": "node scripts/check-idl-routing.mjs",
     "check:v41": "node scripts/check-v41-accounts.mjs",
-    "check:cosign-admission": "node scripts/check-cosign-admission.mjs"
+    "check:cosign-admission": "node scripts/check-cosign-admission.mjs",
+    "check:conversion-metric": "node scripts/check-conversion-metric.mjs"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/check-conversion-metric.mjs
+++ b/scripts/check-conversion-metric.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Guard for the borrow conversion metric.
+ *
+ * The failure this prevents is silent and total: before 2026-08-11 the wrapper
+ * recorded a "customer borrow failure" for every request to this public,
+ * unauthenticated endpoint — including a 5-minute poller sending an invalid
+ * body. 14,842 events had been recorded and ZERO had a wallet attached, so the
+ * metric read 0.0% forever and could never report a real degradation.
+ *
+ * Two ways to regress it, both tested:
+ *   - start counting non-attempts again (metric goes permanently red)
+ *   - start DROPPING real failed attempts (metric goes falsely green — worse)
+ */
+import { isNonBorrowAttempt } from "../src/api/conversion-attempt.js";
+
+let failed = 0;
+const check = (name, cond) => { if (!cond) { failed++; console.error(`✕ ${name}`); } else console.log(`✓ ${name}`); };
+
+// ── must be EXCLUDED: no transaction was ever supplied ────────────────────
+check("no tx supplied (the 5-min poller) is NOT an attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "Missing partialSignedTxBase64" } }) === true);
+check("unparseable JSON body is NOT an attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "Invalid JSON body" } }) === true);
+check("a GET/HEAD probe (405) is NOT an attempt",
+  isNonBorrowAttempt({ status: 405, body: { error: "POST only" } }) === true);
+
+// ── must still be RECORDED: a real caller supplied a tx and it failed ─────
+check("a tx that fails to deserialize IS a real attempt (must be recorded)",
+  isNonBorrowAttempt({ status: 400, body: { error: "Failed to deserialize transaction" } }) === false);
+check("an unsupported versioned tx IS a real attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "Versioned txs not supported by this endpoint yet" } }) === false);
+check("a security rejection (category_byte_mismatch) IS a real attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "category_byte_mismatch" } }) === false);
+check("a malformed_borrow_tx rejection IS a real attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "malformed_borrow_tx" } }) === false);
+check("oracle_warming IS a real attempt",
+  isNonBorrowAttempt({ status: 503, body: { oracle_warming: true } }) === false);
+check("a killswitch pause IS a real attempt",
+  isNonBorrowAttempt({ status: 503, body: { paused: true } }) === false);
+check("a SUCCESS is never excluded",
+  isNonBorrowAttempt({ status: 200, body: { ok: true } }) === false);
+check("a 500 server error IS a real attempt",
+  isNonBorrowAttempt({ status: 500, body: {} }) === false);
+
+// ── never throws on junk ─────────────────────────────────────────────────
+for (const bad of [undefined, null, {}, { status: 400 }, { body: null }, { status: "400", body: { error: 1 } }]) {
+  let threw = false;
+  try { isNonBorrowAttempt(bad); } catch { threw = true; }
+  check(`no throw on ${JSON.stringify(bad)}`, !threw);
+}
+
+if (failed) { console.error(`\n[conversion-metric] ${failed} check(s) failed.`); process.exit(1); }
+console.log("\n[conversion-metric] OK — non-attempts excluded, every real attempt still recorded.");

--- a/src/api/conversion-attempt.js
+++ b/src/api/conversion-attempt.js
@@ -1,0 +1,43 @@
+/**
+ * Was a cosign request ever actually a borrow attempt?
+ *
+ * PURE — zero imports, no side effects — so it can be unit-tested without
+ * booting the bot (same pattern as src/solana/arming-caps.js).
+ *
+ * WHY THIS EXISTS. The conversion wrapper recorded an event for EVERY request
+ * to /api/v1/cosign-borrow, including ones rejected before a transaction was
+ * even supplied. The endpoint is public and unauthenticated, and something
+ * polls it every 5 minutes with an invalid body — so each poll logged a
+ * "customer borrow failure".
+ *
+ * Measured 2026-08-11: 14,842 borrow events recorded, and ZERO had a wallet
+ * attached. Not one real borrow had ever been recorded, while 106 real loans
+ * closed in the same 30 days. The metric read 0.0% success permanently, so it
+ * could never report a REAL degradation — which is the only thing it was built
+ * for ("without this, the operator only learns about failures from user
+ * complaints — too late").
+ *
+ * THE LINE: if no transaction was supplied, there was no borrow to convert.
+ * Anything that DID supply a tx stays recorded — including a tx we could not
+ * deserialize or do not support. Those are genuine failed attempts by a real
+ * caller and are exactly what the metric must catch. Excluding them would make
+ * the metric falsely GREEN, which is worse than falsely red.
+ *
+ * @param {{status?: number, body?: any}} result
+ * @returns {boolean} true when the request never constituted a borrow attempt
+ */
+export function isNonBorrowAttempt(result) {
+  try {
+    const status = result?.status;
+    const err = result?.body?.error;
+    if (status === 405) return true; // GET/HEAD probe — not an attempt
+    if (status === 400 && (err === "Missing partialSignedTxBase64" || err === "Invalid JSON body")) {
+      return true; // no transaction supplied at all
+    }
+    return false;
+  } catch {
+    // Never let this decide wrongly by throwing. Recording a spurious event is
+    // far less harmful than dropping a real one.
+    return false;
+  }
+}

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -54,6 +54,7 @@ import { query } from "../db/pool.js";
 import { rejectIfSiteDisabled } from "../services/site-global.js";
 import { rejectIfLocked } from "../services/site-lock.js";
 import { getTierByOption } from "../services/loan-tier-resolver.js";
+import { isNonBorrowAttempt } from "./conversion-attempt.js";
 
 // Rolling counter of borrow failure classifications. self-monitor reads
 // this via getRecentBorrowFailures() and CRIT-alerts the operator when
@@ -603,6 +604,9 @@ export async function handleCosignBorrow(req) {
   try {
     const result = await _handleCosignBorrowImpl(req, _convCtx);
     if (_convCtx.recorded) return result; // per-class site already recorded — skip dup
+    // Requests that never supplied a transaction are not borrow attempts and
+    // must not pollute the conversion metric — see isNonBorrowAttempt().
+    if (isNonBorrowAttempt(result)) return result;
     const { outcome, klass } = classifyBorrowOutcome(result);
     // Fire-and-forget — never let telemetry block the response.
     import("../services/conversion-tracker.js")


### PR DESCRIPTION
⚠️ **Merging redeploys the bot.** Left unmerged per the standing rule.

## The bug

`handleCosignBorrow` recorded a conversion event for **every** request — including ones rejected *before a transaction was even supplied*. The endpoint is public and unauthenticated, and something polls it every 5 minutes with an invalid body, so **each poll logged a "customer borrow failure"**.

Measured in production (read-only, via `railway run`):

| | |
|---|---|
| path `borrow` | **8,793 attempts / 0 successes / 0.0%** over 30d |
| `borrow_canary` / `x402_path_canary` | ~100% |
| **Real loans closed in those same 30 days** | **106** (101 repaid, 3 active, 2 liquidated) |

- **All 14,842 borrow events ever recorded have `wallet IS NULL` and `mint IS NULL`.** Not one real borrow has *ever* been recorded.
- **571 of 605 inter-event gaps over 2 days are exactly 5 minutes** — a cron, not users.

So the metric read 0.0% permanently and **could never report a real degradation** — the only thing it exists for: *"without this, the operator only learns about failures from user complaints — too late."*

## The fix

New **pure** module `src/api/conversion-attempt.js` (zero imports, no side effects — same pattern as `src/solana/arming-caps.js`), exporting `isNonBorrowAttempt()`. The wrapper skips recording for it.

**The line drawn: if no transaction was supplied, there was no borrow to convert.**

- **Excluded** — 405 probes, `Missing partialSignedTxBase64`, `Invalid JSON body`
- **Still recorded** — everything that *did* supply a tx, including `Failed to deserialize transaction` and `Versioned txs not supported`

Those last two are genuine failed attempts by a real caller and are exactly what the metric must catch. **Excluding them would make it falsely green, which is worse than falsely red.**

## Guarded

`scripts/check-conversion-metric.mjs` — 17 checks, wired to `npm run check:conversion-metric`. Tests **both** regressions: counting non-attempts again (permanently red) *and* dropping real attempts (falsely green).

## Process note — a mistake I caught mid-change

An edit removed the inline copy while its import silently failed to apply. **`node --check` accepts that happily, because it only validates syntax, not undefined references** — the same class as the missing `PROGRAM_ID_V4_1` import in keeper.js. I verified the module actually imports and the function resolves at runtime rather than trusting the syntax check. There is now exactly **one definition and one import**.

All existing guards pass: arming-caps, idl-routing, v4-bp, v41-accounts, cosign-admission, shared-imports.

## What to expect after deploy

`borrow` stops reading 0.0%. It may show **very few events at first** — that's correct, because real borrow volume is genuinely low while the Sec3 audit is pending. A low-n honest number is the point.