### PR TITLE
feat: opt-in auto-extend — safety net for Q-02's hard deadline (doc 18)

### DIFF
--- a/migrations/103_auto_extend.sql
+++ b/migrations/103_auto_extend.sql
@@ -1,0 +1,47 @@
+-- 103 · Opt-in auto-extend (strategy doc 18, phase 2).
+--
+-- WHY. Real borrowers ask "what if I just forget?" — and the Sec3 Q-02
+-- hardening (queued 2026-08-14) makes the deadline final: an overdue loan can
+-- no longer be extended at all. For borrowers who explicitly opt in, the bot
+-- auto-executes extend_loan inside a strictly PRE-due window (T-2h..T-30m)
+-- when the loan is still open, the managed wallet can cover the fee, the loan
+-- is not underwater, and the consecutive-auto-extend cap is not exhausted.
+--
+-- Decisions (operator delegated 2026-08-14): explicit opt-in only (never
+-- default-on for money movement) · cap 2 consecutive auto-extends · skip if
+-- collateral value < 110% of owed · TG-managed wallets only at launch.
+
+-- Explicit opt-in. Lives in user_prefs like auto_protect, toggled via
+-- /autoextend. DEFAULT FALSE deliberately differs from auto_protect's ON:
+-- auto-protect only moves the user's funds to SAVE them from liquidation;
+-- auto-extend CHARGES a fee — spending is never default-on.
+ALTER TABLE user_prefs ADD COLUMN IF NOT EXISTS auto_extend BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Consecutive auto-extends consumed on this loan (manual extends don't count;
+-- a repay closes the loan so the counter naturally dies with it).
+ALTER TABLE loans ADD COLUMN IF NOT EXISTS auto_extend_count INTEGER NOT NULL DEFAULT 0;
+
+-- Decision trail — every auto-extend EXECUTION, FAILURE, and first occurrence
+-- of each skip reason per loan. Captures the why + rule version so any
+-- outcome can be reconstructed later (protocol-data-as-asset mandate).
+CREATE TABLE IF NOT EXISTS auto_extend_events (
+  id            BIGSERIAL PRIMARY KEY,
+  loan_id       BIGINT NOT NULL,
+  user_id       BIGINT NOT NULL,
+  decision      TEXT   NOT NULL,          -- 'extended' | 'failed' | 'skipped'
+  reason        TEXT   NOT NULL,          -- e.g. 'ok', 'underwater', 'insufficient_balance', 'cap_reached'
+  fee_lamports  BIGINT,
+  health_ratio  NUMERIC,                  -- collateral value / owed at decision time (NULL = price unavailable)
+  rule_version  TEXT   NOT NULL,
+  tx_signature  TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Repeated poll-cycle SKIPS collapse into their first occurrence instead of
+-- flooding the table. Partial: 'extended'/'failed' rows are real events and a
+-- loan can legitimately have two of each (cap = 2), so only skips dedup.
+CREATE UNIQUE INDEX IF NOT EXISTS auto_extend_events_skip_dedup
+  ON auto_extend_events (loan_id, reason) WHERE decision = 'skipped';
+
+CREATE INDEX IF NOT EXISTS auto_extend_events_user_idx
+  ON auto_extend_events (user_id, created_at);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check:cosign-admission": "node scripts/check-cosign-admission.mjs",
     "check:conversion-metric": "node scripts/check-conversion-metric.mjs",
     "check:sim-compat": "node scripts/check-sim-compat.mjs",
+    "check:auto-extend": "node scripts/check-auto-extend.mjs",
     "check:rpc-failover": "node scripts/check-rpc-failover.mjs",
     "check:warning-delivery": "node scripts/check-warning-delivery.mjs",
     "check:push-subscribe": "node scripts/check-push-subscribe.mjs",

--- a/scripts/check-auto-extend.mjs
+++ b/scripts/check-auto-extend.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * check:auto-extend — every safety boundary of the auto-extend decision core.
+ *
+ * The core is PURE (src/services/auto-extend-core.js) so this runs without
+ * booting the bot. The boundaries under test ARE the safety envelope:
+ * Q-02 window floor, explicit opt-in, cap, cooldown, underwater guard
+ * (incl. fail-open on missing price), balance buffer, and error fallback.
+ */
+import { strict as assert } from "node:assert";
+import {
+  decideAutoExtend,
+  extendFeeLamports,
+  WINDOW_CEILING_MS,
+  WINDOW_FLOOR_MS,
+  MAX_AUTO_EXTENDS,
+  ATTEMPT_COOLDOWN_MS,
+  BALANCE_BUFFER_LAMPORTS,
+} from "../src/services/auto-extend-core.js";
+
+const NOW = 1_755_000_000_000;
+const base = {
+  status: "active",
+  dueMs: NOW + 60 * 60 * 1000, // 1h out — inside the window
+  optIn: true,
+  autoExtendCount: 0,
+  feeLamports: 10_000_000n, // 0.01 SOL
+  walletBalanceLamports: 1_000_000_000n, // 1 SOL
+  healthRatio: 2.0,
+  lastAttemptMs: null,
+};
+
+let failures = 0;
+function expect(name, loan, want) {
+  const got = decideAutoExtend(loan, NOW);
+  const ok = got.action === want.action && (want.reason === undefined || got.reason === want.reason);
+  if (ok) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.error(`  ✗ ${name} — want ${JSON.stringify(want)} got ${JSON.stringify(got)}`);
+  }
+}
+
+// Happy path
+expect("healthy opted-in loan inside window → extend", base, { action: "extend" });
+
+// Window (the Q-02 envelope)
+expect("due beyond ceiling → skip before_window", { ...base, dueMs: NOW + WINDOW_CEILING_MS + 1 }, { action: "skip", reason: "before_window" });
+expect("due exactly at ceiling → extend", { ...base, dueMs: NOW + WINDOW_CEILING_MS }, { action: "extend" });
+expect("due exactly at floor → skip past_window_floor", { ...base, dueMs: NOW + WINDOW_FLOOR_MS }, { action: "skip", reason: "past_window_floor" });
+expect("due 1ms past floor → extend", { ...base, dueMs: NOW + WINDOW_FLOOR_MS + 1 }, { action: "extend" });
+expect("OVERDUE loan → skip past_window_floor (never brush Q-02)", { ...base, dueMs: NOW - 1000 }, { action: "skip", reason: "past_window_floor" });
+
+// Status + opt-in
+expect("repaid loan → skip not_active", { ...base, status: "repaid" }, { action: "skip", reason: "not_active" });
+expect("not opted in → skip", { ...base, optIn: false }, { action: "skip", reason: "not_opted_in" });
+
+// Cap
+expect(`count=${MAX_AUTO_EXTENDS} → skip cap_reached`, { ...base, autoExtendCount: MAX_AUTO_EXTENDS }, { action: "skip", reason: "cap_reached" });
+expect(`count=${MAX_AUTO_EXTENDS - 1} → extend`, { ...base, autoExtendCount: MAX_AUTO_EXTENDS - 1 }, { action: "extend" });
+
+// Cooldown
+expect("recent attempt → skip cooldown", { ...base, lastAttemptMs: NOW - ATTEMPT_COOLDOWN_MS + 1000 }, { action: "skip", reason: "cooldown" });
+expect("stale attempt → extend", { ...base, lastAttemptMs: NOW - ATTEMPT_COOLDOWN_MS - 1000 }, { action: "extend" });
+
+// Health guard — and its deliberate fail-open on missing price
+expect("underwater (1.05) → skip underwater", { ...base, healthRatio: 1.05 }, { action: "skip", reason: "underwater" });
+expect("exactly 1.10 → extend", { ...base, healthRatio: 1.1 }, { action: "extend" });
+expect("price unavailable (null) → extend (fail open — protects borrower)", { ...base, healthRatio: null }, { action: "extend" });
+
+// Balance
+expect("balance exactly fee+buffer-1 → skip insufficient_balance",
+  { ...base, walletBalanceLamports: base.feeLamports + BALANCE_BUFFER_LAMPORTS - 1n },
+  { action: "skip", reason: "insufficient_balance" });
+expect("balance exactly fee+buffer → extend",
+  { ...base, walletBalanceLamports: base.feeLamports + BALANCE_BUFFER_LAMPORTS },
+  { action: "extend" });
+
+// Malformed row must skip, never throw / never extend
+expect("malformed row → skip decision_error", { ...base, dueMs: { bad: true }, walletBalanceLamports: "x" }, { action: "skip" });
+
+// Fee math mirrors executeExtendLoan's tiers exactly
+assert.equal(extendFeeLamports(30, 1_000_000_000n), 30_000_000n, "express 3%");
+assert.equal(extendFeeLamports(25, 1_000_000_000n), 20_000_000n, "quick 2%");
+assert.equal(extendFeeLamports(20, 1_000_000_000n), 15_000_000n, "standard 1.5%");
+console.log("  ✓ fee tiers mirror executeExtendLoan (3% / 2% / 1.5%)");
+
+// Wiring tripwires
+const { readFileSync } = await import("node:fs");
+const watcher = readFileSync(new URL("../src/services/auto-extend-watcher.js", import.meta.url), "utf8");
+const idx = readFileSync(new URL("../src/index.js", import.meta.url), "utf8");
+for (const [name, ok] of [
+  ["watcher re-checks Q-02 window at execution time", watcher.includes("WINDOW_FLOOR_MS")],
+  ["watcher never DMs negative telegram ids", watcher.includes("< 0) return")],
+  ["watcher has AUTOEXTEND_DISABLED kill switch", watcher.includes("AUTOEXTEND_DISABLED")],
+  ["index.js starts the watcher", idx.includes("startAutoExtendWatcher")],
+  ["index.js registers /autoextend", idx.includes('bot.command("autoextend"')],
+]) {
+  if (ok) console.log(`  ✓ ${name}`);
+  else { failures++; console.error(`  ✗ ${name}`); }
+}
+
+if (failures > 0) {
+  console.error(`\ncheck:auto-extend FAILED — ${failures} check(s)`);
+  process.exit(1);
+}
+console.log("\n[auto-extend] OK — window, opt-in, cap, cooldown, health, balance, wiring all verified.");

--- a/src/commands/autoextend.js
+++ b/src/commands/autoextend.js
@@ -1,0 +1,96 @@
+/**
+ * /autoextend — manage opt-in automatic loan extension (strategy doc 18).
+ *
+ * Shows current opt-in status, recent auto-extend activity, and a toggle.
+ * The actual watcher lives in src/services/auto-extend-watcher.js.
+ * Mirrors /autoprotect's structure; differs in DEFAULT (off — auto-extend
+ * charges a fee, and spending is never default-on).
+ */
+import { InlineKeyboard } from "grammy";
+import { upsertUser } from "../services/users.js";
+import { getPrefs, togglePref } from "../services/prefs.js";
+import { query } from "../db/pool.js";
+
+function fmtSol(lamports) {
+  if (lamports == null) return "—";
+  return (Number(lamports) / 1e9).toFixed(4);
+}
+
+async function render(userId) {
+  const prefs = await getPrefs(userId);
+  const on = !!prefs.auto_extend;
+
+  const { rows } = await query(
+    `SELECT decision, reason, fee_lamports, tx_signature, created_at, loan_id
+     FROM auto_extend_events
+     WHERE user_id = $1 AND created_at >= NOW() - INTERVAL '14 days'
+     ORDER BY created_at DESC
+     LIMIT 5`,
+    [userId],
+  );
+
+  const lines = [
+    `⏱ *Auto-Extend* — ${on ? "✅ Enabled" : "⭕️ Disabled"}`,
+    "",
+    "If a loan is still open shortly before it expires, I'll",
+    "automatically extend it for you — same fee as a manual /extend,",
+    "paid from your wallet.",
+    "",
+    "*How it works:*",
+    "• Fires between *2 hours* and *30 minutes* before expiry",
+    "• Max *2* automatic extensions per loan, then manual only",
+    "• Skipped if your collateral is worth less than what you owe",
+    "  (extending would only cost you fees)",
+    "• Skipped if your wallet can't cover the fee — you'll be DM'd",
+    "• Every action is logged (see below) — never silent",
+    "",
+    "⚠️ *Why it matters:* once a loan is overdue it can no longer be",
+    "extended at all — repayment or liquidation are the only paths.",
+    "",
+    on
+      ? "_Auto-Extend is ON. You'll be DM'd whenever it fires or is skipped._"
+      : "_Auto-Extend is OFF (the default — it spends your SOL on fees, so it's strictly opt-in)._",
+  ];
+
+  if (rows.length > 0) {
+    lines.push("", "*Recent activity (last 14d):*");
+    for (const r of rows) {
+      const ago = Math.floor((Date.now() - new Date(r.created_at).getTime()) / 60_000);
+      const agoStr = ago < 60 ? `${ago}m` : ago < 60 * 24 ? `${Math.floor(ago / 60)}h` : `${Math.floor(ago / (60 * 24))}d`;
+      let line = `${agoStr} ago — `;
+      if (r.decision === "extended") {
+        line += `extended loan #${r.loan_id} (fee \`${fmtSol(r.fee_lamports)} SOL\`)`;
+      } else if (r.decision === "failed") {
+        line += `❌ failed on #${r.loan_id} — extend manually`;
+      } else {
+        line += `⚠️ skipped #${r.loan_id} (${r.reason.replace(/_/g, " ")})`;
+      }
+      lines.push(`• ${line}`);
+    }
+  }
+
+  const kb = new InlineKeyboard().text(
+    on ? "🔕 Turn OFF Auto-Extend" : "⏱ Turn ON Auto-Extend",
+    "autoextend:toggle",
+  );
+
+  return { text: lines.join("\n"), kb };
+}
+
+export async function handleAutoExtend(ctx) {
+  const tgUser = ctx.from;
+  if (!tgUser) return;
+  const user = await upsertUser(tgUser.id, tgUser.username);
+  const { text, kb } = await render(user.id);
+  await ctx.reply(text, { parse_mode: "Markdown", reply_markup: kb });
+}
+
+export function registerAutoExtendCallbacks(bot) {
+  bot.callbackQuery("autoextend:toggle", async (ctx) => {
+    await ctx.answerCallbackQuery();
+    const user = await upsertUser(ctx.from.id, ctx.from.username);
+    await togglePref(user.id, "auto_extend");
+    const { text, kb } = await render(user.id);
+    await ctx.editMessageText(text, { parse_mode: "Markdown", reply_markup: kb });
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,7 @@ import { handleDistributions } from "./commands/distributions.js";
 import { handleSupport, registerSupportCallbacks } from "./commands/support.js";
 import { handleMyTickets, registerMyTicketsCallbacks } from "./commands/my-tickets.js";
 import { handleAutoProtect, registerAutoProtectCallbacks } from "./commands/autoprotect.js";
+import { handleAutoExtend, registerAutoExtendCallbacks } from "./commands/autoextend.js";
 import { handleCalendar, registerCalendarCallbacks } from "./commands/calendar.js";
 import { handleHealth } from "./commands/health.js";
 import { handleShare } from "./commands/share.js";
@@ -245,7 +246,7 @@ bot.use(rateLimit());
 // (/stats, /price, /audit, /refer, etc.) are intentionally NOT gated.
 const DM_ONLY_COMMANDS = new Set([
   "deposit", "borrow", "repay", "partialrepay", "reborrow", "withdraw",
-  "topup", "extend", "lock", "autoprotect", "protect", "tp", "sl",
+  "topup", "extend", "lock", "autoprotect", "protect", "autoextend", "tp", "sl",
   "export", "exportdata", "import", "wallet", "wallets", "switchwallet",
   "signedhistory", "me", "positions", "loans", "history",
   // Agent-delegation commands are account-scoped (they authorize a delegate to
@@ -345,6 +346,7 @@ bot.command("ticket", handleSupport); // alias
 bot.command("mytickets", handleMyTickets);
 bot.command("tickets_mine", handleMyTickets); // alias
 bot.command("autoprotect", handleAutoProtect);
+bot.command("autoextend", handleAutoExtend);
 bot.command("protect", handleAutoProtect); // alias
 bot.command("calendar", handleCalendar);
 bot.command("health", handleHealth);
@@ -645,6 +647,7 @@ registerSupportVigilCallbacks(bot);
 registerLcStalenessCallbacks(bot);
 registerLcRetryingCallbacks(bot);
 registerAutoProtectCallbacks(bot);
+registerAutoExtendCallbacks(bot);
 registerCalendarCallbacks(bot);
 registerUnlockCallbacks(bot);
 registerWalletsCallbacks(bot);
@@ -849,6 +852,7 @@ bot.start({
     setTimeout(() => startLoanWatcher(bot), 5_000);
     setTimeout(() => startHealthWatcher(bot), 10_000);
     setTimeout(() => startRiskEngine(bot), 15_000);
+    setTimeout(() => import("./services/auto-extend-watcher.js").then((m) => m.startAutoExtendWatcher(bot)), 25_000);
     setTimeout(() => startPumpWatcher(bot), 20_000);
     setTimeout(() => startTokenScreener(bot), 25_000);
     setTimeout(() => startTokenHealth(bot), 30_000);

--- a/src/services/auto-extend-core.js
+++ b/src/services/auto-extend-core.js
@@ -1,0 +1,109 @@
+/**
+ * Auto-extend decision core — PURE, zero imports, no side effects — so every
+ * boundary can be unit-tested without booting the bot (same pattern as
+ * conversion-attempt.js and arming-caps.js). Consumed by
+ * auto-extend-watcher.js; guarded by `npm run check:auto-extend`.
+ *
+ * WHY THIS EXISTS (strategy doc 18). Borrowers forget. The Sec3 Q-02
+ * hardening makes the deadline final — an overdue loan can never be extended.
+ * For borrowers who explicitly opted in, the bot auto-executes extend_loan in
+ * a strictly PRE-due window. The rules here are the entire safety envelope:
+ *
+ *   - WINDOW: fire only when due is (30m .. 2h] away. The 30m floor keeps a
+ *     wide margin from the Q-02 boundary (an extend landing after due would
+ *     just burn a fee tx on a program refusal). The 2h ceiling means we act
+ *     after the T-6h human warning has had time to work — auto-extend is the
+ *     safety net, not the first resort.
+ *   - OPT-IN: users.auto_extend_opt_in must be explicitly true. Money
+ *     movement is never default-on.
+ *   - CAP: at most MAX_AUTO_EXTENDS consecutive auto-extends per loan.
+ *     Uncapped auto-extend is a zombie-loan factory (fees bleed forever).
+ *   - HEALTH: skip when collateral value < MIN_HEALTH_RATIO × owed — an
+ *     auto-extend there mostly charges a doomed borrower fees. A NULL ratio
+ *     (price unavailable) ALLOWS the extend: the extension protects the
+ *     borrower, and a transient price outage must not cost them their
+ *     collateral. [[feedback_defense_in_depth_failopen_when_lower_layer_proven]]
+ *   - BALANCE: managed wallet must cover fee + tx overhead. We never touch
+ *     anything but the borrower's own wallet.
+ *   - COOLDOWN: one attempt per loan per ATTEMPT_COOLDOWN_MS, so a failing
+ *     extend doesn't retry-spam fees or DMs inside one window.
+ */
+
+export const RULE_VERSION = "auto-extend-v1 (doc18 2026-08-14)";
+
+export const WINDOW_CEILING_MS = 2 * 60 * 60 * 1000; // start trying at T-2h
+export const WINDOW_FLOOR_MS = 30 * 60 * 1000; // never inside T-30m (Q-02 margin)
+export const MAX_AUTO_EXTENDS = 2;
+export const MIN_HEALTH_RATIO = 1.1;
+export const ATTEMPT_COOLDOWN_MS = 15 * 60 * 1000;
+// Fee-payment overhead beyond the extend fee itself: tx fee + priority fee +
+// temporary wSOL ATA rent (recovered on close, but must be fundable upfront).
+export const BALANCE_BUFFER_LAMPORTS = 5_000_000n; // 0.005 SOL
+
+/**
+ * Decide whether ONE loan gets auto-extended right now.
+ *
+ * @param {{
+ *   status: string,
+ *   dueMs: number,                       // loan due timestamp (ms epoch)
+ *   optIn: boolean,
+ *   autoExtendCount: number,
+ *   feeLamports: bigint,                 // live extend fee for this loan
+ *   walletBalanceLamports: bigint,       // borrower managed-wallet SOL
+ *   healthRatio: number | null,          // collateral value / owed; null = unavailable
+ *   lastAttemptMs: number | null,        // last auto-extend attempt for this loan
+ * }} loan
+ * @param {number} nowMs
+ * @returns {{ action: "extend" } | { action: "skip", reason: string }}
+ */
+export function decideAutoExtend(loan, nowMs) {
+  try {
+    if (loan.status !== "active") return { action: "skip", reason: "not_active" };
+    if (!loan.optIn) return { action: "skip", reason: "not_opted_in" };
+
+    // Explicit input validation. Garbage inputs don't throw in JS relational
+    // ops — NaN comparisons and BigInt-vs-bad-string both quietly evaluate
+    // false — so without these guards a malformed row would fall THROUGH the
+    // window/balance checks and auto-move money. Caught by check:auto-extend.
+    if (typeof loan.feeLamports !== "bigint" || typeof loan.walletBalanceLamports !== "bigint") {
+      return { action: "skip", reason: "decision_error" };
+    }
+    const untilDue = loan.dueMs - nowMs;
+    if (!Number.isFinite(untilDue)) return { action: "skip", reason: "decision_error" };
+    if (untilDue <= WINDOW_FLOOR_MS) {
+      // Includes already-overdue. Never brush the Q-02 boundary.
+      return { action: "skip", reason: "past_window_floor" };
+    }
+    if (untilDue > WINDOW_CEILING_MS) return { action: "skip", reason: "before_window" };
+
+    if (loan.autoExtendCount >= MAX_AUTO_EXTENDS) return { action: "skip", reason: "cap_reached" };
+
+    if (loan.lastAttemptMs != null && nowMs - loan.lastAttemptMs < ATTEMPT_COOLDOWN_MS) {
+      return { action: "skip", reason: "cooldown" };
+    }
+
+    if (loan.healthRatio != null && loan.healthRatio < MIN_HEALTH_RATIO) {
+      return { action: "skip", reason: "underwater" };
+    }
+
+    if (loan.walletBalanceLamports < loan.feeLamports + BALANCE_BUFFER_LAMPORTS) {
+      return { action: "skip", reason: "insufficient_balance" };
+    }
+
+    return { action: "extend" };
+  } catch {
+    // A malformed row must never crash the watcher loop — and must never
+    // auto-move money either. Skip, loudly classifiable.
+    return { action: "skip", reason: "decision_error" };
+  }
+}
+
+/**
+ * Extend fee for a loan, mirroring executeExtendLoan's tier math exactly
+ * (Express 30% LTV → 3%, Quick 25% → 2%, Standard → 1.5% of live owed).
+ * Kept here (pure) so the balance check and the execution can never drift.
+ */
+export function extendFeeLamports(ltvPercentage, owedLiveLamports) {
+  const feeBps = ltvPercentage >= 30 ? 300n : ltvPercentage >= 25 ? 200n : 150n;
+  return (owedLiveLamports * feeBps) / 10_000n;
+}

--- a/src/services/auto-extend-watcher.js
+++ b/src/services/auto-extend-watcher.js
@@ -1,0 +1,218 @@
+/**
+ * Auto-extend watcher — executes opt-in auto-extensions (strategy doc 18).
+ *
+ * Every POLL_INTERVAL_MS: find active loans due within the auto-extend
+ * window whose borrower opted in (/autoextend), run each through the PURE
+ * decision core (auto-extend-core.js — window, cap, health, balance,
+ * cooldown), and execute `extend_loan` via the same executeExtendLoan path a
+ * manual /extend uses (managed wallet signs, tier fee, referral accrual).
+ *
+ * Every execution, failure, and first-occurrence skip that a user would care
+ * about lands in auto_extend_events with the rule version (decision-trail
+ * mandate). Users are DM'd on success, on failure, and ONCE per
+ * user-actionable skip reason (insufficient balance / underwater / cap).
+ *
+ * Kill switch: AUTOEXTEND_DISABLED=1 (same pattern as PIP_*_DISABLED).
+ */
+import { query } from "../db/pool.js";
+import { withFailover } from "../solana/connection.js";
+import { PublicKey } from "@solana/web3.js";
+import {
+  decideAutoExtend,
+  extendFeeLamports,
+  RULE_VERSION,
+  WINDOW_CEILING_MS,
+  WINDOW_FLOOR_MS,
+} from "./auto-extend-core.js";
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+// decision reasons that are user-actionable → recorded + DM'd once per loan
+const RECORDED_SKIPS = new Set(["insufficient_balance", "underwater", "cap_reached"]);
+
+const SKIP_DMS = {
+  insufficient_balance:
+    "⚠️ <b>Auto-extend skipped:</b> your wallet can't cover the extension fee. Top up SOL or repay before expiry — once overdue, the loan can no longer be extended.",
+  underwater:
+    "⚠️ <b>Auto-extend skipped:</b> your collateral is worth less than what you owe, so extending would only cost you fees. Repay before expiry to recover your collateral, or let the loan settle.",
+  cap_reached:
+    "⚠️ <b>Auto-extend limit reached</b> for this loan (2 automatic extensions). Repay or extend manually with /extend before expiry.",
+};
+
+// per-process cooldown tracker: loanId -> last attempt ms
+const lastAttempt = new Map();
+
+async function fetchCandidates() {
+  const windowCeilingSec = Math.ceil(WINDOW_CEILING_MS / 1000) + 300; // small fetch margin
+  const { rows } = await query(
+    `SELECT l.*, u.telegram_id, w.public_key AS wallet_public_key
+       FROM loans l
+       JOIN users u ON u.id = l.user_id
+       JOIN user_prefs p ON p.user_id = l.user_id AND p.auto_extend = TRUE
+  LEFT JOIN wallets w ON w.user_id = l.user_id
+      WHERE l.status = 'active'
+        AND l.due_timestamp > now()
+        AND l.due_timestamp < now() + make_interval(secs => $1)`,
+    [windowCeilingSec],
+  );
+  return rows;
+}
+
+async function recordEvent({ loan, decision, reason, feeLamports, healthRatio, txSignature }) {
+  // Skips dedup on (loan_id, reason); a returned row means "first time".
+  const { rows } = await query(
+    `INSERT INTO auto_extend_events
+       (loan_id, user_id, decision, reason, fee_lamports, health_ratio, rule_version, tx_signature)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     ON CONFLICT DO NOTHING
+     RETURNING id`,
+    [
+      loan.id,
+      loan.user_id,
+      decision,
+      reason,
+      feeLamports != null ? feeLamports.toString() : null,
+      healthRatio,
+      RULE_VERSION,
+      txSignature ?? null,
+    ],
+  );
+  return rows.length > 0;
+}
+
+async function dmUser(bot, telegramId, html) {
+  // NEVER DM a negative telegram id — site-only sentinel rows overlap real
+  // TG group ids ([[project_unwarned_liquidation_incident]]).
+  if (!telegramId || Number(telegramId) < 0) return;
+  try {
+    await bot.api.sendMessage(telegramId, html, { parse_mode: "HTML" });
+  } catch (err) {
+    console.error(`[auto-extend] DM failed for tg ${telegramId}: ${err.message}`);
+  }
+}
+
+async function processLoan(bot, loan, nowMs) {
+  // Assemble decision inputs. Any input failure falls back to a value the
+  // core treats conservatively (see core doc-block).
+  const { getLiveOwedLamports } = await import("./loans.js");
+  const owedLive = await getLiveOwedLamports(loan);
+  const feeLamports = extendFeeLamports(Number(loan.ltv_percentage), owedLive);
+
+  let walletBalanceLamports = 0n;
+  if (loan.wallet_public_key) {
+    try {
+      const bal = await withFailover((conn) => conn.getBalance(new PublicKey(loan.wallet_public_key)));
+      walletBalanceLamports = BigInt(bal);
+    } catch (err) {
+      console.error(`[auto-extend] balance fetch failed loan ${loan.id}: ${err.message}`);
+    }
+  }
+
+  let healthRatio = null;
+  try {
+    const { rows: [mintRow] } = await query(
+      `SELECT decimals FROM supported_mints WHERE mint = $1`,
+      [loan.collateral_mint],
+    );
+    if (mintRow) {
+      const { collateralValueLamports } = await import("./price.js");
+      const valueLamports = await collateralValueLamports(
+        loan.collateral_mint,
+        loan.collateral_amount,
+        Number(mintRow.decimals),
+      );
+      if (valueLamports != null && owedLive > 0n) {
+        healthRatio = Number(valueLamports) / Number(owedLive);
+      }
+    }
+  } catch (err) {
+    // healthRatio stays null → core allows (extension protects the borrower)
+    console.error(`[auto-extend] health calc failed loan ${loan.id}: ${err.message}`);
+  }
+
+  const decision = decideAutoExtend(
+    {
+      status: loan.status,
+      dueMs: new Date(loan.due_timestamp).getTime(),
+      optIn: true, // fetchCandidates JOINs user_prefs.auto_extend = TRUE
+
+      autoExtendCount: Number(loan.auto_extend_count || 0),
+      feeLamports,
+      walletBalanceLamports,
+      healthRatio,
+      lastAttemptMs: lastAttempt.get(loan.id) ?? null,
+    },
+    nowMs,
+  );
+
+  if (decision.action === "skip") {
+    if (RECORDED_SKIPS.has(decision.reason)) {
+      const firstTime = await recordEvent({
+        loan, decision: "skipped", reason: decision.reason, feeLamports, healthRatio,
+      });
+      if (firstTime && SKIP_DMS[decision.reason]) {
+        await dmUser(bot, loan.telegram_id, SKIP_DMS[decision.reason]);
+      }
+    }
+    return;
+  }
+
+  // Execute. Re-check the Q-02 window at the last possible moment.
+  lastAttempt.set(loan.id, nowMs);
+  if (new Date(loan.due_timestamp).getTime() - Date.now() <= WINDOW_FLOOR_MS) return;
+
+  try {
+    const { executeExtendLoan, recordExtendLoan } = await import("./loans.js");
+    const result = await executeExtendLoan({ userId: loan.user_id, loanDbRow: loan });
+    await recordExtendLoan(loan.id, loan.user_id);
+    await query(`UPDATE loans SET auto_extend_count = auto_extend_count + 1 WHERE id = $1`, [loan.id]);
+    await recordEvent({
+      loan, decision: "extended", reason: `ok_${Number(loan.auto_extend_count || 0) + 1}`,
+      feeLamports: result.feeLamports ?? feeLamports, healthRatio, txSignature: result.signature,
+    });
+    const fee = (Number(result.feeLamports ?? feeLamports) / 1e9).toFixed(4);
+    await dmUser(
+      bot,
+      loan.telegram_id,
+      `✅ <b>Loan auto-extended</b> by ${loan.duration_days} days (fee ${fee} SOL). You opted into /autoextend — toggle it there anytime. /positions for status.`,
+    );
+    console.log(`[auto-extend] extended loan ${loan.id} (fee ${fee} SOL)`);
+  } catch (err) {
+    console.error(`[auto-extend] extend FAILED loan ${loan.id}: ${err.message}`);
+    await recordEvent({
+      loan, decision: "failed", reason: (err.message || "unknown").slice(0, 120),
+      feeLamports, healthRatio,
+    });
+    await dmUser(
+      bot,
+      loan.telegram_id,
+      `⚠️ <b>Auto-extend failed</b> for your ${loan.symbol ?? ""} loan — please repay or /extend manually before expiry. Once overdue, extension is no longer possible.`,
+    );
+  }
+}
+
+export function startAutoExtendWatcher(bot) {
+  if (process.env.AUTOEXTEND_DISABLED === "1") {
+    console.log("[auto-extend] disabled via AUTOEXTEND_DISABLED=1");
+    return;
+  }
+  async function cycle() {
+    try {
+      const candidates = await fetchCandidates();
+      if (candidates.length === 0) return;
+      const nowMs = Date.now();
+      for (const loan of candidates) {
+        try {
+          await processLoan(bot, loan, nowMs);
+        } catch (err) {
+          console.error(`[auto-extend] loan ${loan.id} cycle error: ${err.message}`);
+        }
+      }
+    } catch (err) {
+      console.error("[auto-extend] cycle error:", err.message);
+    }
+  }
+  setTimeout(cycle, 20_000);
+  setInterval(cycle, POLL_INTERVAL_MS);
+  console.log("[auto-extend] watcher started");
+}

--- a/src/services/loan-watcher.js
+++ b/src/services/loan-watcher.js
@@ -318,6 +318,8 @@ async function warn24h(bot) {
       `Repay *${solOwed.toFixed(4)} SOL* to reclaim your collateral.`,
       "",
       `Tap the loan number above to open it in the dashboard, or use the buttons below.`,
+      "",
+      `💡 Worried about forgetting? /autoextend can renew this loan automatically before it expires.`,
     ].join("\n");
     const kb = new InlineKeyboard()
       .text("🔧 Repay now", `repay:loan:${row.id}`)

--- a/src/services/prefs.js
+++ b/src/services/prefs.js
@@ -29,13 +29,19 @@ const DEFAULTS = {
   // repay options. Earlier than the health-watcher's liquidation
   // tiers so users have time to act.
   notify_downside_alerts: true,
+  // Auto-extend (strategy doc 18): bot auto-renews a loan in the
+  // T-2h..T-30m pre-due window (fee from the user's wallet, capped at
+  // 2 per loan, skipped when underwater). Unlike auto_protect this
+  // CHARGES a fee, so it is explicit opt-in — spending is never
+  // default-on. Toggled via /autoextend.
+  auto_extend: false,
 };
 
 export async function getPrefs(userId) {
   const { rows } = await query(
     `SELECT notify_deposits, notify_loan_warnings, notify_liquidations,
             notify_health, notify_pump, auto_repay, auto_protect,
-            notify_upside_alerts, notify_downside_alerts
+            notify_upside_alerts, notify_downside_alerts, auto_extend
      FROM user_prefs WHERE user_id = $1`,
     [userId],
   );


### PR DESCRIPTION
Borrowers ask *"what if I just forget?"* — and the queued Sec3 **Q-02** hardening makes the answer final: an overdue loan can never be extended. This ships the product answer (strategy doc 18): for borrowers who **explicitly opt in** (`/autoextend`, default OFF — spending is never default-on), the bot auto-executes `extend_loan` in a strictly pre-due **T-2h..T-30m** window.

## Safety envelope (PURE core, every boundary unit-tested)
- **Window floor 30m** before due — never brushes the Q-02 boundary; re-checked at execution time
- **Cap 2** consecutive auto-extends per loan — no zombie-loan fee bleed
- **Underwater guard**: skip when collateral < 110% of owed; **fail open on missing price** (an outage must not cost a borrower their collateral)
- Managed wallet must cover fee + 0.005 SOL overhead; 15m attempt cooldown
- **Garbage-input rejection** — JS relational ops on malformed rows silently pass; the check caught this and the core now validates explicitly

## Plumbing
- Reuses `executeExtendLoan` (same signing/tier-fees/referral accrual as manual `/extend`)
- **Migration 103**: `user_prefs.auto_extend` (mirrors `auto_protect` pattern), `loans.auto_extend_count`, `auto_extend_events` decision-trail (rule-versioned, skip-dedup partial index) — checksum guard green
- `/autoextend` command mirrors `/autoprotect` (status + recent activity + toggle); DM-only gated
- DMs every outcome; never DMs negative telegram ids; `AUTOEXTEND_DISABLED=1` kill switch
- Discovery: one hint line in the existing 24h warning DM
- **Guard: `npm run check:auto-extend`** — 23 checks, all green

Merging deploys the bot + runs migration 103 on boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)