### PR TITLE
fix(borrow,repay): legacy-tx simulateTransaction overload bug rejected real site borrows

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "check:v41": "node scripts/check-v41-accounts.mjs",
     "check:cosign-admission": "node scripts/check-cosign-admission.mjs",
     "check:conversion-metric": "node scripts/check-conversion-metric.mjs",
+    "check:sim-compat": "node scripts/check-sim-compat.mjs",
     "check:rpc-failover": "node scripts/check-rpc-failover.mjs",
     "check:warning-delivery": "node scripts/check-warning-delivery.mjs",
     "check:push-subscribe": "node scripts/check-push-subscribe.mjs",

--- a/scripts/check-sim-compat.mjs
+++ b/scripts/check-sim-compat.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * check:sim-compat — guard the simulateTransaction overload fix.
+ *
+ * The bug (bitten three times: fee-wallet-sweeper 2026-06-19, cosign-borrow
+ * drain guard + agent-repay pre-sim, surfaced 2026-08-14): passing a config
+ * OBJECT to `simulateTransaction` with a LEGACY Transaction makes web3.js
+ * throw `Invalid arguments` client-side. The shared fix is
+ * src/solana/simulate-compat.js's toVersionedForSim().
+ *
+ * All checks are offline — the "Invalid arguments" throw happens before any
+ * network I/O, and the fixed path is verified to get PAST that throw (a
+ * network error against the loopback URL is the success signal).
+ */
+import { strict as assert } from "node:assert";
+import {
+  Connection,
+  Keypair,
+  SystemProgram,
+  Transaction,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { toVersionedForSim } from "../src/solana/simulate-compat.js";
+
+const conn = new Connection("http://127.0.0.1:1"); // unroutable — no sim ever lands
+const kp = Keypair.generate();
+
+function makeLegacyTx() {
+  const tx = new Transaction();
+  tx.add(SystemProgram.transfer({ fromPubkey: kp.publicKey, toPubkey: kp.publicKey, lamports: 1 }));
+  tx.feePayer = kp.publicKey;
+  tx.recentBlockhash = "11111111111111111111111111111111";
+  return tx;
+}
+
+const CONFIG = { sigVerify: false, commitment: "confirmed" };
+let failures = 0;
+function check(name, ok, detail = "") {
+  if (ok) {
+    console.log(`  ✓ ${name}`);
+  } else {
+    failures++;
+    console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+// 1. The bug is real: legacy tx + config throws "Invalid arguments" locally.
+let bugThrow = null;
+try {
+  await conn.simulateTransaction(makeLegacyTx(), CONFIG);
+} catch (e) {
+  bugThrow = e;
+}
+check(
+  "legacy tx + config object throws Invalid arguments (the bug this guards)",
+  bugThrow?.message === "Invalid arguments",
+  `got: ${bugThrow?.message}`,
+);
+
+// 2. toVersionedForSim returns a VersionedTransaction for legacy input.
+const promoted = toVersionedForSim(makeLegacyTx());
+check("legacy tx promotes to VersionedTransaction", promoted instanceof VersionedTransaction);
+
+// 3. A VersionedTransaction passes through unchanged (no double-wrap).
+const already = toVersionedForSim(promoted);
+check("versioned tx passes through unchanged", already === promoted);
+
+// 4. The promoted tx gets PAST the overload check — the failure becomes a
+//    network error against the unroutable URL, never "Invalid arguments".
+let fixedThrow = null;
+try {
+  await conn.simulateTransaction(promoted, CONFIG);
+} catch (e) {
+  fixedThrow = e;
+}
+check(
+  "promoted tx + config reaches the network layer (overload accepted)",
+  fixedThrow !== null && fixedThrow.message !== "Invalid arguments",
+  `got: ${fixedThrow?.message}`,
+);
+
+// 5. Signatures are carried over so the wire shape survives promotion.
+const signedLegacy = makeLegacyTx();
+signedLegacy.sign(kp);
+const promotedSigned = toVersionedForSim(signedLegacy);
+check(
+  "existing signatures carry over on promotion",
+  Buffer.compare(promotedSigned.signatures[0], signedLegacy.signatures[0].signature) === 0,
+);
+
+// 6. Both production call sites import the helper (regression tripwire).
+const { readFileSync } = await import("node:fs");
+for (const f of ["src/api/cosign-borrow.js", "src/api/agent-repay.js"]) {
+  const src = readFileSync(new URL(`../${f}`, import.meta.url), "utf8");
+  check(`${f} uses toVersionedForSim`, src.includes("toVersionedForSim("));
+}
+
+if (failures > 0) {
+  console.error(`\ncheck:sim-compat FAILED — ${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\ncheck:sim-compat OK");

--- a/src/api/agent-repay.js
+++ b/src/api/agent-repay.js
@@ -53,6 +53,7 @@ import BN from "bn.js";
 import { query } from "../db/pool.js";
 import { connection, withFailover } from "../solana/connection.js";
 import { getDynamicPriorityFee } from "../solana/priority-fee.js";
+import { toVersionedForSim } from "../solana/simulate-compat.js";
 import {
   chooseProgramIdForLoan,
   getProgramForSigner,
@@ -301,8 +302,12 @@ export async function handleAgentBuildRepay(req) {
     // (i.e. the program itself rejected) blocks the response. The on-chain
     // program is the authoritative lower defense layer.
     try {
+      // Legacy Transaction + config object makes web3.js throw "Invalid
+      // arguments" client-side — this guard silently never ran (the catch
+      // below failed open on every call). Promote legacy → versioned so the
+      // (tx, config) overload is valid. [[simulate-compat.js]]
       const sim = await withFailover((conn) =>
-        conn.simulateTransaction(tx, { sigVerify: false, commitment: "confirmed" }),
+        conn.simulateTransaction(toVersionedForSim(tx), { sigVerify: false, commitment: "confirmed" }),
       );
       if (sim?.value?.err) {
         const logs = (sim.value.logs || []).slice(-5).join(" | ").slice(0, 400);

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -55,6 +55,7 @@ import { rejectIfSiteDisabled } from "../services/site-global.js";
 import { rejectIfLocked } from "../services/site-lock.js";
 import { getTierByOption } from "../services/loan-tier-resolver.js";
 import { isNonBorrowAttempt } from "./conversion-attempt.js";
+import { toVersionedForSim } from "../solana/simulate-compat.js";
 
 // Rolling counter of borrow failure classifications. self-monitor reads
 // this via getRecentBorrowFailures() and CRIT-alerts the operator when
@@ -390,12 +391,18 @@ async function detectLenderBalanceDrain(connection, tx, LENDER_PUBKEY) {
   // vs. RPC infrastructure issue vs. unexpected) instead of a generic
   // "oracle settling" message that masks the actual cause.
   // [[feedback_loans_must_never_fail_no_regressions]]
+  // The (tx, config) overload is ONLY valid for VersionedTransaction —
+  // with a legacy Transaction web3.js throws "Invalid arguments" client-side,
+  // which rejected every legacy-tx site borrow here (4 real borrowers turned
+  // away 2026-08-12..14, surfaced by the fixed conversion metric). Promote
+  // legacy → versioned first. [[simulate-compat.js]]
+  const txForSim = toVersionedForSim(tx);
   let sim;
   let lastSimErr = null;
   const MAX_ATTEMPTS = 4;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
-      sim = await withFailover((conn) => conn.simulateTransaction(tx, {
+      sim = await withFailover((conn) => conn.simulateTransaction(txForSim, {
         sigVerify: false,
         commitment: "confirmed",
         accounts: {

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -720,6 +720,12 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
     }
   }
 
+  // Attribute the attempt to the borrower (fee payer) as soon as the tx
+  // parses. Until 2026-08-14 nothing ever set _convCtx.wallet, so every
+  // conversion_events row — success or failure — had wallet=null and a
+  // failing borrower could never be identified or helped from the metric.
+  if (tx.feePayer) _convCtx.wallet = tx.feePayer.toBase58();
+
   // ── SECURITY GATES ──────────────────────────────────────────────
 
   // Gate 0 (NEW, post-2026-06-07 exploit): outer-program allowlist.

--- a/src/solana/simulate-compat.js
+++ b/src/solana/simulate-compat.js
@@ -1,0 +1,42 @@
+/**
+ * simulateTransaction overload compatibility.
+ *
+ * web3.js overloads `Connection.simulateTransaction`:
+ *   - VersionedTransaction  → (tx, config)  — the modern form we want
+ *   - legacy Transaction    → (tx, signers?, includeAccounts?)
+ *
+ * Passing a config OBJECT with a LEGACY Transaction makes web3.js throw
+ * `Invalid arguments` client-side — the request never reaches an RPC.
+ *
+ * This bug has now bitten THREE times:
+ *   - fee-wallet-sweeper, hourly, starting 2026-06-19 (fixed in
+ *     privileged-sign-guard.js with an inline legacy→versioned promotion)
+ *   - cosign-borrow's lender-drain guard: every legacy-tx site borrow was
+ *     rejected with "simulateTransaction failed: Invalid arguments"
+ *     (surfaced 2026-08-14 by the fixed conversion metric — 4 real
+ *     borrowers turned away, 0 successes)
+ *   - agent-repay's pre-flight sim: same throw, but its fail-open catch
+ *     meant the guard silently never ran
+ *
+ * Fix, shared: promote any legacy Transaction to a VersionedTransaction so
+ * the (tx, config) call path is always valid. Signatures are copied so the
+ * wire shape stays right (sims run sigVerify:false, so validity is moot).
+ *
+ * The tx must have `feePayer` and `recentBlockhash` set (true for both a
+ * wire-parsed tx and a locally built one about to be simulated) —
+ * `compileMessage()` throws otherwise.
+ */
+import { Transaction, VersionedTransaction } from "@solana/web3.js";
+
+export function toVersionedForSim(tx) {
+  if (!(tx instanceof Transaction)) return tx; // already versioned (or a message)
+  const message = tx.compileMessage();
+  const versioned = new VersionedTransaction(message);
+  for (let i = 0; i < tx.signatures.length && i < versioned.signatures.length; i++) {
+    const sigPair = tx.signatures[i];
+    if (sigPair?.signature) {
+      versioned.signatures[i] = sigPair.signature;
+    }
+  }
+  return versioned;
+}


### PR DESCRIPTION
**User-facing bug, found by the conversion metric within 2 days of its fix deploying.**

web3.js throws `Invalid arguments` **client-side** when a legacy `Transaction` is passed with a config object — that overload is VersionedTransaction-only. Third bite of this bug (fee-wallet-sweeper 2026-06-19 was first, fixed inline in `privileged-sign-guard.js` but never swept across call sites):

| Site | Impact |
|---|---|
| `cosign-borrow` drain guard | **Every legacy-tx site borrow touching a lender account rejected** — 4 real attempts (3× memecoin, 1× $CARDS) turned away 2026-08-12..14, zero successes |
| `agent-repay` pre-sim | Same throw swallowed by the fail-open catch → guard silently never ran |

**Fix:** shared `src/solana/simulate-compat.js` → `toVersionedForSim()` (promote legacy→versioned, signatures carried), applied at both sites. Sweep confirmed the other two call sites are already safe.

**Guard:** `npm run check:sim-compat` — 7 offline checks: proves the bug throw, the promotion, overload acceptance, signature carry-over, + tripwire that both call sites keep the helper. All green. `check:conversion-metric` still green.

Merging deploys the bot (Railway auto-deploy) — restores site borrows on the legacy-tx lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)