### PR TITLE
Fix TWAP readiness gate: mirror chain constants exactly (1800s window ≠ 300s history)

### DIFF
--- a/src/api/v4-twap.js
+++ b/src/api/v4-twap.js
@@ -62,7 +62,8 @@ import { withFailover } from "../solana/connection.js";
 import { headroomBpsForCategory } from "./safe-collateral-value.js";
 
 const MIN_SAMPLES_FOR_TWAP = 8;
-const TWAP_WINDOW_SECONDS = 300; // V4: MIN_HISTORY_SECONDS = 300
+const TWAP_WINDOW_SECONDS = 1800; // chain membership window (magpie-v4 lib.rs: 30 min)
+const MIN_HISTORY_SECONDS = 300;  // chain: oldest in-window sample must be >= this old
 // Drift headroom is category-sized (see safe-collateral-value.js). The old fixed
 // 30bps (0.3%) tolerated almost no quote→execution movement → volatile V4
 // collateral failed with CollateralValueExceedsAttestation. Single source of
@@ -214,6 +215,26 @@ export async function handleV4Twap(req, url) {
         reason: `only_${inWindow.length}_samples_in_window_need_${MIN_SAMPLES_FOR_TWAP}`,
         latest_sample_age_seconds: latestSample ? Number(now - latestSample.ts) : null,
         samples_total: samples.length,
+        samples_in_window: inWindow.length,
+        fallback_multiplier: 0.89,
+      },
+    };
+  }
+
+  // Mirror the chain's SECOND requirement (magpie-v4 lib.rs): the oldest
+  // in-window sample must be >= MIN_HISTORY_SECONDS old. Count alone is not
+  // enough — the chain rejects TwapInsufficientHistory until history ages.
+  const oldestInWindowTs = inWindow.reduce((min, s) => (s.ts < min ? s.ts : min), inWindow[0].ts);
+  const historySpanSec = Number(now - oldestInWindowTs);
+  if (historySpanSec < MIN_HISTORY_SECONDS) {
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        mint: mintStr,
+        recommendation: "wait_for_warmup",
+        reason: `history_aging_${historySpanSec}s_of_${MIN_HISTORY_SECONDS}s`,
+        eta_seconds: Math.max(1, MIN_HISTORY_SECONDS - historySpanSec),
         samples_in_window: inWindow.length,
         fallback_multiplier: 0.89,
       },

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -185,7 +185,7 @@ export async function getPriceFeedAgeSeconds(mintStr, programIdOverride = null) 
  * the head and overwrites the oldest sample. So we ALWAYS iterate every
  * populated slot and count by timestamp rather than trusting `count`.
  */
-export async function getV4TwapSampleCount(mintStr, windowSec = 300, programIdOverride = null) {
+export async function getV4TwapSampleCount(mintStr, windowSec = 1800, programIdOverride = null) {
   try {
     const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
     // Default to V4 for backward compatibility, but accept V3 too — both
@@ -259,7 +259,15 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
   // age out between the moment we measure and the moment the cosigned
   // tx lands on-chain. Targeting 10 gives 2 samples of headroom.
   const REQUIRED_IN_WINDOW = Number(opts.requiredInWindow ?? 10);
-  const WINDOW_SEC = 300;
+  // MIRROR THE CHAIN EXACTLY (magpie-v4 lib.rs): sample membership uses
+  // TWAP_WINDOW_SECONDS = 1800 (30 min); the SEPARATE history requirement is
+  // oldest-in-window age >= MIN_HISTORY_SECONDS = 300. These are two different
+  // constants. Conflating them (window=300 AND span>=300) made the gate
+  // unsatisfiable except in the 1-second knife-edge when a sample's age is
+  // exactly 300 — feeds reported "span_warming" forever while the chain would
+  // have accepted the borrow. Operator hit this live on TripleT 2026-08-22.
+  const WINDOW_SEC = 1800;
+  const MIN_HISTORY_SEC = 300;
   // 90s budget, 1.5s spacing — comfortably fits 10 samples even from a
   // cold-start PDA that needs init first. Previous 45s/4s budget was too
   // tight: init took ~1s, then 8 attests × 4s = 32s, plus ~2s/attest
@@ -300,15 +308,16 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
       await new Promise((r) => setTimeout(r, 1000));
       continue;
     }
-    // The on-chain V3/V4 TWAP gate requires BOTH >= MIN_SAMPLES in-window AND
-    // >= MIN_HISTORY_SECONDS (300s) of span since the oldest in-window sample
-    // (magpie-lending-v3 lib.rs). Checking the COUNT alone false-readies a
-    // stone-cold feed (10 samples fired in 15s → count ok, span 15s → the chain
-    // REJECTS at broadcast). So require the span too: "ready" here now means
-    // "will pass on-chain", which is what closes the sign-then-fail path.
+    // The on-chain V3/V4 TWAP gate requires BOTH >= MIN_SAMPLES within the
+    // 30-min window AND oldest-in-window age >= MIN_HISTORY_SECONDS (300s)
+    // (magpie-v4 lib.rs `twap()` + borrow validation). Checking the COUNT
+    // alone false-readies a stone-cold feed (10 samples fired in 15s → count
+    // ok, span 15s → the chain REJECTS at broadcast). So require the span
+    // too — against MIN_HISTORY_SEC, NOT the membership window: "ready" here
+    // means "will pass on-chain", which closes the sign-then-fail path.
     const nowSec = Math.floor(Date.now() / 1000);
     const spanSec = status.oldestInWindowTs != null ? nowSec - status.oldestInWindowTs : 0;
-    if (status.inWindow >= REQUIRED_IN_WINDOW && spanSec >= WINDOW_SEC) {
+    if (status.inWindow >= REQUIRED_IN_WINDOW && spanSec >= MIN_HISTORY_SEC) {
       return {
         ok: true,
         inWindow: status.inWindow,
@@ -357,7 +366,7 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
     ok: false,
     inWindow: final?.inWindow ?? 0,
     spanSec: finalSpanSec,
-    secondsToReady: Math.max(5, WINDOW_SEC - finalSpanSec),
+    secondsToReady: Math.max(5, MIN_HISTORY_SEC - finalSpanSec),
     waitedMs: Date.now() - START,
     attests,
     reason: lastErr || (countShort ? "timeout" : "span_warming"),

--- a/src/services/v4-feed-readiness.js
+++ b/src/services/v4-feed-readiness.js
@@ -36,7 +36,8 @@ import { query } from "../db/pool.js";
 import { withFailover } from "../solana/connection.js";
 
 const MIN_SAMPLES_FOR_TWAP = 8;
-const TWAP_WINDOW_SECONDS = 300;
+const TWAP_WINDOW_SECONDS = 1800; // chain membership window (magpie-v4 lib.rs)
+const MIN_HISTORY_SECONDS = 300;  // chain: oldest in-window age requirement
 
 const WARMUP_CONCURRENCY = Number(process.env.V4_WARMUP_CONCURRENCY) || 8;
 const WARMUP_BATCH_SPACING_MS = Number(process.env.V4_WARMUP_BATCH_SPACING_MS) || 4_000;
@@ -228,16 +229,25 @@ async function feedIsWarm(mintStr, lenderPk, programIdV4) {
 
   const now = BigInt(Math.floor(Date.now() / 1000));
   const windowStart = now - BigInt(TWAP_WINDOW_SECONDS);
+  // Mirror the chain: >= MIN_SAMPLES in the 30-min window AND the oldest
+  // in-window sample >= MIN_HISTORY_SECONDS old (two separate constants).
   let inWindow = 0;
+  let oldestInWindowTs = null;
   for (let i = 0; i < Math.min(count, 32); i++) {
     const idx = (head - 1 - i + 32) % 32;
     const start = 112 + idx * 16;
     if (start + 16 > info.data.length) break;
     const ts = info.data.readBigInt64LE(start + 8);
-    if (ts >= windowStart) inWindow++;
-    if (inWindow >= MIN_SAMPLES_FOR_TWAP) return true;
+    if (ts >= windowStart) {
+      inWindow++;
+      if (oldestInWindowTs == null || ts < oldestInWindowTs) oldestInWindowTs = ts;
+    }
   }
-  return false;
+  return (
+    inWindow >= MIN_SAMPLES_FOR_TWAP &&
+    oldestInWindowTs != null &&
+    Number(now - oldestInWindowTs) >= MIN_HISTORY_SECONDS
+  );
 }
 
 async function ensureMintWarm(mint, lenderPk, programIdV4) {
@@ -394,20 +404,37 @@ export async function checkMintReadiness(mintStr) {
   const now = BigInt(Math.floor(Date.now() / 1000));
   const windowStart = now - BigInt(TWAP_WINDOW_SECONDS);
   let inWindow = 0;
+  let oldestInWindowTs = null;
   for (let i = 0; i < Math.min(count, 32); i++) {
     const idx = (head - 1 - i + 32) % 32;
     const start = 112 + idx * 16;
     if (start + 16 > info.data.length) break;
     const ts = info.data.readBigInt64LE(start + 8);
-    if (ts >= windowStart) inWindow++;
+    if (ts >= windowStart) {
+      inWindow++;
+      if (oldestInWindowTs == null || ts < oldestInWindowTs) oldestInWindowTs = ts;
+    }
+  }
+  const spanSec = oldestInWindowTs != null ? Number(now - oldestInWindowTs) : 0;
+  if (inWindow >= MIN_SAMPLES_FOR_TWAP && spanSec >= MIN_HISTORY_SECONDS) {
+    return { ready: true, samples_in_window: inWindow, span_seconds: spanSec };
   }
   if (inWindow >= MIN_SAMPLES_FOR_TWAP) {
-    return { ready: true, samples_in_window: inWindow };
+    // Count met — only history age is missing. ETA is exact: the remaining
+    // seconds until the oldest in-window sample turns MIN_HISTORY_SECONDS old.
+    return {
+      ready: false,
+      reason: "history_aging",
+      samples_in_window: inWindow,
+      span_seconds: spanSec,
+      eta_seconds: Math.max(1, MIN_HISTORY_SECONDS - spanSec),
+    };
   }
   // Estimate ETA: at 3s on-demand spacing per round + ~2s per attest
-  // confirmation, each missing sample costs ~5s.
+  // confirmation, each missing sample costs ~5s; then the history-age
+  // requirement dominates for a cold feed.
   const missing = MIN_SAMPLES_FOR_TWAP - inWindow;
-  const etaSeconds = missing * 5;
+  const etaSeconds = Math.max(missing * 5, MIN_HISTORY_SECONDS - spanSec);
   return {
     ready: false,
     reason: "insufficient_samples_in_window",


### PR DESCRIPTION
Root-cause fix for the live TRIPLET borrow lockout (operator-reported). Gate used 300s as both membership window and required span → unsatisfiable knife-edge → infinite 'Building price history…'. Now mirrors magpie-v4 lib.rs exactly. Bot-side only, Sec3 params untouched. Live-verified: TRIPLET chain-ready YES under corrected gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)