### PR TITLE
test(push): make the subscribe envelope verifiable in isolation

### DIFF
--- a/scripts/check-push-subscribe.mjs
+++ b/scripts/check-push-subscribe.mjs
@@ -17,7 +17,14 @@
  *
  * Run: npm run check:push-subscribe
  */
-import { validateSubscription, endpointHash } from "../src/api/push-subscribe.js";
+import {
+  validateSubscription,
+  endpointHash,
+  verifySubscribeEnvelope,
+} from "../src/api/push-subscribe.js";
+import nacl from "tweetnacl";
+import bs58 from "bs58";
+import { Keypair } from "@solana/web3.js";
 import { isSubscriptionGone } from "../src/services/push-send.js";
 
 let failures = 0;
@@ -102,6 +109,83 @@ expect("401 → NOT gone (config problem, not a dead sub)", isSubscriptionGone({
 expect("network error → NOT gone", isSubscriptionGone(new Error("ETIMEDOUT")), false);
 expect("undefined → NOT gone", isSubscriptionGone(undefined), false);
 expect("null → NOT gone", isSubscriptionGone(null), false);
+
+console.log("\n== END-TO-END: a real signed envelope, exactly as the site builds it ==");
+{
+  const kp = Keypair.generate();
+  const pubkey = kp.publicKey.toBase58();
+  const NOW = Date.parse("2026-08-12T12:00:00.000Z");
+
+  // Mirrors src/lib/solana/site-push.ts line for line. If the two ever drift,
+  // this fails — which is the point: a client/server envelope mismatch would
+  // otherwise only show up as a live user unable to subscribe.
+  const buildEnvelope = (endpointForHash, opts = {}) => {
+    const lines = [
+      `magpie: ${opts.header ?? "push-subscribe-v1"}`,
+      `From: ${opts.from ?? pubkey}`,
+      `EndpointHash: ${endpointHash(endpointForHash)}`,
+      `Nonce: ${opts.nonce ?? "a".repeat(32)}`,
+      `IssuedAt: ${opts.issuedAt ?? new Date(NOW).toISOString()}`,
+    ];
+    const messageBytes = Buffer.from(lines.join("\n"), "utf8");
+    const sig = nacl.sign.detached(messageBytes, kp.secretKey);
+    return {
+      signerPubkey: opts.from ?? pubkey,
+      signatureBase58: bs58.encode(sig),
+      signedMessageBase64: messageBytes.toString("base64"),
+    };
+  };
+  const subFor = (endpoint) => ({ endpoint, keys: KEYS });
+
+  const happy = { ...buildEnvelope(good), subscription: subFor(good) };
+  const r = verifySubscribeEnvelope(happy, NOW);
+  expect("valid envelope from the site format is ACCEPTED", r.ok, true);
+
+  // THE ATTACK: capture a valid envelope, attach your own endpoint.
+  const attacker = "https://fcm.googleapis.com/fcm/send/ATTACKER_ENDPOINT_9999";
+  const swapped = { ...buildEnvelope(good), subscription: subFor(attacker) };
+  const rs = verifySubscribeEnvelope(swapped, NOW);
+  expect("endpoint SWAP is rejected", rs.ok, false);
+  expect("  ...with endpoint_hash_mismatch", rs.error, "endpoint_hash_mismatch");
+
+  // Tamper with the signed bytes.
+  const tampered = { ...happy };
+  const msg = Buffer.from(tampered.signedMessageBase64, "base64").toString("utf8")
+    .replace(/From: \S+/, `From: ${pubkey}`) + " ";
+  tampered.signedMessageBase64 = Buffer.from(msg, "utf8").toString("base64");
+  expect("tampered message body is rejected", verifySubscribeEnvelope(tampered, NOW).ok, false);
+
+  // Signature from a DIFFERENT key.
+  const other = Keypair.generate();
+  const forged = { ...happy, signatureBase58: bs58.encode(
+    nacl.sign.detached(Buffer.from(happy.signedMessageBase64, "base64"), other.secretKey)) };
+  const rf = verifySubscribeEnvelope(forged, NOW);
+  expect("signature from another key is rejected", rf.ok, false);
+  expect("  ...with signature_does_not_match", rf.error, "signature_does_not_match");
+
+  // Someone else's wallet in From.
+  const impersonate = { ...buildEnvelope(good, { from: other.publicKey.toBase58() }),
+                        subscription: subFor(good) };
+  expect("signing for another wallet is rejected", verifySubscribeEnvelope(impersonate, NOW).ok, false);
+
+  // Freshness.
+  const stale = { ...buildEnvelope(good, { issuedAt: new Date(NOW - 10 * 60_000).toISOString() }),
+                  subscription: subFor(good) };
+  expect("10-minute-old envelope is rejected", verifySubscribeEnvelope(stale, NOW).error, "stale_signed_message");
+  const future = { ...buildEnvelope(good, { issuedAt: new Date(NOW + 10 * 60_000).toISOString() }),
+                   subscription: subFor(good) };
+  expect("10-minute-future envelope is rejected", verifySubscribeEnvelope(future, NOW).error, "stale_signed_message");
+
+  // Cross-action replay: a withdraw signature must not subscribe anything.
+  const wrongAction = { ...buildEnvelope(good, { header: "limit-close-arm/v1" }),
+                        subscription: subFor(good) };
+  expect("envelope for a different action is rejected", verifySubscribeEnvelope(wrongAction, NOW).error, "wrong_magpie_header");
+
+  // And the SSRF guard still applies to a perfectly-signed envelope.
+  const meta = "https://169.254.169.254/latest/meta-data/iam/security-credentials/";
+  const signedSsrf = { ...buildEnvelope(meta), subscription: subFor(meta) };
+  expect("signed SSRF endpoint is still rejected", verifySubscribeEnvelope(signedSsrf, NOW).ok, false);
+}
 
 console.log("\n== watcher wiring ==");
 {

--- a/src/api/push-subscribe.js
+++ b/src/api/push-subscribe.js
@@ -128,56 +128,86 @@ export async function handleVapidPublicKey() {
   };
 }
 
+/**
+ * Verify the signed subscribe envelope. PURE — no database, no clock beyond
+ * `now`, no side effects — so the security-critical path can be exercised
+ * directly by the guard script instead of only through a live request.
+ *
+ * Returns `{ ok: true, sub, fields }` or `{ ok: false, status, error }`.
+ *
+ * @param {object} body     the untrusted request body
+ * @param {number} [now]    injectable clock, for freshness tests
+ */
+export function verifySubscribeEnvelope(body, now = Date.now()) {
+  // Field names match every other signed endpoint (site-limit-close, withdraw,
+  // me/export). A one-off naming here would be a trap for the next caller.
+  const { signerPubkey, signatureBase58, signedMessageBase64, subscription } = body || {};
+
+  if (!isValidPubkey(signerPubkey)) {
+    return { ok: false, status: 400, error: "invalid_signerPubkey" };
+  }
+  const v = validateSubscription(subscription);
+  if (!v.ok) return { ok: false, status: 400, error: v.error };
+
+  let messageBytes, signatureBytes, signerPk;
+  try {
+    messageBytes = Buffer.from(String(signedMessageBase64 || ""), "base64");
+    if (!messageBytes.length || messageBytes.length > 2048) throw new Error("size");
+    signatureBytes = bs58decode(String(signatureBase58 || ""));
+    if (signatureBytes.length !== 64) throw new Error("siglen");
+    signerPk = new PublicKey(signerPubkey);
+  } catch {
+    return { ok: false, status: 400, error: "malformed_envelope" };
+  }
+
+  const fields = parseSignedMessage(messageBytes.toString("utf-8"));
+
+  if (fields.magpie !== MAGPIE_HEADER) {
+    return { ok: false, status: 400, error: "wrong_magpie_header" };
+  }
+  if (fields.From !== signerPubkey) {
+    return { ok: false, status: 400, error: "from_signer_mismatch" };
+  }
+  if (!fields.Nonce || !fields.IssuedAt) {
+    return { ok: false, status: 400, error: "missing_nonce_or_issuedat" };
+  }
+
+  // THE BINDING. Without this the signature authorises "a subscription" rather
+  // than "this subscription", and could be replayed with an attacker's endpoint.
+  if (!fields.EndpointHash || fields.EndpointHash !== endpointHash(v.sub.endpoint)) {
+    return { ok: false, status: 400, error: "endpoint_hash_mismatch" };
+  }
+
+  const issuedAt = Date.parse(fields.IssuedAt);
+  if (!Number.isFinite(issuedAt)) {
+    return { ok: false, status: 400, error: "invalid_IssuedAt" };
+  }
+  if (Math.abs(now - issuedAt) > FRESH_WINDOW_MS) {
+    return { ok: false, status: 400, error: "stale_signed_message" };
+  }
+
+  // Signature is checked LAST of the cheap checks so malformed input is
+  // rejected before spending a verify, but still before ANY state is written.
+  let sigOk = false;
+  try { sigOk = naclSign.detached.verify(messageBytes, signatureBytes, signerPk.toBytes()); }
+  catch { return { ok: false, status: 400, error: "signature_verification_failed" }; }
+  if (!sigOk) return { ok: false, status: 401, error: "signature_does_not_match" };
+
+  return { ok: true, sub: v.sub, fields, signerPubkey };
+}
+
 /** POST /api/v1/push/subscribe */
 export async function handlePushSubscribe(req) {
   let body;
   try { body = await readJsonBody(req); }
   catch { return { status: 400, body: { ok: false, error: "invalid_body" } }; }
 
-  const { signerPubkey, signature, signedMessageBase64, subscription } = body || {};
-
-  if (!isValidPubkey(signerPubkey)) {
-    return { status: 400, body: { ok: false, error: "invalid_signerPubkey" } };
+  const verified = verifySubscribeEnvelope(body);
+  if (!verified.ok) {
+    return { status: verified.status, body: { ok: false, error: verified.error } };
   }
-  const v = validateSubscription(subscription);
-  if (!v.ok) return { status: 400, body: { ok: false, error: v.error } };
-
-  let messageBytes, signatureBytes, signerPk;
-  try {
-    messageBytes = Buffer.from(String(signedMessageBase64 || ""), "base64");
-    if (!messageBytes.length || messageBytes.length > 2048) throw new Error("size");
-    signatureBytes = bs58decode(String(signature || ""));
-    if (signatureBytes.length !== 64) throw new Error("siglen");
-    signerPk = new PublicKey(signerPubkey);
-  } catch {
-    return { status: 400, body: { ok: false, error: "malformed_envelope" } };
-  }
-
-  const fields = parseSignedMessage(messageBytes.toString("utf-8"));
-
-  if (fields.magpie !== MAGPIE_HEADER) {
-    return { status: 400, body: { ok: false, error: "wrong_magpie_header" } };
-  }
-  if (fields.From !== signerPubkey) {
-    return { status: 400, body: { ok: false, error: "from_signer_mismatch" } };
-  }
-  if (!fields.Nonce || !fields.IssuedAt) {
-    return { status: 400, body: { ok: false, error: "missing_nonce_or_issuedat" } };
-  }
-
-  // THE BINDING. Without this the signature authorises "a subscription" rather
-  // than "this subscription", and could be replayed with an attacker's endpoint.
-  if (!fields.EndpointHash || fields.EndpointHash !== endpointHash(v.sub.endpoint)) {
-    return { status: 400, body: { ok: false, error: "endpoint_hash_mismatch" } };
-  }
-
-  const issuedAt = Date.parse(fields.IssuedAt);
-  if (!Number.isFinite(issuedAt)) {
-    return { status: 400, body: { ok: false, error: "invalid_IssuedAt" } };
-  }
-  if (Math.abs(Date.now() - issuedAt) > FRESH_WINDOW_MS) {
-    return { status: 400, body: { ok: false, error: "stale_signed_message" } };
-  }
+  const { sub: verifiedSub, fields, signerPubkey } = verified;
+  const v = { sub: verifiedSub };
 
   const now = Date.now();
   const last = lastAttemptBySigner.get(signerPubkey) || 0;
@@ -185,11 +215,6 @@ export async function handlePushSubscribe(req) {
     return { status: 429, body: { ok: false, error: "too_fast" } };
   }
   lastAttemptBySigner.set(signerPubkey, now);
-
-  let sigOk = false;
-  try { sigOk = naclSign.detached.verify(messageBytes, signatureBytes, signerPk.toBytes()); }
-  catch { return { status: 400, body: { ok: false, error: "signature_verification_failed" } }; }
-  if (!sigOk) return { status: 401, body: { ok: false, error: "signature_does_not_match" } };
 
   // One-shot nonce, same table and purpose-tagging as every other signed
   // endpoint, so a captured envelope cannot be replayed inside the window.


### PR DESCRIPTION
Follow-up to #655.

## A real bug this caught

The original handler read `signature` from the body. **Every existing signed client on the site sends `signatureBase58`** (`site-limit-close`, `withdraw`, `me/export`). The endpoint would have rejected every genuine subscribe attempt. Fixed, and now covered by a test that builds the envelope exactly as the client does.

## Pure verifier

`verifySubscribeEnvelope()` is extracted with no database and no ambient clock, so the security-critical path can be exercised directly rather than only through a live request. `handlePushSubscribe` keeps the stateful work (rate limit, nonce, wallet lookup, upsert).

## Attacks covered — all rejected

| Attack | Result |
|---|---|
| **Endpoint swap** — capture a valid envelope, attach your own endpoint | ✅ `endpoint_hash_mismatch` |
| Tampered message body | ✅ |
| Signature from a different key | ✅ `signature_does_not_match` |
| Signing on behalf of another wallet | ✅ |
| Stale envelope (10 min old) | ✅ `stale_signed_message` |
| **Future-dated** envelope | ✅ |
| Cross-action replay (limit-close signature used to subscribe) | ✅ `wrong_magpie_header` |
| Perfectly-signed SSRF endpoint | ✅ |

The end-to-end block mirrors `src/lib/solana/site-push.ts` line for line. If client and server formats drift, this fails — otherwise a mismatch surfaces only as live users unable to subscribe, which is exactly how the `signature`/`signatureBase58` bug would have shipped.

## Mutation results

| Mutation | Caught |
|---|---|
| Endpoint binding removed | ✅ |
| Freshness window removed | ✅ |
| `From`/signer check removed | ❌ — **and that's correct** |

The last one is an equivalent mutant on purpose: the wallet lookup keys on `signerPubkey`, whose signature actually verified, never on `fields.From`. So that check is defense-in-depth, not the load-bearing one, and an attacker dropping it can only subscribe themselves to their own account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)