### PR TITLE
fix: V4.1 feed freshness (120s wall) + lane-aware attestor tick

### DIFF
--- a/src/api/safe-collateral-value.js
+++ b/src/api/safe-collateral-value.js
@@ -137,7 +137,7 @@ function decodeSingleAttestation(data) {
 export async function computeSafeCollateralValue({ mintStr, decimals, amountRaw, version, category }) {
   const headroomBps = headroomBpsForCategory(category);
   const cfg = VERSIONS[version];
-  if (!cfg) return { ok: false, status: 400, body: { error: "invalid_program", detail: "program must be v1|v2|v3|v4" } };
+  if (!cfg) return { ok: false, status: 400, body: { error: "invalid_program", detail: "program must be v1|v2|v3|v4|v41" } };
   if (!cfg.programId) {
     return { ok: true, status: 200, body: { ok: true, mint: mintStr, recommendation: "wait_for_warmup", reason: `${version}_not_configured`, fallback_multiplier: 0.89 } };
   }

--- a/src/services/price-attestor.js
+++ b/src/services/price-attestor.js
@@ -317,16 +317,29 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
     // means "will pass on-chain", which closes the sign-then-fail path.
     const nowSec = Math.floor(Date.now() / 1000);
     const spanSec = status.oldestInWindowTs != null ? nowSec - status.oldestInWindowTs : 0;
-    if (status.inWindow >= REQUIRED_IN_WINDOW && spanSec >= MIN_HISTORY_SEC) {
+    // FRESHNESS (2026-08-30 V4.1 canary): the program ALSO rejects a borrow
+    // when the NEWEST sample is older than 120s (StalePriceAttestation 6013)
+    // — count + span alone is not "will pass on-chain". On V4 the attestor
+    // tick masked this (every mint refreshed every 35s); on the V4.1 lane a
+    // mint with a full-but-idle ring buffer failed 3 cosign attempts in a
+    // row with "oracle finalizing". A newest sample older than FRESH_MAX_SEC
+    // gets exactly one more push (only once span is already met, so the
+    // wrap-the-buffer hazard below cannot apply).
+    const FRESH_MAX_SEC = Number(process.env.V4_TWAP_FRESH_MAX_SEC) || 75;
+    const newestAgeSec = status.newestTs != null ? nowSec - status.newestTs : Infinity;
+    const fresh = newestAgeSec <= FRESH_MAX_SEC;
+    if (status.inWindow >= REQUIRED_IN_WINDOW && spanSec >= MIN_HISTORY_SEC && fresh) {
       return {
         ok: true,
         inWindow: status.inWindow,
         spanSec,
+        newestAgeSec,
         waitedMs: Date.now() - START,
         attests,
         programId: programId.toBase58().slice(0, 8),
       };
     }
+    const needsFreshPush = status.inWindow >= REQUIRED_IN_WINDOW && spanSec >= MIN_HISTORY_SEC && !fresh;
     // Fire an attest ONLY when we're short on SAMPLES. Once the window is
     // populated (count met) but the SPAN is still < 300s, firing more would
     // wrap the 32-slot circular buffer and keep the oldest in-window sample
@@ -334,7 +347,7 @@ export async function ensureV4TwapReady(mintStr, decimals, opts = {}) {
     // become borrowable. When count is met, just WAIT for the span to age
     // (the transient-interest continuous attestor the caller registers keeps
     // the feed fresh at the ~30s cadence that lets span grow naturally).
-    if (status.inWindow < REQUIRED_IN_WINDOW) {
+    if (status.inWindow < REQUIRED_IN_WINDOW || needsFreshPush) {
       try {
         await attestPrice(mintStr, decimals, undefined, programId);
         attests++;
@@ -971,6 +984,32 @@ export function startPriceAttestor(intervalMs = 30_000) {
   // ≤120s freshness + TWAP window). Borrow-time warming is separate —
   // the JIT warmer already receives the routed program id.
   const lastAttestAtV41 = new Map();
+  // Lane-aware coverage (operator pool plan 2026-08-30: V4 = RWA exits,
+  // V4.1 = memecoin exits). Each program's feed set is kept ≤35s fresh for
+  // exactly the mints that can BORROW or FIRE there:
+  //   V4   → RWA mints (new RWA exit-borrows) + mints backing an ACTIVE V4 loan
+  //   V4.1 → memecoins (new memecoin exit-borrows) + mints backing an ACTIVE V4.1 loan
+  // Memecoins therefore MOVE from the V4 tick to the V4.1 tick — cost-neutral —
+  // instead of being attested on both. Active-loan sets come from the DB and
+  // are refreshed every 60s.
+  const _activeMintsCache = new Map(); // programId → { set, at }
+  async function activeMintsFor(programId) {
+    const key = programId.toBase58();
+    const hit = _activeMintsCache.get(key);
+    if (hit && Date.now() - hit.at < 60_000) return hit.set;
+    let set = hit?.set ?? new Set();
+    try {
+      const r = await query(
+        `SELECT DISTINCT collateral_mint FROM loans WHERE status = 'active' AND program_id = $1`,
+        [key],
+      );
+      set = new Set(r.rows.map((x) => x.collateral_mint));
+    } catch (e) {
+      console.error(`[PriceAttestor] activeMintsFor ${key.slice(0, 8)} query failed: ${e.message?.slice(0, 120)}`);
+    }
+    _activeMintsCache.set(key, { set, at: Date.now() });
+    return set;
+  }
   let _v41ActiveMints = new Set();
   let _v41ActiveMintsAt = 0;
   async function v41ActiveMints() {
@@ -1123,14 +1162,22 @@ export function startPriceAttestor(intervalMs = 30_000) {
     // then process with bounded concurrency. Per-worker error handling
     // mirrors the prior sequential logic so init fallback + drift skip
     // still apply.
-    const { PROGRAM_ID_V3: V3PID_LIVE, PROGRAM_ID_V4: V4PID_LIVE, PROGRAM_ID_V4_1: V41PID_LIVE } = await import("../solana/program.js");
-    const v41Mints = await v41ActiveMints();
+    const { PROGRAM_ID_V3: V3PID_LIVE, PROGRAM_ID_V4: V4PID_LIVE, PROGRAM_ID_V4_1: V41PID_LIVE, isRwaCategory: isRwaCat } = await import("../solana/program.js");
+    const routeMemeExitsToV41 = !!V41PID_LIVE && process.env.ROUTE_EXITS_TO_V4_1 === "true";
+    const v4Active = V4PID_LIVE ? await activeMintsFor(V4PID_LIVE) : new Set();
+    const v41Active = V41PID_LIVE ? await activeMintsFor(V41PID_LIVE) : new Set();
+    // `wants(mint, category)` decides per target whether this mint's feed on
+    // that program must stay fresh. RWA-vs-memecoin uses the same predicate as
+    // exitProgramForCategory(), so routing and attestation flip together.
     const v3v4Targets = [
-      V4PID_LIVE ? { id: V4PID_LIVE, label: "V4", lastMap: lastAttestAtV4 } : null,
-      // V4.1 rides the V4 cadence but ONLY for mints with an active
-      // V4.1 loan (see v41ActiveMints above) — onlyForMints gates it in
-      // the per-mint loop below.
-      V41PID_LIVE ? { id: V41PID_LIVE, label: "V4.1", lastMap: lastAttestAtV41, onlyForMints: v41Mints } : null,
+      V4PID_LIVE ? {
+        id: V4PID_LIVE, label: "V4", lastMap: lastAttestAtV4,
+        wants: (mint, category) => !routeMemeExitsToV41 || isRwaCat(category) || v4Active.has(mint),
+      } : null,
+      V41PID_LIVE ? {
+        id: V41PID_LIVE, label: "V4.1", lastMap: lastAttestAtV41,
+        wants: (mint, category) => (routeMemeExitsToV41 && !isRwaCat(category)) || v41Active.has(mint),
+      } : null,
       V3PID_LIVE ? { id: V3PID_LIVE, label: "V3", lastMap: lastAttestAtV3 } : null,
     ].filter(Boolean);
 
@@ -1148,7 +1195,7 @@ export function startPriceAttestor(intervalMs = 30_000) {
         queue.push({ kind: "legacy", mint, decimals, priceSol, priceLamports, category });
       }
       for (const target of v3v4Targets) {
-        if (target.onlyForMints && !target.onlyForMints.has(mint)) continue;
+        if (target.wants && !target.wants(mint, category)) continue;
         // V3 is the RWA-only program WHILE ROUTE_MEMECOINS_TO_V3 is off:
         // memecoins route V1+V4 and never borrow on V3, so writing their V3
         // feed every tick is pure wasted SOL. Skip the explicit V3 write for

--- a/src/services/v4-feed-readiness.js
+++ b/src/services/v4-feed-readiness.js
@@ -405,7 +405,7 @@ export async function startFeedReadinessWarmup() {
  * Used by the /api/v1/v4/feed-ready endpoint and as the source of
  * truth in requestMintWarm.
  */
-export async function checkMintReadiness(mintStr, programIdOverride = null) {
+export async function checkMintReadiness(mintStr, programIdOverride = null, { requireFresh = true } = {}) {
   const { PROGRAM_ID_V4 } = await import("../solana/program.js");
   if (!PROGRAM_ID_V4 || !process.env.LENDER_PUBKEY) {
     return { ready: false, reason: "v4_not_configured", samples_in_window: 0 };
@@ -446,8 +446,25 @@ export async function checkMintReadiness(mintStr, programIdOverride = null) {
     }
   }
   const spanSec = oldestInWindowTs != null ? Number(now - oldestInWindowTs) : 0;
+  // Chain freshness wall: request_and_fund_loan / extend_loan reject when the
+  // NEWEST sample is >120s old (StalePriceAttestation / ExtendRequiresAuthority).
+  // A full-but-idle ring buffer is NOT ready — report it so the burst /
+  // continuous loops push one more sample. (2026-08-30 V4.1 canary.)
+  let newestTs = null;
+  for (let i = 0; i < Math.min(count, 32); i++) {
+    const idx = (head - 1 - i + 32) % 32;
+    const start = 112 + idx * 16;
+    if (start + 16 > info.data.length) break;
+    const ts = info.data.readBigInt64LE(start + 8);
+    if (newestTs == null || ts > newestTs) newestTs = ts;
+  }
+  const newestAgeSec = newestTs != null ? Number(now - newestTs) : Infinity;
+  const FRESH_MAX_SEC = Number(process.env.V4_READY_FRESH_MAX_SEC) || 90;
+  if (requireFresh && inWindow >= MIN_SAMPLES_FOR_TWAP && spanSec >= MIN_HISTORY_SECONDS && newestAgeSec > FRESH_MAX_SEC) {
+    return { ready: false, reason: "stale_latest_sample", samples_in_window: inWindow, span_seconds: spanSec, newest_age_seconds: newestAgeSec, eta_seconds: 5 };
+  }
   if (inWindow >= MIN_SAMPLES_FOR_TWAP && spanSec >= MIN_HISTORY_SECONDS) {
-    return { ready: true, samples_in_window: inWindow, span_seconds: spanSec, program: targetPid.toBase58() };
+    return { ready: true, samples_in_window: inWindow, span_seconds: spanSec, newest_age_seconds: newestAgeSec, program: targetPid.toBase58() };
   }
   if (inWindow >= MIN_SAMPLES_FOR_TWAP) {
     // Count met — only history age is missing. ETA is exact: the remaining
@@ -860,7 +877,10 @@ async function continuousAllMintsLoop(lenderPk, programIdV4) {
     batch.map(async (m) => {
       if (state.inFlight.has(m.mint)) return;
       try {
-        const readiness = await checkMintReadiness(m.mint);
+        // Count-based only (no freshness) — keeps the continuous loop's spend
+        // profile unchanged; borrow/extend-time freshness is the JIT warmer's
+        // and the burst loop's job. [[feedback_tiered_attestation_cost_conscious]]
+        const readiness = await checkMintReadiness(m.mint, null, { requireFresh: false });
         const buffered =
           readiness.ready &&
           typeof readiness.samples_in_window === "number" &&


### PR DESCRIPTION
Found by the site-shaped V4.1 canary (loan A9vNhK… landed only on the 4th cosign attempt). See commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)