### PR TITLE
pip: canonical-fact parity guard across both knowledge brains

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check:warning-delivery": "node scripts/check-warning-delivery.mjs",
     "check:push-subscribe": "node scripts/check-push-subscribe.mjs",
     "check:migration-checksums": "node scripts/check-migration-checksums.mjs",
+    "check:pip-parity": "node scripts/check-pip-parity.mjs",
     "check:borrow-reservation-race": "node scripts/check-borrow-reservation-race.mjs",
     "check:captcha-deeplink": "node scripts/check-captcha-deeplink.mjs",
     "check:holder-carryforward": "node scripts/check-holder-carryforward.mjs",

--- a/scripts/check-pip-parity.mjs
+++ b/scripts/check-pip-parity.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Parity guard for Pip's TWO knowledge brains.
+ *
+ * Pip answers from two separate prose knowledge bases:
+ *   - src/services/community-pip.js  (the @MagpieTalk community brain)
+ *   - src/services/ai-support.js     (the DM / support brain)
+ *
+ * They are worded independently on purpose, so a plain diff is useless. But
+ * they must agree on the load-bearing FACTS. On 2026-08-17 they didn't: the
+ * support brain still carried a stale, pre-final Sec3 audit posture ("second
+ * review is back … 18 resolved, 2 returned … resubmitted for the final
+ * round") while the community brain had the final 20-resolved / none-open
+ * result. A user asking support would have been told an outdated, incorrect,
+ * LESS-favorable security status. Nothing failed — both files parse fine.
+ *
+ * This guard pins the canonical facts. Each rule is either:
+ *   present : a fact that MUST appear in every listed brain, or
+ *   absent  : a stale/forbidden phrasing that must appear in NONE of them.
+ *
+ * When a fact legitimately CHANGES (a new audit concludes, a tier LTV moves),
+ * the fix is: update BOTH brains and this guard together. That is the whole
+ * point — the guard forces the dual-brain update to be conscious, never
+ * silent. Keep the fact list small and high-value; do not encode prose that
+ * is expected to vary (asset counts, live metrics, dates other than the
+ * audit's).
+ *
+ * Zero dependencies — reads the files as text, imports nothing.
+ *
+ * Usage: node scripts/check-pip-parity.mjs
+ * Exit:  0 the brains agree · 1 a canonical fact drifted
+ */
+import { readFileSync } from "node:fs";
+
+const BRAINS = {
+  community: "src/services/community-pip.js",
+  support: "src/services/ai-support.js",
+};
+
+// Each brain read once, lowercased for case-tolerant matching.
+const text = Object.fromEntries(
+  Object.entries(BRAINS).map(([k, f]) => [k, readFileSync(f, "utf8").toLowerCase()]),
+);
+
+/**
+ * mode "present": every pattern must match in every brain.
+ * mode "absent":  no pattern may match in any brain.
+ * Patterns are matched case-insensitively (text is pre-lowercased).
+ */
+const RULES = [
+  {
+    why: "Sec3 V4 audit — final posture (24 findings · 20 resolved · 4 acknowledged · none open · both Highs resolved)",
+    mode: "present",
+    patterns: [/24 findings/, /20 resolved/, /4 acknowledged/, /none open/, /both high/],
+  },
+  {
+    why: "Sec3 audit — stale INTERIM phrasing must never reappear in either brain",
+    mode: "absent",
+    patterns: [
+      /18 resolved/,
+      /2 returned/,
+      /resubmitted for the final round/,
+      /second review of our fixes is back/,
+      /not "?audited"? until the final re-checked report/,
+    ],
+  },
+  {
+    why: "Collectibles honesty invariant — the third class is IN DESIGN / NOT LIVE, in both brains",
+    mode: "present",
+    patterns: [/in design/, /not live/],
+  },
+  {
+    why: "Collectibles tier LTV ladder — Tier A up to 50% LTV, Tier B up to 40% LTV, in both brains",
+    mode: "present",
+    patterns: [/up to 50% ltv/, /up to 40% ltv/],
+  },
+  {
+    why: "No margin calls — the core liquidation-model promise, in both brains",
+    mode: "present",
+    patterns: [/no margin call/],
+  },
+];
+
+const failures = [];
+for (const rule of RULES) {
+  for (const [brain, body] of Object.entries(text)) {
+    for (const re of rule.patterns) {
+      const hit = re.test(body);
+      if (rule.mode === "present" && !hit)
+        failures.push(`  ✗ [${brain}] MISSING: ${re} — ${rule.why}`);
+      if (rule.mode === "absent" && hit)
+        failures.push(`  ✗ [${brain}] FORBIDDEN present: ${re} — ${rule.why}`);
+    }
+  }
+}
+
+if (failures.length) {
+  console.error(`[pip-parity] FAIL — ${failures.length} canonical-fact problem(s):`);
+  console.error(failures.join("\n"));
+  console.error(
+    "\nFix: bring BOTH brains to the same current fact, then update this guard if the fact itself changed.",
+  );
+  process.exit(1);
+}
+console.log(`[pip-parity] OK — ${RULES.length} canonical facts consistent across both brains.`);


### PR DESCRIPTION
## Why
Root-cause fix for the drift caught in #689. Pip answers from **two** prose knowledge brains — `community-pip.js` and `ai-support.js` — and nothing verified they agree on load-bearing facts. So the support brain silently carried a stale Sec3 audit posture (*"18 resolved, 2 returned, resubmitted for the final round"*) while the community brain had the final one. A plain diff is useless (they're worded independently on purpose), so this guard pins the **facts**.

## What
`scripts/check-pip-parity.mjs` (`npm run check:pip-parity`), dependency-free. Asserts case-insensitively:
- **present in BOTH**: Sec3 final posture (24 findings / 20 resolved / 4 acknowledged / none open / both Highs resolved) · collectibles **IN DESIGN + NOT LIVE** · Tier A up to 50% LTV + Tier B up to 40% LTV · no margin calls
- **absent from BOTH**: the stale interim audit phrasings (`18 resolved`, `2 returned`, `resubmitted for the final round`, `second review … is back`, `not audited until the final re-checked report`)

When a fact legitimately changes, the fix is to update **both** brains and this guard together — that's the point: the dual-brain update becomes conscious, never silent.

## Verified it can fail
A guard that can't fail is decoration. Reintroducing `18 resolved`, dropping `none open`, and drifting Tier B 40%→35% each exit 1 naming the rule; clean brains exit 0.

## One follow-up (needs you)
CI wiring is **not** in this PR — this repo blocks `.github/workflows/` pushes without the workflow scope. It runs today via `npm run check:pip-parity`. To enforce in CI, add one step to `.github/workflows/protocol-guards.yml`:

```yaml
      - name: pip knowledge-brain parity (canonical facts must not drift)
        run: node scripts/check-pip-parity.mjs
```
(place it with the other dependency-free guards, before `npm ci`). Or grant the workflow scope and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)