### PR TITLE
feat: farm guard — every protective measure on the auto-approver

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:sim-compat": "node scripts/check-sim-compat.mjs",
     "check:auto-extend": "node scripts/check-auto-extend.mjs",
     "check:symbol-collisions": "node scripts/check-symbol-collisions.mjs",
+    "check:farm-guard": "node scripts/check-farm-guard.mjs",
     "check:rpc-failover": "node scripts/check-rpc-failover.mjs",
     "check:warning-delivery": "node scripts/check-warning-delivery.mjs",
     "check:push-subscribe": "node scripts/check-push-subscribe.mjs",

--- a/scripts/check-farm-guard.mjs
+++ b/scripts/check-farm-guard.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Regression guard for the farm-guard pure classifier (no DB needed).
+ * Run: npm run check:farm-guard
+ */
+import { classifyFarmSignals, normalizeName } from "../src/services/farm-guard.js";
+
+let failures = 0;
+function expect(label, cond) {
+  if (cond) { console.log(`  ok  ${label}`); } else { failures++; console.error(`FAIL  ${label}`); }
+}
+
+// normalizeName
+expect("normalize strips punctuation/case", normalizeName("United  Oil Trust-Fund!") === "unitedoiltrustfund");
+expect("normalize handles garbage", normalizeName(null) === "" && normalizeName(42) === "");
+
+// Hard signatures
+expect("name clone is hard", classifyFarmSignals({ nameCloneCount: 1, normalizedName: "unitedoiltrustfund" }).hard.length === 1);
+expect("image reuse is hard", classifyFarmSignals({ imageReuseCount: 2 }).hard.length === 1);
+expect("creator cluster ≥2 is hard", classifyFarmSignals({ creatorScreens7d: 2 }).hard.length === 1);
+expect("creator single prior is NOT hard", classifyFarmSignals({ creatorScreens7d: 1 }).hard.length === 0);
+
+// Soft signals
+{
+  const r = classifyFarmSignals({ autoApprovals24h: 10 });
+  expect("approval wave at cap is soft", r.soft.length === 1 && r.hard.length === 0);
+}
+{
+  const r = classifyFarmSignals({ volume24h: 3_000_000, liquidity: 100_000 });
+  expect("wash-trade shape is soft", r.soft.length === 1 && r.hard.length === 0);
+}
+expect("healthy vol/liq is clean", classifyFarmSignals({ volume24h: 500_000, liquidity: 100_000 }).soft.length === 0);
+
+// Unevaluated context never signals
+{
+  const r = classifyFarmSignals({});
+  expect("empty ctx is clean", r.hard.length === 0 && r.soft.length === 0);
+}
+{
+  const r = classifyFarmSignals({ nameCloneCount: NaN, creatorScreens7d: undefined, autoApprovals24h: null, volume24h: NaN, liquidity: 0 });
+  expect("garbage ctx is clean (skip, not signal)", r.hard.length === 0 && r.soft.length === 0);
+}
+
+// Compound: farm wave — every signature at once
+{
+  const r = classifyFarmSignals({
+    nameCloneCount: 4, imageReuseCount: 1, creatorScreens7d: 4,
+    autoApprovals24h: 15, volume24h: 5_000_000, liquidity: 150_000,
+    normalizedName: "unitedoiltrustfund",
+  });
+  expect("full farm signature: 3 hard + 2 soft", r.hard.length === 3 && r.soft.length === 2);
+}
+
+if (failures > 0) { console.error(`\n${failures} failure(s)`); process.exit(1); }
+console.log("\nfarm-guard: all checks passed");

--- a/src/services/farm-guard.js
+++ b/src/services/farm-guard.js
@@ -1,0 +1,189 @@
+/**
+ * Farm guard — approval-time defenses against serial-launch farms and
+ * coordinated scam listings (UOTF/SAOF/USWR/TNOS incident 2026-08-15:
+ * up to five near-identical tokens per ticker auto-approved within days,
+ * each with six-figure "liquidity").
+ *
+ * Split like auto-extend-core: classifyFarmSignals() is a pure function
+ * over a gathered context (unit-testable, no I/O); assessFarmRisk()
+ * gathers the context from the DB + rugcheck and classifies.
+ *
+ * Signal policy:
+ *   HARD  → never auto-approve (reject with the reason). These are
+ *           adversarial signatures with near-zero legit base rate:
+ *           name clones, image reuse, creator launch-clusters.
+ *   SOFT  → demote to manual review instead of auto-approving. These are
+ *           anomalies with a real legit base rate: approval waves,
+ *           wash-trade-shaped volume.
+ *
+ * Every gather step fails SKIP (signal not evaluated, logged) — an
+ * outage of rugcheck or one query can never block legitimate listings
+ * outright, matching the screener's existing degradation posture.
+ */
+import { query } from "../db/pool.js";
+
+const AUTO_APPROVALS_24H_CAP = Number(process.env.FARM_GUARD_AUTO_APPROVALS_24H_CAP) || 10;
+const WASH_VOL_LIQ_RATIO = Number(process.env.FARM_GUARD_WASH_VOL_LIQ_RATIO) || 25;
+const CREATOR_CLUSTER_MIN = Number(process.env.FARM_GUARD_CREATOR_CLUSTER_MIN) || 2;
+
+/** Lowercased alphanumeric skeleton — "United  Oil Trust-Fund!" → "unitedoiltrustfund". */
+export function normalizeName(name) {
+  if (typeof name !== "string") return "";
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Pure classifier. ctx fields default to "not evaluated" (null) so a
+ * failed gather step contributes nothing rather than a false signal.
+ */
+export function classifyFarmSignals(ctx) {
+  const hard = [];
+  const soft = [];
+
+  if (Number.isFinite(ctx?.nameCloneCount) && ctx.nameCloneCount > 0) {
+    hard.push(`name clone — ${ctx.nameCloneCount} other listing(s) share the normalized name "${ctx.normalizedName}"`);
+  }
+  if (Number.isFinite(ctx?.imageReuseCount) && ctx.imageReuseCount > 0) {
+    hard.push(`image reuse — logo URL already used by ${ctx.imageReuseCount} other listing(s)`);
+  }
+  if (Number.isFinite(ctx?.creatorScreens7d) && ctx.creatorScreens7d >= CREATOR_CLUSTER_MIN) {
+    hard.push(`creator cluster — deployer launched ${ctx.creatorScreens7d} other screened token(s) in 7d`);
+  }
+
+  if (Number.isFinite(ctx?.autoApprovals24h) && ctx.autoApprovals24h >= AUTO_APPROVALS_24H_CAP) {
+    soft.push(`approval wave — ${ctx.autoApprovals24h} auto-approvals in 24h (cap ${AUTO_APPROVALS_24H_CAP}); manual review while the wave clears`);
+  }
+  if (
+    Number.isFinite(ctx?.volume24h) && Number.isFinite(ctx?.liquidity) &&
+    ctx.liquidity > 0 && ctx.volume24h > WASH_VOL_LIQ_RATIO * ctx.liquidity
+  ) {
+    soft.push(`wash-trade shape — 24h volume $${Math.floor(ctx.volume24h)} is >${WASH_VOL_LIQ_RATIO}x liquidity $${Math.floor(ctx.liquidity)}`);
+  }
+
+  return { hard, soft };
+}
+
+// ── Context gathering ───────────────────────────────────────────────────────
+
+let _creatorTableReady = false;
+async function ensureCreatorLog() {
+  if (_creatorTableReady) return;
+  // Inline DDL follows the submitter_rejections precedent (ops-side
+  // tracking table, not protocol state — kept out of the migration ledger).
+  await query(
+    `CREATE TABLE IF NOT EXISTS screener_creator_log (
+       mint TEXT PRIMARY KEY,
+       creator TEXT NOT NULL,
+       seen_at TIMESTAMPTZ DEFAULT NOW()
+     )`,
+  );
+  await query(
+    `CREATE INDEX IF NOT EXISTS idx_creator_log_creator ON screener_creator_log (creator, seen_at)`,
+  );
+  _creatorTableReady = true;
+}
+
+const _creatorCache = new Map(); // mint → { creator|null, at }
+const CREATOR_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+/** Deployer wallet from rugcheck's full report; null = unknown (skip signal). */
+async function fetchCreator(mint) {
+  const hit = _creatorCache.get(mint);
+  if (hit && Date.now() - hit.at < CREATOR_CACHE_TTL_MS) return hit.creator;
+  let creator = null;
+  try {
+    const res = await fetch(`https://api.rugcheck.xyz/v1/tokens/${mint}/report`, {
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (typeof data?.creator === "string" && data.creator.length >= 32) creator = data.creator;
+    }
+  } catch { /* unreachable → signal skipped */ }
+  _creatorCache.set(mint, { creator, at: Date.now() });
+  return creator;
+}
+
+/**
+ * Gather + classify for one candidate. Never throws; every failed step
+ * leaves its signal unevaluated.
+ */
+export async function assessFarmRisk({ mint, name, imageUrl, liquidity, volume24h }) {
+  const ctx = {
+    normalizedName: normalizeName(name),
+    liquidity: Number(liquidity),
+    volume24h: Number(volume24h),
+  };
+
+  // Name clones: any enabled row, any row we disabled for colliding, or
+  // any screening-queue row from the last 14 days sharing the skeleton.
+  if (ctx.normalizedName.length >= 4) {
+    try {
+      const { rows } = await query(
+        `SELECT (
+           SELECT COUNT(*) FROM supported_mints
+            WHERE mint <> $1
+              AND (enabled = TRUE OR source = 'disabled_symbol_collision')
+              AND LOWER(REGEXP_REPLACE(name, '[^a-zA-Z0-9]', '', 'g')) = $2
+         ) + (
+           SELECT COUNT(*) FROM token_screen_queue
+            WHERE mint <> $1 AND created_at > NOW() - INTERVAL '14 days'
+              AND LOWER(REGEXP_REPLACE(name, '[^a-zA-Z0-9]', '', 'g')) = $2
+         ) AS n`,
+        [mint, ctx.normalizedName],
+      );
+      ctx.nameCloneCount = Number(rows[0]?.n);
+    } catch (e) {
+      console.warn(`[farm-guard] name-clone check failed for ${mint}: ${e.message?.slice(0, 80)}`);
+    }
+  } else {
+    ctx.nameCloneCount = 0; // too-short skeletons ("pepe" ≠ evidence) never signal
+  }
+
+  if (typeof imageUrl === "string" && imageUrl.length > 12) {
+    try {
+      const { rows } = await query(
+        `SELECT COUNT(*) AS n FROM supported_mints
+          WHERE mint <> $1 AND image_url = $2
+            AND (enabled = TRUE OR source = 'disabled_symbol_collision')`,
+        [mint, imageUrl],
+      );
+      ctx.imageReuseCount = Number(rows[0]?.n);
+    } catch (e) {
+      console.warn(`[farm-guard] image-reuse check failed for ${mint}: ${e.message?.slice(0, 80)}`);
+    }
+  }
+
+  try {
+    await ensureCreatorLog();
+    const creator = await fetchCreator(mint);
+    if (creator) {
+      await query(
+        `INSERT INTO screener_creator_log (mint, creator) VALUES ($1, $2)
+         ON CONFLICT (mint) DO NOTHING`,
+        [mint, creator],
+      );
+      const { rows } = await query(
+        `SELECT COUNT(*) AS n FROM screener_creator_log
+          WHERE creator = $1 AND mint <> $2 AND seen_at > NOW() - INTERVAL '7 days'`,
+        [creator, mint],
+      );
+      ctx.creatorScreens7d = Number(rows[0]?.n);
+    }
+  } catch (e) {
+    console.warn(`[farm-guard] creator check failed for ${mint}: ${e.message?.slice(0, 80)}`);
+  }
+
+  try {
+    const { rows } = await query(
+      `SELECT COUNT(*) AS n FROM supported_mints
+        WHERE auto_approved = TRUE AND source IN ('screener', 'review_auto')
+          AND screened_at > NOW() - INTERVAL '24 hours'`,
+    );
+    ctx.autoApprovals24h = Number(rows[0]?.n);
+  } catch (e) {
+    console.warn(`[farm-guard] wave check failed: ${e.message?.slice(0, 80)}`);
+  }
+
+  return { ...classifyFarmSignals(ctx), ctx };
+}

--- a/src/services/token-screener.js
+++ b/src/services/token-screener.js
@@ -13,6 +13,7 @@
  */
 import { query } from "../db/pool.js";
 import { Connection, PublicKey } from "@solana/web3.js";
+import { assessFarmRisk } from "./farm-guard.js";
 import { connection } from "../solana/connection.js";
 import { cachedJson } from "../lib/http-cache.js";
 import { markCycle } from "../lib/heartbeat.js";
@@ -1387,6 +1388,24 @@ async function tick(bot) {
     }
 
     if (verdict === "auto_approve") {
+      // Farm guard (see farm-guard.js): hard signatures never list; soft
+      // anomalies demote to the manual review queue instead of auto-listing.
+      const farm = await assessFarmRisk({
+        mint, name: market.name, imageUrl: market.imageUrl,
+        liquidity: market.liquidity, volume24h: market.volume24h,
+      });
+      if (farm.hard.length > 0) {
+        await markSeen(mint);
+        console.log(`[screener] FARM-GUARD reject ${market.symbol} (${mint}): ${farm.hard.join("; ")}`);
+        continue;
+      }
+      if (farm.soft.length > 0) {
+        await queueForReview(mint, onChain, market, holderCount, safetyScore, [...fails, ...farm.soft], ageHours, category);
+        await markSeen(mint);
+        queued.push({ symbol: market.symbol, mint, safetyScore, fails: farm.soft, category });
+        console.log(`[screener] FARM-GUARD demoted ${market.symbol} to manual review: ${farm.soft.join("; ")}`);
+        continue;
+      }
       const listed = await autoApproveToken(mint, onChain, market, holderCount, ageHours, category);
       await markSeen(mint);
       if (listed !== false) {
@@ -1685,6 +1704,13 @@ const REVIEW_AUTO_APPROVE_MS = 30 * 60 * 1000; // 30 min (retained for compat)
 const REVIEW_AUTO_MAX_TOP10_PCT = Number(process.env.REVIEW_AUTO_MAX_TOP10_PCT) || 65;
 const REVIEW_AUTO_MAX_TOP20_PCT = Number(process.env.REVIEW_AUTO_MAX_TOP20_PCT) || 85;
 const REVIEW_VIABILITY_MIN_LIQ_USD = Number(process.env.REVIEW_VIABILITY_MIN_LIQ_USD) || 15000;
+// Maturity floors for UNATTENDED promotion (farm incident 2026-08-15: the
+// UOTF/SAOF/USWR/TNOS cluster was 0–2 days old at approval — an age floor
+// alone would have stopped it). Young/thin tokens stay QUEUED and promote
+// once they mature — self-resolving, so this never strands a legit token.
+const REVIEW_PROMOTE_MIN_AGE_HOURS = Number(process.env.REVIEW_PROMOTE_MIN_AGE_HOURS) || 48;
+const REVIEW_PROMOTE_MIN_HOLDERS = Number(process.env.REVIEW_PROMOTE_MIN_HOLDERS) || 100;
+const REVIEW_PROMOTE_GIVE_UP_HOURS = Number(process.env.REVIEW_PROMOTE_GIVE_UP_HOURS) || 336;
 
 async function processReviewQueue(bot) {
   const { rows } = await query(
@@ -1822,6 +1848,50 @@ async function processReviewQueue(bot) {
       // Gauntlet-clean + viable → APPROVE (expand). Fall through to the promote
       // below; nothing is left pending.
       console.log(`[screener] Review auto-APPROVING ${t.symbol} (expand-mindset, no limbo) — gauntlet-clean + viable: liq=$${Math.floor(liveMarket.liquidity)}, holders=${liveHolderCount}, fast-track-verdict was '${liveVerdict}'`);
+    }
+
+    // Maturity floors: unattended promotion requires a track record. Young
+    // or thin tokens WAIT in the queue (self-resolving as they age); only
+    // tokens that never mature within the give-up window get rejected.
+    const liveAgeHours = liveMarket.pairCreatedAt
+      ? Math.floor((Date.now() - liveMarket.pairCreatedAt) / 3_600_000)
+      : Number(t.token_age_hours) || 0;
+    if (liveAgeHours < REVIEW_PROMOTE_MIN_AGE_HOURS) {
+      continue; // stays queued; promotes once it has ≥48h of history
+    }
+    if (liveHolderCount >= 0 && liveHolderCount < REVIEW_PROMOTE_MIN_HOLDERS) {
+      if (liveAgeHours > REVIEW_PROMOTE_GIVE_UP_HOURS) {
+        await query(
+          `UPDATE token_screen_queue
+              SET status = 'rejected', reviewed_at = NOW(), fail_reasons = $2
+            WHERE mint = $1`,
+          [t.mint, [`never matured: ${liveHolderCount} holders after ${Math.floor(liveAgeHours / 24)} days (needs ${REVIEW_PROMOTE_MIN_HOLDERS} for unattended promotion)`]],
+        );
+        console.log(`[screener] Review REJECTED ${t.symbol} — never matured (${liveHolderCount} holders after ${Math.floor(liveAgeHours / 24)}d)`);
+      }
+      continue; // young + thin → wait
+    }
+
+    // Farm guard: hard signatures (name clones, image reuse, creator
+    // launch-clusters) are rejected; soft anomalies (approval wave,
+    // wash-shaped volume) wait for the anomaly to clear or an admin.
+    const farm = await assessFarmRisk({
+      mint: t.mint, name: t.name, imageUrl: t.image_url,
+      liquidity: liveMarket.liquidity, volume24h: liveMarket.volume24h,
+    });
+    if (farm.hard.length > 0) {
+      await query(
+        `UPDATE token_screen_queue
+            SET status = 'rejected', reviewed_at = NOW(), fail_reasons = $2
+          WHERE mint = $1`,
+        [t.mint, farm.hard],
+      );
+      console.log(`[screener] FARM-GUARD rejected ${t.symbol} (${t.mint}) at promote: ${farm.hard.join("; ")}`);
+      continue;
+    }
+    if (farm.soft.length > 0) {
+      console.log(`[screener] FARM-GUARD holding ${t.symbol} in queue: ${farm.soft.join("; ")}`);
+      continue;
     }
 
     // Automatic path: an enabled incumbent always keeps the ticker — a


### PR DESCRIPTION
Response to the 2026-08-15 serial-launch farm (UOTF/SAOF/USWR/TNOS). Layers, in order:

1. Symbol-collision guard (#681, shipped) — incumbent keeps the ticker.
2. Name-clone detection — normalized-name match vs enabled rows, collision-disabled rows, and 14d of the screening queue → hard reject.
3. Logo-URL reuse → hard reject.
4. Deployer clustering — rugcheck creator wallet, ≥2 other screened launches in 7d → hard reject (creators logged to screener_creator_log).
5. Approval-wave throttle — >10 auto-approvals/24h → demote to manual review until the wave clears.
6. Wash-trade shape — 24h volume >25× liquidity → demote to manual review.
7. Maturity floors for unattended promotion — 48h age + 100 holders; young tokens wait (self-resolving), never-maturing ones reject at 14d.

Fail-open per signal (an outage skips that signal, never blocks legit listings); pure classifier unit-checked via `check:farm-guard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)