### PR TITLE
Raise exposure caps: RWA default 75, memecoin bluechip 75 / large 50

### DIFF
--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -123,7 +123,7 @@ const PER_TOKEN_OPEN_LAMPORTS_CAP = BigInt(
 // listed, protected tokenized stock fall through to memecoin tiering where
 // issuer compliance keys (mint/freeze authority) hard-demote it to "small".
 const RWA_DEFAULT_OPEN_LAMPORTS_CAP = BigInt(
-  Math.floor((Number(process.env.RWA_DEFAULT_OPEN_CAP_SOL) || 30) * 1e9),
+  Math.floor((Number(process.env.RWA_DEFAULT_OPEN_CAP_SOL) || 75) * 1e9),
 );
 
 // Tier-based per-token caps. Larger, more-liquid, older tokens have a
@@ -141,7 +141,7 @@ const RWA_DEFAULT_OPEN_LAMPORTS_CAP = BigInt(
 const TOKEN_TIERS = [
   {
     label: "bluechip",
-    capSol: 30,
+    capSol: 75,
     minLiquidityUsd: 1_000_000,
     minHolderCount: 10_000,
     minAgeHours: 1440,         // 60 days
@@ -150,7 +150,7 @@ const TOKEN_TIERS = [
   },
   {
     label: "large",
-    capSol: 25,
+    capSol: 50,
     minLiquidityUsd: 400_000,
     minHolderCount: 3_000,
     minAgeHours: 480,          // 20 days
@@ -189,8 +189,8 @@ const TOKEN_TIERS = [
 // purpose (promote a high-mcap token with solid-but-sub-primary liquidity),
 // high enough that a fake mcap on a $50k pool can no longer earn 25–30 SOL.
 const MCAP_FALLBACK_TIERS = [
-  { label: "bluechip", capSol: 30, minMarketCapUsd: 100_000_000, minLiquidityUsd: 500_000 },
-  { label: "large",    capSol: 25, minMarketCapUsd:  30_000_000, minLiquidityUsd: 250_000 },
+  { label: "bluechip", capSol: 75, minMarketCapUsd: 100_000_000, minLiquidityUsd: 500_000 },
+  { label: "large",    capSol: 50, minMarketCapUsd:  30_000_000, minLiquidityUsd: 250_000 },
   { label: "mid",      capSol: 15, minMarketCapUsd:  10_000_000, minLiquidityUsd: 100_000 },
 ];
 


### PR DESCRIPTION
Operator-directed cap increases. Tier qualification criteria and LTVs unchanged. Premium whitelist rows already at 75 in DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)