### PR TITLE
RWA default cap → 30 SOL (premium tiers stay 75)

### DIFF
--- a/src/services/anti-exploit.js
+++ b/src/services/anti-exploit.js
@@ -123,7 +123,7 @@ const PER_TOKEN_OPEN_LAMPORTS_CAP = BigInt(
 // listed, protected tokenized stock fall through to memecoin tiering where
 // issuer compliance keys (mint/freeze authority) hard-demote it to "small".
 const RWA_DEFAULT_OPEN_LAMPORTS_CAP = BigInt(
-  Math.floor((Number(process.env.RWA_DEFAULT_OPEN_CAP_SOL) || 75) * 1e9),
+  Math.floor((Number(process.env.RWA_DEFAULT_OPEN_CAP_SOL) || 30) * 1e9),
 );
 
 // Tier-based per-token caps. Larger, more-liquid, older tokens have a


### PR DESCRIPTION
Operator-directed: non-whitelisted RWA default back to 30 SOL; vetted premium tiers keep 75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)