### PR TITLE
Farm-guard: count approval events, not screened_at — phantom wave held all candidates

### DIFF
--- a/scripts/tmp-queue-truth.mjs
+++ b/scripts/tmp-queue-truth.mjs
@@ -1,0 +1,13 @@
+import pg from "pg";
+const c = new pg.Client({ connectionString: process.env.DATABASE_URL });
+await c.connect();
+const a = await c.query("SELECT symbol, source, category, auto_approved, liquidity_usd, screened_at FROM supported_mints WHERE enabled = true AND screened_at > NOW() - INTERVAL '24 hours' ORDER BY screened_at");
+console.log("ENABLED last 24h:", a.rows.length);
+for (const r of a.rows) console.log("  ", r.screened_at.toISOString().slice(5, 16), r.symbol, r.source || "", "liq=$"+Math.floor(r.liquidity_usd||0), r.auto_approved ? "fast" : "review");
+const q = await c.query("SELECT status, COUNT(*)::int AS n FROM token_screen_queue GROUP BY status");
+console.log("QUEUE:", JSON.stringify(q.rows));
+try {
+  const ann = await c.query("SELECT mint, last_enabled, updated_at FROM token_catalog_announce_state ORDER BY updated_at DESC LIMIT 12");
+  console.log("ANNOUNCE recent:", ann.rows.map(r => `${r.mint.slice(0,6)}:${r.last_enabled}@${r.updated_at.toISOString().slice(5,16)}`).join(" "));
+} catch (e) { console.log("ANNOUNCE err:", e.message); }
+await c.end();

--- a/src/services/farm-guard.js
+++ b/src/services/farm-guard.js
@@ -176,9 +176,14 @@ export async function assessFarmRisk({ mint, name, imageUrl, liquidity, volume24
 
   try {
     const { rows } = await query(
-      `SELECT COUNT(*) AS n FROM supported_mints
-        WHERE auto_approved = TRUE AND source IN ('screener', 'review_auto')
-          AND screened_at > NOW() - INTERVAL '24 hours'`,
+      // Count real approval EVENTS (queue transitions), not supported_mints
+      // screened_at — token-health re-stamps screened_at on every periodic
+      // liquidity refresh for ALL enabled tokens, which made this counter
+      // read ~54 forever and hold every clean candidate in a phantom
+      // "approval wave" that could never clear.
+      `SELECT COUNT(*) AS n FROM token_screen_queue
+        WHERE status = 'approved'
+          AND reviewed_at > NOW() - INTERVAL '24 hours'`,
     );
     ctx.autoApprovals24h = Number(rows[0]?.n);
   } catch (e) {


### PR DESCRIPTION
token-health stamps screened_at=NOW() on every periodic liquidity
refresh for all enabled tokens, so the wave counter permanently read
~54 'approvals in 24h' and soft-held every gauntlet-clean candidate
for a wave that could never clear. Count token_screen_queue approved
transitions (reviewed_at) instead — an immutable event timestamp. The
10/24h wave cap itself is unchanged and still guards real mass waves.
