### PR TITLE
fix(db): make the ledger tooling say which ledger it means, and guard checksums

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:rpc-failover": "node scripts/check-rpc-failover.mjs",
     "check:warning-delivery": "node scripts/check-warning-delivery.mjs",
     "check:push-subscribe": "node scripts/check-push-subscribe.mjs",
+    "check:migration-checksums": "node scripts/check-migration-checksums.mjs",
     "simulate:expiry-warnings": "node scripts/simulate-expiry-warnings.mjs"
   },
   "dependencies": {

--- a/scripts/check-migration-checksums.mjs
+++ b/scripts/check-migration-checksums.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Guard: never edit a migration that has already been applied.
+ *
+ * WHY THIS EXISTS — a real incident, 2026-08-12.
+ *
+ * There are two ledgers. `schema_migrations` is written by
+ * src/db/migrations-runner.js, runs on EVERY BOOT, and stores a sha256 per
+ * file. `_migrations` is written by scripts/migrate.js, is manual-only, and has
+ * no checksums.
+ *
+ * I read `_migrations`, concluded migration 047 had never been applied, and
+ * rewrote it as a no-op. The authoritative ledger said otherwise: 047 was
+ * applied on 2026-06-13. On the next boot the runner would have hit its tamper
+ * check —
+ *
+ *   "047... was edited after apply (recorded sha256 294a6001..., current ...)"
+ *
+ * — thrown, dropped the bot into DEGRADED mode, paged the operator, and, because
+ * the apply loop aborts on the first failure, blocked every later migration
+ * from ever running. The runner's own comments record a previous ledger desync
+ * doing exactly this: a crashloop that took the site and Pip down for ~30
+ * minutes.
+ *
+ * The failure mode is nasty because it is INVISIBLE AT REVIEW TIME. The diff
+ * looks like a harmless comment change; nothing fails until a deploy, and what
+ * fails then is unrelated to the change.
+ *
+ * This runs the same comparison the boot runner does, so the answer arrives in
+ * CI instead of at 3am.
+ *
+ * Needs DATABASE_URL:
+ *   railway run --service magpie-bot node scripts/check-migration-checksums.mjs
+ *
+ * Without a database it SKIPS rather than fails — a guard that cannot run must
+ * not block unrelated work, and the boot runner is still the real backstop.
+ */
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const migrationsDir = path.join(__dirname, "..", "migrations");
+
+if (!process.env.DATABASE_URL) {
+  console.log("⏭  DATABASE_URL not set — skipping (run via `railway run`).");
+  process.exit(0);
+}
+
+const pg = (await import("pg")).default;
+const c = new pg.Client({ connectionString: process.env.DATABASE_URL });
+await c.connect();
+
+let failures = 0;
+try {
+  const { rows } = await c.query(
+    `SELECT filename, checksum_sha256 FROM schema_migrations`,
+  );
+  const ledger = new Map(rows.map((r) => [r.filename, r.checksum_sha256]));
+  const files = readdirSync(migrationsDir).filter((f) => f.endsWith(".sql")).sort();
+
+  const edited = [];
+  const pending = [];
+
+  for (const f of files) {
+    const sql = readFileSync(path.join(migrationsDir, f), "utf-8");
+    const sum = createHash("sha256").update(sql).digest("hex");
+    if (!ledger.has(f)) { pending.push(f); continue; }
+    const recorded = ledger.get(f);
+    // A NULL recorded checksum predates checksum tracking — nothing to compare.
+    if (recorded && recorded !== sum) {
+      edited.push({ f, recorded: recorded.slice(0, 12), current: sum.slice(0, 12) });
+    }
+  }
+
+  console.log(`\nschema_migrations: ${ledger.size} applied · ${files.length} files on disk\n`);
+
+  if (edited.length) {
+    failures += edited.length;
+    console.error("❌ APPLIED MIGRATIONS WERE EDITED — the next boot will throw:\n");
+    for (const e of edited) {
+      console.error(`   ${e.f}`);
+      console.error(`      recorded ${e.recorded}…  current ${e.current}…`);
+    }
+    console.error(
+      "\n   Restore the exact original bytes (`git checkout <commit> -- <file>`)\n" +
+      "   and put the change in a NEW migration file instead.\n",
+    );
+  } else {
+    console.log("✅ every applied migration still matches its recorded checksum");
+  }
+
+  if (pending.length) {
+    // Not a failure: a new migration is pending until it is applied.
+    console.log(`\nℹ️  pending (will apply on next boot): ${pending.join(", ")}`);
+  }
+} catch (err) {
+  console.error("❌ checksum guard errored:", err.message);
+  failures++;
+} finally {
+  await c.end().catch(() => {});
+}
+
+console.log(failures === 0 ? "\n✅ migration checksum guard passed\n" : `\n❌ ${failures} problem(s)\n`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/lib/migration-introspect.mjs
+++ b/scripts/lib/migration-introspect.mjs
@@ -1,13 +1,54 @@
 /**
  * Shared introspection for the migration-ledger tools.
  *
- * Both `audit-migration-ledger.mjs` (read-only report) and
- * `reconcile-migration-ledger.mjs` (records verified migrations) parse the same
- * DDL and read the same live schema. Keeping that in one place means the thing
- * that REPORTS a migration as applied and the thing that RECORDS it can never
- * drift apart — which matters, because recording is effectively irreversible:
- * the runner will skip that file forever after.
+ * ⚠️ READ THIS BEFORE USING THESE TOOLS — THERE ARE TWO LEDGERS.
+ *
+ *   schema_migrations   written by src/db/migrations-runner.js. This is the
+ *                       REAL one. It runs on EVERY BOOT, stores a sha256 per
+ *                       file, and REFUSES TO START CLEAN if an applied
+ *                       migration's bytes change. Treat it as authoritative.
+ *
+ *   _migrations         written by scripts/migrate.js. Legacy, manual-only,
+ *                       no checksums. Nothing runs it automatically.
+ *
+ * These tools operate on `_migrations`. That is deliberate but easy to
+ * misread, and misreading it caused a real incident on 2026-08-12: I concluded
+ * from `_migrations` that migration 047 had never been applied, edited it, and
+ * thereby broke the checksum the BOOT runner verifies. The next restart would
+ * have thrown, degraded the bot, and blocked every later migration.
+ *
+ * Two rules follow:
+ *   1. NEVER edit a migration file that appears in `schema_migrations`. Add a
+ *      new file instead. `_migrations` saying "not applied" proves nothing.
+ *   2. Before concluding anything about whether a migration ran, check
+ *      `schema_migrations` — not this ledger, and not object presence alone.
+ *
+ * Both `audit-migration-ledger.mjs` and `reconcile-migration-ledger.mjs` share
+ * this parser so the thing that REPORTS a migration as applied and the thing
+ * that RECORDS it can never drift apart.
  */
+
+/** The ledger the boot runner uses — authoritative. */
+export const AUTHORITATIVE_LEDGER = "schema_migrations";
+/** The ledger these tools reconcile — legacy, manual-only. */
+export const LEGACY_LEDGER = "_migrations";
+
+/**
+ * Cross-check a file against the AUTHORITATIVE ledger before anyone edits it.
+ * Returns {applied, checksumMatches} — `applied` true means the file is frozen:
+ * editing it will break boot.
+ */
+export async function checkAuthoritativeLedger(c, filename, currentSql) {
+  const { createHash } = await import("node:crypto");
+  const { rows } = await c.query(
+    `SELECT checksum_sha256 FROM schema_migrations WHERE filename = $1`,
+    [filename],
+  );
+  if (!rows.length) return { applied: false, checksumMatches: null };
+  const recorded = rows[0].checksum_sha256;
+  const current = createHash("sha256").update(currentSql).digest("hex");
+  return { applied: true, checksumMatches: recorded === current, recorded, current };
+}
 
 /** Strip comments and string literals so keywords inside them don't match. */
 export function scrub(sql) {


### PR DESCRIPTION
Follow-up to #658, where I broke the boot migration ledger by editing an already-applied migration.

## Root cause: the tooling answered a different question than the one I asked

| Ledger | Written by | Runs | Checksums |
|---|---|---|---|
| **`schema_migrations`** | `src/db/migrations-runner.js` | **every boot** | **yes** |
| `_migrations` | `scripts/migrate.js` | manual only | no |

The audit/reconcile tools operate on `_migrations` **and never said so.** I read *"047 not applied"* from them and edited the file. The authoritative ledger had it applied since 2026-06-13 with a recorded checksum, so the next boot would have thrown, degraded the bot, and blocked every later migration.

## Changes

**`migration-introspect.mjs`** now names both ledgers up front, states plainly which one the tools use, and exports `checkAuthoritativeLedger()` so a caller can ask the question that actually matters before touching a file.

**`check-migration-checksums.mjs`** runs the same comparison the boot runner does.

This failure mode deserves a guard specifically because it is **invisible at review time**: the diff looks like a harmless comment change, nothing fails until a deploy, and what fails then is unrelated to the change that caused it.

It **skips** (exit 0) without `DATABASE_URL` rather than failing — a guard that can't run shouldn't block unrelated work, and the boot runner remains the real backstop.

## Verification

Mutation-tested by reproducing the exact mistake — appending one comment line to 047:

```
❌ APPLIED MIGRATIONS WERE EDITED — the next boot will throw:
   047_limit_close_orders_per_direction_unique.sql
      recorded 294a60013d11…  current 40bf8cfaf9aa…
```

Against production: **98 applied, 98 on disk, zero mismatches.**

## Note on #654

Its framing was overstated. `npm run db:migrate` is the *legacy* path; the active runner was healthy the whole time. The reconciliation of `_migrations` was harmless housekeeping, and the 047 edit — the one genuinely consequential thing in it — was wrong and is reverted in #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)