### PR TITLE
fix: V4.1 memecoin exit lane on every bot surface

### DIFF
--- a/src/api/agent-repay.js
+++ b/src/api/agent-repay.js
@@ -252,7 +252,9 @@ export async function handleAgentBuildRepay(req) {
     // V1/V3 paths unchanged. Mirrors the TG repay pattern in loans.js (task
     // #267). Audit-mandated 2026-06-19 PM after full-protocol audit revealed
     // agent-repay diverged from TG repay on V4 accounts.
-    const isV4 = !!PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4);
+    const isV4 =
+      (!!PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4)) ||
+      (!!process.env.PROGRAM_ID_V4_1 && programId.toBase58() === process.env.PROGRAM_ID_V4_1);
     let v4ExtraAccounts = {};
     if (isV4) {
       const [solProceedsVault] = PublicKey.findProgramAddressSync(

--- a/src/api/agent.js
+++ b/src/api/agent.js
@@ -375,7 +375,9 @@ export async function buildBorrowTx({
     const RWA_CATEGORIES = new Set(["stock", "etf", "metal"]);
     const programIdB58 = programId.toBase58();
     const isV3 = process.env.PROGRAM_ID_V3 && programIdB58 === process.env.PROGRAM_ID_V3;
-    const isV4 = process.env.PROGRAM_ID_V4 && programIdB58 === process.env.PROGRAM_ID_V4;
+    const isV4 =
+      (process.env.PROGRAM_ID_V4 && programIdB58 === process.env.PROGRAM_ID_V4) ||
+      (process.env.PROGRAM_ID_V4_1 && programIdB58 === process.env.PROGRAM_ID_V4_1);
     const needsCategoryArg = isV3 || isV4;
     const categoryByte = RWA_CATEGORIES.has(mintRow.category) ? 1 : 0;
     const ixArgs = needsCategoryArg

--- a/src/api/cosign-borrow.js
+++ b/src/api/cosign-borrow.js
@@ -177,6 +177,14 @@ const ROUTE_RWA_TO_V3 = process.env.ROUTE_RWA_TO_V3 === "true";
 const V4_PROGRAM_ID = process.env.PROGRAM_ID_V4
   ? new PublicKey(process.env.PROGRAM_ID_V4)
   : null;
+// V4.1 — Sec3-remediated build; the memecoin exit lane (operator plan
+// 2026-08-30: V4 = RWA exits, V4.1 = memecoin exits). MUST be on the
+// allowlist or every website memecoin exit-borrow is refused as a
+// "drain attempt" the moment the site routes to V4.1.
+const V4_1_PROGRAM_ID = process.env.PROGRAM_ID_V4_1
+  ? new PublicKey(process.env.PROGRAM_ID_V4_1)
+  : null;
+const ROUTE_EXITS_TO_V4_1 = process.env.ROUTE_EXITS_TO_V4_1 === "true";
 const ROUTE_MEMECOINS_TO_V4 = process.env.ROUTE_MEMECOINS_TO_V4 === "true";
 const ROUTE_RWA_TO_V4 = process.env.ROUTE_RWA_TO_V4 === "true";
 
@@ -212,6 +220,7 @@ const OUTER_INSTRUCTION_PROGRAM_ALLOWLIST = new Set([
   ...(V2_PROGRAM_ID ? [V2_PROGRAM_ID.toBase58()] : []),
   ...(V3_PROGRAM_ID ? [V3_PROGRAM_ID.toBase58()] : []),
   ...(V4_PROGRAM_ID ? [V4_PROGRAM_ID.toBase58()] : []),
+  ...(V4_1_PROGRAM_ID ? [V4_1_PROGRAM_ID.toBase58()] : []),
   "ComputeBudget111111111111111111111111111111",
   "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  // Associated Token Account
   "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",  // SPL Token
@@ -515,6 +524,7 @@ function isMagpieProgram(programIdPk) {
   if (V2_PROGRAM_ID && programIdPk.equals(V2_PROGRAM_ID)) return true;
   if (V3_PROGRAM_ID && programIdPk.equals(V3_PROGRAM_ID)) return true;
   if (V4_PROGRAM_ID && programIdPk.equals(V4_PROGRAM_ID)) return true;
+  if (V4_1_PROGRAM_ID && programIdPk.equals(V4_1_PROGRAM_ID)) return true;
   return false;
 }
 
@@ -1194,7 +1204,34 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
           // (limit-close-arm-core's exits_require_v4_loan refusal) is
           // what enforces "V4 loans are the only ones that can host
           // exits"; this endpoint just signs the borrow.
-          const isV4Borrow = V4_PROGRAM_ID && ixProgramId.equals(V4_PROGRAM_ID);
+          const isV41Borrow = !!(V4_1_PROGRAM_ID && ixProgramId.equals(V4_1_PROGRAM_ID));
+          const isV4Borrow =
+            !!(V4_PROGRAM_ID && ixProgramId.equals(V4_PROGRAM_ID)) || isV41Borrow;
+
+          // ── POOL PLAN ENFORCEMENT (operator 2026-08-30) ─────────────────
+          // V4 = exit-armed tokenized stocks/RWA; V4.1 = exit-armed memecoins.
+          // (a) RWA on V4.1 can never work — V4.1's H-01 fix rejects the
+          //     PermanentDelegate extension every xStock carries — so refuse
+          //     with a readable reason instead of an opaque on-chain error.
+          // (b) Memecoin on OLD V4 while V4.1 routing is on = a stale client
+          //     bundle. Don't block the borrower (loan execution is #1), but
+          //     alarm so it's never silent again.
+          if (isV41Borrow && isRwaMint) {
+            return {
+              status: 400,
+              body: {
+                error: "rwa_exits_use_v4",
+                detail: `${mintRow.symbol || collateralMintStr} is a tokenized ${mintRow.category}; exit-armed RWA borrows run on the V4 program, not V4.1. Refresh the page and try again.`,
+              },
+            };
+          }
+          if (isV4Borrow && !isV41Borrow && !isRwaMint && V4_1_PROGRAM_ID && ROUTE_EXITS_TO_V4_1) {
+            console.warn(`[cosign-borrow] PLAN DRIFT: memecoin ${mintRow.symbol || collateralMintStr} exit-borrow targets OLD V4 while ROUTE_EXITS_TO_V4_1=true — stale client bundle? Signing anyway (loan execution first).`);
+            try {
+              const { notifyAdmin } = await import("../services/admin-notify.js");
+              notifyAdmin(`⚠️ Memecoin exit-borrow (${mintRow.symbol || collateralMintStr.slice(0, 8)}) landed on OLD V4 instead of V4.1 — a client is still routing to V4. Check site deploy / NEXT_PUBLIC_ROUTE_EXITS_TO_V4_1.`).catch(() => {});
+            } catch {}
+          }
 
           // ── CRITICAL: validate the on-chain LTV-tier `category` byte ──────
           // (2026-06-28 security audit.) V3/V4 request_and_fund_loan takes a
@@ -1572,6 +1609,8 @@ async function _handleCosignBorrowImpl(req, _convCtx) {
         const usesTwapGate =
           (process.env.PROGRAM_ID_V4 &&
             borrowProgramId.toBase58() === process.env.PROGRAM_ID_V4) ||
+          (process.env.PROGRAM_ID_V4_1 &&
+            borrowProgramId.toBase58() === process.env.PROGRAM_ID_V4_1) ||
           (process.env.PROGRAM_ID_V3 &&
             borrowProgramId.toBase58() === process.env.PROGRAM_ID_V3);
 

--- a/src/api/safe-collateral-value.js
+++ b/src/api/safe-collateral-value.js
@@ -41,6 +41,7 @@ import {
   PROGRAM_ID_V2,
   PROGRAM_ID_V3,
   PROGRAM_ID_V4,
+  PROGRAM_ID_V4_1,
 } from "../solana/program.js";
 
 const MIN_SAMPLES_FOR_TWAP = 8;
@@ -98,6 +99,7 @@ const VERSIONS = {
   v2: { programId: PROGRAM_ID_V2, kind: "single" },
   v3: { programId: PROGRAM_ID_V3, kind: "history" },
   v4: { programId: PROGRAM_ID_V4, kind: "history" },
+  v41: { programId: PROGRAM_ID_V4_1, kind: "history" },
 };
 
 function isValidPubkey(s) {

--- a/src/api/site-limit-close-preflight.js
+++ b/src/api/site-limit-close-preflight.js
@@ -98,7 +98,9 @@ export async function handleSiteLimitCloseArmPreflight(req) {
   // signing.
   const v4Enforce = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
   const v4ProgramId = process.env.PROGRAM_ID_V4 ?? null;
-  if (v4Enforce && v4ProgramId && loan.program_id && loan.program_id !== v4ProgramId) {
+  const v41ProgramId = process.env.PROGRAM_ID_V4_1 ?? null;
+  const loanIsV4Family = loan.program_id === v4ProgramId || (!!v41ProgramId && loan.program_id === v41ProgramId);
+  if (v4Enforce && v4ProgramId && loan.program_id && !loanIsV4Family) {
     return {
       status: 409,
       body: {
@@ -265,7 +267,7 @@ export async function handleSiteLimitCloseArmPreflight(req) {
         loan_db_id: loan.id,
         loan_id_chain: loan.loan_id,
         program_id: loan.program_id,
-        is_v4_loan: !!(v4ProgramId && loan.program_id === v4ProgramId),
+        is_v4_loan: !!(v4ProgramId && loan.program_id === v4ProgramId) || !!(process.env.PROGRAM_ID_V4_1 && loan.program_id === process.env.PROGRAM_ID_V4_1),
         collateral_mint: loan.collateral_mint,
         collateral_symbol: mintRow.symbol,
         trigger_kind: triggerKind,

--- a/src/api/site-limit-close.js
+++ b/src/api/site-limit-close.js
@@ -551,7 +551,8 @@ export async function handleSiteLimitCloseList(req, url) {
     // V4 enforcement: non-V4 loans can't take new exits. NOTE: this
     // intentionally does NOT touch already-armed orders — those keep
     // firing through their legacy path. Only blocks NEW arms.
-    if (v4EnforceOn && v4ProgramIdStr && l.program_id && l.program_id !== v4ProgramIdStr) {
+    const lIsV4Family = l.program_id === v4ProgramIdStr || (!!process.env.PROGRAM_ID_V4_1 && l.program_id === process.env.PROGRAM_ID_V4_1);
+    if (v4EnforceOn && v4ProgramIdStr && l.program_id && !lIsV4Family) {
       baseReasons.push("exits_require_v4_loan");
     }
     // 2026-06-13 (PR C): RWA categories (stock/etf/metal) are NOW eligible

--- a/src/commands/borrow.js
+++ b/src/commands/borrow.js
@@ -1049,7 +1049,9 @@ export function registerBorrowCallbacks(bot) {
     // landed on, not on whether arming was requested.
     const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
     const v4Enforced = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
-    const isV4Loan = !!v4ProgramId && result.programId === v4ProgramId;
+    const isV4Loan =
+      (!!v4ProgramId && result.programId === v4ProgramId) ||
+      (!!process.env.PROGRAM_ID_V4_1 && result.programId === process.env.PROGRAM_ID_V4_1);
     const canArmExits = isV4Loan || !v4Enforced;
 
     // Build inline keyboard. Show protect buttons only when (a) some leg

--- a/src/commands/limit-close.js
+++ b/src/commands/limit-close.js
@@ -533,7 +533,9 @@ export async function handleLimitClose(ctx, direction = "above", opts = {}) {
   // The success DM must describe what will actually happen so users
   // know to repay when they want their SOL.
   const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
-  const isV4 = !!v4ProgramId && loan?.program_id === v4ProgramId;
+  const isV4 =
+    (!!v4ProgramId && loan?.program_id === v4ProgramId) ||
+    (!!process.env.PROGRAM_ID_V4_1 && loan?.program_id === process.env.PROGRAM_ID_V4_1);
   const purpose = isV4
     ? (isStopLoss
         ? `If ${symbol} ${triggerVerb} your floor, I'll sell that slice into SOL on-chain — the proceeds accumulate inside your loan's vault (V4 in-vault auto-sell). The loan stays Active; run /repay when you want the SOL released to your wallet.`
@@ -718,7 +720,9 @@ export async function handleTrailingStop(ctx) {
   // loan STAYS active until borrower-signed repay. Legacy programs
   // close the loan on fire.
   const v4ProgramIdTrail = process.env.PROGRAM_ID_V4 || null;
-  const isV4Trail = !!v4ProgramIdTrail && armed.loan?.program_id === v4ProgramIdTrail;
+  const isV4Trail =
+    (!!v4ProgramIdTrail && armed.loan?.program_id === v4ProgramIdTrail) ||
+    (!!process.env.PROGRAM_ID_V4_1 && armed.loan?.program_id === process.env.PROGRAM_ID_V4_1);
   const fireLine = isV4Trail
     ? `Fires when price retraces ${(trailingDistanceBps / 100).toFixed(1)}% from peak — sells into SOL on-chain, proceeds accumulate inside your loan's vault. Run /repay when you want the SOL released.`
     : `Fires when price retraces ${(trailingDistanceBps / 100).toFixed(1)}% from peak.`;
@@ -975,7 +979,9 @@ export async function handleBracket(ctx) {
   // and sibling-cancels the other leg; the loan stays Active and the
   // user releases the SOL via /repay. Legacy programs close the loan.
   const v4ProgramIdBracket = process.env.PROGRAM_ID_V4 || null;
-  const isV4Bracket = !!v4ProgramIdBracket && tpArm.loan?.program_id === v4ProgramIdBracket;
+  const isV4Bracket =
+    (!!v4ProgramIdBracket && tpArm.loan?.program_id === v4ProgramIdBracket) ||
+    (!!process.env.PROGRAM_ID_V4_1 && tpArm.loan?.program_id === process.env.PROGRAM_ID_V4_1);
   const bracketFireLine = isV4Bracket
     ? `First leg to fire converts that slice to SOL inside your loan's vault, auto-cancels the other leg, and leaves the loan Active. Run /repay when you want the SOL released.`
     : `First leg to fire closes the loan and auto-cancels the other.`;

--- a/src/commands/positions.js
+++ b/src/commands/positions.js
@@ -185,7 +185,9 @@ export async function handlePositions(ctx) {
     const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
     const v4Enforced = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
     const canArmExits =
-      (!!v4ProgramId && loan.program_id === v4ProgramId) || !v4Enforced;
+      (!!v4ProgramId && loan.program_id === v4ProgramId) ||
+      (!!process.env.PROGRAM_ID_V4_1 && loan.program_id === process.env.PROGRAM_ID_V4_1) ||
+      !v4Enforced;
     if (!existing) {
       if (canArmExits) {
         lines.push(`   _no take-profit set_ · \`/takeprofit ${loan.loan_id} at 2x\``);

--- a/src/commands/repay.js
+++ b/src/commands/repay.js
@@ -268,7 +268,9 @@ export function registerRepayCallbacks(bot) {
       // The loan row was fetched BEFORE the repay so its
       // sol_proceeds_amount is the exact balance just released.
       const v4ProgramIdRepay = process.env.PROGRAM_ID_V4 || null;
-      const isV4Repay = !!v4ProgramIdRepay && loan.program_id === v4ProgramIdRepay;
+      const isV4Repay =
+        (!!v4ProgramIdRepay && loan.program_id === v4ProgramIdRepay) ||
+        (!!process.env.PROGRAM_ID_V4_1 && loan.program_id === process.env.PROGRAM_ID_V4_1);
       const vaultLamportsReleased = isV4Repay
         ? BigInt(loan.sol_proceeds_amount || 0)
         : 0n;

--- a/src/services/canary-watcher.js
+++ b/src/services/canary-watcher.js
@@ -52,6 +52,7 @@ function fmtAgeMs(ms) {
 
 function programLabel(program, v4ProgramId) {
   if (v4ProgramId && program === v4ProgramId) return "V4 (in-vault exits)";
+  if (process.env.PROGRAM_ID_V4_1 && program === process.env.PROGRAM_ID_V4_1) return "V4.1 (audited, memecoin exits)";
   if (program === "legacy") return "legacy/V1";
   return `program ${String(program).slice(0, 8)}…`;
 }

--- a/src/services/loan-reconciler.js
+++ b/src/services/loan-reconciler.js
@@ -73,6 +73,7 @@ function resolveProgramPubkey(programIdStr) {
     if (pk.equals(PROGRAM_ID)) return PROGRAM_ID;
     if (PROGRAM_ID_V3 && pk.equals(PROGRAM_ID_V3)) return PROGRAM_ID_V3;
     if (PROGRAM_ID_V4 && pk.equals(PROGRAM_ID_V4)) return PROGRAM_ID_V4;
+    if (process.env.PROGRAM_ID_V4_1 && pk.toBase58() === process.env.PROGRAM_ID_V4_1) return pk;
     return pk; // unknown but parseable — caller may handle defensively
   } catch {
     return null;

--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -300,7 +300,9 @@ export async function executeBorrow({
   const RWA_CATEGORIES = new Set(["stock", "etf", "metal"]);
   const programIdB58 = programId.toBase58();
   const isV3 = process.env.PROGRAM_ID_V3 && programIdB58 === process.env.PROGRAM_ID_V3;
-  const isV4 = process.env.PROGRAM_ID_V4 && programIdB58 === process.env.PROGRAM_ID_V4;
+  const isV4 =
+    (process.env.PROGRAM_ID_V4 && programIdB58 === process.env.PROGRAM_ID_V4) ||
+    (process.env.PROGRAM_ID_V4_1 && programIdB58 === process.env.PROGRAM_ID_V4_1); // V4-family: V4.1 takes the same 5-arg shape
   // V3 and V4 both take the 5-arg shape (extra `category` u8).
   const needsCategoryArg = isV3 || isV4;
   const categoryByte = RWA_CATEGORIES.has(category) ? 1 : 0;
@@ -512,7 +514,9 @@ async function _executeRepayImpl({ userId, loanDbRow }) {
   // it can `init_if_needed` the vault for loans whose auto-sell never
   // fired. Without these the V4 repay tx fails AccountNotEnoughKeys.
   // V1/V2/V3 paths unchanged.
-  const isV4 = !!PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4);
+  const isV4 =
+    (!!PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4)) ||
+    (!!PROGRAM_ID_V4_1 && programId.equals(PROGRAM_ID_V4_1)); // V4.1 repay_loan has the identical accounts struct
   let v4ExtraAccounts = {};
   if (isV4) {
     const [solProceedsVault] = PublicKey.findProgramAddressSync(
@@ -1022,7 +1026,9 @@ export async function executeAddCollateral({ userId, loanDbRow, extraRawAmount }
   // mitigation: block topup while the order is armed. User can cancel
   // the order, topup, then re-arm — explicit and predictable.
   const v4ProgramIdStr = process.env.PROGRAM_ID_V4 || null;
-  const isV4Loan = v4ProgramIdStr && programId.toBase58() === v4ProgramIdStr;
+  const isV4Loan =
+    (v4ProgramIdStr && programId.toBase58() === v4ProgramIdStr) ||
+    (process.env.PROGRAM_ID_V4_1 && programId.toBase58() === process.env.PROGRAM_ID_V4_1);
   if (isV4Loan) {
     const { rows: [armed] } = await query(
       `SELECT id FROM limit_close_orders

--- a/src/services/notification-sender.js
+++ b/src/services/notification-sender.js
@@ -424,7 +424,9 @@ function renderLimitCloseNearTrigger(p) {
   const dirLabel = p.trigger_direction === "below" ? "stop-loss" : "take-profit";
   const moveDir  = p.trigger_direction === "below" ? "drops" : "moves up";
   const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
-  const isV4 = !!v4ProgramId && p.engine_program_id === v4ProgramId;
+  const isV4 =
+    (!!v4ProgramId && p.engine_program_id === v4ProgramId) ||
+    (!!process.env.PROGRAM_ID_V4_1 && p.engine_program_id === process.env.PROGRAM_ID_V4_1);
   const owedSol = p.owed_lamports
     ? (Number(p.owed_lamports) / 1e9).toFixed(3)
     : null;

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -133,9 +133,9 @@ export async function getPriceFeedAgeSeconds(mintStr, programIdOverride = null) 
     const [priceFeed] = priceFeedPda(mintPk, pool, programId);
     const info = await connection.getAccountInfo(priceFeed);
     if (!info) return null;
-    const { PROGRAM_ID_V3, PROGRAM_ID_V4 } = await import("../solana/program.js");
+    const { PROGRAM_ID_V3, PROGRAM_ID_V4, PROGRAM_ID_V4_1 } = await import("../solana/program.js");
     const isV3 = PROGRAM_ID_V3 && programId.equals(PROGRAM_ID_V3);
-    const isV4 = PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4);
+    const isV4 = (PROGRAM_ID_V4 && programId.equals(PROGRAM_ID_V4)) || (PROGRAM_ID_V4_1 && programId.equals(PROGRAM_ID_V4_1));
     let ts;
     if (isV3 || isV4) {
       // PriceHistory layout — minimum is disc+mint+pool+authority+
@@ -437,6 +437,14 @@ export async function ensureMintFeedsInitialized(mintStr) {
   const programs = [];
   if (defaultPid) programs.push(defaultPid);
   if (PROGRAM_ID_V4 && !programs.some((p) => p.equals(PROGRAM_ID_V4))) programs.push(PROGRAM_ID_V4);
+  // Exit lane per operator plan: memecoins → V4.1 (RWA stays V4, already
+  // covered above). A memecoin's V4.1 feed PDA must exist before its first
+  // exit-armed borrow or the borrow hits AccountNotInitialized.
+  {
+    const { exitProgramForCategory } = await import("../solana/program.js");
+    const exitPid = exitProgramForCategory(category);
+    if (exitPid && !programs.some((p) => p.equals(exitPid))) programs.push(exitPid);
+  }
 
   const out = [];
   let allExist = true;

--- a/src/services/upside-watcher.js
+++ b/src/services/upside-watcher.js
@@ -128,7 +128,9 @@ async function processLoan(loan) {
   const v4ProgramId = process.env.PROGRAM_ID_V4 || null;
   const v4Enforced = process.env.V4_EXIT_EXCLUSIVE_ENFORCE === "true";
   const canArmExits =
-    (!!v4ProgramId && loan.program_id === v4ProgramId) || !v4Enforced;
+    (!!v4ProgramId && loan.program_id === v4ProgramId) ||
+    (!!process.env.PROGRAM_ID_V4_1 && loan.program_id === process.env.PROGRAM_ID_V4_1) ||
+    !v4Enforced;
   if (!canArmExits) return { skipped: "loan_not_v4_eligible" };
 
   const apprec = await computeAppreciation(loan);

--- a/src/services/v4-feed-readiness.js
+++ b/src/services/v4-feed-readiness.js
@@ -131,6 +131,26 @@ const state = {
 /**
  * Public snapshot for health endpoint consumers. Cheap — no I/O.
  */
+// ── Per-mint exit program (operator plan 2026-08-30) ─────────────────────
+// V4 = exit-armed tokenized stocks/RWA; V4.1 = exit-armed memecoins. The
+// feed we warm MUST be the one on the program the borrow will land on —
+// warming V4 for a memecoin that borrows on V4.1 leaves the V4.1 feed cold
+// and the borrow hits TwapInsufficientHistory / AccountNotInitialized.
+const _categoryCache = new Map(); // mint → { category, at }
+async function categoryForMint(mintStr) {
+  const hit = _categoryCache.get(mintStr);
+  if (hit && Date.now() - hit.at < 10 * 60_000) return hit.category;
+  const { rows: [row] } = await query(`SELECT category FROM supported_mints WHERE mint = $1`, [mintStr]);
+  const category = row?.category ?? null;
+  _categoryCache.set(mintStr, { category, at: Date.now() });
+  return category;
+}
+async function programForMint(mintStr, category) {
+  const { exitProgramForCategory } = await import("../solana/program.js");
+  const cat = category !== undefined ? category : await categoryForMint(mintStr);
+  return exitProgramForCategory(cat);
+}
+
 export function getFeedReadinessSnapshot() {
   const total = state.priorityMints.length;
   const warm = state.warmMints.size;
@@ -250,11 +270,12 @@ async function feedIsWarm(mintStr, lenderPk, programIdV4) {
   );
 }
 
-async function ensureMintWarm(mint, lenderPk, programIdV4) {
+async function ensureMintWarm(mint, lenderPk, _programIdV4) {
   if (state.warmMints.has(mint.mint)) return { mint: mint.mint, action: "already_warm" };
   if (state.inFlight.has(mint.mint)) return { mint: mint.mint, action: "in_flight_skip" };
   state.inFlight.add(mint.mint);
   try {
+    const programIdV4 = (await programForMint(mint.mint, mint.category)) || _programIdV4;
     // Quick read first — maybe already warm from on-chain ring buffer
     // (samples persist across bot restarts within the 5-min window).
     if (await feedIsWarm(mint.mint, lenderPk, programIdV4)) {
@@ -265,7 +286,7 @@ async function ensureMintWarm(mint, lenderPk, programIdV4) {
     // wraps the ring and resets the span clock (see burst_paused_history_aging).
     // Site polls hit this path repeatedly; without the gate, each poll would
     // keep the feed perpetually 150s from ready.
-    const r = await checkMintReadiness(mint.mint);
+    const r = await checkMintReadiness(mint.mint, programIdV4);
     if (r.reason === "history_aging") {
       return { mint: mint.mint, action: "history_aging_no_attest", eta_seconds: r.eta_seconds };
     }
@@ -384,16 +405,17 @@ export async function startFeedReadinessWarmup() {
  * Used by the /api/v1/v4/feed-ready endpoint and as the source of
  * truth in requestMintWarm.
  */
-export async function checkMintReadiness(mintStr) {
+export async function checkMintReadiness(mintStr, programIdOverride = null) {
   const { PROGRAM_ID_V4 } = await import("../solana/program.js");
   if (!PROGRAM_ID_V4 || !process.env.LENDER_PUBKEY) {
     return { ready: false, reason: "v4_not_configured", samples_in_window: 0 };
   }
+  const targetPid = programIdOverride || (await programForMint(mintStr)) || PROGRAM_ID_V4;
   const lenderPk = new PublicKey(process.env.LENDER_PUBKEY);
   const { lendingPoolPda, priceFeedPda } = await import("../solana/pdas.js");
   const mintPk = new PublicKey(mintStr);
-  const [pool] = lendingPoolPda(lenderPk, PROGRAM_ID_V4);
-  const [pf] = priceFeedPda(mintPk, pool, PROGRAM_ID_V4);
+  const [pool] = lendingPoolPda(lenderPk, targetPid);
+  const [pf] = priceFeedPda(mintPk, pool, targetPid);
 
   let info;
   try {
@@ -425,7 +447,7 @@ export async function checkMintReadiness(mintStr) {
   }
   const spanSec = oldestInWindowTs != null ? Number(now - oldestInWindowTs) : 0;
   if (inWindow >= MIN_SAMPLES_FOR_TWAP && spanSec >= MIN_HISTORY_SECONDS) {
-    return { ready: true, samples_in_window: inWindow, span_seconds: spanSec };
+    return { ready: true, samples_in_window: inWindow, span_seconds: spanSec, program: targetPid.toBase58() };
   }
   if (inWindow >= MIN_SAMPLES_FOR_TWAP) {
     // Count met — only history age is missing. ETA is exact: the remaining
@@ -882,12 +904,25 @@ async function continuousAllMintsLoop(lenderPk, programIdV4) {
       // Guard against double-attest races with the on-demand/burst loops.
       for (const it of items) state.inFlight.add(it.mint);
       try {
-        const res = await attestPriceBatch(items, programIdV4, { label: "v4-continuous" });
-        state.continuousAttestations += res.attested.length;
-        state.continuousErrors += res.failed.length;
-        if (res.failed.length) {
-          state.lastError = `v4-continuous batch: ${res.failed[0].err}`;
-          state.lastErrorAt = new Date().toISOString();
+        // Group by the program each mint actually borrows on (memecoin →
+        // V4.1, RWA → V4) — one batch per program.
+        const byProgram = new Map();
+        for (const it of items) {
+          const m = needy.find((n) => n.mint === it.mint);
+          const pid = (await programForMint(it.mint, m?.category)) || programIdV4;
+          const key = pid.toBase58();
+          if (!byProgram.has(key)) byProgram.set(key, { pid, items: [] });
+          byProgram.get(key).items.push(it);
+        }
+        for (const { pid, items: group } of byProgram.values()) {
+          const label = process.env.PROGRAM_ID_V4_1 && pid.toBase58() === process.env.PROGRAM_ID_V4_1 ? "v41-continuous" : "v4-continuous";
+          const res = await attestPriceBatch(group, pid, { label });
+          state.continuousAttestations += res.attested.length;
+          state.continuousErrors += res.failed.length;
+          if (res.failed.length) {
+            state.lastError = `${label} batch: ${res.failed[0].err}`;
+            state.lastErrorAt = new Date().toISOString();
+          }
         }
       } finally {
         for (const it of items) state.inFlight.delete(it.mint);

--- a/src/solana/program.js
+++ b/src/solana/program.js
@@ -133,6 +133,28 @@ const ROUTE_RWA_TO_V4 = process.env.ROUTE_RWA_TO_V4 === "true";
 // their own stored program_id via chooseProgramIdForLoan.
 const ROUTE_EXITS_TO_V4_1 = process.env.ROUTE_EXITS_TO_V4_1 === "true";
 
+// ── V4 FAMILY ────────────────────────────────────────────────────────────
+// Operator pool plan (2026-08-30): V4 = exit-armed TOKENIZED STOCKS/RWA,
+// V4.1 = exit-armed MEMECOINS. Both are "V4-family" for every lifecycle
+// concern (in-vault exits, sol_proceeds_vault on repay, category arg on
+// borrow, TWAP gate, topup-while-armed block, exit eligibility). Any code
+// that asks "is this a V4 loan?" must use these helpers, never a bare
+// PROGRAM_ID_V4 equality — that exact bare check is what left the website
+// routing memecoin exits to old V4 after V4.1 went live.
+export const V4_FAMILY_IDS = new Set(
+  [process.env.PROGRAM_ID_V4, process.env.PROGRAM_ID_V4_1].filter(Boolean),
+);
+export function isV4Family(programId) {
+  if (!programId) return false;
+  const s = typeof programId === "string" ? programId : programId.toBase58();
+  return V4_FAMILY_IDS.has(s);
+}
+/** Which exit-capable program a NEW exit-armed borrow of this category lands on. */
+export function exitProgramForCategory(category) {
+  const rwa = isRwaCategory(category);
+  return PROGRAM_ID_V4_1 && ROUTE_EXITS_TO_V4_1 && !rwa ? PROGRAM_ID_V4_1 : PROGRAM_ID_V4;
+}
+
 // Categories that should route to v2 once it's deployed. Source of truth
 // for the category vocabulary lives in supported_mints.category — keep in
 // sync with isRwa() in token-screener.js.


### PR DESCRIPTION
Operator pool plan (2026-08-30): **V4 = exit-armed tokenized stocks/RWA, V4.1 = exit-armed memecoins.** Companion to the site PR that routes website exit-borrows to V4.1. See commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)