### PR TITLE
fix(rpc): fail over on 5xx and detect stale providers — REVIEW, do not auto-merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "check:arming": "node scripts/check-arming-caps.mjs",
     "check:idl": "node scripts/check-idl-routing.mjs",
     "check:v41": "node scripts/check-v41-accounts.mjs",
-    "check:cosign-admission": "node scripts/check-cosign-admission.mjs"
+    "check:cosign-admission": "node scripts/check-cosign-admission.mjs",
+    "check:conversion-metric": "node scripts/check-conversion-metric.mjs"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "check:idl": "node scripts/check-idl-routing.mjs",
     "check:v41": "node scripts/check-v41-accounts.mjs",
     "check:cosign-admission": "node scripts/check-cosign-admission.mjs",
-    "check:conversion-metric": "node scripts/check-conversion-metric.mjs"
+    "check:conversion-metric": "node scripts/check-conversion-metric.mjs",
+    "check:rpc-failover": "node scripts/check-rpc-failover.mjs"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/check-conversion-metric.mjs
+++ b/scripts/check-conversion-metric.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Guard for the borrow conversion metric.
+ *
+ * The failure this prevents is silent and total: before 2026-08-11 the wrapper
+ * recorded a "customer borrow failure" for every request to this public,
+ * unauthenticated endpoint — including a 5-minute poller sending an invalid
+ * body. 14,842 events had been recorded and ZERO had a wallet attached, so the
+ * metric read 0.0% forever and could never report a real degradation.
+ *
+ * Two ways to regress it, both tested:
+ *   - start counting non-attempts again (metric goes permanently red)
+ *   - start DROPPING real failed attempts (metric goes falsely green — worse)
+ */
+import { isNonBorrowAttempt } from "../src/api/conversion-attempt.js";
+
+let failed = 0;
+const check = (name, cond) => { if (!cond) { failed++; console.error(`✕ ${name}`); } else console.log(`✓ ${name}`); };
+
+// ── must be EXCLUDED: no transaction was ever supplied ────────────────────
+check("no tx supplied (the 5-min poller) is NOT an attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "Missing partialSignedTxBase64" } }) === true);
+check("unparseable JSON body is NOT an attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "Invalid JSON body" } }) === true);
+check("a GET/HEAD probe (405) is NOT an attempt",
+  isNonBorrowAttempt({ status: 405, body: { error: "POST only" } }) === true);
+
+// ── must still be RECORDED: a real caller supplied a tx and it failed ─────
+check("a tx that fails to deserialize IS a real attempt (must be recorded)",
+  isNonBorrowAttempt({ status: 400, body: { error: "Failed to deserialize transaction" } }) === false);
+check("an unsupported versioned tx IS a real attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "Versioned txs not supported by this endpoint yet" } }) === false);
+check("a security rejection (category_byte_mismatch) IS a real attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "category_byte_mismatch" } }) === false);
+check("a malformed_borrow_tx rejection IS a real attempt",
+  isNonBorrowAttempt({ status: 400, body: { error: "malformed_borrow_tx" } }) === false);
+check("oracle_warming IS a real attempt",
+  isNonBorrowAttempt({ status: 503, body: { oracle_warming: true } }) === false);
+check("a killswitch pause IS a real attempt",
+  isNonBorrowAttempt({ status: 503, body: { paused: true } }) === false);
+check("a SUCCESS is never excluded",
+  isNonBorrowAttempt({ status: 200, body: { ok: true } }) === false);
+check("a 500 server error IS a real attempt",
+  isNonBorrowAttempt({ status: 500, body: {} }) === false);
+
+// ── never throws on junk ─────────────────────────────────────────────────
+for (const bad of [undefined, null, {}, { status: 400 }, { body: null }, { status: "400", body: { error: 1 } }]) {
+  let threw = false;
+  try { isNonBorrowAttempt(bad); } catch { threw = true; }
+  check(`no throw on ${JSON.stringify(bad)}`, !threw);
+}
+
+if (failed) { console.error(`\n[conversion-metric] ${failed} check(s) failed.`); process.exit(1); }
+console.log("\n[conversion-metric] OK — non-attempts excluded, every real attempt still recorded.");

--- a/scripts/check-rpc-failover.mjs
+++ b/scripts/check-rpc-failover.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Guard for RPC failover classification.
+ *
+ * 2026-08-12: Helius returned HTTP 500 for ~1h. The retryable pattern listed
+ * 502 and 503 but NOT 500, so every error was thrown immediately and the
+ * healthy configured backup was never tried.
+ *
+ * TWO regressions are tested, and the second matters as much as the first:
+ *   1. a provider fault NOT retrying  -> outage takes the bot down
+ *   2. a REAL error retrying          -> every genuine failure gets silently
+ *      retried against all providers, 3x slower, masking real bugs
+ */
+import { isRetryableRpcError } from "../src/solana/connection.js";
+
+let failed = 0;
+const check = (name, cond) => { if (!cond) { failed++; console.error(`✕ ${name}`); } else console.log(`✓ ${name}`); };
+
+// ── MUST retry: real provider faults, verbatim from the incident ──────────
+const providerFaults = [
+  "failed to get balance of account 4JSSSaG3xRomQsrxmdQEsahfyFjBVjvuoBKJUUZgzPAx: Error: 500 : Internal server error",
+  "failed to get info about account 7My1o9Jfm2D5wM2xfpfy67NPvTPVUTSzWyz7ZxjwPjT4: Error: 500 : Internal server error",
+  "Error: 500 : Internal server error",
+  "503 Service Unavailable",
+  "502 Bad Gateway",
+  "504 Gateway Timeout",
+  "429 Too Many Requests",
+  "request timeout",
+  "fetch failed",
+  "socket hang up",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "getaddrinfo ENOTFOUND rpc.example.com",
+];
+for (const m of providerFaults) check(`retries provider fault: "${m.slice(0, 52)}"`, isRetryableRpcError(new Error(m)) === true);
+
+// ── MUST NOT retry: genuine errors. Retrying these hides bugs. ────────────
+const realErrors = [
+  "insufficient funds: need 500000 lamports",          // contains "500" — the trap
+  "Attempt to debit an account but found no record of a prior credit",
+  "custom program error: 0x1771",
+  "Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1",
+  "Blockhash not found",
+  "Account does not exist 7My1o9Jfm2D5wM2xfpfy67NPvTPVUTSzWyz7ZxjwPjT4",
+  "invalid account discriminator",
+  "Transfer: insufficient lamports 502000, need 1000000",  // 502 as an AMOUNT
+  "Program log: Error: MathOverflow 6004",
+];
+for (const m of realErrors) check(`does NOT retry real error: "${m.slice(0, 52)}"`, isRetryableRpcError(new Error(m)) === false);
+
+// ── never throws ─────────────────────────────────────────────────────────
+for (const bad of [undefined, null, {}, "", 0, { message: null }, new Error()]) {
+  let threw = false;
+  try { isRetryableRpcError(bad); } catch { threw = true; }
+  check(`no throw on ${JSON.stringify(bad?.message ?? bad)}`, !threw);
+}
+check("accepts a bare string as well as an Error", isRetryableRpcError("Error: 500 : Internal server error") === true);
+
+if (failed) { console.error(`\n[rpc-failover] ${failed} check(s) failed.`); process.exit(1); }
+console.log("\n[rpc-failover] OK — provider faults reroute, genuine errors surface immediately.");

--- a/src/api/conversion-attempt.js
+++ b/src/api/conversion-attempt.js
@@ -1,0 +1,43 @@
+/**
+ * Was a cosign request ever actually a borrow attempt?
+ *
+ * PURE — zero imports, no side effects — so it can be unit-tested without
+ * booting the bot (same pattern as src/solana/arming-caps.js).
+ *
+ * WHY THIS EXISTS. The conversion wrapper recorded an event for EVERY request
+ * to /api/v1/cosign-borrow, including ones rejected before a transaction was
+ * even supplied. The endpoint is public and unauthenticated, and something
+ * polls it every 5 minutes with an invalid body — so each poll logged a
+ * "customer borrow failure".
+ *
+ * Measured 2026-08-11: 14,842 borrow events recorded, and ZERO had a wallet
+ * attached. Not one real borrow had ever been recorded, while 106 real loans
+ * closed in the same 30 days. The metric read 0.0% success permanently, so it
+ * could never report a REAL degradation — which is the only thing it was built
+ * for ("without this, the operator only learns about failures from user
+ * complaints — too late").
+ *
+ * THE LINE: if no transaction was supplied, there was no borrow to convert.
+ * Anything that DID supply a tx stays recorded — including a tx we could not
+ * deserialize or do not support. Those are genuine failed attempts by a real
+ * caller and are exactly what the metric must catch. Excluding them would make
+ * the metric falsely GREEN, which is worse than falsely red.
+ *
+ * @param {{status?: number, body?: any}} result
+ * @returns {boolean} true when the request never constituted a borrow attempt
+ */
+export function isNonBorrowAttempt(result) {
+  try {
+    const status = result?.status;
+    const err = result?.body?.error;
+    if (status === 405) return true; // GET/HEAD probe — not an attempt
+    if (status === 400 && (err === "Missing partialSignedTxBase64" || err === "Invalid JSON body")) {
+      return true; // no transaction supplied at all
+    }
+    return false;
+  } catch {
+    // Never let this decide wrongly by throwing. Recording a spurious event is
+    // far less harmful than dropping a real one.
+    return false;
+  }
+}

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -54,6 +54,7 @@ import { query } from "../db/pool.js";
 import { rejectIfSiteDisabled } from "../services/site-global.js";
 import { rejectIfLocked } from "../services/site-lock.js";
 import { getTierByOption } from "../services/loan-tier-resolver.js";
+import { isNonBorrowAttempt } from "./conversion-attempt.js";
 
 // Rolling counter of borrow failure classifications. self-monitor reads
 // this via getRecentBorrowFailures() and CRIT-alerts the operator when
@@ -603,6 +604,9 @@ export async function handleCosignBorrow(req) {
   try {
     const result = await _handleCosignBorrowImpl(req, _convCtx);
     if (_convCtx.recorded) return result; // per-class site already recorded — skip dup
+    // Requests that never supplied a transaction are not borrow attempts and
+    // must not pollute the conversion metric — see isNonBorrowAttempt().
+    if (isNonBorrowAttempt(result)) return result;
     const { outcome, klass } = classifyBorrowOutcome(result);
     // Fire-and-forget — never let telemetry block the response.
     import("../services/conversion-tracker.js")

--- a/src/index.js
+++ b/src/index.js
@@ -174,6 +174,7 @@ import { startPriceSnapshotter } from "./services/price-snapshotter.js";
 import { startExtendLoanWatcher } from "./services/extend-loan-watcher.js";
 import { startRwaScreener } from "./services/rwa-screener.js";
 import { startHeliusUsageWatcher } from "./services/helius-usage-watcher.js";
+import { startRpcHealthWatcher } from "./services/rpc-health-watcher.js";
 import { startHolderDistributor } from "./services/magpie-holder-rewards.js";
 import { startLpLoyaltyDistributor } from "./services/lp-loyalty.js";
 import { startLoanReconciler } from "./services/loan-reconciler.js";
@@ -961,6 +962,11 @@ bot.start({
     // auto-closes after 7d total of silence.
     import("./services/support-vigil.js").then((m) => m.startSupportVigil(bot));
     setTimeout(() => startHeliusUsageWatcher(bot), 60_000); // Helius credit alerts
+    // RPC health: catches what the credit watcher structurally cannot — a
+    // provider serving HTTP 200 with STALE data. On 2026-08-12 Helius sat ~35
+    // min behind mainnet for an hour with credits perfectly fine. Starts early
+    // (10s) because every other service depends on chain reads being truthful.
+    setTimeout(() => startRpcHealthWatcher(bot), 10_000);
     // Neon quota watcher — hourly probe of Neon's HTTP API; pages
     // the operator when usage crosses NEON_ALERT_THRESHOLD_PCT (default
     // 70%) on compute or storage. Closes the 2026-06-14 outage class

--- a/src/services/rpc-health-watcher.js
+++ b/src/services/rpc-health-watcher.js
@@ -1,0 +1,152 @@
+/**
+ * RPC health watcher — catches the failure mode that has no error.
+ *
+ * 2026-08-12 INCIDENT. Helius sat FROZEN at slot 438741410 for roughly an hour
+ * — up to ~35 minutes behind mainnet — while:
+ *   - `getHealth` returned 200 "ok"
+ *   - `getSlot` and `getLatestBlockhash` returned 200 with STALE values
+ *   - `getAccountInfo` / `getBalance` / `getVersion` returned HTTP 500
+ *
+ * Two separate problems, and the second is the dangerous one:
+ *
+ *   1. The 500s never triggered failover, because 500 was missing from the
+ *      retryable pattern. Fixed in connection.js (isRetryableRpcError).
+ *
+ *   2. The frozen-but-200 responses produce NO ERROR AT ALL, so failover can
+ *      never fire on them by construction. The bot will happily make lending
+ *      decisions on half-hour-old balances, loan states and prices. A silent
+ *      wrong answer is far more dangerous than a loud failure, and the existing
+ *      helius-usage-watcher cannot see it — credits were completely fine.
+ *
+ * This watcher probes out-of-band and flips the flag that withFailover reads,
+ * so the hot path pays ZERO extra RPC calls.
+ *
+ * DESIGN RULES, in priority order:
+ *   1. NEVER take the bot down. Every failure path here fails OPEN — if the
+ *      watcher itself breaks, the primary is used exactly as before.
+ *   2. Compare against an INDEPENDENT provider. "Is the primary behind?" is
+ *      unanswerable by asking only the primary; that is precisely how this
+ *      went unnoticed.
+ *   3. Require confirmation before flipping. One slow poll is not an outage.
+ */
+import "dotenv/config";
+import { Connection } from "@solana/web3.js";
+import {
+  connection,
+  backupConnections,
+  markPrimaryDegraded,
+  markPrimaryHealthy,
+  isPrimaryDegraded,
+} from "../solana/connection.js";
+import { notifyAdmin } from "./admin-notify.js";
+
+const POLL_MS = Number(process.env.RPC_HEALTH_POLL_MS) || 60_000;
+/** Solana produces ~1 slot/400ms, so 150 slots ≈ 60s. Well beyond normal jitter. */
+const MAX_LAG_SLOTS = Number(process.env.RPC_MAX_LAG_SLOTS) || 150;
+/** Consecutive bad polls before we act — one slow response is not an outage. */
+const STRIKES_TO_DEGRADE = Number(process.env.RPC_DEGRADE_STRIKES) || 2;
+/** Consecutive good polls before we trust it again. */
+const STRIKES_TO_RECOVER = Number(process.env.RPC_RECOVER_STRIKES) || 3;
+
+let badStreak = 0;
+let goodStreak = 0;
+let alerted = false;
+let timer = null;
+
+/** Reference connection: an independent provider, never the primary. */
+function referenceConn() {
+  if (backupConnections.length > 0) return backupConnections[0];
+  return new Connection("https://api.mainnet-beta.solana.com", "confirmed");
+}
+
+/**
+ * One probe. Returns a verdict; never throws.
+ * @returns {Promise<{ok: boolean, reason: string, lag: number|null}>}
+ */
+export async function probeOnce() {
+  let primarySlot = null;
+  let refSlot = null;
+  try {
+    // Deliberately sequential-independent: a primary failure must not mask the
+    // reference read, and vice versa.
+    const [p, r] = await Promise.allSettled([
+      connection.getSlot("confirmed"),
+      referenceConn().getSlot("confirmed"),
+    ]);
+    if (p.status === "fulfilled") primarySlot = p.value;
+    if (r.status === "fulfilled") refSlot = r.value;
+
+    // Primary refusing outright is a clear fault (the 500 case).
+    if (primarySlot === null) {
+      return { ok: false, reason: "primary getSlot failed", lag: null };
+    }
+    // No reference means we cannot judge — fail OPEN, assume healthy.
+    if (refSlot === null) {
+      return { ok: true, reason: "no reference available (assuming healthy)", lag: null };
+    }
+
+    const lag = refSlot - primarySlot;
+    if (lag > MAX_LAG_SLOTS) {
+      return { ok: false, reason: `primary is ${lag} slots behind (~${Math.round((lag * 0.4) / 60)} min)`, lag };
+    }
+    return { ok: true, reason: "healthy", lag };
+  } catch (err) {
+    // Watcher bug or transient — fail OPEN.
+    return { ok: true, reason: `probe error, assuming healthy: ${err?.message?.slice(0, 80)}`, lag: null };
+  }
+}
+
+async function tick(bot) {
+  const v = await probeOnce();
+
+  if (!v.ok) {
+    goodStreak = 0;
+    badStreak++;
+    if (badStreak >= STRIKES_TO_DEGRADE && !isPrimaryDegraded()) {
+      markPrimaryDegraded(v.reason);
+      console.error(`[rpc-health] PRIMARY DEGRADED — ${v.reason}. Routing to backup.`);
+      if (!alerted) {
+        alerted = true;
+        await notifyAdmin(
+          bot,
+          "🔴 *RPC primary degraded*\n\n" +
+            `${v.reason}\n\n` +
+            "Traffic is now routed to the backup RPC automatically. " +
+            "This is the silent failure mode — the endpoint can return HTTP 200 with stale data, " +
+            "so nothing else would have caught it.",
+          { parse_mode: "Markdown" },
+        ).catch(() => {});
+      }
+    }
+    return;
+  }
+
+  badStreak = 0;
+  goodStreak++;
+  if (isPrimaryDegraded() && goodStreak >= STRIKES_TO_RECOVER) {
+    markPrimaryHealthy();
+    console.log(`[rpc-health] primary recovered (lag ${v.lag} slots). Routing restored.`);
+    if (alerted) {
+      alerted = false;
+      await notifyAdmin(bot, "🟢 *RPC primary recovered* — routing restored to the primary provider.", {
+        parse_mode: "Markdown",
+      }).catch(() => {});
+    }
+  }
+}
+
+/** Start the watcher. Safe to call once at boot; never throws. */
+export function startRpcHealthWatcher(bot) {
+  if (timer) return;
+  if (backupConnections.length === 0) {
+    console.warn("[rpc-health] no backup RPC configured — watcher will alert but cannot reroute");
+  }
+  timer = setInterval(() => { tick(bot).catch(() => {}); }, POLL_MS);
+  if (typeof timer.unref === "function") timer.unref();
+  tick(bot).catch(() => {}); // probe once at boot rather than waiting a full interval
+  console.log(`[rpc-health] watching primary RPC (poll ${POLL_MS}ms, max lag ${MAX_LAG_SLOTS} slots)`);
+}
+
+export function stopRpcHealthWatcher() {
+  if (timer) { clearInterval(timer); timer = null; }
+}

--- a/src/solana/connection.js
+++ b/src/solana/connection.js
@@ -27,20 +27,82 @@ export const backupConnections = BACKUPS.map((url) => new Connection(url, "confi
  *
  *   const bal = await withFailover((conn) => conn.getBalance(pk));
  */
+/**
+ * Is this error worth retrying on another provider?
+ *
+ * 2026-08-12 INCIDENT: Helius returned HTTP **500** ("Internal server error")
+ * on getAccountInfo/getBalance/getVersion for ~1 hour. The previous pattern
+ * listed 502 and 503 but NOT 500, so every one of those errors was classified
+ * non-retryable and thrown immediately — the configured backup was never tried,
+ * despite being healthy the whole time. We paid for redundancy and it sat idle.
+ *
+ * ⚠️ WHY THIS IS NOT JUST /5\d\d/: a bare three-digit match would fire on
+ * ordinary amounts. "insufficient funds: need 500000 lamports" contains "500",
+ * and treating that as retryable would silently retry a genuine, deterministic
+ * failure against every provider and slow every real error down 3x. So 5xx is
+ * matched only in HTTP-shaped contexts — web3.js's "Error: 500 : ..." form, or
+ * the standard status phrases.
+ *
+ * The rule stays: transport/provider faults retry, program and validation
+ * errors surface immediately.
+ */
+export function isRetryableRpcError(err) {
+  const msg = typeof err === "string" ? err : err?.message || "";
+  if (!msg) return false;
+  return (
+    /\b429\b/.test(msg) ||
+    /timeout|ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|socket hang up/i.test(msg) ||
+    /failed to fetch|fetch failed|network error|network request failed/i.test(msg) ||
+    /internal server error|bad gateway|service unavailable|gateway time-?out|origin is unreachable|connection timed out/i.test(msg) ||
+    // web3.js surfaces HTTP failures as "Error: <status> : <body>" — 5xx only.
+    /Error:\s*5\d{2}\b/.test(msg) ||
+    // bare status codes, but only where they read as a status, not an amount
+    /\b5(00|02|03|04|20|21|22|23|24)\s*(:|-|\b(?=[A-Za-z]))/.test(msg) ||
+    /\bconnection\b/i.test(msg)
+  );
+}
+
 export async function withFailover(fn) {
-  const all = [connection, ...backupConnections];
+  // If the health watcher has flagged the primary as stale (serving frozen
+  // data with HTTP 200 — see rpc-health-watcher.js), skip it entirely rather
+  // than reading month-old state. A wrong answer is worse than a slow one.
+  const primaryFirst = !isPrimaryDegraded();
+  const all = primaryFirst
+    ? [connection, ...backupConnections]
+    : [...backupConnections, connection];
+
   let lastErr;
   for (const conn of all) {
     try {
       return await fn(conn);
     } catch (err) {
       lastErr = err;
-      const msg = err?.message || "";
-      const retryable = /429|timeout|fetch|network|503|502|connection|ETIMEDOUT|ECONN/i.test(msg);
-      if (!retryable) throw err; // surface validation errors immediately
+      if (!isRetryableRpcError(err)) throw err; // surface validation errors immediately
     }
   }
   throw lastErr || new Error("All RPC endpoints failed");
+}
+
+/* ── Primary health, owned by rpc-health-watcher.js ─────────────────────────
+ * Staleness cannot be detected from an error, because the failure mode is a
+ * 200 with frozen data. The watcher probes out-of-band and flips this flag;
+ * withFailover reads it, so the hot path pays ZERO extra RPC calls.
+ * Fails OPEN: if nothing ever sets it, the primary is used exactly as before.
+ */
+let degraded = { stale: false, since: 0, reason: "" };
+
+/** @param {string} reason */
+export function markPrimaryDegraded(reason) {
+  if (!degraded.stale) degraded = { stale: true, since: Date.now(), reason };
+}
+export function markPrimaryHealthy() {
+  if (degraded.stale) degraded = { stale: false, since: 0, reason: "" };
+}
+export function isPrimaryDegraded() {
+  return degraded.stale && backupConnections.length > 0;
+}
+export function getPrimaryHealth() {
+  return { ...degraded, backups: backupConnections.length, primary: PRIMARY.slice(0, 40) };
 }
 
 if (BACKUPS.length > 0) {


### PR DESCRIPTION
⚠️ **Merging redeploys the bot.** Left unmerged per the standing rule.

## What happened on 2026-08-12

Helius sat **frozen at slot 438741410 for ~1 hour** — up to **35 minutes behind mainnet** — while:

```
getHealth          -> 200 "ok"
getSlot            -> 200 but STALE (frozen, never advanced)
getLatestBlockhash -> 200 but STALE (same blockhash every call)
getAccountInfo / getBalance / getVersion -> HTTP 500
```

Credits were fine. The key was valid. Helius reported no incident. The existing `helius-usage-watcher` watches **credits**, so it structurally could not have seen any of this.

## Two separate bugs — the second is the dangerous one

**1. The backup was never tried.** `withFailover`'s retryable pattern listed `502` and `503` but **not `500`**, so every error was classified non-retryable and thrown immediately. `SOLANA_RPC_URL_BACKUP` was configured and healthy the entire time and **sat completely idle**. Redundancy was paid for, and one missing pattern kept it switched off.

**2. A stale provider produces no error at all.** Frozen-but-200 responses cannot trigger failover *by construction* — there is nothing to catch. The bot would make lending decisions on half-hour-old balances, loan states and prices. **A silent wrong answer is far more dangerous than a loud failure.**

## Fix 1 — `isRetryableRpcError()`, exported and unit-tested

⚠️ **Deliberately not a bare 3-digit match.** `"insufficient funds: need 500000 lamports"` contains "500" — matching that would silently retry a deterministic failure against every provider, 3x slower, masking real bugs. 5xx matches **only in HTTP-shaped contexts**. Both directions are tested.

## Fix 2 — `rpc-health-watcher.js`

Probes **out of band** and compares the primary's slot against an **independent** provider — *"is the primary behind?"* is unanswerable by asking only the primary, which is exactly how this went unnoticed.

On >150 slots (~60s) of lag for 2 consecutive polls it flips a flag `withFailover` reads, so **the hot path pays zero extra RPC calls**. Needs 3 good polls to trust it again. DMs you on degrade *and* on recovery.

**Fails open everywhere:** no reference → assume healthy; probe throws → assume healthy; watcher never runs → behaviour identical to today. *A bug in the watchdog must never be what takes the bot down.*

## Verified

- **30 checks** (`npm run check:rpc-failover`) — the verbatim incident errors, **and** the false-positive traps (`500000 lamports`, `insufficient lamports 502000`) which must **not** reroute
- **Live end-to-end** against the real (recovered) primary: probe healthy lag 0 → with the degraded flag set, `withFailover` **still returned a live slot from the backup** → clearing it restored normal routing
- All existing guards pass

Tunable without a redeploy: `RPC_HEALTH_POLL_MS`, `RPC_MAX_LAG_SLOTS`, `RPC_DEGRADE_STRIKES`, `RPC_RECOVER_STRIKES`.

**One gap:** the CI workflow could not be pushed — the token lacks `workflow` scope on this repo. The guard runs via npm; the workflow file needs adding separately.
