### PR TITLE
chore(distributions): commit the payout scripts, and self-heal the rent floor

### DIFF
--- a/scripts/distributions/capture-holder-dist.mjs
+++ b/scripts/distributions/capture-holder-dist.mjs
@@ -1,0 +1,33 @@
+// CAPTURE-ONLY holder distribution snapshot. Creates a magpie_holder_distributions
+// row + magpie_holder_rewards rows at 'snapshot_pending'. NO SOL MOVES.
+// The flag forces snapshot-only mode inside snapshotAndDistribute().
+import { query } from "../../src/db/pool.js";
+
+// Arm snapshot-only, then capture in the same process (no window for auto-pay).
+await query("UPDATE magpie_holder_pool SET next_run_snapshot_only = TRUE, updated_at = NOW() WHERE id = 1");
+const armed = await query("SELECT next_run_snapshot_only FROM magpie_holder_pool WHERE id = 1");
+if (armed.rows[0].next_run_snapshot_only !== true) {
+  console.error("ABORT: snapshot-only flag not armed"); process.exit(1);
+}
+console.log("snapshot-only armed:", armed.rows[0].next_run_snapshot_only);
+
+const { snapshotAndDistribute } = await import("../../src/services/magpie-holder-rewards.js");
+const res = await snapshotAndDistribute();
+if (!res) { console.error("ABORT: snapshotAndDistribute returned null (pool below min / no holders)"); process.exit(1); }
+if (res.mode !== "snapshot_only") { console.error("ABORT: mode was", res.mode, "— expected snapshot_only"); process.exit(1); }
+
+console.log("\n── CAPTURE RESULT ──");
+console.log("distribution_id:", res.distribution_id);
+console.log("pool_lamports:  ", (Number(res.pool_lamports) / 1e9).toFixed(6), "SOL");
+console.log("holder_count:   ", res.holder_count);
+console.log("eligible_count: ", res.eligible_count);
+console.log("allocated:      ", (Number(res.allocated_lamports) / 1e9).toFixed(6), "SOL");
+console.log("mode:           ", res.mode, "(NO SOL SENT)");
+
+// Verify the rows landed at snapshot_pending
+const v = await query(
+  "SELECT COUNT(*)::int n, COALESCE(SUM(reward_lamports),0)::text s FROM magpie_holder_rewards WHERE distribution_id=$1 AND status='snapshot_pending'",
+  [res.distribution_id],
+);
+console.log("\nverified snapshot_pending rows:", v.rows[0].n, "sum:", (Number(v.rows[0].s) / 1e9).toFixed(6), "SOL");
+process.exit(0);

--- a/scripts/distributions/mark-unpayable-rent-exempt.mjs
+++ b/scripts/distributions/mark-unpayable-rent-exempt.mjs
@@ -1,0 +1,109 @@
+/**
+ * Mark holder-reward rows that CANNOT be paid because the transfer would leave
+ * the recipient's account below Solana's rent-exempt minimum.
+ *
+ * WHY THIS EXISTS (dist #9, 2026-08-13). The holder pool shrank to 0.3947 SOL
+ * spread over 1,433 eligible holders — an average reward of 0.000275 SOL, about
+ * a THIRD of the 0.00089088 SOL rent-exempt minimum. 94% of rewards are below
+ * that minimum.
+ *
+ * A sub-minimum transfer is only impossible when the recipient's account is
+ * empty; a funded wallet can receive any amount. But `retryAccruedPayouts()`
+ * batches 10 transfers per transaction, and a transaction fails ATOMICALLY, so
+ * ONE unpayable recipient kills the other nine. At 94% sub-minimum, nearly every
+ * batch contained one and the payout stalled after 10 of 1,433.
+ *
+ * This is the same failure the runbook documents for the LP pool, where the fix
+ * is to mark sub-rent rows `unpayable_rent_exempt` and pay the rest. `LP` has
+ * used that status since dist #25; the holder table has no CHECK constraint, so
+ * the same value applies cleanly.
+ *
+ * MOVES NO SOL. It only reclassifies rows so the guarded payout script can make
+ * progress. Run `run-holder-payout.mjs` afterwards to pay the remainder.
+ *
+ * DRY RUN BY DEFAULT — pass --write to apply.
+ *
+ *   DIST_ID=9 railway run --service magpie-bot node mark-unpayable-rent-exempt.mjs
+ *   DIST_ID=9 railway run --service magpie-bot node mark-unpayable-rent-exempt.mjs --write
+ */
+import { query } from "../../src/db/pool.js";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+/** Rent-exempt minimum for a 0-data System account. */
+const RENT_MIN = 890_880;
+
+const WRITE = process.argv.includes("--write");
+const DIST_ID = Number(process.env.DIST_ID);
+if (!Number.isInteger(DIST_ID) || DIST_ID <= 0) {
+  console.error("ABORT: set DIST_ID (e.g. DIST_ID=9)");
+  process.exit(1);
+}
+
+const rpc =
+  process.env.HELIUS_RPC_URL || process.env.RPC_URL || process.env.SOLANA_RPC_URL;
+if (!rpc) {
+  console.error("ABORT: no RPC configured — refusing to judge payability blind");
+  process.exit(1);
+}
+const conn = new Connection(rpc, "confirmed");
+
+const { rows } = await query(
+  `SELECT wallet_address, reward_lamports
+     FROM magpie_holder_rewards
+    WHERE distribution_id = $1 AND status = 'accrued'`,
+  [DIST_ID],
+);
+console.log(`dist ${DIST_ID}: ${rows.length} accrued row(s) to assess`);
+if (rows.length === 0) process.exit(0);
+
+const unpayable = [];
+let payable = 0;
+for (let i = 0; i < rows.length; i += 100) {
+  const chunk = rows.slice(i, i + 100);
+  let infos;
+  try {
+    infos = await conn.getMultipleAccountsInfo(chunk.map((r) => new PublicKey(r.wallet_address)));
+  } catch (e) {
+    // Never guess. An RPC failure must not cause a row to be written off.
+    console.error(`ABORT: RPC failed mid-assessment (${e.message}). Nothing written.`);
+    process.exit(1);
+  }
+  infos.forEach((info, j) => {
+    const bal = info?.lamports ?? 0;
+    const reward = Number(chunk[j].reward_lamports);
+    // Payable iff the account ends at or above the rent-exempt minimum.
+    if (bal + reward >= RENT_MIN) payable++;
+    else unpayable.push({ wallet: chunk[j].wallet_address, reward, bal });
+  });
+}
+
+const forfeited = unpayable.reduce((a, r) => a + r.reward, 0);
+console.log(`  payable:   ${payable}`);
+console.log(`  unpayable: ${unpayable.length}  (${(forfeited / 1e9).toFixed(6)} SOL)`);
+console.log(
+  `  NOTE: unpayable SOL stays in CHCAM — the pool was already decremented at accrual.`,
+);
+
+if (!WRITE) {
+  console.log("\nDRY RUN — nothing written. Re-run with --write to apply.");
+  process.exit(0);
+}
+if (unpayable.length === 0) {
+  console.log("nothing to mark");
+  process.exit(0);
+}
+
+// Mark in one statement, scoped to this distribution and to rows still accrued,
+// so a concurrent payout that just succeeded cannot be clobbered.
+const wallets = unpayable.map((r) => r.wallet);
+const res = await query(
+  `UPDATE magpie_holder_rewards
+      SET status = 'unpayable_rent_exempt'
+    WHERE distribution_id = $1
+      AND status = 'accrued'
+      AND wallet_address = ANY($2)`,
+  [DIST_ID, wallets],
+);
+console.log(`✓ marked ${res.rowCount} row(s) unpayable_rent_exempt`);
+console.log(`Next: DIST_ID=${DIST_ID} railway run --service magpie-bot node run-holder-payout.mjs`);
+process.exit(0);

--- a/scripts/distributions/run-holder-payout.mjs
+++ b/scripts/distributions/run-holder-payout.mjs
@@ -1,0 +1,197 @@
+// GUARDED holder-rewards payout for a captured distribution (snapshot_pending → paid).
+// Safe to re-run: retryAccruedPayouts() is idempotent (only pays 'accrued' rows).
+//
+// SECURITY GUARDS (all must pass before any SOL moves):
+//   1. Force the distributor key = the CHCAM MGP-001 sender (never the LENDER fallback).
+//   2. Assert the resolved signer pubkey === CHCAM, else ABORT.
+//   3. Assert NO 'accrued' rows exist outside the target distribution, else ABORT
+//      (prevents accidentally paying a stale/foreign batch).
+//
+// Usage (operator, harness blocks the send so run via `!`):
+//   ! cd ~/bagbank-bot && DIST_ID=5 railway run --service magpie-bot node run-holder-payout.mjs
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PublicKey } from "@solana/web3.js";
+
+const CHCAM = "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac";
+const DIST_ID = Number(process.env.DIST_ID);
+if (!Number.isInteger(DIST_ID) || DIST_ID <= 0) {
+  console.error("ABORT: set DIST_ID env to the target distribution id (e.g. DIST_ID=5)");
+  process.exit(1);
+}
+
+// ── Guard 1: load the CHCAM key and force it as the distributor (BEFORE importing services,
+// so getRewardsDistributorKeypair() caches the CHCAM key, not the LENDER fallback). ──
+const keyPath = path.join(os.homedir(), ".magpie-private", "distribution-keypairs", "MGP-001-sender.json");
+if (!fs.existsSync(keyPath)) {
+  console.error("ABORT: CHCAM distributor key not found at", keyPath);
+  process.exit(1);
+}
+const bs58 = (await import("bs58")).default;
+const secretBytes = Uint8Array.from(JSON.parse(fs.readFileSync(keyPath, "utf8")));
+process.env.REWARDS_DISTRIBUTOR_PRIVATE_KEY = bs58.encode(secretBytes);
+
+const { getRewardsDistributorKeypair } = await import("../../src/services/distributor-keypair.js");
+const distributor = getRewardsDistributorKeypair();
+const signer = distributor.publicKey.toBase58();
+
+// ── Guard 2: signer MUST be CHCAM ──
+if (signer !== CHCAM) {
+  console.error(`ABORT: distributor signer ${signer} !== CHCAM ${CHCAM}. Refusing to pay from the wrong wallet.`);
+  process.exit(1);
+}
+console.log("✓ distributor signer verified:", signer, "(CHCAM)");
+
+const { query, pool: dbPool } = await import("../../src/db/pool.js");
+
+// ── Guard 3: no 'accrued' rows may exist outside DIST_ID ──
+const stray = await query(
+  "SELECT COUNT(*)::int n FROM magpie_holder_rewards WHERE status = 'accrued' AND distribution_id <> $1",
+  [DIST_ID],
+);
+if (stray.rows[0].n > 0) {
+  console.error(`ABORT: ${stray.rows[0].n} 'accrued' row(s) exist outside dist ${DIST_ID}. Resolve them first.`);
+  process.exit(1);
+}
+
+// Target-distribution pending rows
+const pend = await query(
+  "SELECT COUNT(*)::int n, COALESCE(SUM(reward_lamports),0)::text s FROM magpie_holder_rewards WHERE status = 'snapshot_pending' AND distribution_id = $1",
+  [DIST_ID],
+);
+const pendCount = pend.rows[0].n;
+const pendSum = BigInt(pend.rows[0].s);
+if (pendCount === 0 || pendSum <= 0n) {
+  // Idempotent re-run: nothing pending, maybe already flipped/paid — fall through to retry sweep.
+  console.log(`No snapshot_pending rows for dist ${DIST_ID} (already flipped? continuing to retry sweep).`);
+} else {
+  console.log(`dist ${DIST_ID}: ${pendCount} pending rows, ${(Number(pendSum) / 1e9).toFixed(6)} SOL`);
+
+  // ── Flip snapshot_pending → accrued + decrement pool (atomic), mirroring the
+  // normal auto-pay path (relative decrement preserves concurrent accruals). ──
+  const client = await dbPool.connect();
+  try {
+    await client.query("BEGIN");
+    // Lock the pending rows under the transaction (no aggregate — Postgres
+    // rejects FOR UPDATE + SUM), then sum in JS to avoid TOCTOU.
+    const { rows: lockedRows } = await client.query(
+      "SELECT reward_lamports FROM magpie_holder_rewards WHERE status = 'snapshot_pending' AND distribution_id = $1 FOR UPDATE",
+      [DIST_ID],
+    );
+    const flipSum = lockedRows.reduce((acc, r) => acc + BigInt(r.reward_lamports), 0n);
+    const live = { n: lockedRows.length, s: flipSum.toString() };
+    await client.query(
+      "UPDATE magpie_holder_rewards SET status = 'accrued' WHERE status = 'snapshot_pending' AND distribution_id = $1",
+      [DIST_ID],
+    );
+    await client.query(
+      `UPDATE magpie_holder_pool
+          SET accrued_lamports = accrued_lamports - $1::numeric,
+              last_distribution_at = NOW(),
+              next_distribution_at = NOW() + interval '30 days',
+              updated_at = NOW()
+        WHERE id = 1`,
+      [flipSum.toString()],
+    );
+    await client.query("COMMIT");
+    console.log(`✓ flipped ${live.n} rows to 'accrued', pool decremented by ${(Number(flipSum) / 1e9).toFixed(6)} SOL`);
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    client.release();
+    console.error("ABORT: flip/decrement failed:", err.message);
+    process.exit(1);
+  }
+  client.release();
+}
+
+/**
+ * Mark rows Solana physically cannot pay: the transfer would leave an EMPTY
+ * recipient account below the rent-exempt minimum. Returns how many were
+ * marked. Never guesses — an RPC failure marks nothing.
+ */
+const RENT_MIN = 890_880;
+let triedRentHeal = false;
+async function markUnpayableRentExempt(distId) {
+  const rpc = process.env.HELIUS_RPC_URL || process.env.RPC_URL || process.env.SOLANA_RPC_URL;
+  if (!rpc) { console.error("  (no RPC configured — cannot assess payability; marking nothing)"); return 0; }
+  const { Connection, PublicKey } = await import("@solana/web3.js");
+  const conn = new Connection(rpc, "confirmed");
+  const { rows } = await query(
+    `SELECT wallet_address, reward_lamports FROM magpie_holder_rewards
+      WHERE distribution_id = $1 AND status = 'accrued' AND reward_lamports < ${RENT_MIN}`,
+    [distId],
+  );
+  if (rows.length === 0) return 0;
+  const unpayable = [];
+  for (let i = 0; i < rows.length; i += 100) {
+    const chunk = rows.slice(i, i + 100);
+    let infos;
+    try {
+      infos = await conn.getMultipleAccountsInfo(chunk.map((r) => new PublicKey(r.wallet_address)));
+    } catch (e) {
+      console.error(`  (RPC failed mid-assessment: ${e.message} — marking nothing)`);
+      return 0;
+    }
+    infos.forEach((info, j) => {
+      const bal = info?.lamports ?? 0;
+      if (bal + Number(chunk[j].reward_lamports) < RENT_MIN) unpayable.push(chunk[j].wallet_address);
+    });
+  }
+  if (unpayable.length === 0) return 0;
+  const res = await query(
+    `UPDATE magpie_holder_rewards SET status = 'unpayable_rent_exempt'
+      WHERE distribution_id = $1 AND status = 'accrued' AND wallet_address = ANY($2)`,
+    [distId, unpayable],
+  );
+  return res.rowCount;
+}
+
+// ── Pay: loop retryAccruedPayouts() until drained (LIMIT 200/call). ──
+const { retryAccruedPayouts } = await import("../../src/services/magpie-holder-rewards.js");
+let totalPaid = 0;
+for (let iter = 1; iter <= 30; iter++) {
+  const r = await retryAccruedPayouts();
+  totalPaid += r.paid || 0;
+  console.log(`[iter ${iter}] retried=${r.retried} paid=${r.paid}${r.skipped ? ` skipped=${r.skipped}` : ""} (cumulative paid=${totalPaid})`);
+  if (r.skipped) { console.error("STOP: distributor balance too low — top up CHCAM and re-run."); break; }
+  if (!r.retried || r.retried === 0) break;      // nothing left
+  if (r.paid === 0) {
+    // ── Rent-exempt self-heal (added after dist #9, 2026-08-13) ──────────
+    // Solana refuses a transfer that would leave an account below the
+    // rent-exempt minimum (~0.00089 SOL). Payouts batch 10 per transaction and
+    // a transaction fails ATOMICALLY, so ONE unpayable recipient kills the
+    // other nine. Once the pool shrank below that floor, 94% of dist #9's
+    // rewards were sub-minimum and the run stalled at 10 of 1433 — it took a
+    // manual side-script to unblock, mid-distribution.
+    //
+    // Only EMPTY accounts are actually blocked; a funded wallet accepts any
+    // amount. So on a fully-failed pass, check the remaining rows on-chain,
+    // mark the genuinely-unpayable ones, and continue paying the rest. Rows
+    // are marked (not deleted) so the outcome stays auditable and reversible.
+    if (!triedRentHeal) {
+      triedRentHeal = true;
+      console.error("A full pass failed — checking whether rent-exempt recipients are blocking the batches…");
+      const healed = await markUnpayableRentExempt(DIST_ID);
+      if (healed > 0) {
+        console.error(`Marked ${healed} row(s) unpayable_rent_exempt (empty accounts below the rent minimum). Continuing.`);
+        continue;
+      }
+      console.error("No rent-blocked rows found — the failure is something else.");
+    }
+    console.error("STOP: a batch failed with 0 paid this pass — inspect logs.");
+    break;
+  }
+}
+
+// Final tally
+const done = await query(
+  "SELECT status, COUNT(*)::int n, COALESCE(SUM(reward_lamports),0)::text s FROM magpie_holder_rewards WHERE distribution_id = $1 GROUP BY status ORDER BY status",
+  [DIST_ID],
+);
+console.log(`\n── dist ${DIST_ID} final status ──`);
+for (const row of done.rows) {
+  console.log(`  ${row.status}: ${row.n} rows, ${(Number(row.s) / 1e9).toFixed(6)} SOL`);
+}
+console.log(`\nTotal paid this run: ${totalPaid} rows.`);
+process.exit(0);

--- a/scripts/distributions/run-lp-payout.mjs
+++ b/scripts/distributions/run-lp-payout.mjs
@@ -1,0 +1,91 @@
+// GUARDED LP-loyalty payout: capture → batched pay → straggler sweep → rent-exempt finish.
+// Mirrors run-holder-payout.mjs security guards. Idempotent-ish: safe to re-run (only touches
+// 'accrued' rows; already-paid rows are untouched; sub-rent rows become 'unpayable_rent_exempt').
+//
+// GUARDS (all must pass before any SOL moves):
+//   1. Force distributor key = CHCAM MGP-001 sender (never the LENDER fallback).
+//   2. Assert resolved signer pubkey === CHCAM, else ABORT.
+//
+// Usage: ! cd ~/bagbank-bot && railway run --service magpie-bot node run-lp-payout.mjs
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Connection, PublicKey, SystemProgram, Transaction, sendAndConfirmTransaction } from "@solana/web3.js";
+
+const CHCAM = "CHCAMWtnmgyjsJqHcq5MdeDdg4X3Ux1XAwA2rMCXj1Ac";
+
+// ── Guard 1: load CHCAM key and force it as the distributor BEFORE importing services ──
+const keyPath = path.join(os.homedir(), ".magpie-private", "distribution-keypairs", "MGP-001-sender.json");
+if (!fs.existsSync(keyPath)) { console.error("ABORT: CHCAM key not found at", keyPath); process.exit(1); }
+const bs58 = (await import("bs58")).default;
+const secretBytes = Uint8Array.from(JSON.parse(fs.readFileSync(keyPath, "utf8")));
+process.env.REWARDS_DISTRIBUTOR_PRIVATE_KEY = bs58.encode(secretBytes);
+
+const { getRewardsDistributorKeypair } = await import("../../src/services/distributor-keypair.js");
+const distributor = getRewardsDistributorKeypair();
+const signer = distributor.publicKey.toBase58();
+// ── Guard 2: signer MUST be CHCAM ──
+if (signer !== CHCAM) { console.error(`ABORT: signer ${signer} !== CHCAM. Refusing to pay from wrong wallet.`); process.exit(1); }
+console.log("✓ distributor signer verified:", signer, "(CHCAM)");
+
+const { query } = await import("../../src/db/pool.js");
+const lp = await import("../../src/services/lp-loyalty.js");
+const RPC = process.env.SOLANA_RPC_URL || "https://api.mainnet-beta.solana.com";
+const conn = new Connection(RPC, "confirmed");
+
+// Pool state before
+const st0 = await lp.getLpLoyaltyPoolState();
+console.log(`LP pool accrued before: ${(Number(st0.accrued_lamports) / 1e9).toFixed(6)} SOL`);
+
+// ── Capture + first-pass batched payout ──
+const res = await lp.snapshotAndDistributeLpLoyalty();
+if (res) {
+  console.log(`captured dist ${res.distribution_id}: ${res.eligible_count} eligible, allocated ${(Number(res.allocated_lamports)/1e9).toFixed(6)} SOL, first-pass paid ${res.paid_count}`);
+} else {
+  console.log("snapshotAndDistributeLpLoyalty returned null (pool below min / no eligible / already captured) — sweeping any accrued stragglers.");
+}
+
+// ── Sweep accrued stragglers in batches ──
+for (let iter = 1; iter <= 30; iter++) {
+  const r = await lp.retryAccruedLpLoyaltyPayouts();
+  console.log(`[retry ${iter}] retried=${r.retried} paid=${r.paid}${r.skipped ? ` skipped=${r.skipped}` : ""}`);
+  if (r.skipped) { console.error("STOP: CHCAM balance too low — top up and re-run."); break; }
+  if (!r.retried) break;
+  if (r.paid === 0) break; // remaining are batch-blocked (likely rent-exempt) → handle below
+}
+
+// ── Rent-exempt finish: pay remaining 'accrued' ONE-per-tx; mark truly-unpayable ones ──
+const rentMin = await conn.getMinimumBalanceForRentExemption(0);
+const { rows: rem } = await query("SELECT id, wallet_address, reward_lamports FROM lp_loyalty_rewards WHERE status = 'accrued' ORDER BY id ASC");
+console.log(`\n${rem.length} straggler(s) remaining → per-tx finish (rent-exempt min ${(rentMin/1e9).toFixed(6)} SOL)`);
+let finished = 0, unpayable = 0;
+for (const r of rem) {
+  const reward = BigInt(r.reward_lamports);
+  let recipBal;
+  try { recipBal = BigInt(await conn.getBalance(new PublicKey(r.wallet_address))); } catch { recipBal = 0n; }
+  // If the recipient is empty AND the reward can't lift it to rent-exempt, it's unpayable (SOL stays in CHCAM).
+  if (recipBal === 0n && reward < BigInt(rentMin)) {
+    await query("UPDATE lp_loyalty_rewards SET status = 'unpayable_rent_exempt' WHERE id = $1", [r.id]);
+    unpayable++;
+    continue;
+  }
+  try {
+    const tx = new Transaction().add(SystemProgram.transfer({ fromPubkey: distributor.publicKey, toPubkey: new PublicKey(r.wallet_address), lamports: reward }));
+    const sig = await sendAndConfirmTransaction(conn, tx, [distributor], { commitment: "confirmed" });
+    await query("UPDATE lp_loyalty_rewards SET status = 'paid', paid_at = NOW(), paid_tx_signature = $2 WHERE id = $1", [r.id, sig]);
+    finished++;
+  } catch (err) {
+    // Single-tx still failed with a fundable reward → likely rent-exempt on an empty account; mark unpayable.
+    if (recipBal === 0n) { await query("UPDATE lp_loyalty_rewards SET status = 'unpayable_rent_exempt' WHERE id = $1", [r.id]); unpayable++; }
+    else console.error(`  row ${r.id} (${r.wallet_address.slice(0,6)}…) failed:`, err.message.slice(0, 80));
+  }
+}
+console.log(`per-tx finish: ${finished} paid, ${unpayable} marked unpayable_rent_exempt`);
+
+// ── Final tally for the newest LP distribution ──
+const { rows: last } = await query("SELECT id FROM lp_loyalty_distributions ORDER BY id DESC LIMIT 1");
+const distId = last[0]?.id;
+const { rows: tally } = await query("SELECT status, COUNT(*)::int n, COALESCE(SUM(reward_lamports),0)::text s FROM lp_loyalty_rewards WHERE distribution_id = $1 GROUP BY status ORDER BY status", [distId]);
+console.log(`\n── LP dist ${distId} final status ──`);
+for (const row of tally) console.log(`  ${row.status}: ${row.n} rows, ${(Number(row.s) / 1e9).toFixed(6)} SOL`);
+process.exit(0);


### PR DESCRIPTION
## The scripts were never in the repo

`capture-holder-dist.mjs`, `run-holder-payout.mjs` and `run-lp-payout.mjs` existed only as **untracked files in a second local checkout** (`~/bagbank-bot`).

The distribution runbook has already been bitten by this once — the LP scripts went missing and had to be rebuilt mid-cycle. One lost laptop and the payout path is gone. Now tracked, with import paths rewritten for the new location and **verified to resolve against the real services**, not just pattern-matched.

They contain **no secrets**: the only long literal is CHCAM's *public* address, and the signing key is read from `~/.magpie-private/` outside the repo.

## Rent-exempt self-heal

Solana refuses a transfer that would leave an account below the rent-exempt minimum (~0.00089 SOL). Payouts batch 10 per transaction and a transaction fails **atomically**, so one unpayable recipient kills the other nine.

Dist #9 was the first cycle where the holder pool fell below that floor — **94% of rewards were sub-minimum and the run stalled at 10 of 1,433**, needing a manual side-script to unblock *mid-distribution*.

`run-holder-payout.mjs` now detects a fully-failed pass, checks the remaining recipients **on-chain**, marks only the genuinely unpayable ones (empty accounts that would land below the minimum), and continues paying the rest. A funded wallet accepts any amount, so this writes off nobody who could actually have been paid.

Deliberately conservative:

- runs **at most once** per invocation
- marks **nothing** if no RPC is configured, or if RPC fails mid-assessment
- **marks** rows rather than deleting them, so the outcome stays auditable and reversible
- if nothing is rent-blocked it says so and stops — a different failure is never silently absorbed

## Verification

Run against the already-settled dist #9 as a no-op: signer verified CHCAM, `retried=0`, nothing paid, status unchanged (1,114 paid / 319 unpayable). The self-heal correctly did **not** fire, since it only triggers when there are rows to retry but none succeed.

Note this does **not** decide the policy question — 319 holders still got nothing, and whether to set a minimum-balance eligibility threshold or roll small amounts forward is still open. This only stops the mechanical stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)