### PR TITLE
security(v1,v3): port Sec3 H-01 (token-2022 custody) — adapted per pool

### DIFF
--- a/programs/SEC3_V4_COVERAGE_MATRIX.md
+++ b/programs/SEC3_V4_COVERAGE_MATRIX.md
@@ -1,0 +1,64 @@
+# Sec3 V4 Findings — Coverage in the Unaudited Pools (V1, V3)
+
+**Purpose.** Sec3 audited **V4** (final report 2026-08-09: 24 findings, 20 resolved, 4
+acknowledged, 0 open). This is the evidence-based confirmation that **every** finding is
+accounted for in the two live unaudited lending programs — V1 (memecoin, `magpie-lending`,
+`4FEFPeMH…`) and V3 (RWA, `magpie-lending-v3`, `B8AwYzFm…`) — either **ported**, **already
+covered**, **not applicable**, or **documented as an accepted design choice**.
+
+**Status:** code complete on branch `security/port-sec3-h01-v1-v3` (PR #674). **Both programs
+`cargo check` clean. Program IDs unchanged. NOT deployed** — deploy is gated on operator go + a
+migration plan at a new program id.
+
+Legend: ✅ ported · ☑️ already covered (verified) · ⊘ not applicable · 📝 documented choice ·
+⚠️ operator decision needed.
+
+| # | Finding | V1 | V3 | Evidence / rationale |
+|---|---|---|---|---|
+| **H-01** | Unchecked Token-2022 extensions | ✅ | ✅ | `assert_collateral_custody_safe` + vault-received measurement. **Adapted:** V1 rejects PermanentDelegate+NonTransferable; V3 rejects NonTransferable only (PermanentDelegate is the norm for RWAs — full reject would brick every stock/metal borrow). |
+| **H-02** | Compromised engine steals collateral | ⊘ | ⊘ | No `convert_collateral_slice` / auto-sell engine in V1/V3. |
+| **M-01** | Loan extension lacks health check | ⚠️ | ⚠️ | Q-02 overdue-refusal added (below). A full mid-life LTV re-check on extend is **not** ported: extending only delays liquidation for a fee and never releases collateral or increases the loan, so it is not a value-extraction vector. Adding it would stop a not-yet-overdue but underwater borrower from extending — a UX change. **Flagged for operator decision.** |
+| **M-02** | Fully repaid loans still liquidatable | ☑️ | ☑️ | `liquidate_loan` requires `status == Active` **and** `now > due_timestamp` in both. A repaid loan (status≠Active) cannot be liquidated. |
+| **M-03** | Oracle floor ignores decimal normalization | ☑️ | ☑️ | Valuation divides by `10u128.pow(decimals)` — collateral value is decimal-normalized. |
+| **M-04** | Pool authority price trust | ✅ | ✅ | `update_price` now bounds a single update to ≤100× either way (`price_change_within_bound` + `MAX_PRICE_UPDATE_FACTOR`) + monotonic-timestamp guard. Same mitigation V4.1 adopted. |
+| **L-01** | Same-timestamp samples weaken TWAP | ⊘ | ☑️ | V1 has no TWAP. V3 already requires `oldest_age >= MIN_HISTORY_SECONDS` **and** `MIN_SAMPLES_FOR_TWAP` — same-timestamp spam adds no time coverage, so it can't weaken the gate. Identical to audited V4.1. |
+| **L-02** | Liquidation recoveries not returned to LPs | 📝 | 📝 | Model difference: V1/V3 send collateral to the authority on default and credit LPs via the **off-chain `/recover`** path (no in-vault conversion exists). V4's on-chain recovery-to-LP fix does not map. |
+| **L-03** | Upfront `pool_cut` first-exit advantage | ☑️ | ☑️ | `pool_cut` stays in the vault (LPs earn via share appreciation); no upfront cut is skimmed to an exiting LP. |
+| **L-04** | Auto-sell uses spot not TWAP | ⊘ | ⊘ | No auto-sell. |
+| **L-05** | Missing pool binding weakens oracle floor | ☑️ | ☑️ | `price_feed` is a PDA seeded `[b"price", mint, pool]` — cryptographically bound to both the collateral mint and the pool; plus `PriceMintMismatch` handler checks. A foreign/substituted feed cannot be passed. |
+| **L-06** | Dust debt extends loan without fee | ✅ | ✅ | Extension fee now rounds **up** and `require!(fee > 0)` — a dust-balance loan can't extend for free via floor division. |
+| **L-07** | Old shares steal new deposits | ☑️ | ☑️ | Share math uses the **internal `total_deposits` counter** (not live vault balance, so a donation can't inflate it) and `require!(shares > 0)` rejects a rounds-to-zero deposit. Standard share-inflation defense. |
+| **L-08** | Swap allowlist route semantics | ⊘ | ⊘ | No swap CPI / auto-sell. |
+| **I-01** | Missing wSOL mint checks | ☑️ | ☑️ | Loan-asset accounts are constrained `token::mint = loan_token_mint` against the pool's mint, and the vault is a per-pool PDA — a foreign loan mint cannot be substituted. |
+| **I-02** | Admin excess ignores outstanding loans | 📝 | 📝 | `admin_withdraw` is a deliberate **authority-gated emergency** lever (recover stuck funds). Capping it to "excess minus outstanding loans" could brick a legitimate recovery. Authority is already fully trusted for this pool. Accepted trust-model item (same class as V4's acknowledged M-04). |
+| **I-03** | Liquidation event reports wrong amounts | ☑️ | ☑️ | Amounts (`keeper_reward`, `authority_amount`) are computed locally from `loan.collateral_amount`, which — with H-01's receipt check — equals the actual locked collateral. No reported-vs-real divergence. |
+| **I-04** | Tiny loans avoid fees | ✅ | ✅ | Origination fee rounds **up** and `require!(fee > 0)`. |
+| **I-05** | Unsynced wSOL inflates proceeds delta | ⊘ | ⊘ | Specific to the in-vault conversion **proceeds delta**, which V1/V3 don't have. |
+| **I-06** | Tiny conversions avoid protocol fees | ⊘ | ⊘ | No conversion path. |
+| **Q-01** | Should confidence affect valuation? | 📝 | 📝 | Acknowledged/intentional in V4; V1/V3 likewise exclude per-sample confidence by design. |
+| **Q-02** | Overdue loans extendable? | ✅ | ✅ | `extend_loan` now refuses `now > due_timestamp`. **⚠️ Behavior change** — a late borrower can no longer extend; flagged for operator sign-off. |
+| **Q-03** | Caller specifies collateral value? | ☑️ | ☑️ | Borrower-supplied `collateral_value` is checked against the pool-bound attested price within a tolerance (`MAX_VALUE_TOLERANCE_BPS`), and capped by it — the caller cannot set their own borrowing power. |
+| **Q-04** | Armed slice cap per conversion | ⊘ | ⊘ | No conversion/arming. |
+
+## Summary
+
+- **Ported (5):** H-01, M-04, L-06, I-04, Q-02 — all compile-verified, matching audited V4.1.
+- **Already covered, verified (9):** M-02, M-03, L-01(V3), L-03, L-05, L-07, I-01, I-03, Q-03.
+- **Not applicable — no auto-sell/conversion engine (7):** H-02, L-04, L-08, I-05, I-06, Q-04, L-01(V1).
+- **Documented design choice (3):** L-02 (off-chain recover), I-02 (emergency lever), Q-01 (intentional).
+- **Operator decision (1):** M-01 — full mid-life health-recheck on extend (not a value-extraction vector; a UX change if added).
+
+**Net: every one of the 24 findings is accounted for.** The only item awaiting a call is M-01
+(a design choice, not an open vulnerability), plus the Q-02 UX sign-off.
+
+## Collectibles (design-only)
+
+Ported into the design before code exists: `magpie-collectibles-lending` **doc 45**. The
+fixed-term, oracle-less, no-mid-loan-liquidation model neutralizes the oracle/TWAP/auto-sell
+class by construction; the remaining lifecycle findings became build acceptance criteria.
+
+## ⛔ Deploy gate
+
+V1/V3 hold live user funds. This is reviewable code only. Any deploy ships at a **new program
+id** (never same-id), requires a migration plan, and needs explicit operator go-ahead. Build and
+test in each program's deploy environment before deploying.

--- a/programs/magpie-lending-v3/Cargo.toml
+++ b/programs/magpie-lending-v3/Cargo.toml
@@ -19,4 +19,4 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
 anchor-lang = { version = "0.32.1", features = ["init-if-needed"] }
-anchor-spl = "0.32.1"
+anchor-spl = { version = "0.32.1", features = ["token_2022"] }

--- a/programs/magpie-lending-v3/src/lib.rs
+++ b/programs/magpie-lending-v3/src/lib.rs
@@ -143,6 +143,45 @@ const TWAP_WINDOW_SECONDS: i64 = 30 * 60; // 30 min
 // Program
 // ---------------------------------------------------------------------------
 
+
+/// [H-01 · Sec3, ported from V4 — RWA CARVE-OUT] Reject collateral mints whose
+/// Token-2022 extensions break vault custody.
+///
+/// V3 holds REAL-WORLD ASSETS (tokenized stocks, ETFs, metals). Unlike the
+/// memecoin pool, it must NOT reject PermanentDelegate: every regulated RWA
+/// issuer (Backed, Dominion, ...) uses PermanentDelegate for compliance
+/// clawback and redemption — it is the NORM for this asset class, not a defect.
+/// Rejecting it would refuse EVERY stock and metal borrow. That custody risk is
+/// accepted for vetted issuers (mirroring the V4.1 decision, off-chain vetting
+/// via the canonical RWA allowlist).
+///
+/// NonTransferable, however, is a hard reject regardless of issuer: it would
+/// make seized or repaid collateral impossible to return or liquidate — no
+/// vetting changes that. Legacy SPL Token mints carry no extensions and pass.
+fn assert_collateral_custody_safe(mint_ai: &AccountInfo) -> Result<()> {
+    use anchor_spl::token_2022::spl_token_2022::extension::{
+        BaseStateWithExtensions, ExtensionType, StateWithExtensions,
+    };
+    use anchor_spl::token_2022::spl_token_2022::state::Mint as Mint2022;
+
+    if mint_ai.owner == &anchor_spl::token::ID {
+        return Ok(());
+    }
+    let data = mint_ai.try_borrow_data()?;
+    let state = StateWithExtensions::<Mint2022>::unpack(&data)
+        .map_err(|_| error!(ErrorCode::UnsupportedCollateralExtension))?;
+    let exts = state
+        .get_extension_types()
+        .map_err(|_| error!(ErrorCode::UnsupportedCollateralExtension))?;
+    for ext in exts {
+        // NonTransferable only — PermanentDelegate is accepted for RWAs.
+        if matches!(ext, ExtensionType::NonTransferable) {
+            return err!(ErrorCode::UnsupportedCollateralExtension);
+        }
+    }
+    Ok(())
+}
+
 #[program]
 pub mod magpie_lending {
     use super::*;
@@ -549,6 +588,10 @@ pub mod magpie_lending {
         require!(loan_option <= 2, ErrorCode::InvalidLoanOption);
         require!(collateral_amount > 0, ErrorCode::InvalidCollateralAmount);
         require!(collateral_value > 0, ErrorCode::InvalidCollateralValue);
+
+        // [H-01 · Sec3, RWA carve-out] Reject NonTransferable collateral;
+        // PermanentDelegate is accepted for vetted RWA issuers (see helper).
+        assert_collateral_custody_safe(&ctx.accounts.collateral_mint.to_account_info())?;
         // Validate category early — before any expensive TWAP / token work —
         // so a bad caller fails cheaply.
         require!(category <= 1, ErrorCode::InvalidCategory);
@@ -651,6 +694,11 @@ pub mod magpie_lending {
         let now = Clock::get()?.unix_timestamp;
 
         // --- Transfer collateral from borrower to vault (Token or Token-2022) ---
+        // [H-01 · Sec3] Measure what the vault ACTUALLY receives. RWAs are not
+        // fee-on-transfer, but a mint that skimmed a fee would let the pool
+        // over-lend against collateral it never received — require the vault
+        // balance to increase by EXACTLY the transferred amount.
+        let vault_balance_before = ctx.accounts.collateral_vault.amount;
         token_interface::transfer_checked(
             CpiContext::new(
                 ctx.accounts.token_program.to_account_info(),
@@ -664,6 +712,17 @@ pub mod magpie_lending {
             collateral_amount,
             decimals,
         )?;
+        ctx.accounts.collateral_vault.reload()?;
+        let received = ctx
+            .accounts
+            .collateral_vault
+            .amount
+            .checked_sub(vault_balance_before)
+            .ok_or(ErrorCode::MathOverflow)?;
+        require!(
+            received == collateral_amount,
+            ErrorCode::CollateralTransferFeeUnsupported
+        );
 
         // --- Disburse loan tokens from pool vault to borrower ---
         let authority_key = ctx.accounts.pool.authority.key();
@@ -1936,6 +1995,10 @@ pub enum ErrorCode {
     InvalidLoanOption,
     #[msg("Invalid collateral amount.")]
     InvalidCollateralAmount,
+    #[msg("Collateral mint carries a Token-2022 extension that breaks vault custody")]
+    UnsupportedCollateralExtension,
+    #[msg("Fee-on-transfer collateral is not supported: vault received less than sent")]
+    CollateralTransferFeeUnsupported,
     #[msg("Invalid collateral value.")]
     InvalidCollateralValue,
     #[msg("Invalid amount.")]

--- a/programs/magpie-lending-v3/src/lib.rs
+++ b/programs/magpie-lending-v3/src/lib.rs
@@ -144,6 +144,20 @@ const TWAP_WINDOW_SECONDS: i64 = 30 * 60; // 30 min
 // ---------------------------------------------------------------------------
 
 
+/// [M-04 · Sec3] Per-update price sanity bound (fat-finger / compromised-
+/// authority blast-radius limiter, not a volatility cap).
+const MAX_PRICE_UPDATE_FACTOR: u64 = 100;
+
+fn price_change_within_bound(prev: u64, new: u64) -> bool {
+    if prev == 0 {
+        return true;
+    }
+    let prev = prev as u128;
+    let new = new as u128;
+    let factor = MAX_PRICE_UPDATE_FACTOR as u128;
+    new <= prev.saturating_mul(factor) && new.saturating_mul(factor) >= prev
+}
+
 /// [H-01 · Sec3, ported from V4 — RWA CARVE-OUT] Reject collateral mints whose
 /// Token-2022 extensions break vault custody.
 ///
@@ -289,6 +303,11 @@ pub mod magpie_lending {
         // (clock skew or replay). Time must move forward.
         if let Some(latest) = feed.latest() {
             require!(now >= latest.timestamp, ErrorCode::PriceTimestampWentBackwards);
+            // [M-04 · Sec3] Bound a single update's blast radius.
+            require!(
+                price_change_within_bound(latest.price_lamports, price_lamports),
+                ErrorCode::PriceChangeExceedsBound
+            );
         }
 
         feed.append(PriceSample {
@@ -671,11 +690,16 @@ pub mod magpie_lending {
             .ok_or(ErrorCode::MathOverflow)?;
 
         // Compute fee
+        // [I-04 · Sec3] Round the origination fee UP and require it be > 0 so a
+        // tiny loan cannot dodge the fee via floor division.
         let fee = gross_loan
             .checked_mul(fee_bps)
             .ok_or(ErrorCode::MathOverflow)?
+            .checked_add(BPS_DENOM - 1)
+            .ok_or(ErrorCode::MathOverflow)?
             .checked_div(BPS_DENOM)
             .ok_or(ErrorCode::MathOverflow)?;
+        require!(fee > 0, ErrorCode::InvalidAmount);
 
         let net_loan = gross_loan
             .checked_sub(fee)
@@ -998,6 +1022,10 @@ pub mod magpie_lending {
     pub fn extend_loan(ctx: Context<ExtendLoan>) -> Result<()> {
         let loan = &ctx.accounts.loan;
         require!(loan.status == LoanStatus::Active, ErrorCode::LoanNotActive);
+        // [Q-02 · Sec3] An overdue loan is liquidatable and must not be
+        // extendable.
+        let now = Clock::get()?.unix_timestamp;
+        require!(now <= loan.due_timestamp, ErrorCode::LoanOverdueForExtension);
 
         // Resolve tier from the loan's stored (category, option) — the option
         // is derived from ltv_bps within the category's ladder. RWA Standard
@@ -1008,12 +1036,17 @@ pub mod magpie_lending {
             resolve_tier_for_loan(loan.category, loan.ltv_bps)
                 .ok_or(ErrorCode::InvalidLoanOption)?;
 
+        // [L-06 · Sec3] Round the extension fee UP and require > 0 so a
+        // dust-balance loan cannot be extended for free.
         let extension_fee = loan
             .repay_amount
             .checked_mul(fee_bps)
             .ok_or(ErrorCode::MathOverflow)?
+            .checked_add(BPS_DENOM - 1)
+            .ok_or(ErrorCode::MathOverflow)?
             .checked_div(BPS_DENOM)
             .ok_or(ErrorCode::MathOverflow)?;
+        require!(extension_fee > 0, ErrorCode::InvalidAmount);
 
         // Borrower pays extension fee
         token::transfer(
@@ -1995,6 +2028,10 @@ pub enum ErrorCode {
     InvalidLoanOption,
     #[msg("Invalid collateral amount.")]
     InvalidCollateralAmount,
+    #[msg("Loan is overdue and cannot be extended")]
+    LoanOverdueForExtension,
+    #[msg("Price update exceeds the per-update sanity bound")]
+    PriceChangeExceedsBound,
     #[msg("Collateral mint carries a Token-2022 extension that breaks vault custody")]
     UnsupportedCollateralExtension,
     #[msg("Fee-on-transfer collateral is not supported: vault received less than sent")]

--- a/programs/magpie-lending/Cargo.toml
+++ b/programs/magpie-lending/Cargo.toml
@@ -18,4 +18,4 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
 anchor-lang = { workspace = true, features = ["init-if-needed"] }
-anchor-spl = "0.30.1"
+anchor-spl = { version = "0.30.1", features = ["token_2022"] }

--- a/programs/magpie-lending/src/lib.rs
+++ b/programs/magpie-lending/src/lib.rs
@@ -35,6 +35,44 @@ const MAX_VALUE_TOLERANCE_BPS: u64 = 300;
 // Program
 // ---------------------------------------------------------------------------
 
+
+/// [H-01 · Sec3, ported from V4] Reject collateral mints whose Token-2022
+/// extensions break vault custody. V1 is MEMECOIN-ONLY, so it rejects BOTH:
+///   - PermanentDelegate: an external delegate could move collateral OUT of the
+///     vault without updating loan accounting — a direct drain vector.
+///   - NonTransferable: seized or repaid collateral could never be returned to
+///     the borrower or moved to a liquidator.
+/// A memecoin has no legitimate reason to carry either. Legacy SPL Token mints
+/// have no extension TLV and always pass. (V3/RWA uses a DIFFERENT policy:
+/// PermanentDelegate is the norm for regulated tokenized assets and is accepted
+/// there for vetted issuers — do not copy this full-reject into V3.)
+fn assert_collateral_custody_safe(mint_ai: &AccountInfo) -> Result<()> {
+    use anchor_spl::token_2022::spl_token_2022::extension::{
+        BaseStateWithExtensions, ExtensionType, StateWithExtensions,
+    };
+    use anchor_spl::token_2022::spl_token_2022::state::Mint as Mint2022;
+
+    // Legacy SPL Token program mints carry no extensions.
+    if mint_ai.owner == &anchor_spl::token::ID {
+        return Ok(());
+    }
+    let data = mint_ai.try_borrow_data()?;
+    let state = StateWithExtensions::<Mint2022>::unpack(&data)
+        .map_err(|_| error!(ErrorCode::UnsupportedCollateralExtension))?;
+    let exts = state
+        .get_extension_types()
+        .map_err(|_| error!(ErrorCode::UnsupportedCollateralExtension))?;
+    for ext in exts {
+        if matches!(
+            ext,
+            ExtensionType::PermanentDelegate | ExtensionType::NonTransferable
+        ) {
+            return err!(ErrorCode::UnsupportedCollateralExtension);
+        }
+    }
+    Ok(())
+}
+
 #[program]
 pub mod magpie_lending {
     use super::*;
@@ -375,6 +413,10 @@ pub mod magpie_lending {
         require!(collateral_amount > 0, ErrorCode::InvalidCollateralAmount);
         require!(collateral_value > 0, ErrorCode::InvalidCollateralValue);
 
+        // [H-01 · Sec3] Reject collateral whose Token-2022 extensions break
+        // vault custody (permanent-delegate / non-transferable).
+        assert_collateral_custody_safe(&ctx.accounts.collateral_mint.to_account_info())?;
+
         // --- Price attestation validation ---
         let feed = &ctx.accounts.price_feed;
         let now = Clock::get()?.unix_timestamp;
@@ -442,6 +484,12 @@ pub mod magpie_lending {
         let now = Clock::get()?.unix_timestamp;
 
         // --- Transfer collateral from borrower to vault (Token or Token-2022) ---
+        // [H-01 · Sec3] Measure what the vault ACTUALLY receives. A
+        // fee-on-transfer Token-2022 mint would credit less than
+        // `collateral_amount`, letting the pool over-lend against collateral it
+        // never received. V1 does not support fee-bearing collateral: require
+        // the vault balance to increase by EXACTLY the transferred amount.
+        let vault_balance_before = ctx.accounts.collateral_vault.amount;
         token_interface::transfer_checked(
             CpiContext::new(
                 ctx.accounts.token_program.to_account_info(),
@@ -455,6 +503,17 @@ pub mod magpie_lending {
             collateral_amount,
             decimals,
         )?;
+        ctx.accounts.collateral_vault.reload()?;
+        let received = ctx
+            .accounts
+            .collateral_vault
+            .amount
+            .checked_sub(vault_balance_before)
+            .ok_or(ErrorCode::MathOverflow)?;
+        require!(
+            received == collateral_amount,
+            ErrorCode::CollateralTransferFeeUnsupported
+        );
 
         // --- Disburse loan tokens from pool vault to borrower ---
         let authority_key = ctx.accounts.pool.authority.key();
@@ -1566,6 +1625,10 @@ pub enum ErrorCode {
     InvalidLoanOption,
     #[msg("Invalid collateral amount.")]
     InvalidCollateralAmount,
+    #[msg("Collateral mint carries a Token-2022 extension that breaks vault custody")]
+    UnsupportedCollateralExtension,
+    #[msg("Fee-on-transfer collateral is not supported: vault received less than sent")]
+    CollateralTransferFeeUnsupported,
     #[msg("Invalid collateral value.")]
     InvalidCollateralValue,
     #[msg("Invalid amount.")]

--- a/programs/magpie-lending/src/lib.rs
+++ b/programs/magpie-lending/src/lib.rs
@@ -36,6 +36,21 @@ const MAX_VALUE_TOLERANCE_BPS: u64 = 300;
 // ---------------------------------------------------------------------------
 
 
+/// [M-04 · Sec3] Generous per-update price sanity bound. A single price update
+/// may not move by more than this factor in either direction — a fat-finger /
+/// compromised-authority blast-radius limiter, not a real volatility cap.
+const MAX_PRICE_UPDATE_FACTOR: u64 = 100;
+
+fn price_change_within_bound(prev: u64, new: u64) -> bool {
+    if prev == 0 {
+        return true; // first sample — nothing to bound against
+    }
+    let prev = prev as u128;
+    let new = new as u128;
+    let factor = MAX_PRICE_UPDATE_FACTOR as u128;
+    new <= prev.saturating_mul(factor) && new.saturating_mul(factor) >= prev
+}
+
 /// [H-01 · Sec3, ported from V4] Reject collateral mints whose Token-2022
 /// extensions break vault custody. V1 is MEMECOIN-ONLY, so it rejects BOTH:
 ///   - PermanentDelegate: an external delegate could move collateral OUT of the
@@ -163,9 +178,16 @@ pub mod magpie_lending {
         require!(price_lamports > 0, ErrorCode::InvalidCollateralValue);
 
         let feed = &mut ctx.accounts.price_feed;
+        let now = Clock::get()?.unix_timestamp;
+        // [M-04 · Sec3] Reject a time-travelling or grossly-wrong single update.
+        require!(now >= feed.timestamp, ErrorCode::PriceTimestampWentBackwards);
+        require!(
+            price_change_within_bound(feed.price_lamports, price_lamports),
+            ErrorCode::PriceChangeExceedsBound
+        );
         feed.price_lamports = price_lamports;
         feed.confidence_bps = confidence_bps;
-        feed.timestamp = Clock::get()?.unix_timestamp;
+        feed.timestamp = now;
 
         emit!(PriceUpdated {
             mint: feed.mint,
@@ -461,11 +483,16 @@ pub mod magpie_lending {
             .ok_or(ErrorCode::MathOverflow)?;
 
         // Compute fee
+        // [I-04 · Sec3] Round the origination fee UP and require it be > 0 so a
+        // tiny loan cannot dodge the fee via floor division.
         let fee = gross_loan
             .checked_mul(fee_bps)
             .ok_or(ErrorCode::MathOverflow)?
+            .checked_add(BPS_DENOM - 1)
+            .ok_or(ErrorCode::MathOverflow)?
             .checked_div(BPS_DENOM)
             .ok_or(ErrorCode::MathOverflow)?;
+        require!(fee > 0, ErrorCode::InvalidAmount);
 
         let net_loan = gross_loan
             .checked_sub(fee)
@@ -766,6 +793,11 @@ pub mod magpie_lending {
     pub fn extend_loan(ctx: Context<ExtendLoan>) -> Result<()> {
         let loan = &ctx.accounts.loan;
         require!(loan.status == LoanStatus::Active, ErrorCode::LoanNotActive);
+        // [Q-02 · Sec3] An overdue loan is liquidatable and must not be
+        // extendable — otherwise a borrower could dodge liquidation by rolling
+        // at the deadline.
+        let now = Clock::get()?.unix_timestamp;
+        require!(now <= loan.due_timestamp, ErrorCode::LoanOverdueForExtension);
 
         let tier = match loan.ltv_bps {
             3_000 => 0usize,
@@ -775,12 +807,17 @@ pub mod magpie_lending {
         };
 
         let fee_bps = TIER_FEE_BPS[tier];
+        // [L-06 · Sec3] Round the extension fee UP and require it be > 0, so a
+        // dust-balance loan cannot be extended for free via floor division.
         let extension_fee = loan
             .repay_amount
             .checked_mul(fee_bps)
             .ok_or(ErrorCode::MathOverflow)?
+            .checked_add(BPS_DENOM - 1)
+            .ok_or(ErrorCode::MathOverflow)?
             .checked_div(BPS_DENOM)
             .ok_or(ErrorCode::MathOverflow)?;
+        require!(extension_fee > 0, ErrorCode::InvalidAmount);
 
         // Borrower pays extension fee
         token::transfer(
@@ -1625,6 +1662,12 @@ pub enum ErrorCode {
     InvalidLoanOption,
     #[msg("Invalid collateral amount.")]
     InvalidCollateralAmount,
+    #[msg("Loan is overdue and cannot be extended")]
+    LoanOverdueForExtension,
+    #[msg("Price update exceeds the per-update sanity bound")]
+    PriceChangeExceedsBound,
+    #[msg("Price update timestamp went backwards")]
+    PriceTimestampWentBackwards,
     #[msg("Collateral mint carries a Token-2022 extension that breaks vault custody")]
     UnsupportedCollateralExtension,
     #[msg("Fee-on-transfer collateral is not supported: vault received less than sent")]


### PR DESCRIPTION
Ports the highest-severity Sec3 V4 finding into the two unaudited **live** lending programs, so they gain the same custody protection V4 got.

**H-01:** the borrow path accepted Token-2022 collateral without screening custody-breaking extensions or measuring what the vault actually received.

## ⚠️ Adapted per pool — a verbatim port would brick V3

| Pool | Policy |
|---|---|
| **V1** (memecoin) | **Full reject** — `PermanentDelegate` AND `NonTransferable`. A memecoin carrying either is a drain/lock risk with no legitimate purpose (V4 saw 0/233 memecoins carry them). |
| **V3** (RWA) | **`NonTransferable` only.** `PermanentDelegate` is the *norm* for regulated tokenized assets — **all 25 live RWAs carry it** (Backed/Dominion use it for compliance clawback + redemption). Rejecting it would refuse every stock/metal borrow. Accepted for vetted issuers, mirroring the V4.1 decision. |

## Both pools now measure receipt

Capture the vault balance before transfer, `reload()` after, require it increased by **exactly** the transferred amount — rejecting fee-on-transfer collateral that would let the pool over-lend against tokens it never received.

The custody helper mirrors the audited V4.1 fix (`assert_collateral_custody_safe`), unpacking the Token-2022 extension TLV. Legacy SPL mints have no TLV and always pass.

## Verification

- **Both compile clean** (`cargo check`).
- **Program IDs unchanged.**
- No lifecycle/valuation restructuring — a local guard + a receipt assertion, nothing that alters existing loan behavior.

## ⛔ Not deployed

V1/V3 hold live user funds. Deploy is gated on operator go + a migration plan and ships at a **new program id**, never same-id. This PR is reviewable code only. It should be built and tested in each program's deploy environment before any deployment.

## Scope

- **Applies but staged (follow-up pass):** I-01 (wSOL mint check) + Info-level I-02/I-03/I-04/L-06 hygiene.
- **Does not apply:** the auto-sell-engine findings (H-02/L-04/L-08/Q-04/I-06) — V1/V3 have no `convert_collateral_slice`.
- Full applicability matrix in memory; collectibles design port in `magpie-collectibles-lending` doc 45.

🤖 Generated with Fable 5