### PR TITLE
fix(loan-watcher): flag structurally-unreachable borrowers a day early

### DIFF
--- a/scripts/check-warning-delivery.mjs
+++ b/scripts/check-warning-delivery.mjs
@@ -111,6 +111,16 @@ console.log("\n== watcher wiring ==");
   expect("backstop runs each tick", /await checkUnwarnedNearDue\(bot\)/.test(src), true);
   expect("backstop ignores the classifier", /warn_escalated_at IS NULL/.test(src), true);
   expect("undeliverable rows still retried hourly", /warn_undeliverable_at < NOW\(\)/.test(src), true);
+  expect("backstop LEFT joins users (never drops broken rows)", /LEFT JOIN users u/.test(src), true);
+  expect("two-tier backstop window", /BACKSTOP_UNREACHABLE_HOURS/.test(src), true);
+  expect("unreachable tier keyed on negative telegram_id", /telegram_id::bigint < 0/.test(src), true);
+  // Scope to the backstop function: warn24h/warn6h legitimately inner-join,
+  // because they cannot DM a borrower with no user row. Only the backstop must
+  // survive a broken/missing user, so only its FROM clause is asserted here.
+  const backstop = src.slice(src.indexOf("async function checkUnwarnedNearDue"));
+  const backstopBody = backstop.slice(0, backstop.indexOf("\n}"));
+  expect("backstop query uses LEFT JOIN", /FROM loans l LEFT JOIN users/.test(backstopBody), true);
+  expect("backstop query is not an inner join", /FROM loans l JOIN users/.test(backstopBody), false);
 }
 
 console.log(

--- a/src/services/loan-watcher.js
+++ b/src/services/loan-watcher.js
@@ -55,6 +55,25 @@ const UNDELIVERABLE_RETRY = "1 hour";
 const BACKSTOP_HOURS = Number(process.env.LOAN_WARN_BACKSTOP_HOURS) || 3;
 
 /**
+ * Earlier backstop for borrowers we know are STRUCTURALLY unreachable.
+ *
+ * A site-native account is auto-bootstrapped with a synthetic NEGATIVE
+ * telegram_id derived from the wallet (see api/account-link.js), and no real
+ * Telegram account exists behind it. Every DM to one fails `chat not found`.
+ *
+ * That is knowable the moment the loan is created — it is not a delivery
+ * failure we discover late. Waiting until 3h before the deadline to mention it
+ * wastes the entire window in which a human could actually do something. These
+ * get flagged a full day out instead.
+ *
+ * Real TG users (positive id) keep the 3h window: for them a missing warning
+ * means something went wrong recently, and alerting a day early on what is
+ * usually a transient blip would just train the operator to ignore it.
+ */
+const BACKSTOP_UNREACHABLE_HOURS =
+  Number(process.env.LOAN_WARN_BACKSTOP_UNREACHABLE_HOURS) || 24;
+
+/**
  * Deliver one warning DM and record the outcome honestly.
  *
  * Returns nothing and never throws — the watcher must survive any single
@@ -118,13 +137,22 @@ async function checkUnwarnedNearDue(bot) {
     const { rows } = await query(
       `SELECT l.id, l.loan_id, l.borrower_wallet, l.due_timestamp,
               l.warn_undeliverable_reason,
-              l.original_loan_amount_lamports
-         FROM loans l
+              l.original_loan_amount_lamports,
+              (u.telegram_id::bigint < 0) AS structurally_unreachable
+         -- LEFT so a loan with a missing/broken user row still gets a backstop.
+         -- An inner join would silently drop exactly the rows most likely to be
+         -- wrong, and losing coverage is the one thing this layer must not do.
+         -- NULL telegram_id falls through the CASE to the ordinary 3h window.
+         FROM loans l LEFT JOIN users u ON u.id = l.user_id
         WHERE l.status = 'active'
           AND l.warned_6h_at IS NULL
           AND l.warn_escalated_at IS NULL
           AND l.due_timestamp > NOW()
-          AND l.due_timestamp <= NOW() + INTERVAL '${BACKSTOP_HOURS} hours'`,
+          AND l.due_timestamp <= NOW() + (
+                CASE WHEN u.telegram_id::bigint < 0
+                     THEN INTERVAL '${BACKSTOP_UNREACHABLE_HOURS} hours'
+                     ELSE INTERVAL '${BACKSTOP_HOURS} hours'
+                END)`,
     );
 
     for (const row of rows) {
@@ -143,9 +171,13 @@ async function checkUnwarnedNearDue(bot) {
           `Loan \`#${row.loan_id}\` is due in *${hrs}h* and no expiry warning has been delivered.\n` +
           `Wallet: \`${fmtWallet(row.borrower_wallet)}\`\n` +
           `Owed: *${sol} SOL*\n\n` +
-          (row.warn_undeliverable_reason
-            ? `Telegram rejected the DM: \`${row.warn_undeliverable_reason}\`\n\n`
-            : "No delivery failure was recorded — the warning simply never went out.\n\n") +
+          (row.structurally_unreachable
+            ? "This borrower opened the loan on the website and has **no Telegram account** — " +
+              "there is no channel to warn them on, and there never was. The dashboard notice " +
+              "is the only thing that will reach them, and only if they visit.\n\n"
+            : row.warn_undeliverable_reason
+              ? `Telegram rejected the DM: \`${row.warn_undeliverable_reason}\`\n\n`
+              : "No delivery failure was recorded — the warning simply never went out.\n\n") +
           "They can still be reached another way before the deadline.",
         { parse_mode: "Markdown" },
       ).catch(() => {});


### PR DESCRIPTION
Follow-up to #652.

## The problem with a 3h backstop

For a borrower who **can** be reached, 3h is right: a missing warning means something broke recently, and alerting a day early on what is usually a transient blip would train the operator to ignore the alert.

For a **site-native** borrower it's far too late. Their account is auto-bootstrapped with a synthetic **negative** `telegram_id` derived from the wallet (`api/account-link.js`) and no Telegram account exists behind it — every DM fails `chat not found`. That's knowable the moment the loan is created. It isn't a delivery failure discovered late. Alerting 3h out burns the entire window in which a human could reach them by some other means.

## Two tiers

| Borrower | Backstop |
|---|---|
| Structurally unreachable (`telegram_id < 0`) | **24h** |
| Everyone else | 3h |

Both overridable via env.

The alert text also stops implying a delivery fault for the unreachable case. There is no channel to fail — there never was one — and "Telegram rejected the DM" would send you hunting for a bug instead of for a person.

## The LEFT join is deliberate

The backstop query uses `LEFT JOIN users`. An inner join would silently drop loans with a missing or broken user row — exactly the rows most likely to be wrong — and losing coverage is the one thing this layer must never do. A NULL `telegram_id` falls through the CASE to the ordinary 3h window rather than being skipped.

`warn24h`/`warn6h` keep their inner joins: they can't DM a borrower with no user row, so there's nothing to do for those.

I initially wrote this as an inner join and caught it before shipping; the guard now has an assertion **scoped to the backstop's FROM clause** so it can't regress unnoticed.

## Verification

`npm run check:warning-delivery` — 30 assertions, all passing. Dry-run against production: query parses and returns 0, correct with both active loans still >24h out. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)