### PR TITLE
watchers: negative-id guard + push fallback + failure classification

### DIFF
--- a/src/services/health-watcher.js
+++ b/src/services/health-watcher.js
@@ -17,6 +17,8 @@ import { collateralValueLamports } from "./price.js";
 import { getPrefs } from "./prefs.js";
 import { connection } from "../solana/connection.js";
 import { getSupportedBalances } from "./deposits.js";
+import { isPermanentDeliveryFailure, deliveryFailureReason } from "./telegram-delivery.js";
+import { sendPushToUser, isPushConfigured } from "./push-send.js";
 
 /**
  * Look at the user's wallet and recommend the ONE best action to take
@@ -232,20 +234,65 @@ async function checkLoan(bot, row) {
     rec ? `*Recommended:* ${rec.text}` : "Options: /repay · /partialrepay · /topup collateral · /extend",
   ].filter((s) => s !== null).join("\n");
 
-  try {
-    await bot.api.sendMessage(row.telegram_id, msg, {
-      parse_mode: "Markdown",
-      reply_markup: kb,
-      // Suppress the big card from the magpie.capital dashboard link
-      // so the alert stays compact.
-      disable_web_page_preview: true,
-    });
+  // Delivery discipline — same rules as loan-watcher's warning path:
+  //
+  //  1. NEVER DM a negative telegram_id. Site-native users carry synthetic
+  //     negative ids that share the id space with real Telegram GROUPS. If the
+  //     bot happens to be a member of a colliding group, this alert — loan id,
+  //     collateral value, amount owed, wallet label — would post into a public
+  //     chat. Those users go straight to web push.
+  //  2. On DM failure, classify (permanent vs transient) so the log tells the
+  //     truth, then fall back to web push.
+  //  3. Only a DELIVERED alert marks last_health_alert. A failure must keep
+  //     retrying next tick rather than laundering into "alerted".
+  const tgId = Number(row.telegram_id);
+  const tgDeliverable = Number.isFinite(tgId) && tgId > 0;
+  let delivered = false;
+
+  if (tgDeliverable) {
+    try {
+      await bot.api.sendMessage(row.telegram_id, msg, {
+        parse_mode: "Markdown",
+        reply_markup: kb,
+        // Suppress the big card from the magpie.capital dashboard link
+        // so the alert stays compact.
+        disable_web_page_preview: true,
+      });
+      delivered = true;
+    } catch (err) {
+      const permanent = isPermanentDeliveryFailure(err);
+      console.error(
+        `[health-watcher] DM failed for loan ${row.loan_id} ` +
+          `(${permanent ? "PERMANENT" : "transient"}): ${deliveryFailureReason(err)}`,
+      );
+    }
+  }
+
+  // Web push fallback. Body deliberately carries NO wallet and NO loan id —
+  // a lock screen is a far more public surface than a DM.
+  if (!delivered) {
+    try {
+      if (isPushConfigured()) {
+        const r = await sendPushToUser(row.user_id, {
+          title: "Loan health alert",
+          body: "A loan's collateral health has dropped — open your dashboard to review it.",
+          url: "https://www.magpie.capital/dashboard",
+        });
+        if (r.sent > 0) {
+          delivered = true;
+          console.log(`[health-watcher] alert delivered via web push for loan ${row.loan_id}`);
+        }
+      }
+    } catch (err) {
+      console.error(`[health-watcher] push attempt failed for loan ${row.loan_id}: ${err.message}`);
+    }
+  }
+
+  if (delivered) {
     await query(`UPDATE loans SET last_health_alert = $2 WHERE id = $1`, [
       row.id,
       alert.ratio,
     ]);
-  } catch (err) {
-    console.error(`[health-watcher] DM failed for loan ${row.loan_id}: ${err.message}`);
   }
 }
 

--- a/src/services/pump-watcher.js
+++ b/src/services/pump-watcher.js
@@ -10,6 +10,8 @@ import { InlineKeyboard } from "grammy";
 import { query } from "../db/pool.js";
 import { collateralValueLamports } from "./price.js";
 import { getPrefs } from "./prefs.js";
+import { isPermanentDeliveryFailure, deliveryFailureReason } from "./telegram-delivery.js";
+import { sendPushToUser, isPushConfigured } from "./push-send.js";
 
 const POLL_INTERVAL_MS = Number(process.env.PUMP_WATCH_MS) || 300_000; // 5 min
 
@@ -87,17 +89,53 @@ async function checkLoan(bot, row) {
     .row()
     .text("🔕 Mute pump alerts", "pump:mute");
 
-  try {
-    await bot.api.sendMessage(row.telegram_id, msg, {
-      parse_mode: "Markdown",
-      reply_markup: kb,
-    });
+  // Same delivery discipline as health-watcher / loan-watcher:
+  // never DM a negative (site-native synthetic) id — group-id collision would
+  // post this user's position into a public chat; classify DM failures; fall
+  // back to web push; only a DELIVERED alert marks last_pump_alert_value.
+  const tgId = Number(row.telegram_id);
+  const tgDeliverable = Number.isFinite(tgId) && tgId > 0;
+  let delivered = false;
+
+  if (tgDeliverable) {
+    try {
+      await bot.api.sendMessage(row.telegram_id, msg, {
+        parse_mode: "Markdown",
+        reply_markup: kb,
+      });
+      delivered = true;
+    } catch (err) {
+      const permanent = isPermanentDeliveryFailure(err);
+      console.error(
+        `[pump-watcher] DM failed for loan ${row.loan_id} ` +
+          `(${permanent ? "PERMANENT" : "transient"}): ${deliveryFailureReason(err)}`,
+      );
+    }
+  }
+
+  if (!delivered) {
+    try {
+      if (isPushConfigured()) {
+        const r = await sendPushToUser(row.user_id, {
+          title: "Your collateral is up",
+          body: "A loan's collateral has pumped — open your dashboard to review it.",
+          url: "https://www.magpie.capital/dashboard",
+        });
+        if (r.sent > 0) {
+          delivered = true;
+          console.log(`[pump-watcher] alert delivered via web push for loan ${row.loan_id}`);
+        }
+      }
+    } catch (err) {
+      console.error(`[pump-watcher] push attempt failed for loan ${row.loan_id}: ${err.message}`);
+    }
+  }
+
+  if (delivered) {
     await query(
       `UPDATE loans SET last_pump_alert_value = $2 WHERE id = $1`,
       [row.id, bestThreshold.multiple],
     );
-  } catch (err) {
-    console.error(`[pump-watcher] DM failed for loan ${row.loan_id}: ${err.message}`);
   }
 }
 


### PR DESCRIPTION
Production logs showed `health-watcher` and `pump-watcher` DMs failing (`chat not found`) for multiple loans, every tick, forever. Both watchers still had the pre-incident naive send. Three defects, one funds/privacy-adjacent:

1. **No negative-id guard** — site-native users carry synthetic negative ids sharing Telegram's *group* id space. `loan-watcher` refuses to DM them because a collision would post a borrower's loan id, collateral value, and owed amount **into a public group**; the health alert (same payload sensitivity) sent unguarded.
2. **No fallback** — users unreachable on Telegram never received health alerts at all: the same silent-non-delivery class as the unwarned-liquidation incident, one layer earlier in the funnel.
3. **No classification** — permanent failures retried undifferentiated every tick (the log spam that surfaced this).

**Fix**: mirrors `loan-watcher`'s proven discipline exactly — skip DM for non-positive ids → classify failures via the shared `telegram-delivery` module → web-push fallback with privacy-safe body (no wallet/loan id) → only a **delivered** alert marks `last_health_alert` / `last_pump_alert_value`.

Verified: `node --check` clean on both; pip-parity, x402-contracts, sim-compat green; `sendPushToUser` return contract (`{sent}`) confirmed against the module. **Merge ≠ deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)