### PR TITLE
feat(community): remove a scammer on their first scam post, not the third

### DIFF
--- a/src/handlers/community-handlers.js
+++ b/src/handlers/community-handlers.js
@@ -590,12 +590,44 @@ async function handleGroupMessage(ctx) {
           );
           const count = await bumpWarnedCount(ctx.chat.id, sender.id);
           const isSolicit = cat === "solicitation" || cat === "spam";
+
+          // ── Operator directive 2026-08-13: a SCAMMER who posts is removed
+          // immediately, not warned. Previously every removal was warn-only
+          // with a possible mute at strike 3, which let a wallet-drainer keep
+          // posting into the group between strikes.
+          //
+          // Scoped to SCAM/PHISHING only. Solicitation and spam stay warn-only
+          // on purpose: shilling another project is obnoxious, not theft, and
+          // banning for it would remove real members over a judgement call —
+          // the opposite of the allow-biased standard. Impersonation already
+          // bans on sight further up, so this closes the last gap.
+          //
+          // Confidence gate: only an explicit judge verdict bans. The LLM-down
+          // hard-scam fallback still DELETES but does NOT ban, because nobody
+          // should be removed on a regex alone.
+          const isScamCategory = !isSolicit;
+          const banScammer = isScamCategory && verdict && isConfidentRemoval(verdict);
+          if (banScammer) {
+            try {
+              await ctx.api.banChatMember(ctx.chat.id, sender.id);
+              await recordModAction(
+                ctx.chat.id, sender.id, "ban_scammer_post",
+                `conf=${verdict.confidence.toFixed(2)} · ${verdict.reason}`,
+                bodyText.slice(0, 500),
+              );
+            } catch (err) {
+              // A failed ban must never swallow the delete + warning above.
+              console.warn("[community] scammer ban failed:", err.message);
+            }
+          }
           const notice = isSolicit
             ? `Hey — your message was removed because it read as solicitation/promotion (offering services, shilling another project, etc.), which we keep out of the group. Genuine questions and ideas about Magpie are always welcome — feel free to ask! 🙂`
             : `Hey — your message was removed because it matched a scam/phishing pattern we filter (seed-phrase or private-key asks, "DM me to claim", fake airdrops, drainer links, etc.). If that was a genuine misunderstanding, just rephrase — real questions are always welcome. 🙂`;
           await softWarn(
             ctx, sender.id,
-            notice + (count >= 3 ? `\n\n(Heads up: warning #${count} — repeated removals may lead to a temporary mute.)` : ``),
+            banScammer
+              ? `Your message matched a scam/phishing pattern (seed-phrase or private-key asks, "DM me to claim", fake airdrops, drainer links) and you have been removed from the group. If this was a genuine mistake, reply here and a human will review it.`
+              : notice + (count >= 3 ? `\n\n(Heads up: warning #${count} — repeated removals may lead to a temporary mute.)` : ``),
           );
           return; // removed; skip remaining checks
         }


### PR DESCRIPTION
Operator directive: *"if an impersonator or scammer posts, you need to delete it ASAP and kick them out."*

## The gap

Impersonators were **already** deleted + banned on sight (`ban_impersonator`, 56 to date). Scam **posts** were not:

```
delete message → friendly warning → mute only floated at strike 3
```

So a wallet-drainer could keep posting into the group between strikes. That's what this closes — a confirmed scam post now removes the sender immediately.

## Scoped deliberately

The ban fires for **scam/phishing only**. Solicitation and spam stay warn-only.

Shilling another project is obnoxious; it isn't theft. Banning for it would remove real members over a judgement call, which is the opposite of the allow-biased standard. This makes the response to *actual theft* immediate without widening what counts as theft.

## Confidence-gated

Only an explicit judge verdict passing `isConfidentRemoval()` bans.

The LLM-down hard-scam regex fallback still **deletes** but does **not** ban — nobody should be removed from the community on a regex alone, and that path exists precisely for when the judge is unavailable and therefore can't be trusted to adjudicate a ban.

## Details

- The ban is wrapped so a failure can't swallow the delete or the notice.
- A banned user no longer gets copy telling them to "just rephrase" — it explains the removal and offers human review.
- New mod action `ban_scammer_post` records confidence + reason, so this is auditable and its false-positive rate measurable.

Guards pass: `warning-delivery`, `push-subscribe`, `arming`, `idl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)