### PR TITLE
feat(community): "mag my fucking pie" → "Your fucking pie has been Magged"

### DIFF
--- a/src/handlers/community-handlers.js
+++ b/src/handlers/community-handlers.js
@@ -1054,6 +1054,28 @@ async function maybeAnswerPipQuestion(ctx, msg, sender) {
   }
   if (!question) return false;
 
+  // ── Easter egg: "mag my fucking pie" ─────────────────────────────────────
+  // Answered BEFORE the rate limit and the LLM call: it costs nothing, should
+  // never be throttled away, and must never be paraphrased by the model into
+  // something less funny. Deterministic in, deterministic out.
+  //
+  // Mirrors the caller's own wording rather than hardcoding the profanity, so
+  // "mag my pie" gets a clean reply and "mag my fucking pie" gets the version
+  // the joke is actually about. Matched loosely (any filler between "my" and
+  // "pie") so near-misses still land.
+  const magMyPie = question.match(/\bmag\s+my\s+(.{0,20}?)\bpie\b/i);
+  if (magMyPie) {
+    const filler = (magMyPie[1] || "").trim();
+    const reply = filler
+      ? `Your ${filler} pie has been Magged. 🥧`
+      : `Your pie has been Magged. 🥧`;
+    await ctx.api.sendMessage(ctx.chat.id, reply, {
+      reply_to_message_id: msg.message_id,
+      allow_sending_without_reply: true,
+    }).catch(() => {});
+    return true;
+  }
+
   // Rate limit + safety gate
   const { checkRateLimit, answerGroupQuestion, looksLikePromptInjection } =
     await import("../services/community-pip.js");


### PR DESCRIPTION
Operator-requested easter egg for Magpie Talk.

## Placement

Answered **before** the rate limit and the LLM call — it costs nothing, shouldn't be throttled away as if it were a support question, and must never be paraphrased by the model into something less funny. Deterministic in, deterministic out.

## It mirrors the caller

Rather than hardcoding the profanity, it echoes whatever they said:

| Input | Reply |
|---|---|
| `mag my fucking pie` | Your **fucking** pie has been Magged. 🥧 |
| `mag my pie` | Your pie has been Magged. 🥧 |
| `hey mag my goddamn pie please` | Your **goddamn** pie has been Magged. 🥧 |
| `MAG MY FUCKING PIE` | Your **FUCKING** pie has been Magged. 🥧 |

## Doesn't hijack real conversation

Verified it falls through to Pip normally on messages that merely contain the words:

- "what is the LTV on my pie" — no match
- "magpie is great" — no match
- "how do I borrow" — no match

It's also only reachable once the bot is already addressed (@-mention, `/ask`, or a reply to the bot), so it can't interrupt unrelated group chatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)