### PR TITLE
chore(db): reconcile the migration ledger, and defuse migration 047

### DIFF
--- a/migrations/047_limit_close_orders_per_direction_unique.sql
+++ b/migrations/047_limit_close_orders_per_direction_unique.sql
@@ -1,35 +1,62 @@
--- migration 047: allow ONE armed TP + ONE armed SL on the same loan.
+-- migration 047: SUPERSEDED — intentionally a no-op. DO NOT RESTORE.
 --
--- Background
--- Previously a UNIQUE partial index on (loan_id WHERE status='armed')
--- physically capped a loan to ONE armed limit-close order at a time.
--- That meant a borrower had to choose between take-profit OR
--- stop-loss; they couldn't protect both sides simultaneously.
+-- ============================================================================
+-- WHY THIS FILE IS EMPTY
+-- ============================================================================
 --
--- This migration replaces that index with a per-direction one. Now:
---   ONE armed TP (trigger_direction='above')   +   ONE armed SL
---   (trigger_direction='below')   on the same loan is allowed.
---   TWO armed TPs OR TWO armed SLs on the same loan still throws —
---   that's the intended dedupe: you can't have two TPs racing.
+-- This migration was written to replace 025's index
+--   limit_close_orders_one_armed_per_loan_idx        (one armed order per loan)
+-- with
+--   limit_close_orders_one_armed_per_direction_idx   (one armed order per
+--                                                     loan + trigger_direction)
+-- so a borrower could hold a take-profit and a stop-loss simultaneously.
 --
--- COALESCE handles legacy rows that pre-date the trigger_direction
--- column (migration 039); they're treated as TP ('above'), matching
--- the column DEFAULT.
+-- It was never applied, and it must never be applied, because migration 064
+-- (slice_pct ladders) went further and made BOTH indexes wrong.
 --
--- Engine-side effect (paired magpie-limitclose change): when one
--- order fires successfully, the loan is closed (collateral sold,
--- repay done), so any sibling armed order on that loan must be
--- auto-cancelled with reason='sibling_order_fired'. Without that,
--- an SL on a TP'd-out loan would sit armed against a non-existent
--- position. Engine handles this in markFired().
+-- A ladder arms SEVERAL orders in the SAME direction on the same loan, each
+-- selling a slice of the collateral — e.g. 60% at one price and 40% at another.
+-- A UNIQUE index on (loan_id, trigger_direction) WHERE status='armed' rejects
+-- the second rung of every ladder. Verified against production on 2026-08-12:
+-- four loans were holding live 2-rung ladders (60/40, 60/40, 70/30, 80/20),
+-- so `CREATE UNIQUE INDEX` here would have failed outright — and since
+-- migrate.js exits on the first failure, every migration after 047 would have
+-- been skipped too.
+--
+-- The invariant did not disappear; it moved and got stricter in the useful
+-- direction. "At most one armed order per direction" was only ever a proxy for
+-- the thing that actually matters: YOU CANNOT SELL MORE THAN 100% OF THE
+-- COLLATERAL. That is now enforced by migration 064's trigger
+--
+--   limit_close_orders_slice_sum_check
+--     BEFORE INSERT OR UPDATE OF status, slice_pct, trigger_direction, loan_id
+--     EXECUTE FUNCTION limit_close_orders_validate_slice_sum()
+--
+-- which caps SUM(slice_pct) <= 10000 bps per (loan_id, trigger_direction).
+-- Confirmed live: the trigger exists and zero armed groups exceed 100%.
+-- The arm path (limit-close-arm-core.js) and the site preflight
+-- (site-limit-close-preflight.js) both check the same rule before insert, so
+-- the user gets a clean 409 instead of a raw constraint error.
+--
+-- 025's original index is likewise absent on purpose. Do not recreate it.
+--
+-- The file is kept rather than deleted so the numbering stays contiguous and
+-- so this reasoning survives. Restoring the DDL below would break ladders.
+--
+-- ============================================================================
+-- ORIGINAL CONTENT, PRESERVED FOR THE RECORD — DO NOT UNCOMMENT
+-- ============================================================================
+--
+--   DROP INDEX IF EXISTS limit_close_orders_one_armed_per_loan_idx;
+--
+--   CREATE UNIQUE INDEX IF NOT EXISTS limit_close_orders_one_armed_per_direction_idx
+--     ON limit_close_orders(loan_id, COALESCE(trigger_direction, 'above'))
+--     WHERE status = 'armed';
+--
+--   COMMENT ON INDEX limit_close_orders_one_armed_per_direction_idx IS
+--     'One armed limit-close order per (loan_id, trigger_direction). ...';
+--
+-- ============================================================================
 
-DROP INDEX IF EXISTS limit_close_orders_one_armed_per_loan_idx;
-
-CREATE UNIQUE INDEX IF NOT EXISTS limit_close_orders_one_armed_per_direction_idx
-  ON limit_close_orders(loan_id, COALESCE(trigger_direction, 'above'))
-  WHERE status = 'armed';
-
-COMMENT ON INDEX limit_close_orders_one_armed_per_direction_idx IS
-  'One armed limit-close order per (loan_id, trigger_direction).
-   Allows simultaneous TP + SL on the same loan. Replaces the prior
-   single-direction index from migration 025.';
+-- No-op. Present so the runner records this file and never revisits it.
+SELECT 1 WHERE FALSE;

--- a/scripts/audit-migration-ledger.mjs
+++ b/scripts/audit-migration-ledger.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * READ-ONLY audit of the `_migrations` ledger against the live schema.
+ *
+ * THE PROBLEM. The ledger records only 001-016 plus 082, but objects from
+ * migrations all across 017-098 verifiably exist. Migrations were applied
+ * out-of-band and never recorded. That makes `npm run db:migrate` dangerous:
+ * it would try to replay ~80 files, including destructive DDL
+ * (069_drop_orphan_cap_in_range_constraint, 072_drop_users_telegram_id_not_null).
+ *
+ * WHAT THIS DOES. For every unrecorded migration, parse the DDL to work out
+ * which objects it should have created, then check whether each exists now.
+ *
+ *   APPLIED       every creatable object it declares is present
+ *   NOT_APPLIED   none of them are present
+ *   PARTIAL       some present, some missing  <- never auto-record these
+ *   UNVERIFIABLE  contains DROP / INSERT / UPDATE / DO blocks whose effect
+ *                 cannot be proven from the schema alone
+ *
+ * WHY IT ONLY REPORTS. Recording a migration as applied is irreversible in
+ * effect: the runner will skip it forever. Doing that on a bad inference would
+ * silently skip a real schema change. So this script writes nothing — a human
+ * reads the output and decides. `--write` is deliberately NOT an option here.
+ *
+ * Usage:  railway run --service magpie-bot node scripts/audit-migration-ledger.mjs
+ */
+import pg from "pg";
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const migrationsDir = path.join(__dirname, "..", "migrations");
+
+/** Strip comments and string literals so keywords inside them don't match. */
+function scrub(sql) {
+  return sql
+    .replace(/--[^\n]*/g, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/'(?:[^']|'')*'/g, "''");
+}
+
+/** Objects a migration declares, as {kind, name} / {kind, table, column}. */
+function declaredObjects(sqlRaw) {
+  const sql = scrub(sqlRaw);
+  const out = [];
+
+  for (const m of sql.matchAll(
+    /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?"?([a-z0-9_]+)"?/gi,
+  )) out.push({ kind: "table", name: m[1].toLowerCase() });
+
+  for (const m of sql.matchAll(
+    /CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?/gi,
+  )) out.push({ kind: "index", name: m[1].toLowerCase() });
+
+  for (const m of sql.matchAll(/CREATE\s+TYPE\s+(?:public\.)?"?([a-z0-9_]+)"?/gi))
+    out.push({ kind: "type", name: m[1].toLowerCase() });
+
+  // ALTER TABLE <t> ... ADD COLUMN [IF NOT EXISTS] <c>  (one statement may add several)
+  for (const stmt of sql.split(";")) {
+    const t = stmt.match(/ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:public\.)?"?([a-z0-9_]+)"?/i);
+    if (!t) continue;
+    for (const c of stmt.matchAll(/ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?/gi)) {
+      out.push({ kind: "column", table: t[1].toLowerCase(), name: c[1].toLowerCase() });
+    }
+  }
+  return out;
+}
+
+/** Statements whose effect cannot be confirmed from schema introspection. */
+function unverifiableReasons(sqlRaw) {
+  const sql = scrub(sqlRaw);
+  const r = [];
+  if (/\bDROP\s+(TABLE|COLUMN|INDEX|CONSTRAINT|TYPE)\b/i.test(sql)) r.push("DROP");
+  if (/\bALTER\s+COLUMN\b/i.test(sql)) r.push("ALTER COLUMN");
+  if (/\bADD\s+CONSTRAINT\b/i.test(sql)) r.push("ADD CONSTRAINT");
+  if (/\bINSERT\s+INTO\b/i.test(sql)) r.push("INSERT");
+  if (/\bUPDATE\s+[a-z0-9_]+\s+SET\b/i.test(sql)) r.push("UPDATE");
+  if (/\bDO\s+\$\$/i.test(sql)) r.push("DO block");
+  if (/CREATE\s+OR\s+REPLACE/i.test(sql)) r.push("CREATE OR REPLACE");
+  return r;
+}
+
+const c = new pg.Client({ connectionString: process.env.DATABASE_URL });
+await c.connect();
+
+const { rows: appliedRows } = await c.query("SELECT name FROM _migrations");
+const applied = new Set(appliedRows.map((r) => r.name));
+
+const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort();
+const pending = files.filter((f) => !applied.has(f));
+
+// Snapshot the live schema once.
+const { rows: tRows } = await c.query(
+  `SELECT table_name FROM information_schema.tables WHERE table_schema='public'`,
+);
+const tables = new Set(tRows.map((r) => r.table_name.toLowerCase()));
+
+const { rows: cRows } = await c.query(
+  `SELECT table_name, column_name FROM information_schema.columns WHERE table_schema='public'`,
+);
+const columns = new Set(cRows.map((r) => `${r.table_name.toLowerCase()}.${r.column_name.toLowerCase()}`));
+
+const { rows: iRows } = await c.query(`SELECT indexname FROM pg_indexes WHERE schemaname='public'`);
+const indexes = new Set(iRows.map((r) => r.indexname.toLowerCase()));
+
+const { rows: yRows } = await c.query(
+  `SELECT t.typname FROM pg_type t JOIN pg_namespace n ON n.oid=t.typnamespace WHERE n.nspname='public'`,
+);
+const types = new Set(yRows.map((r) => r.typname.toLowerCase()));
+
+const exists = (o) =>
+  o.kind === "table" ? tables.has(o.name)
+  : o.kind === "column" ? columns.has(`${o.table}.${o.name}`)
+  : o.kind === "index" ? indexes.has(o.name)
+  : o.kind === "type" ? types.has(o.name)
+  : false;
+
+const buckets = { APPLIED: [], NOT_APPLIED: [], PARTIAL: [], UNVERIFIABLE: [], NO_OBJECTS: [] };
+
+for (const f of pending) {
+  const sql = await readFile(path.join(migrationsDir, f), "utf8");
+  const objs = declaredObjects(sql);
+  const unver = unverifiableReasons(sql);
+  const present = objs.filter(exists);
+  const missing = objs.filter((o) => !exists(o));
+
+  const label = (o) =>
+    o.kind === "column" ? `${o.table}.${o.name}` : `${o.kind} ${o.name}`;
+
+  if (objs.length === 0) {
+    buckets.NO_OBJECTS.push({ f, unver, note: "declares no creatable objects" });
+  } else if (missing.length === 0) {
+    // Everything creatable is present. If it ALSO has unverifiable statements,
+    // it is still not safe to auto-record — say so rather than round up.
+    (unver.length ? buckets.UNVERIFIABLE : buckets.APPLIED).push({
+      f, unver, present: present.map(label), missing: [],
+    });
+  } else if (present.length === 0) {
+    buckets.NOT_APPLIED.push({ f, unver, present: [], missing: missing.map(label) });
+  } else {
+    buckets.PARTIAL.push({ f, unver, present: present.map(label), missing: missing.map(label) });
+  }
+}
+
+const line = (e) =>
+  `  ${e.f}` +
+  (e.missing?.length ? `\n      MISSING: ${e.missing.join(", ")}` : "") +
+  (e.unver?.length ? `\n      unverifiable: ${e.unver.join(", ")}` : "") +
+  (e.note ? `\n      ${e.note}` : "");
+
+console.log(`\nledger records ${applied.size} of ${files.length} migration files`);
+console.log(`unrecorded: ${pending.length}\n`);
+
+console.log(`=== APPLIED — every declared object present, safe to record (${buckets.APPLIED.length}) ===`);
+buckets.APPLIED.forEach((e) => console.log(line(e)));
+
+console.log(`\n=== PARTIAL — SOME objects missing, DO NOT record (${buckets.PARTIAL.length}) ===`);
+buckets.PARTIAL.forEach((e) => console.log(line(e)));
+
+console.log(`\n=== NOT_APPLIED — nothing present, genuinely outstanding (${buckets.NOT_APPLIED.length}) ===`);
+buckets.NOT_APPLIED.forEach((e) => console.log(line(e)));
+
+console.log(`\n=== UNVERIFIABLE — objects present but has DROP/INSERT/etc, needs eyes (${buckets.UNVERIFIABLE.length}) ===`);
+buckets.UNVERIFIABLE.forEach((e) => console.log(line(e)));
+
+console.log(`\n=== NO_OBJECTS — pure data/constraint migrations, needs eyes (${buckets.NO_OBJECTS.length}) ===`);
+buckets.NO_OBJECTS.forEach((e) => console.log(line(e)));
+
+console.log(
+  `\nSUMMARY applied=${buckets.APPLIED.length} partial=${buckets.PARTIAL.length} ` +
+  `not_applied=${buckets.NOT_APPLIED.length} unverifiable=${buckets.UNVERIFIABLE.length} ` +
+  `no_objects=${buckets.NO_OBJECTS.length}`,
+);
+console.log("\nThis script wrote NOTHING. Recording is a separate, deliberate step.\n");
+
+await c.end();

--- a/scripts/lib/migration-introspect.mjs
+++ b/scripts/lib/migration-introspect.mjs
@@ -1,0 +1,189 @@
+/**
+ * Shared introspection for the migration-ledger tools.
+ *
+ * Both `audit-migration-ledger.mjs` (read-only report) and
+ * `reconcile-migration-ledger.mjs` (records verified migrations) parse the same
+ * DDL and read the same live schema. Keeping that in one place means the thing
+ * that REPORTS a migration as applied and the thing that RECORDS it can never
+ * drift apart — which matters, because recording is effectively irreversible:
+ * the runner will skip that file forever after.
+ */
+
+/** Strip comments and string literals so keywords inside them don't match. */
+export function scrub(sql) {
+  return sql
+    .replace(/--[^\n]*/g, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/'(?:[^']|'')*'/g, "''");
+}
+
+/**
+ * Objects a migration declares that can be checked for existence afterwards.
+ * Covers tables, columns, indexes, types, named constraints, triggers and
+ * functions — the constraint/trigger/function cases matter because several
+ * migrations here create NOTHING else, and an earlier version of this parser
+ * wrongly filed them as unverifiable.
+ */
+export function declaredObjects(sqlRaw) {
+  const sql = scrub(sqlRaw);
+  const out = [];
+
+  for (const m of sql.matchAll(
+    /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?"?([a-z0-9_]+)"?/gi,
+  )) out.push({ kind: "table", name: m[1].toLowerCase() });
+
+  for (const m of sql.matchAll(
+    /CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?/gi,
+  )) out.push({ kind: "index", name: m[1].toLowerCase() });
+
+  for (const m of sql.matchAll(/CREATE\s+TYPE\s+(?:public\.)?"?([a-z0-9_]+)"?/gi))
+    out.push({ kind: "type", name: m[1].toLowerCase() });
+
+  // A trigger/function may be dropped and recreated in the same file; the final
+  // state is what we check, so a bare name is enough.
+  for (const m of sql.matchAll(
+    /CREATE\s+(?:OR\s+REPLACE\s+)?TRIGGER\s+"?([a-z0-9_]+)"?/gi,
+  )) out.push({ kind: "trigger", name: m[1].toLowerCase() });
+
+  for (const m of sql.matchAll(
+    /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(?:public\.)?"?([a-z0-9_]+)"?/gi,
+  )) out.push({ kind: "function", name: m[1].toLowerCase() });
+
+  for (const stmt of sql.split(";")) {
+    const t = stmt.match(/ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:public\.)?"?([a-z0-9_]+)"?/i);
+    if (!t) continue;
+    for (const c of stmt.matchAll(/ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([a-z0-9_]+)"?/gi)) {
+      out.push({ kind: "column", table: t[1].toLowerCase(), name: c[1].toLowerCase() });
+    }
+    // ADD CONSTRAINT <name> — checkable via pg_constraint.
+    for (const c of stmt.matchAll(/ADD\s+CONSTRAINT\s+"?([a-z0-9_]+)"?/gi)) {
+      out.push({ kind: "constraint", name: c[1].toLowerCase() });
+    }
+  }
+  return out;
+}
+
+/** Statements whose effect cannot be confirmed from schema introspection. */
+export function unverifiableReasons(sqlRaw) {
+  const sql = scrub(sqlRaw);
+  const r = [];
+  if (/\bDROP\s+(TABLE|COLUMN|INDEX|CONSTRAINT|TYPE|TRIGGER)\b/i.test(sql)) r.push("DROP");
+  if (/\bALTER\s+COLUMN\b/i.test(sql)) r.push("ALTER COLUMN");
+  if (/\bINSERT\s+INTO\b/i.test(sql)) r.push("INSERT");
+  if (/\bUPDATE\s+[a-z0-9_]+\s+SET\b/i.test(sql)) r.push("UPDATE");
+  if (/\bDO\s+\$\$/i.test(sql)) r.push("DO block");
+  return r;
+}
+
+/** Snapshot every checkable name in the live schema, once. */
+export async function loadSchema(c) {
+  const one = async (sql, fn) => new Set((await c.query(sql)).rows.map(fn));
+  return {
+    tables: await one(
+      `SELECT table_name FROM information_schema.tables WHERE table_schema='public'`,
+      (r) => r.table_name.toLowerCase(),
+    ),
+    columns: await one(
+      `SELECT table_name, column_name FROM information_schema.columns WHERE table_schema='public'`,
+      (r) => `${r.table_name.toLowerCase()}.${r.column_name.toLowerCase()}`,
+    ),
+    indexes: await one(
+      `SELECT indexname FROM pg_indexes WHERE schemaname='public'`,
+      (r) => r.indexname.toLowerCase(),
+    ),
+    types: await one(
+      `SELECT t.typname FROM pg_type t JOIN pg_namespace n ON n.oid=t.typnamespace WHERE n.nspname='public'`,
+      (r) => r.typname.toLowerCase(),
+    ),
+    constraints: await one(
+      `SELECT conname FROM pg_constraint`,
+      (r) => r.conname.toLowerCase(),
+    ),
+    triggers: await one(
+      `SELECT tgname FROM pg_trigger WHERE NOT tgisinternal`,
+      (r) => r.tgname.toLowerCase(),
+    ),
+    functions: await one(
+      `SELECT p.proname FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public'`,
+      (r) => r.proname.toLowerCase(),
+    ),
+  };
+}
+
+export function objectExists(schema, o) {
+  switch (o.kind) {
+    case "table": return schema.tables.has(o.name);
+    case "column": return schema.columns.has(`${o.table}.${o.name}`);
+    case "index": return schema.indexes.has(o.name);
+    case "type": return schema.types.has(o.name);
+    case "constraint": return schema.constraints.has(o.name);
+    case "trigger": return schema.triggers.has(o.name);
+    case "function": return schema.functions.has(o.name);
+    default: return false;
+  }
+}
+
+export function labelObject(o) {
+  return o.kind === "column" ? `${o.table}.${o.name}` : `${o.kind} ${o.name}`;
+}
+
+/**
+ * Migrations whose effect is pure data or a drop, so schema introspection alone
+ * cannot decide them. Each carries the SQL that PROVES it ran, verified against
+ * production on 2026-08-12. A migration reaches the ledger only if its proof
+ * returns a row — the evidence lives in code, not in someone's memory.
+ */
+export const DATA_PROOFS = {
+  "024_pin_aaplx.sql":
+    `SELECT 1 FROM canonical_rwa_mints WHERE symbol='AAPLx'`,
+  "056_rwa_loan_tiers_match_onchain.sql":
+    `SELECT 1 FROM rwa_loan_tiers WHERE option=0 AND ltv_pct=30 AND duration_days=2 AND fee_bps=300`,
+  "063_first_v3_fire_milestone.sql":
+    `SELECT 1 FROM engine_milestone_flags WHERE milestone_key='first_v3_fire'`,
+  "067_first_v4_fire_milestone.sql":
+    `SELECT 1 FROM engine_milestone_flags WHERE milestone_key='first_v4_fire'`,
+  // Proven by ABSENCE — the migration's whole job was to drop this constraint.
+  "069_drop_orphan_cap_in_range_constraint.sql":
+    `SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='limit_close_orders_cap_in_range')`,
+  "072_drop_users_telegram_id_not_null.sql":
+    `SELECT 1 FROM information_schema.columns
+      WHERE table_name='users' AND column_name='telegram_id' AND is_nullable='YES'`,
+  // Guarded by `IF EXISTS` throughout, so replaying it is a no-op either way.
+  "060_liquidation_economics_distribute_states.sql":
+    `SELECT 1`,
+};
+
+/**
+ * Objects an earlier migration created and a LATER one deliberately removed.
+ *
+ * Without this, such a migration looks half-applied forever: the audit reports
+ * a missing object, and a careless reader "fixes" it by recreating something
+ * that was removed on purpose. Both entries below are confirmations that a
+ * later migration did its job, not defects.
+ *
+ * Keyed by the label the introspector produces, so it matches on exactly the
+ * string a human sees in the report.
+ */
+export const EXPECTED_ABSENT = {
+  "index limit_close_orders_one_armed_per_loan_idx":
+    "Created by 025, superseded by 064's slice_pct ladders — a ladder arms " +
+    "several orders per loan by design. Absent on purpose; see 047's header. " +
+    "The real invariant is trigger limit_close_orders_slice_sum_check.",
+  "constraint limit_close_orders_cap_in_range":
+    "Created by 027 and dropped on purpose by 069 " +
+    "(069_drop_orphan_cap_in_range_constraint.sql). Its absence IS 069 applied.",
+};
+
+/**
+ * Migrations that must NEVER be applied, with the reason. These get recorded so
+ * the runner skips them permanently; the file itself is also neutered to a
+ * no-op so a future reader cannot resurrect it by accident.
+ */
+export const SUPERSEDED = {
+  "047_limit_close_orders_per_direction_unique.sql":
+    "Its UNIQUE (loan_id, trigger_direction) index would reject the 2nd rung of " +
+    "every slice_pct ladder (migration 064). Four live ladders violated it on " +
+    "2026-08-12, so it would have failed and aborted every later migration. The " +
+    "real invariant (SUM(slice_pct) <= 100% per direction) is enforced by " +
+    "trigger limit_close_orders_slice_sum_check.",
+};

--- a/scripts/reconcile-migration-ledger.mjs
+++ b/scripts/reconcile-migration-ledger.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Reconcile the `_migrations` ledger with the schema that actually exists.
+ *
+ * THE PROBLEM. The ledger recorded 18 of 97 migration files. Everything else
+ * had been applied out-of-band and never written down, which made
+ * `npm run db:migrate` a loaded gun: it would have replayed ~79 files against a
+ * schema that already had them. Worse, migration 047 would have FAILED outright
+ * (its unique index is violated by four live ladders), and since migrate.js
+ * exits on first failure, every migration after it would have been skipped.
+ *
+ * WHAT THIS DOES. For every unrecorded migration it re-derives a verdict from
+ * live evidence — never from a stored list — and records only what it can prove:
+ *
+ *   - every table / column / index / type / constraint / trigger / function the
+ *     file declares must exist; or
+ *   - for pure-data or pure-drop migrations, the proof query in DATA_PROOFS
+ *     must return a row; or
+ *   - the file is listed in SUPERSEDED, meaning it must never run.
+ *
+ * Anything that fails is left unrecorded and printed. Recording is effectively
+ * irreversible — the runner skips that file forever — so the bar is evidence,
+ * not inference.
+ *
+ * Idempotent: re-running it records nothing new.
+ *
+ *   railway run --service magpie-bot node scripts/reconcile-migration-ledger.mjs
+ *   railway run --service magpie-bot node scripts/reconcile-migration-ledger.mjs --write
+ *
+ * Without --write it only reports. Nothing is ever dropped or altered; the sole
+ * mutation is INSERT INTO _migrations.
+ */
+import pg from "pg";
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import {
+  declaredObjects,
+  loadSchema,
+  objectExists,
+  labelObject,
+  EXPECTED_ABSENT,
+  DATA_PROOFS,
+  SUPERSEDED,
+} from "./lib/migration-introspect.mjs";
+
+const WRITE = process.argv.includes("--write");
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const migrationsDir = path.join(__dirname, "..", "migrations");
+
+const c = new pg.Client({ connectionString: process.env.DATABASE_URL });
+await c.connect();
+
+const { rows: appliedRows } = await c.query("SELECT name FROM _migrations");
+const applied = new Set(appliedRows.map((r) => r.name));
+const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort();
+const pending = files.filter((f) => !applied.has(f));
+
+const schema = await loadSchema(c);
+
+const willRecord = [];
+const cannot = [];
+
+for (const f of pending) {
+  if (SUPERSEDED[f]) {
+    willRecord.push({ f, why: "SUPERSEDED — must never run", detail: SUPERSEDED[f] });
+    continue;
+  }
+
+  const objs = declaredObjects(await readFile(path.join(migrationsDir, f), "utf8"));
+  const allMissing = objs.filter((o) => !objectExists(schema, o));
+
+  // An object a LATER migration deliberately removed is not evidence that this
+  // one failed — it is evidence the later one worked. Split those out rather
+  // than letting them mask a genuine gap.
+  const removedLater = allMissing.filter((o) => EXPECTED_ABSENT[labelObject(o)]);
+  const missing = allMissing.filter((o) => !EXPECTED_ABSENT[labelObject(o)]);
+
+  if (objs.length > 0 && missing.length === 0) {
+    willRecord.push({
+      f,
+      why:
+        `all ${objs.length} declared object(s) accounted for` +
+        (removedLater.length
+          ? ` (${removedLater.map(labelObject).join(", ")} removed later, on purpose)`
+          : ""),
+      detail: removedLater.length ? EXPECTED_ABSENT[labelObject(removedLater[0])] : undefined,
+    });
+    continue;
+  }
+
+  const proof = DATA_PROOFS[f];
+  if (proof) {
+    let proven = false;
+    try {
+      proven = (await c.query(proof)).rows.length > 0;
+    } catch (e) {
+      cannot.push({ f, why: `proof query errored: ${e.message.slice(0, 80)}` });
+      continue;
+    }
+    if (proven) willRecord.push({ f, why: "data proof satisfied" });
+    else cannot.push({ f, why: "data proof returned no rows — NOT applied" });
+    continue;
+  }
+
+  cannot.push({
+    f,
+    why: missing.length
+      ? `missing: ${missing.map(labelObject).join(", ")}`
+      : "declares nothing checkable and has no proof entry",
+  });
+}
+
+console.log(`\nledger: ${applied.size} of ${files.length} recorded · ${pending.length} unrecorded\n`);
+console.log(`=== WILL RECORD (${willRecord.length}) ===`);
+for (const e of willRecord) {
+  console.log(`  ${e.f}\n      ${e.why}`);
+  if (e.detail) console.log(`      ${e.detail.replace(/\s+/g, " ").slice(0, 300)}`);
+}
+console.log(`\n=== CANNOT VERIFY — left unrecorded (${cannot.length}) ===`);
+if (!cannot.length) console.log("  (none)");
+for (const e of cannot) console.log(`  ${e.f}\n      ${e.why}`);
+
+if (!WRITE) {
+  console.log(`\nDRY RUN — nothing written. Re-run with --write to record the ${willRecord.length} above.\n`);
+  await c.end();
+  process.exit(0);
+}
+
+let recorded = 0;
+for (const e of willRecord) {
+  // ON CONFLICT keeps this safe under concurrent runs and makes re-running a
+  // no-op rather than an error.
+  const r = await c.query(
+    "INSERT INTO _migrations (name) VALUES ($1) ON CONFLICT (name) DO NOTHING",
+    [e.f],
+  );
+  recorded += r.rowCount;
+}
+console.log(`\n✓ recorded ${recorded} migration(s)`);
+
+const { rows: after } = await c.query("SELECT COUNT(*)::int AS n FROM _migrations");
+console.log(`ledger now: ${after[0].n} of ${files.length}`);
+console.log(
+  cannot.length
+    ? `⚠️  ${cannot.length} still unrecorded — db:migrate would attempt these.`
+    : "✓ ledger complete — `npm run db:migrate` is safe again.",
+);
+await c.end();


### PR DESCRIPTION
## The landmine

`_migrations` recorded **18 of 97** files. The rest were applied out-of-band and never written down, so `npm run db:migrate` would have replayed ~79 migrations against a schema that already had them.

The sharp edge was **047**. It creates a UNIQUE index on `(loan_id, COALESCE(trigger_direction,'above')) WHERE status='armed'`. Migration **064** later added `slice_pct` **ladders**, which arm *several* orders in the same direction on one loan **by design**.

Four loans were holding live 2-rung ladders when I checked — 60/40, 60/40, 70/30, 80/20 — so the index would have **failed to build**. And `migrate.js` exits on first failure, so every migration after 047 would have been silently skipped.

## 047 is now a documented no-op

Original DDL preserved in comments under a DO-NOT-RESTORE header. The invariant it reached for didn't vanish — it got better. *"One armed order per direction"* was only ever a proxy for **"you cannot sell more than 100% of the collateral"**, and that's enforced by 064's trigger:

```
limit_close_orders_slice_sum_check
  BEFORE INSERT OR UPDATE OF status, slice_pct, trigger_direction, loan_id
  EXECUTE FUNCTION limit_close_orders_validate_slice_sum()
```

Verified live: trigger exists, **zero** armed groups exceed 100%. The arm path and site preflight both check the same rule first, so users get a clean 409 rather than a raw constraint error.

## Two migrations looked half-applied and were not

| Migration | "Missing" | Reality |
|---|---|---|
| 025 | `one_armed_per_loan_idx` | Superseded by ladders — absent on purpose |
| 027 | `constraint limit_close_orders_cap_in_range` | **069 exists specifically to drop it.** Its absence *is* 069 having worked |

Modelled as `EXPECTED_ABSENT` with reasons, rather than papered over — so a future reader can't "fix" it by recreating something removed deliberately.

## Tooling

- **`lib/migration-introspect.mjs`** — shared parser + schema snapshot, so the thing that *reports* applied and the thing that *records* it can't drift. Checks tables, columns, indexes, types, **constraints, triggers and functions** — those last three matter because several migrations create nothing else, and my first parser wrongly filed them unverifiable.
- **`audit-migration-ledger.mjs`** — read-only report. Writes nothing, by construction.
- **`reconcile-migration-ledger.mjs`** — re-derives every verdict from live evidence, never a stored list. **Dry by default.** Pure-data migrations carry the proof query demonstrating they ran, in code, so the evidence outlives this session.

## Result

Ledger **97/97**. `npm run db:migrate` verified as a clean no-op: **97 skipped, 0 applied, 0 failed.**

No schema was changed. The only DB mutation was `INSERT INTO _migrations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)