### PR TITLE
feat(rewards): carry forward rewards Solana cannot deliver, instead of writing them off

### DIFF
--- a/migrations/102_holder_carryforward.sql
+++ b/migrations/102_holder_carryforward.sql
@@ -1,0 +1,49 @@
+-- 102 · Carry forward rewards that Solana physically could not deliver.
+--
+-- WHY. Solana refuses a transfer that would leave an account below the
+-- rent-exempt minimum (~0.00089088 SOL). In distribution #9 (2026-08-13) the
+-- holder pool had shrunk to 0.3947 SOL across 1,433 holders — an average reward
+-- of 0.000275 SOL, about a third of that floor — and 319 holders with empty
+-- wallets could not be paid at all. Their 0.004773 SOL was written off and
+-- stayed in CHCAM.
+--
+-- Writing it off means those holders never receive it, and the same wallets
+-- fail again every cycle: the amount is always too small, so it is always
+-- forfeited. This table breaks that loop by accumulating what they were owed
+-- until it is large enough to actually send (or until their wallet is funded,
+-- at which point any amount goes through).
+--
+-- IMPORTANT — this is NOT part of the pool. The pool was already decremented
+-- when these rewards were first allocated, and the SOL is already sitting in
+-- CHCAM. A carried balance is therefore paid FROM that existing balance and
+-- must never be added to `allocatedSum` when the next distribution decrements
+-- the pool, or the pool would be double-charged.
+--
+-- Only the 319 genuinely-undeliverable rows carry. Holders below the rent floor
+-- whose wallets are funded are paid normally and never touch this table —
+-- measured: 1,028 of the 1,347 sub-rent holders in dist #9 were paid fine.
+
+CREATE TABLE IF NOT EXISTS magpie_holder_carryforward (
+  wallet_address   TEXT PRIMARY KEY,
+
+  -- Undeliverable rewards accumulated so far. Added on top of the wallet's
+  -- pro-rata share at the next capture, and reset to 0 once actually paid.
+  lamports         BIGINT NOT NULL DEFAULT 0 CHECK (lamports >= 0),
+
+  -- Diagnostics: how long this holder has been waiting, and across how many
+  -- distributions. If cycles climbs without the balance ever clearing, the
+  -- floor is beating the accrual rate and the policy needs revisiting.
+  cycles           INT NOT NULL DEFAULT 0,
+  first_carried_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The capture path loads every non-zero carry in one read.
+CREATE INDEX IF NOT EXISTS magpie_holder_carryforward_nonzero_idx
+  ON magpie_holder_carryforward (wallet_address)
+  WHERE lamports > 0;
+
+COMMENT ON TABLE magpie_holder_carryforward IS
+  'Rewards that could not be delivered because the transfer would leave the recipient below the rent-exempt minimum. Accumulates until payable. NOT part of magpie_holder_pool — the pool was already decremented and this SOL already sits in CHCAM.';
+COMMENT ON COLUMN magpie_holder_carryforward.lamports IS
+  'Owed to this wallet from prior undeliverable payouts. Added to their next allocation; zeroed once paid.';

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check:migration-checksums": "node scripts/check-migration-checksums.mjs",
     "check:borrow-reservation-race": "node scripts/check-borrow-reservation-race.mjs",
     "check:captcha-deeplink": "node scripts/check-captcha-deeplink.mjs",
+    "check:holder-carryforward": "node scripts/check-holder-carryforward.mjs",
     "simulate:expiry-warnings": "node scripts/simulate-expiry-warnings.mjs"
   },
   "dependencies": {

--- a/scripts/check-holder-carryforward.mjs
+++ b/scripts/check-holder-carryforward.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Guard: holder reward carry-forward accounting.
+ *
+ * WHY. Distribution #9 (2026-08-13) wrote off 319 holders whose rewards Solana
+ * could not deliver — a transfer would have left their empty account below the
+ * rent-exempt minimum. Writing off means they never receive it AND the same
+ * wallets fail again every cycle, because the amount is always too small.
+ * Migration 102 accumulates it instead, until it clears the floor or their
+ * wallet gets funded.
+ *
+ * THE INVARIANT THIS PROTECTS. A carried balance is NOT new money. The pool was
+ * already decremented for those lamports when they were first allocated, and
+ * the SOL has been sitting in CHCAM ever since. So carry is added to the
+ * holder's `reward_lamports` but MUST NOT be added to `allocatedSum`, which is
+ * what decrements `magpie_holder_pool`. Getting that wrong charges the pool
+ * twice for the same SOL and silently over-draws it every cycle.
+ *
+ * The second failure mode is carry that never clears: if a successful payout
+ * doesn't zero it, the holder is paid the same lamports again next cycle.
+ *
+ * Run: npm run check:holder-carryforward
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(dir, "../src/services/magpie-holder-rewards.js"), "utf8");
+const mark = readFileSync(path.join(dir, "distributions/mark-unpayable-rent-exempt.mjs"), "utf8");
+
+let failures = 0;
+const ok = (n) => console.log(`  ✅ ${n}`);
+const bad = (n, d) => { failures++; console.error(`  ❌ ${n}${d ? ` — ${d}` : ""}`); };
+const expect = (n, a, w) => (a === w ? ok(n) : bad(n, `got ${JSON.stringify(a)}, wanted ${JSON.stringify(w)}`));
+
+console.log("\n== the allocation math (modelled exactly as shipped) ==");
+{
+  // Mirrors the loop in snapshotAndDistribute.
+  const allocate = (pool, holders, carry) => {
+    let allocatedSum = 0n;
+    const rows = [];
+    for (const h of holders) {
+      const base = (pool * h.balance) / holders.reduce((a, x) => a + x.balance, 0n);
+      const owed = carry.get(h.owner) || 0n;
+      const reward = base + owed;
+      if (reward <= 0n) continue;
+      rows.push({ owner: h.owner, reward });
+      allocatedSum += base; // pool portion ONLY
+    }
+    return { rows, allocatedSum };
+  };
+
+  const holders = [
+    { owner: "A", balance: 50n },
+    { owner: "B", balance: 50n },
+  ];
+  const pool = 1000n;
+
+  const noCarry = allocate(pool, holders, new Map());
+  expect("without carry, allocatedSum equals the pool", noCarry.allocatedSum, 1000n);
+
+  const withCarry = allocate(pool, holders, new Map([["A", 777n]]));
+  expect("carry does NOT inflate allocatedSum (pool charged once)", withCarry.allocatedSum, 1000n);
+  expect("carried holder's reward includes the carry", withCarry.rows.find((r) => r.owner === "A").reward, 500n + 777n);
+  expect("uncarried holder is unaffected", withCarry.rows.find((r) => r.owner === "B").reward, 500n);
+
+  // The whole point: someone with no new share still gets paid what they are owed.
+  const dust = allocate(0n, holders, new Map([["A", 900n]]));
+  expect("zero pool + carry still produces a row", dust.rows.length, 1);
+  expect("  ...for the carried holder only", dust.rows[0].owner, "A");
+  expect("  ...and charges the pool nothing", dust.allocatedSum, 0n);
+}
+
+console.log("\n== accumulation must ADD UP, never compound ==");
+{
+  // capture folds carry INTO reward_lamports, so writing reward_lamports back
+  // as the new carry accumulates correctly. Compounding would mean the holder's
+  // owed balance grows without any new allocation.
+  let carry = 100n;
+  for (let cycle = 0; cycle < 3; cycle++) {
+    const base = 50n;             // their share that cycle
+    const reward = base + carry;  // what capture writes
+    carry = reward;               // written off again → becomes the new carry
+  }
+  expect("3 cycles of 50 on top of 100 = 250", carry, 250n);
+}
+
+console.log("\n== source: the accounting rule is actually in the code ==");
+expect("allocatedSum adds base, not reward", /allocatedSum \+= base;/.test(src), true);
+expect("  ...and never adds the carried amount", /allocatedSum \+= (reward|owed)\b/.test(src), false);
+expect("reward = base + carried", /const reward = base \+ owed;/.test(src), true);
+expect("carry is read from the carryforward table", /FROM magpie_holder_carryforward WHERE lamports > 0/.test(src), true);
+expect("a carry-table failure cannot block a distribution", /carryforward read failed \(continuing without\)/.test(src), true);
+
+console.log("\n== source: carry is cleared when actually paid ==");
+{
+  const clears = [...src.matchAll(/UPDATE magpie_holder_carryforward\s+SET lamports = 0/g)].length;
+  expect("both payout paths clear it", clears, 2);
+  // The claim path selects only (id, reward_lamports) — mapping rows for a
+  // wallet_address there yields [undefined], silently clears nothing, and the
+  // holder is paid the same lamports again next cycle.
+  expect("claim path clears by its walletAddress param", /wallet_address = \$1 AND lamports > 0/.test(src), true);
+  expect("batch path clears by the batch's wallet_address", /wallet_address = ANY\(\$1::text\[\]\) AND lamports > 0/.test(src), true);
+}
+
+console.log("\n== source: write-off records the carry ==");
+expect("marking script inserts into carryforward", /INSERT INTO magpie_holder_carryforward/.test(mark), true);
+expect("  ...accumulating via ON CONFLICT", /ON CONFLICT \(wallet_address\) DO UPDATE/.test(mark), true);
+expect("  ...and counts cycles waited", /cycles     = magpie_holder_carryforward\.cycles \+ 1/.test(mark), true);
+
+console.log(
+  failures === 0 ? "\n✅ carry-forward guard passed\n" : `\n❌ ${failures} check(s) failed\n`,
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/distributions/mark-unpayable-rent-exempt.mjs
+++ b/scripts/distributions/mark-unpayable-rent-exempt.mjs
@@ -81,7 +81,7 @@ const forfeited = unpayable.reduce((a, r) => a + r.reward, 0);
 console.log(`  payable:   ${payable}`);
 console.log(`  unpayable: ${unpayable.length}  (${(forfeited / 1e9).toFixed(6)} SOL)`);
 console.log(
-  `  NOTE: unpayable SOL stays in CHCAM — the pool was already decremented at accrual.`,
+  `  NOTE: this SOL stays in CHCAM and is CARRIED FORWARD to the holder's next payout (migration 102) — the pool was already decremented at accrual, so it is never charged twice.`,
 );
 
 if (!WRITE) {
@@ -105,5 +105,31 @@ const res = await query(
   [DIST_ID, wallets],
 );
 console.log(`✓ marked ${res.rowCount} row(s) unpayable_rent_exempt`);
+
+// CARRY FORWARD (migration 102). Writing these off means the holder never
+// receives them AND the same wallet fails again every cycle, because the amount
+// is always too small. Accumulating instead means it eventually clears the rent
+// floor — or their wallet gets funded, at which point any amount sends.
+//
+// The full reward_lamports carries, which already includes any balance carried
+// in from previous cycles (capture folds carry into the reward), so this
+// accumulates correctly rather than compounding.
+const carried = await query(
+  `INSERT INTO magpie_holder_carryforward (wallet_address, lamports, cycles)
+   SELECT wallet_address, reward_lamports, 1
+     FROM magpie_holder_rewards
+    WHERE distribution_id = $1 AND status = 'unpayable_rent_exempt'
+      AND wallet_address = ANY($2)
+   ON CONFLICT (wallet_address) DO UPDATE
+     SET lamports   = EXCLUDED.lamports,
+         cycles     = magpie_holder_carryforward.cycles + 1,
+         updated_at = NOW()`,
+  [DIST_ID, wallets],
+);
+const { rows: owed } = await query(
+  `SELECT COUNT(*)::int n, COALESCE(SUM(lamports),0)::text total FROM magpie_holder_carryforward WHERE lamports > 0`,
+);
+console.log(`✓ carried forward for ${carried.rowCount} wallet(s)`);
+console.log(`  outstanding carry: ${owed[0].n} wallet(s), ${(Number(owed[0].total)/1e9).toFixed(9)} SOL — paid from CHCAM next cycle`);
 console.log(`Next: DIST_ID=${DIST_ID} railway run --service magpie-bot node run-holder-payout.mjs`);
 process.exit(0);

--- a/src/services/magpie-holder-rewards.js
+++ b/src/services/magpie-holder-rewards.js
@@ -1013,6 +1013,15 @@ async function payHolderRewardBatches(rows, distributor, onBatchPaid) {
             WHERE id = ANY($1::bigint[])`,
           [batch.map((r) => r.id), sig],
         );
+        // Their carried balance was folded INTO this reward_lamports at
+        // capture, so a successful send settles it — zero it or they would be
+        // paid the same lamports again next cycle.
+        await query(
+          `UPDATE magpie_holder_carryforward
+              SET lamports = 0, cycles = 0, updated_at = NOW()
+            WHERE wallet_address = ANY($1::text[]) AND lamports > 0`,
+          [batch.map((r) => r.wallet_address)],
+        ).catch((e) => console.warn("[holder-rewards] carry clear failed:", e.message));
         paidCount += batch.length;
         paidLamports += batchTotal;
         avail -= batchTotal + TX_FEE_HEADROOM;
@@ -1129,12 +1138,41 @@ export async function snapshotAndDistribute() {
     );
     distributionId = distRow.id;
 
+    // Carried balances: rewards a previous cycle could not deliver because the
+    // transfer would have left an EMPTY recipient below Solana's rent-exempt
+    // minimum. See migration 102.
+    //
+    // ⚠️ ACCOUNTING: carry is deliberately EXCLUDED from `allocatedSum`.
+    // allocatedSum is what decrements magpie_holder_pool, and the pool was
+    // ALREADY decremented for these lamports when they were first allocated —
+    // the SOL has been sitting in CHCAM ever since. Adding carry here would
+    // charge the pool twice for the same SOL.
+    const carry = new Map();
+    try {
+      const { rows: cf } = await client.query(
+        `SELECT wallet_address, lamports FROM magpie_holder_carryforward WHERE lamports > 0`,
+      );
+      for (const r of cf) carry.set(r.wallet_address, BigInt(r.lamports));
+      if (cf.length) {
+        const owed = cf.reduce((a, r) => a + BigInt(r.lamports), 0n);
+        console.log(`[holder-rewards] carrying forward ${owed} lamports owed to ${cf.length} wallet(s)`);
+      }
+    } catch (e) {
+      // A missing/broken carry table must never block a distribution.
+      console.warn("[holder-rewards] carryforward read failed (continuing without):", e.message);
+    }
+
     const inserts = [];
     for (const h of holders) {
-      const reward = (pool * h.balance_raw) / totalBalance;
+      const base = (pool * h.balance_raw) / totalBalance;
+      const owed = carry.get(h.owner) || 0n;
+      const reward = base + owed;
+      // Skip only when there is genuinely nothing to send. A holder with no
+      // new share but an outstanding carry still gets a row — that is the
+      // whole point.
       if (reward <= 0n) continue;
       inserts.push([distributionId, h.owner, h.balance_raw.toString(), reward.toString()]);
-      allocatedSum += reward;
+      allocatedSum += base; // pool portion ONLY — see the accounting note above
     }
 
     if (inserts.length > 0) {
@@ -1377,6 +1415,18 @@ export async function claimHolderRewards({ walletAddress }) {
           SET status = 'paid', paid_at = NOW(), paid_tx_signature = $2
         WHERE id = ANY($1::bigint[])`,
       [rows.map((r) => r.id), res.sig],
+    );
+
+    // Use the function's own walletAddress — this query selects only
+    // (id, reward_lamports), so rows carry no wallet_address. Mapping over them
+    // would produce [undefined] here, silently match nothing, and leave the
+    // carry in place to be PAID A SECOND TIME next cycle. Inside the
+    // transaction so it commits or rolls back with the payout itself.
+    await client.query(
+      `UPDATE magpie_holder_carryforward
+          SET lamports = 0, cycles = 0, updated_at = NOW()
+        WHERE wallet_address = $1 AND lamports > 0`,
+      [walletAddress],
     );
 
     await client.query("COMMIT");


### PR DESCRIPTION
Distribution #9 wrote off **319 holders** whose rewards couldn't be sent — the transfer would have left their **empty** account below the rent-exempt minimum (~0.00089 SOL). Their 0.004773 SOL stayed in CHCAM and they got nothing.

Writing it off is a trap, not just a loss: **the same wallets fail again every cycle**, because the amount is always too small. Forfeited forever. Carrying it accumulates until it clears the floor (~4 cycles at current rates) or their wallet gets funded, at which point any amount sends.

## Targeted, not a blanket policy

Measured on dist #9: **1,347 holders were below the rent floor but only 319 actually failed** — the other 1,028 had funded wallets and were paid normally.

The obvious alternative, a minimum-balance eligibility threshold, would have been far worse:

| Threshold | Paid | Excluded |
|---|---|---|
| 1× rent | 86 | **1,347** |
| 2× rent | 51 | 1,382 |

**This excludes nobody.** Only genuinely-undeliverable rows carry.

## ⚠️ The accounting rule

A carried balance **is not new money**. The pool was already decremented for those lamports at first allocation, and the SOL has been sitting in CHCAM since.

So carry is added to the holder's `reward_lamports` but **never** to `allocatedSum`, which is what decrements `magpie_holder_pool`. Adding it there would charge the pool twice for the same SOL, every cycle, silently.

## A bug I caught while building this

My first version cleared the carry in `claimHolderRewards()` via `rows.map(r => r.wallet_address)` — but **that query selects only `(id, reward_lamports)`**. It would have produced `[undefined]`, matched nothing, and **paid the same lamports again next cycle**. Now uses the function's own `walletAddress` param, inside the transaction so it commits or rolls back with the payout.

## Verification

Migration 102 applied; dist #9's write-offs backfilled — **319 wallets / 0.004772899 SOL**, matching the written-off total exactly.

`npm run check:holder-carryforward`, mutation-tested:

| Mutation | Caught |
|---|---|
| `allocatedSum += reward` (pool double-charged) | ✅ |
| Claim path stops clearing carry (double payment) | ✅ |

Also asserts the zero-pool-plus-carry case still produces a row — that's the whole point — and that accumulation adds up rather than compounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)