### PR TITLE
notifications: render engine crash + stall-restart operator DMs (completes #542)

### DIFF
--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -469,6 +469,37 @@ function renderEnginePreflightFailed(p) {
   return lines.join("\n");
 }
 
+// Engine crash — uncaughtException/unhandledRejection caught the engine and
+// it exit(1)'d for a clean Railway restart. The fail-closed breadcrumb means
+// no order double-fires. Operator-facing (enqueued with userId=OPERATOR_USER_ID).
+function renderEngineCrash(p = {}) {
+  return [
+    "🔴 *Limit-close engine crashed & restarted*",
+    "",
+    `Type: \`${p.crash_kind || "unknown"}\``,
+    `Error: \`${String(p.error || "unknown").slice(0, 300)}\``,
+    p.detected_at ? `When: \`${p.detected_at}\`` : null,
+    "",
+    p.remedy ||
+      "The engine hit an unhandled error and auto-restarted. No order double-fires (fail-closed breadcrumb). Check the Railway logs for the stack trace.",
+  ].filter((l) => l !== null).join("\n");
+}
+
+// Engine stall — the in-process watchdog saw no tick progress past the
+// threshold and exit(1)'d to self-heal a wedged loop. Operator-facing.
+function renderEngineStallRestart(p = {}) {
+  return [
+    "🟠 *Limit-close engine stalled & auto-restarted*",
+    "",
+    `No tick progress for ~${p.stalled_for_seconds ?? "?"}s (threshold ${p.stall_threshold_seconds ?? "?"}s)`,
+    `Last status: \`${p.last_status || "unknown"}\``,
+    p.detected_at ? `When: \`${p.detected_at}\`` : null,
+    "",
+    p.remedy ||
+      "The fire loop wedged and was auto-restarted. Check RPC/DB health; no order double-fired.",
+  ].filter((l) => l !== null).join("\n");
+}
+
 const RENDERERS = {
   limit_close_armed:        renderLimitCloseArmed,
   limit_close_arm_failed:   renderLimitCloseArmFailed,
@@ -483,6 +514,8 @@ const RENDERERS = {
   limit_close_staleness_nudge: renderLimitCloseStalenessNudge,
   limit_close_near_trigger:    renderLimitCloseNearTrigger,
   engine_preflight_failed:  renderEnginePreflightFailed,
+  engine_crash:             renderEngineCrash,
+  engine_stall_restart:     renderEngineStallRestart,
   pip_upside_alert:         renderPipUpsideAlert,
   // Downside alert reuses the same renderer — the watcher pre-renders
   // the entire DM body into payload.text, identical contract.


### PR DESCRIPTION
## Silent gap this closes
The limit-close engine (`magpie-limitclose`) already enqueues operator alerts on:
- **crash** — `index.js`, `kind: "engine_crash"` (uncaughtException/unhandledRejection → exit 1 for a clean restart)
- **stall-restart** — `health-server.js`, `kind: "engine_stall_restart"` (watchdog sees no tick progress → self-heal)

But the bot's `notification-sender` had **no renderers** for those kinds, so `renderPayload()` returned `null` and **both alerts were silently dropped**. When the fire engine crashed or self-restarted a wedged loop, the operator got nothing — a real reliability gap for a fund-adjacent engine.

## Fix
Adds the two missing renderers and registers them. Fields verified against the engine's **exact** payloads (`crash_kind`/`error`/`detected_at`/`remedy`; `stalled_for_seconds`/`stall_threshold_seconds`/`last_status`/…).

## Why a fresh branch
Re-applied cleanly onto current main rather than merging the stale #542 branch (2026-08-16), which had drifted behind dozens of merges and conflicted across ~14 unrelated files. Same change, no cross-file noise. **Supersedes #542.**

## Verification
- `node --check` clean
- Both renderers produce correct DMs against the engine's real payload shapes (crash + stall tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)