### PR TITLE
fix: V4.1 TG extend — omit optional authority explicitly

### DIFF
--- a/src/services/loans.js
+++ b/src/services/loans.js
@@ -1235,6 +1235,12 @@ export async function executeExtendLoan({ userId, loanDbRow }) {
     const [priceHistoryPda] = priceFeedPda(extendCollateralMint, lendingPool, programId);
     v41ExtendAccounts.collateralMint = extendCollateralMint;
     v41ExtendAccounts.priceHistory = priceHistoryPda;
+    // Explicit null: Anchor's client auto-fills an omitted optional SIGNER with
+    // the provider wallet (the borrower), which the program then rejects as
+    // Unauthorized (6008) instead of the intended ExtendRequiresAuthority
+    // (6031). Passing null encodes "absent" (program-id placeholder) so an
+    // unhealthy loan fails with the right, actionable error. (2026-08-30 canary)
+    v41ExtendAccounts.authority = null;
   }
 
   const sig = await program.methods


### PR DESCRIPTION
Found by the mainnet V4.1 canary: an unhealthy loan returned Unauthorized (6008) because Anchor auto-filled the omitted optional signer with the borrower. Pass authority: null so the program sees it absent and returns ExtendRequiresAuthority (6031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)