### PR TITLE
security(deps): axios 1.15.0 → 1.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^10.59.0",
         "@solana/spl-token": "^0.4.14",
         "@solana/web3.js": "^1.95.0",
-        "axios": "^1.7.9",
+        "axios": "^1.19.0",
         "bn.js": "^5.2.2",
         "bs58": "^6.0.0",
         "dotenv": "^16.4.7",
@@ -1259,14 +1259,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -1849,9 +1875,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2244,16 +2270,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2454,9 +2480,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@sentry/node": "^10.59.0",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.95.0",
-    "axios": "^1.7.9",
+    "axios": "^1.19.0",
     "bn.js": "^5.2.2",
     "bs58": "^6.0.0",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
`npm audit` flags axios **HIGH** with a long list of prototype-pollution, NO_PROXY/SSRF-bypass and credential-leak advisories. #623 has been open since 2026-08-01 for the same CVE.

## Reachability — checked before treating this as urgent

axios appears in exactly **4 files** (`price.js`, `pyth-price.js`, `risk-engine.js`, `limit-close-preflight.js`) and every use is a plain `axios.get` to a known host — Jupiter, DexScreener, Pyth Hermes — with a **static config object**.

The prototype-pollution gadgets require attacker-controlled config merging; the proxy bypasses require attacker-controlled URLs. **Neither is reachable here.** So this is hygiene rather than an active hole — patched anyway because it's a minor bump within 1.x and the advisories are real.

## The one genuine upgrade hazard

`pyth-price.js` documents a dependency on axios's default array serializer collapsing single-element arrays (Hermes rejects the non-bracket form). That code **already sidesteps it** by building the `ids[]=` query string by hand, so a serializer change can't affect it.

## Verified against live pricing, not just a build

Broken pricing breaks borrows, so the paths were exercised against production:

- `getPriceInSol(SOL)` → `1`
- 4 real enabled mints — **JCAT, CYCLOSPORA, WORLD, GOAP** — all priced
- cross-sourced path exercised

An earlier probe appeared to fail, on a `$MAGPIE` address I had **guessed** rather than read from `supported_mints`. The mint was wrong, not the upgrade — worth stating because that near-miss is exactly how a bad "it's broken" conclusion gets made.

## Guards

All **11** pass: `arming`, `idl`, `v41`, `cosign-admission`, `conversion-metric`, `rpc-failover`, `warning-delivery`, `push-subscribe`, `migration-checksums`, `borrow-reservation-race`.

Supersedes #623 and #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)