### PR TITLE
anti-exploit: extend off-chain TWAP pump-gate to RWAs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,6 @@ API_PORT=3001
 DEPOSIT_POLL_MS=
 # Loan-due warning watcher interval (ms). Default 60000.
 LOAN_WATCH_MS=
+
+# Off-chain TWAP pump-gate (anti-exploit)
+BORROW_TWAP_MAX_PUMP_PCT_RWA=0.20

--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -431,6 +431,16 @@ const TWAP_MIN_SAMPLES = Math.max(
   3,
   Number(process.env.BORROW_TWAP_MIN_SAMPLES) || 5,
 );
+// RWAs (tokenized stocks/ETFs/metals) get a LOOSER pump threshold than
+// memecoins: crypto-adjacent equities (MSTR, COIN) can genuinely move
+// >15% in a 30-min window, and a false block violates the never-block-legit
+// mandate. 20% still sits far below the ~43% a pump must clear to profit
+// against the 70% max RWA LTV, so the attack margin is untouched.
+const TWAP_MAX_PUMP_PCT_RWA = Math.max(
+  0,
+  Math.min(1, Number(process.env.BORROW_TWAP_MAX_PUMP_PCT_RWA) || 0.20),
+);
+const RWA_CATEGORIES = new Set(["stock", "etf", "metal"]);
 
 /**
  * The full pre-borrow defensive check. Returns null if all gates pass;
@@ -466,6 +476,7 @@ export async function preBorrowAntiExploitCheck(opts) {
     // OR source='operator_trusted' ⇒ the operator has explicitly vetted this
     // token, so it is exempt from the thin-pool liquidity floor + pool-% cap.
     let tokenIsTrusted = false;
+    let mintCategory = "memecoin";
 
     // 0. PER_TOKEN_CAP — refuse if total open loans against this mint
     // already exceed the cap. Four-step cap resolution:
@@ -495,7 +506,7 @@ export async function preBorrowAntiExploitCheck(opts) {
     // account, imported-wallet, TWAP, etc.).
     {
       const { rows: capRows } = await query(
-        `SELECT sm.max_open_lamports, sm.liquidity_usd, sm.holder_count, sm.token_age_hours,
+        `SELECT sm.category, sm.max_open_lamports, sm.liquidity_usd, sm.holder_count, sm.token_age_hours,
                 sm.top10_holder_pct, sm.has_mint_authority, sm.has_freeze_authority, sm.lp_burned,
                 sm.symbol, sm.market_cap_usd, sm.protected, sm.source,
                 pt.max_open_lamports::text AS pt_cap,
@@ -507,6 +518,7 @@ export async function preBorrowAntiExploitCheck(opts) {
         [String(collateralMint)],
       );
       const mintRow = capRows[0];
+      mintCategory = mintRow?.category || "memecoin";
       tokenIsTrusted =
         mintRow?.protected === true || mintRow?.source === "operator_trusted";
       const override = mintRow?.max_open_lamports;
@@ -648,7 +660,10 @@ export async function preBorrowAntiExploitCheck(opts) {
         );
         if (stats && stats.avgPrice > 0 && stats.lastPrice > 0) {
           const pump = (stats.lastPrice - stats.avgPrice) / stats.avgPrice;
-          if (pump > TWAP_MAX_PUMP_PCT) {
+          const pumpMax = RWA_CATEGORIES.has(mintCategory)
+            ? TWAP_MAX_PUMP_PCT_RWA
+            : TWAP_MAX_PUMP_PCT;
+          if (pump > pumpMax) {
             return {
               blocked: true,
               reason: "twap_pump",

--- a/src/services/price-snapshotter.js
+++ b/src/services/price-snapshotter.js
@@ -43,13 +43,21 @@ const MAX_MINTS_PER_TICK = Math.max(
 const DISABLED = process.env.PRICE_SNAPSHOTTER_DISABLED === "true";
 
 async function fetchMintsToSnapshot() {
-  // Snapshot enabled non-RWA mints. RWAs track real-world prices
-  // (xStocks, etc.) and don't share the pump-and-borrow attack model
-  // — their oracle is the underlying market, not a Solana DEX.
+  // Snapshot ALL enabled mints — including RWAs (stock/etf/metal).
+  //
+  // RWAs were originally excluded on the theory that "their oracle is the
+  // underlying market, not a Solana DEX". But collateral VALUATION for RWAs
+  // reads the on-chain pool price (price.js routes rwa-category=* through
+  // DexScreener/Jupiter), and a thin xStock pool can be pumped independently
+  // of the real-world quote — exactly the pump-and-borrow model this TWAP
+  // exists to catch. The exclusion left every RWA borrow with fail-open
+  // off-chain protection ("TWAP pump-gate SKIPPED" warns on every RWA
+  // borrow eval) and only the on-chain V3/V4 TWAP as backstop. Genuine
+  // fast market moves are handled by a looser RWA threshold in
+  // anti-exploit.js, not by blinding the guard.
   const { rows } = await query(
     `SELECT mint FROM supported_mints
       WHERE enabled = TRUE
-        AND COALESCE(category, 'memecoin') NOT IN ('stock', 'metal', 'etf')
       ORDER BY mint
       LIMIT $1`,
     [MAX_MINTS_PER_TICK],


### PR DESCRIPTION
Production warn-logs showed `TWAP pump-gate SKIPPED … (fail-open)` on **every RWA borrow eval** (surfaced via COINx). The snapshotter excluded stock/etf/metal on the theory that RWAs price from the real-world market — but RWA **collateral valuation reads the on-chain pool price**, and a thin xStock pool can be pumped independently of the real-world quote. That's exactly the pump-and-borrow model this gate exists for; RWAs were running fail-open with only the on-chain V3/V4 TWAP backstop.

**Fix**
- Snapshotter covers **all enabled mints** (167 vs 1000 ceiling — no truncation; +25 mints/120s tick).
- Tiered threshold: memecoins keep **15%**; RWAs get **20%** (`BORROW_TWAP_MAX_PUMP_PCT_RWA`) — crypto-adjacent equities (MSTR/COIN) can genuinely move >15%/30min (never-block-legit), while 20% is still far under the **~43%** a pump needs to profit at 70% LTV.
- Category threads through the `supported_mints` row the gate already fetches unconditionally before the TWAP branch. Fail-open semantics unchanged; the loud SKIPPED warn remains for genuinely uncovered mints.

**Verified**: all six guards green, `node --check` clean. Merge ≠ deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)