### PR TITLE
fix(routing): keep RWA exit-armed borrows on V4 — V4.1 would reject them

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:captcha-deeplink": "node scripts/check-captcha-deeplink.mjs",
     "check:holder-carryforward": "node scripts/check-holder-carryforward.mjs",
     "verify:token": "node scripts/verify-token-listing.mjs",
+    "check:v41-rwa-routing": "node scripts/check-v41-rwa-routing.mjs",
     "simulate:expiry-warnings": "node scripts/simulate-expiry-warnings.mjs"
   },
   "dependencies": {

--- a/scripts/check-v41-rwa-routing.mjs
+++ b/scripts/check-v41-rwa-routing.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Guard: an exit-armed RWA borrow must NEVER route to V4.1.
+ *
+ * WHY. V4.1 ships Sec3's [H-01] fix, which rejects any Token-2022 collateral
+ * carrying `PermanentDelegate`. Scanned mainnet 2026-08-13:
+ *
+ *   memecoins            0 of 233 blocked
+ *   stocks/ETFs/metals  25 of  25 blocked  ← every single one
+ *
+ * Regulated issuers use PermanentDelegate for compliance clawback and
+ * redemption, so it is the norm for real-world assets. Operator decision
+ * 2026-08-13 was to ship Sec3's recommendation unmodified and keep RWAs on V4
+ * rather than carve an exemption into audited custody logic.
+ *
+ * That decision is only safe if ROUTING enforces it. Without the guard,
+ * flipping ROUTE_EXITS_TO_V4_1=true sends an exit-armed RWA borrow to a program
+ * that refuses the mint, and the borrower gets an opaque
+ * `UnsupportedCollateralExtension` failure at signing time.
+ *
+ * This is a live path, not hypothetical: 34 RWA take-profit/stop-loss orders
+ * have been armed to date and 5 are still armed.
+ *
+ * The failure mode is invisible until the flag flips — which is exactly when
+ * nobody is looking for it. Hence a guard rather than a comment.
+ *
+ * Run: npm run check:v41-rwa-routing
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(dir, "../src/solana/program.js"), "utf8");
+
+let failures = 0;
+const ok = (n) => console.log(`  ✅ ${n}`);
+const bad = (n, d) => { failures++; console.error(`  ❌ ${n}${d ? ` — ${d}` : ""}`); };
+const expect = (n, a, w) => (a === w ? ok(n) : bad(n, `got ${JSON.stringify(a)}, wanted ${JSON.stringify(w)}`));
+
+console.log("\n== the routing decision, modelled exactly as shipped ==");
+{
+  const RWA = new Set(["stock", "etf", "metal"]);
+  // Mirrors chooseProgramId's exit-arming branch.
+  const pick = ({ category, hasV41, routeFlag }) => {
+    const rwaMustStayOnV4 = RWA.has(category);
+    return hasV41 && routeFlag && !rwaMustStayOnV4 ? "V4.1" : "V4";
+  };
+
+  // The dangerous configuration: V4.1 deployed AND the flag flipped on.
+  const live = { hasV41: true, routeFlag: true };
+  expect("memecoin exit-armed  → V4.1", pick({ ...live, category: "memecoin" }), "V4.1");
+  expect("stock exit-armed     → V4 (NOT V4.1)", pick({ ...live, category: "stock" }), "V4");
+  expect("etf exit-armed       → V4 (NOT V4.1)", pick({ ...live, category: "etf" }), "V4");
+  expect("metal exit-armed     → V4 (NOT V4.1)", pick({ ...live, category: "metal" }), "V4");
+  // GLDx and SILV are both 'metal' — the tokens this actually protects.
+  expect("undefined category   → V4.1 (treated as memecoin, existing behaviour)",
+    pick({ ...live, category: undefined }), "V4.1");
+
+  // Flag off: byte-identical to today, nothing reaches V4.1.
+  const off = { hasV41: true, routeFlag: false };
+  for (const c of ["memecoin", "stock", "etf", "metal"]) {
+    if (pick({ ...off, category: c }) !== "V4") bad(`flag OFF: ${c} should stay on V4`);
+  }
+  ok("flag OFF → everything stays on V4 (routing identical to today)");
+
+  // V4.1 not deployed: same.
+  const nodeploy = { hasV41: false, routeFlag: true };
+  for (const c of ["memecoin", "stock", "etf", "metal"]) {
+    if (pick({ ...nodeploy, category: c }) !== "V4") bad(`V4.1 absent: ${c} should stay on V4`);
+  }
+  ok("V4.1 not configured → everything stays on V4");
+}
+
+console.log("\n== the guard is actually in the shipped source ==");
+expect("RWA guard present", /const rwaMustStayOnV4 = isRwaCategory\(category\);/.test(src), true);
+expect("  ...and gates the V4.1 selection", /ROUTE_EXITS_TO_V4_1 && !rwaMustStayOnV4/.test(src), true);
+expect("RWA category set is the canonical one",
+  /RWA_CATEGORIES = new Set\(\["stock", "etf", "metal"\]\)/.test(src), true);
+expect("the reason is documented at the call site", /PermanentDelegate/.test(src), true);
+
+console.log(
+  failures === 0 ? "\n✅ V4.1 RWA routing guard passed\n" : `\n❌ ${failures} check(s) failed\n`,
+);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -210,8 +210,29 @@ export function chooseProgramId(category, opts = {}) {
     // once the operator flips ROUTE_EXITS_TO_V4_1. Resolved BEFORE the
     // not-configured check so retiring V4 later doesn't block exits, and placed
     // AFTER the pause check above so V4_BORROWS_PAUSED still freezes both.
+    // ── RWA EXITS STAY ON V4, NOT V4.1 ──────────────────────────────────
+    // V4.1 ships Sec3's [H-01] fix, which REJECTS any Token-2022 collateral
+    // carrying PermanentDelegate. Measured on mainnet 2026-08-13: ALL 25
+    // enabled RWAs carry it — every Backed xStock, all 3 ETFs, and both metals
+    // (GLDx, SILV). Regulated issuers use it for compliance clawback and
+    // redemption, so it is the norm for the asset class, not an anomaly.
+    // Memecoins are unaffected: 0 of 233 are blocked.
+    //
+    // Without this guard, flipping ROUTE_EXITS_TO_V4_1 would send an
+    // exit-armed RWA borrow to a program that refuses the mint outright, and
+    // the borrower gets an opaque UnsupportedCollateralExtension failure. RWA
+    // exit arming is small but REAL — 34 orders armed to date, 5 still armed —
+    // so this is a live path, not a hypothetical one.
+    //
+    // Operator decision 2026-08-13: ship Sec3's recommendation as written and
+    // keep RWAs on V4, rather than carve an exemption into audited custody
+    // logic. Revisit only if Sec3 reviews and accepts the exemption proposal
+    // (branch proposal/rwa-custody-exemption in magpie-v4-1).
+    const rwaMustStayOnV4 = isRwaCategory(category);
     const exitProgram =
-      PROGRAM_ID_V4_1 && ROUTE_EXITS_TO_V4_1 ? PROGRAM_ID_V4_1 : PROGRAM_ID_V4;
+      PROGRAM_ID_V4_1 && ROUTE_EXITS_TO_V4_1 && !rwaMustStayOnV4
+        ? PROGRAM_ID_V4_1
+        : PROGRAM_ID_V4;
     if (!exitProgram) {
       throw new Error(
         "EXIT_ARMING_REQUIRES_V4: exit-armed borrow requested but PROGRAM_ID_V4 is not configured. " +


### PR DESCRIPTION
**Operator decision 2026-08-13:** ship Sec3's [H-01] recommendation exactly as written — no carve-out into audited custody logic.

That decision is only safe if **routing enforces it.**

## The gap

V4.1 rejects any Token-2022 collateral carrying `PermanentDelegate`. Scanned mainnet:

| Class | Enabled | Blocked by V4.1 |
|---|---|---|
| Memecoins | 233 | **0** |
| Stocks / ETFs / metals | 25 | **25 — every one** |

Regulated issuers use `PermanentDelegate` for compliance clawback and redemption, so it's the norm for real-world assets, not a defect.

`chooseProgramId()` sent **every** exit-armed borrow to V4.1 once `ROUTE_EXITS_TO_V4_1` flipped — **no category check**. So the day that flag goes on, an RWA borrower arming a TP/SL is routed to a program that refuses their mint, and gets an opaque `UnsupportedCollateralExtension` at signing time.

This is a live path, not hypothetical: **34 RWA take-profit/stop-loss orders armed to date, 5 still armed right now.**

## The fix

RWA exit-armed borrows stay on **V4**, where they work today. Memecoins route to V4.1 as intended.

**Nothing user-facing changes** — RWA TP/SL keeps working, just on the program it already runs on. No public copy claims V4.1 handles all collateral, so no messaging is now inaccurate.

## Why a guard rather than a comment

The failure would have been invisible until the flag flipped — which is exactly when nobody is watching for it.

`check:v41-rwa-routing` models the routing decision and asserts it in source: memecoin→V4.1, stock/etf/metal→V4, flag-off→everything on V4, V4.1-absent→everything on V4. Mutation-tested by deleting the guard.

Guards pass: `v41-rwa-routing`, `warning-delivery`, `captcha-deeplink`, `arming`, `idl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)