### PR TITLE
Jupiter 429 resilience: lite-tier fallback + screener transient-guard

### DIFF
--- a/src/services/agent-surface-canary.js
+++ b/src/services/agent-surface-canary.js
@@ -60,7 +60,9 @@ async function getText(url, timeoutMs = 12000) {
 // Each check returns { ok, latencyMs, detail? } or throws.
 const CHECKS = [
   ["mcp_registry_listing", async () => {
-    const d = await getJson(REGISTRY);
+    // registry API can be slow (7s+ observed) — generous timeout; the check
+    // asserts LISTING, not their latency
+    const d = await getJson(REGISTRY, 25_000);
     const mine = (d.servers || []).filter((s) => s.server?.name === MCP_NAME);
     if (!mine.length) throw new Error("magpie not found in MCP registry");
     const latest = mine.find((s) => s._meta?.["io.modelcontextprotocol.registry/official"]?.isLatest);

--- a/src/services/price.js
+++ b/src/services/price.js
@@ -56,6 +56,24 @@ const JUP_BATCH_SIZE = 50;
  * to agree. This function is the low-stakes "just give me a price"
  * path used by the on-chain price-feed attestor.
  */
+
+/**
+ * Lite-tier fallback (2026-08-25): when the PAID api.jup.ag key is rate-limited
+ * (429 storms), the free lite-api.jup.ag tier has a SEPARATE quota and is very
+ * often still serving. Trying it before DexScreener keeps pricing on
+ * Jupiter-primary (cross-source posture intact) instead of dropping to the
+ * single-source escape hatch. No key sent — this is the anonymous tier.
+ */
+async function jupiterLitePriceInSol(mint) {
+  const resp = await axios.get("https://lite-api.jup.ag/price/v3", {
+    params: { ids: `${mint},${SOL_MINT}` },
+    timeout: 8_000,
+  });
+  const tokenUsd = resp.data?.[mint]?.usdPrice;
+  const solUsd = resp.data?.[SOL_MINT]?.usdPrice;
+  if (!tokenUsd || !solUsd) throw new Error(`lite: no price data for ${mint}`);
+  return tokenUsd / solUsd;
+}
 async function jupiterPriceInSol(mint) {
   try {
     const resp = await axios.get(JUPITER_API, {
@@ -168,7 +186,16 @@ export async function getPriceInSol(mint, opts = {}) {
       }
     }
 
-    // Transient — wait 200-700ms with jitter, retry Jupiter once IF budget allows.
+    // Transient — first try the FREE lite tier (separate quota from the Pro
+    // key) so a paid-tier 429 storm doesn't degrade us off Jupiter at all.
+    if (JUPITER_API_KEY) {
+      try {
+        const lite = await jupiterLitePriceInSol(mint);
+        console.warn(`[price] ${mint.slice(0, 8)} served by Jupiter LITE tier (paid tier: ${err1.message})`);
+        return lite;
+      } catch { /* lite also failing — continue to retry/Dex path */ }
+    }
+    // wait 200-700ms with jitter, retry Jupiter once IF budget allows.
     await new Promise((r) => setTimeout(r, 200 + Math.random() * 500));
     if (!tryAcquireJupiterToken()) {
       // No budget for retry. Skip to Dex.

--- a/src/services/token-screener.js
+++ b/src/services/token-screener.js
@@ -1759,6 +1759,14 @@ async function processReviewQueue(bot) {
           checkHolderConcentration(t.mint, { fresh: true, maxTop10Pct: REVIEW_AUTO_MAX_TOP10_PCT, maxTop20Pct: REVIEW_AUTO_MAX_TOP20_PCT }),
           rugcheckRisk(t.mint, { fresh: true }),
         ]);
+        // A sell-check that failed NON-definitively (Jupiter 429/5xx/network)
+        // is a TRANSIENT infrastructure error, not a honeypot verdict — skip
+        // this tick and retry next cycle instead of permanently rejecting.
+        // (CYBERLEEK was wrongly branded honeypot off a quote 429, 2026-08-25.)
+        if (!sell.sellable && sell.definitive === false) {
+          console.log(`[screener] Review deferred ${t.symbol} (transient sell-check: ${sell.reason}) — will retry`);
+          continue;
+        }
         scamReason =
           !sell.sellable ? `honeypot — ${sell.reason}`
           : !ext.safe ? `unsafe extension — ${ext.reason}`


### PR DESCRIPTION
Free lite-api tier (separate quota) before DexScreener; transient sell-checks defer instead of honeypot-reject; registry canary timeout raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)