### PR TITLE
IndexNow ping on every new-collateral announcement

### DIFF
--- a/src/services/indexnow.js
+++ b/src/services/indexnow.js
@@ -1,0 +1,44 @@
+/**
+ * indexnow.js — instant search-index pings for newly listed collateral.
+ *
+ * Why (2026-08-25): tokens are listed while they're TRENDING, and the
+ * attention window is hours. IndexNow tells Bing/Yandex/Seznam/Naver about
+ * the token's borrow landing page within minutes of listing — and Bing's
+ * index feeds the browsing stacks behind several LLM assistants, which is
+ * exactly where "what is $<token>" questions get answered. Google ignores
+ * IndexNow but re-reads our live sitemap hourly, so it catches up on its own.
+ *
+ * Fail-soft by design: an indexing ping must never block or fail an
+ * announcement. No key configured → silently disabled.
+ */
+import axios from "axios";
+
+const SITE_HOST = "www.magpie.capital";
+const KEY = process.env.INDEXNOW_KEY || null;
+
+export async function pingIndexNowForListing(symbol) {
+  if (!KEY) return false;
+  const slug = encodeURIComponent(String(symbol || "").toLowerCase());
+  if (!slug) return false;
+  const urlList = [
+    `https://${SITE_HOST}/borrow/${slug}`,
+    `https://${SITE_HOST}/tokens`,
+  ];
+  try {
+    const res = await axios.post(
+      "https://api.indexnow.org/indexnow",
+      {
+        host: SITE_HOST,
+        key: KEY,
+        keyLocation: `https://${SITE_HOST}/${KEY}.txt`,
+        urlList,
+      },
+      { timeout: 10_000, headers: { "Content-Type": "application/json; charset=utf-8" } },
+    );
+    console.log(`[indexnow] pinged for $${symbol} (status ${res.status})`);
+    return true;
+  } catch (e) {
+    console.warn(`[indexnow] ping failed for $${symbol}: ${e.response?.status ?? e.code ?? e.message?.slice(0, 80)}`);
+    return false;
+  }
+}

--- a/src/services/token-catalog-announcer.js
+++ b/src/services/token-catalog-announcer.js
@@ -183,6 +183,15 @@ async function tick() {
         const { notifyAdmin } = await import("./admin-notify.js");
         await notifyAdmin(`✅ Auto-announced ${t.type === "added" ? "new collateral" : "catalog change"}: $${t.row.symbol} → MagPie Talk${res.ok ? " + X" : " (TG only — X credits depleted)"}`);
       } catch { /* receipt is best-effort */ }
+      // Instant search-index ping for the token's borrow landing page —
+      // the trending-attention window is hours, so indexing must be too.
+      // Fail-soft: never blocks the announce loop.
+      if (t.type === "added") {
+        try {
+          const { pingIndexNowForListing } = await import("./indexnow.js");
+          await pingIndexNowForListing(t.row.symbol);
+        } catch { /* indexing is best-effort */ }
+      }
     }
     // Silent-failure alarm (lesson: 48 adds went unannounced with no page).
     if (!announcedSomewhere) {


### PR DESCRIPTION
Pairs with magpie-site's instant token pages: when the announcer posts a new-collateral 🦅, it now pings IndexNow (api.indexnow.org) for `/borrow/<symbol>` + `/tokens` so Bing-family indexes — which feed several LLM assistants' browsing stacks — pick up the landing page within minutes of listing, inside the trending-attention window. Google ignores IndexNow but re-reads the site's live sitemap hourly.

Fail-soft everywhere: no `INDEXNOW_KEY` env → silently disabled; ping failures log and never block the announce loop. Key is public-by-design (matches the key file the site hosts). `INDEXNOW_KEY` set on Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)